### PR TITLE
Add PAI pack importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ bun run soma import algorithm --dry-run
 bun run soma import algorithm --apply
 ```
 
+The PAI Pack importer ports PAI skill packs into Soma skills. Dry-run is the
+default so the file classification can be reviewed before writing:
+
+```bash
+bun run soma import pai-pack --pai-pack-dir /Users/fischer/work/PAI/Packs/Telos
+bun run soma import pai-pack --apply --pai-pack-dir /Users/fischer/work/PAI/Packs/Telos
+```
+
+It preserves PAI pack source docs as references, copies portable workflows and
+tools under `~/.soma/skills/<skill>/`, and records a `soma-pack.json` manifest.
+Existing skills require `--overwrite`; substrate-specific files require
+`--include-substrate-specific`; likely secret files are denied. See
+[docs/pai-pack-importer.md](docs/pai-pack-importer.md).
+
 Soma also exposes a deterministic Algorithm harness. The harness wraps ISA work
 in a one-way phase machine:
 

--- a/docs/pai-pack-importer.md
+++ b/docs/pai-pack-importer.md
@@ -1,0 +1,91 @@
+# PAI Pack Importer
+
+PAI packs are the migration unit for the PAI skill layer. Soma imports them as
+portable Soma skills instead of installing them into a substrate home directly.
+
+## V0 Contract
+
+`soma import pai-pack` reads a PAI pack directory containing:
+
+- `README.md`
+- `INSTALL.md`
+- `VERIFY.md`
+- `src/SKILL.md`
+- optional `src/Workflows/`, `src/Tools/`, and template directories
+
+Dry-run is the default:
+
+```bash
+bun run soma import pai-pack --pai-pack-dir /Users/fischer/work/PAI/Packs/Telos
+```
+
+Apply requires an explicit flag:
+
+```bash
+bun run soma import pai-pack --apply --pai-pack-dir /Users/fischer/work/PAI/Packs/Telos
+```
+
+`--pai-pack-dir` is required. Existing Soma skills are not overwritten unless
+`--overwrite` is supplied. Files classified as `substrate-specific` are refused
+unless `--include-substrate-specific` is supplied. Likely secret files such as
+`.env`, private keys, credentials, tokens, and local settings files are denied
+by default.
+
+## Target Layout
+
+Imported packs land under `~/.soma/skills/<skill-name>/`.
+
+```text
+skills/telos/
+  SKILL.md
+  Workflows/
+  Tools/
+  DashboardTemplate/
+  ReportTemplate/
+  references/
+    PAI-PACK-README.md
+    PAI-PACK-INSTALL.md
+    PAI-PACK-VERIFY.md
+  soma-pack.json
+```
+
+The importer rewrites `SKILL.md` frontmatter to use a substrate-portable,
+lowercase Soma skill name. Source docs are preserved under `references/` so
+Claude-specific installation guidance remains available without becoming the
+Soma install procedure.
+
+## Classification
+
+The import plan classifies each file:
+
+- `portable`: skill entrypoint, workflows, tools, and the generated manifest.
+- `template`: dashboard/report application templates.
+- `source-doc`: original PAI pack README, INSTALL, and VERIFY docs.
+- `substrate-specific`: anything outside the known portable/template/doc paths.
+
+Each planned file also has an `origin`: `source` files include a PAI pack source
+path, while `generated` files carry a generator name for importer metadata. The
+generated `soma-pack.json` follows the exported `PaiPackManifest` contract.
+
+The classification is advisory in V0. It gives later adapters and review tools a
+stable place to decide what should project into Codex, Pi.dev, Claude Code, or a
+Cortex daemon.
+
+When substrate-specific files are explicitly included, Soma stores them outside
+the skill payload under `~/.soma/imports/pai-packs/<skill>/source/`. They are
+kept as migration source material, not projected skill content.
+
+## Boundaries
+
+The importer does not:
+
+- execute the PAI pack installer,
+- modify `~/.claude`,
+- overwrite existing Soma skills without `--overwrite`,
+- copy likely secret files,
+- run template dependency installs,
+- infer personal TELOS content,
+- publish imported skills to substrates by itself.
+
+Projection remains the adapter's job. Import makes the capability available in
+Soma; install/projection makes it available in a substrate.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,11 +8,13 @@ import {
   createAlgorithmRun,
   importAlgorithm,
   importPaiIdentity,
+  importPaiPack,
   installSomaForCodex,
   installSomaForPiDev,
   listAlgorithmRunSummaries,
   planAlgorithmImport,
   planPaiImport,
+  planPaiPackImport,
   planSomaForCodexInstall,
   planSomaForPiDevInstall,
   promoteAlgorithmRunMemory,
@@ -42,6 +44,9 @@ import type {
   PaiImportOptions,
   PaiImportPlan,
   PaiImportResult,
+  PaiPackImportOptions,
+  PaiPackImportPlan,
+  PaiPackImportResult,
   SomaInstallOptions,
   SomaInstallPlan,
   SomaInstallResult,
@@ -67,9 +72,9 @@ interface ParsedInstallArgs {
 
 interface ParsedImportArgs {
   command: "import";
-  source: "pai" | "algorithm";
+  source: "pai" | "algorithm" | "pai-pack";
   apply: boolean;
-  options: PaiImportOptions | AlgorithmImportOptions;
+  options: PaiImportOptions | AlgorithmImportOptions | PaiPackImportOptions;
 }
 
 interface ParsedAlgorithmArgs {
@@ -196,17 +201,18 @@ function parseInstallArgs(args: string[]): ParsedInstallArgs {
 function parseImportArgs(args: string[]): ParsedImportArgs {
   const [command, source, ...rest] = args;
 
-  if (command !== "import" || (source !== "pai" && source !== "algorithm")) {
+  if (command !== "import" || (source !== "pai" && source !== "algorithm" && source !== "pai-pack")) {
     throw new Error(
       [
         "Usage:",
         "  soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>]",
         "  soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
+        "  soma import pai-pack [--dry-run] [--apply] [--home-dir <dir>] --pai-pack-dir <dir> [--soma-home <dir>] [--skill-name <name>] [--overwrite] [--include-substrate-specific]",
       ].join("\n"),
     );
   }
 
-  const options: PaiImportOptions & AlgorithmImportOptions = {};
+  const options: PaiImportOptions & AlgorithmImportOptions & PaiPackImportOptions = {};
   let apply = false;
 
   for (let index = 0; index < rest.length; index += 1) {
@@ -236,6 +242,32 @@ function parseImportArgs(args: string[]): ParsedImportArgs {
         }
         options.paiAlgorithmDir = readOption(rest, index, arg);
         index += 1;
+        break;
+      case "--pai-pack-dir":
+        if (source !== "pai-pack") {
+          throw new Error("--pai-pack-dir is only valid for soma import pai-pack.");
+        }
+        options.paiPackDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--skill-name":
+        if (source !== "pai-pack") {
+          throw new Error("--skill-name is only valid for soma import pai-pack.");
+        }
+        options.skillName = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--overwrite":
+        if (source !== "pai-pack") {
+          throw new Error("--overwrite is only valid for soma import pai-pack.");
+        }
+        options.overwrite = true;
+        break;
+      case "--include-substrate-specific":
+        if (source !== "pai-pack") {
+          throw new Error("--include-substrate-specific is only valid for soma import pai-pack.");
+        }
+        options.includeSubstrateSpecific = true;
         break;
       case "--soma-home":
         options.somaHome = readOption(rest, index, arg);
@@ -951,6 +983,48 @@ function formatAlgorithmImportResult(result: AlgorithmImportResult): string {
   ].join("\n");
 }
 
+function formatPaiPackImportPlan(plan: PaiPackImportPlan): string {
+  const counts = plan.files.reduce<Partial<Record<string, number>>>((acc, file) => {
+    acc[file.classification] = (acc[file.classification] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return [
+    "Soma PAI Pack import plan",
+    "source: pai-pack",
+    `mode: ${plan.apply ? "apply" : "dry-run"}`,
+    `paiPackDir: ${plan.paiPackDir}`,
+    `somaHome: ${plan.somaHome}`,
+    `skillName: ${plan.skillName}`,
+    `packName: ${plan.packName}`,
+    `description: ${plan.description}`,
+    "",
+    "Classification:",
+    `- portable: ${counts.portable ?? 0}`,
+    `- template: ${counts.template ?? 0}`,
+    `- source-doc: ${counts["source-doc"] ?? 0}`,
+    `- substrate-specific: ${counts["substrate-specific"] ?? 0}`,
+    "",
+    "Files:",
+    ...plan.files.map((file) => {
+      const source = file.origin === "source" ? file.source : `generated:${file.generator}`;
+      return `- [${file.classification}] ${source} -> ${file.target}`;
+    }),
+  ].join("\n");
+}
+
+function formatPaiPackImportResult(result: PaiPackImportResult): string {
+  return [
+    "Soma PAI Pack import applied",
+    `paiPackDir: ${result.paiPackDir}`,
+    `somaHome: ${result.somaHome}`,
+    `skillName: ${result.skillName}`,
+    "",
+    "Files:",
+    ...result.files.map((path) => `- ${path}`),
+  ].join("\n");
+}
+
 function formatAlgorithmRunResult(result: { path: string; run: { id: string; phase: string; effort: string } }): string {
   return [
     "Soma Algorithm run created",
@@ -1262,6 +1336,16 @@ export async function runSomaCli(args: string[]): Promise<string> {
       }
 
       return formatAlgorithmImportResult(await importAlgorithm(options));
+    }
+
+    if (parsed.source === "pai-pack") {
+      const options = parsed.options as PaiPackImportOptions;
+
+      if (!parsed.apply) {
+        return formatPaiPackImportPlan(await planPaiPackImport(options));
+      }
+
+      return formatPaiPackImportResult(await importPaiPack(options));
     }
 
     const options = parsed.options as PaiImportOptions;

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,12 @@ export type {
   PaiImportOptions,
   PaiImportPlan,
   PaiImportResult,
+  PaiPackImportFile,
+  PaiPackImportOptions,
+  PaiPackImportPlan,
+  PaiPackImportResult,
+  PaiPackManifest,
+  PaiPackManifestFile,
   WrittenContextBundle,
 } from "./types";
 
@@ -118,6 +124,7 @@ export {
 export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from "./memory";
 export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
+export { importPaiPack, planPaiPackImport } from "./pai-pack-importer";
 export { checkSomaPolicy, checkSomaPolicyBatch } from "./policy-audit";
 export { evaluateSomaPolicy } from "./policy";
 export { bootstrapSomaHome, loadSomaHome } from "./soma-home";

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -1,0 +1,573 @@
+import { access, copyFile, lstat, mkdir, readdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { routePaiPackSourceFile, type PaiPackRenderMode } from "./pai-pack-routing";
+import type {
+  PaiPackGeneratedImportFile,
+  PaiPackImportFile,
+  PaiPackImportOptions,
+  PaiPackImportPlan,
+  PaiPackImportResult,
+  PaiPackManifest,
+  PaiPackSourceImportFile,
+} from "./types";
+
+interface PackMetadata {
+  name: string;
+  description: string;
+}
+
+const RESERVED_SKILL_NAMES = new Set(["soma", "the-algorithm"]);
+const REQUIRED_PACK_FILES = ["README.md", "INSTALL.md", "VERIFY.md", "src/SKILL.md"];
+const NORMALIZED_SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const SECRET_FILE_PATTERNS = [
+  /(^|\/)\.env$/,
+  /(^|\/)\.env\.(?!example$)[^/]+$/,
+  /(^|\/)id_[a-z0-9_-]+$/,
+  /(^|\/)[^/]+\.(pem|key|p12|pfx)$/,
+  /(^|\/)(credentials|secrets|tokens?)\.(json|yaml|yml|toml|ini|txt)$/,
+  /(^|\/)(settings|config)\.json$/,
+  /(^|\/)settings\.local\.json$/,
+  /(^|\/)local\.settings\.json$/,
+  /(^|\/)\.npmrc$/,
+  /(^|\/)\.pypirc$/,
+  /(^|\/)\.netrc$/,
+  /(^|\/)\.gem\/credentials$/,
+  /(^|\/)\.cargo\/credentials(?:\.toml)?$/,
+  /(^|\/)(\.aws|aws)\/credentials$/,
+  /(^|\/)(\.kube|kube)\/config$/,
+  /(^|\/)pip\.conf$/,
+];
+
+type RoutedPaiPackImportFile =
+  | (PaiPackSourceImportFile & { renderMode: Extract<PaiPackRenderMode, "copy" | "skill"> })
+  | (PaiPackGeneratedImportFile & { renderMode: Extract<PaiPackRenderMode, "manifest" | "archive-manifest"> });
+
+interface InternalPaiPackImportPlan extends PaiPackImportPlan {
+  routedFiles: RoutedPaiPackImportFile[];
+}
+
+function isRoutedSourceFile(file: RoutedPaiPackImportFile): file is Extract<RoutedPaiPackImportFile, { origin: "source" }> {
+  return file.origin === "source";
+}
+
+function resolvePackHomes(options: PaiPackImportOptions = {}): { paiPackDir: string; somaHome: string } {
+  if (!options.paiPackDir) {
+    throw new Error("soma import pai-pack requires --pai-pack-dir <dir>.");
+  }
+
+  const home = resolve(options.homeDir ?? homedir());
+
+  return {
+    paiPackDir: resolve(options.paiPackDir),
+    somaHome: resolve(options.somaHome ?? join(home, ".soma")),
+  };
+}
+
+function slugifySkillName(value: string): string {
+  return value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function parseFrontmatter(content: string): Partial<Record<string, string>> {
+  if (!content.startsWith("---\n")) {
+    return {};
+  }
+
+  const end = content.indexOf("\n---", 4);
+  if (end === -1) {
+    return {};
+  }
+
+  const frontmatter = content.slice(4, end);
+  const fields: Partial<Record<string, string>> = {};
+
+  for (const line of frontmatter.split("\n")) {
+    const separator = line.indexOf(":");
+    if (separator === -1) continue;
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (key && value && !value.startsWith("[")) {
+      fields[key] = value.replace(/^["']|["']$/g, "");
+    }
+  }
+
+  return fields;
+}
+
+async function readPackMetadata(paiPackDir: string): Promise<PackMetadata> {
+  const readme = await readFile(join(paiPackDir, "README.md"), "utf8");
+  const fields = parseFrontmatter(readme);
+  const heading = /^#\s+(.+)$/m.exec(readme)?.[1]?.trim();
+
+  return {
+    name: fields.name ?? heading ?? "pai-pack",
+    description: fields.description ?? "",
+  };
+}
+
+async function collectFiles(root: string): Promise<string[]> {
+  const files: string[] = [];
+  const realRoot = await realpath(root);
+
+  async function visit(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.name.includes("\\")) {
+        throw new Error(`PAI pack import refused ambiguous path separator: ${relative(root, fullPath).split(sep).join("/")}`);
+      }
+
+      if (entry.isSymbolicLink()) {
+        throw new Error(`PAI pack import refused symlink path: ${relative(root, fullPath).split(sep).join("/")}`);
+      }
+
+      if (entry.isDirectory()) {
+        if (entry.name === "node_modules" || entry.name === ".next" || entry.name === "dist") {
+          continue;
+        }
+        if (entry.name === ".git" || entry.name === ".hg" || entry.name === ".svn") {
+          throw new Error(`PAI pack import refused VCS metadata directory: ${relative(root, fullPath).split(sep).join("/")}`);
+        }
+        await visit(fullPath);
+      } else if (entry.isFile()) {
+        const realFile = await realpath(fullPath);
+        if (!isWithinPath(realRoot, realFile)) {
+          throw new Error(`PAI pack import refused path outside pack root: ${relative(root, fullPath).split(sep).join("/")}`);
+        }
+        const path = relative(root, fullPath).split(sep).join("/");
+        if (!path.startsWith("..") && !path.includes("../")) {
+          files.push(path);
+        }
+      }
+    }
+  }
+
+  await visit(root);
+  return files.sort();
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  return access(path)
+    .then(() => true)
+    .catch((error: unknown) => {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+      throw error;
+    });
+}
+
+function isLikelySecretPath(path: string): boolean {
+  const normalizedPath = path.replace(/\\/g, "/");
+  const segments = normalizedPath.split("/").map((segment) => segment.toLowerCase());
+  if (segments.some((segment) => segment === ".git" || segment === ".hg" || segment === ".svn")) {
+    return true;
+  }
+  if (segments.some((segment) => /^(secrets?|credentials?|tokens?)$/.test(segment))) {
+    return true;
+  }
+
+  const basename = segments.at(-1) ?? "";
+  if (/\b(token|secret|credential|key)s?\b/i.test(basename.replace(/[_\-.]+/g, " "))) {
+    return true;
+  }
+
+  return SECRET_FILE_PATTERNS.some((pattern) => pattern.test(normalizedPath.toLowerCase()));
+}
+
+function assertRequiredPackFiles(sourceFiles: string[]): void {
+  const sourceFileSet = new Set(sourceFiles);
+  const missing = REQUIRED_PACK_FILES.filter((path) => !sourceFileSet.has(path));
+  if (missing.length > 0) {
+    throw new Error(`PAI pack import requires V0 pack file(s): ${missing.join(", ")}`);
+  }
+}
+
+function assertSafePackPaths(sourceFiles: string[]): void {
+  const unsafePaths = sourceFiles.filter((path) => path.replace(/\\/g, "/").split("/").includes(".."));
+  if (unsafePaths.length > 0) {
+    throw new Error(`PAI pack import refused unsafe path segment(s): ${unsafePaths.join(", ")}`);
+  }
+}
+
+function assertUniqueTargets(files: Pick<PaiPackSourceImportFile | PaiPackGeneratedImportFile, "target">[]): void {
+  const seen = new Map<string, string>();
+  const duplicates: string[] = [];
+
+  for (const file of files) {
+    const key = file.target.toLowerCase();
+    const previous = seen.get(key);
+    if (previous) {
+      duplicates.push(`${previous} <-> ${file.target}`);
+    } else {
+      seen.set(key, file.target);
+    }
+  }
+
+  if (duplicates.length > 0) {
+    throw new Error(`PAI pack import refused duplicate target path(s): ${duplicates.join(", ")}`);
+  }
+}
+
+function isWithinPath(root: string, target: string): boolean {
+  const path = relative(root, target);
+  return path === "" || (!path.startsWith(`..${sep}`) && path !== ".." && !isAbsolute(path));
+}
+
+async function nearestExistingAncestor(path: string): Promise<string> {
+  let candidate = path;
+  while (!(await pathExists(candidate))) {
+    const parent = dirname(candidate);
+    if (parent === candidate) {
+      return candidate;
+    }
+    candidate = parent;
+  }
+  return candidate;
+}
+
+async function assertParentWithinRealRoot(root: string, target: string): Promise<void> {
+  const realRoot = await realpath(root);
+  const ancestor = await nearestExistingAncestor(dirname(target));
+  const realAncestor = await realpath(ancestor);
+  if (!isWithinPath(realRoot, realAncestor)) {
+    throw new Error(`PAI pack import refused target parent outside Soma home: ${target}`);
+  }
+}
+
+async function resolveSafeSourceFile(realPackRoot: string, source: string): Promise<string> {
+  const sourceStat = await lstat(source);
+  if (sourceStat.isSymbolicLink()) {
+    throw new Error(`PAI pack import refused symlink source during apply: ${source}`);
+  }
+
+  const realSource = await realpath(source);
+  if (!isWithinPath(realPackRoot, realSource)) {
+    throw new Error(`PAI pack import refused source outside pack root during apply: ${source}`);
+  }
+
+  return realSource;
+}
+
+async function mapWithConcurrency<T, R>(items: T[], concurrency: number, worker: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = [];
+  let nextIndex = 0;
+
+  async function runWorker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await worker(items[index]);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, runWorker));
+  return results;
+}
+
+function renderManifest(plan: PaiPackImportPlan): string {
+  const skillRoot = join(plan.somaHome, "skills", plan.skillName);
+  const skillFiles = plan.files.filter((file) => isWithinPath(skillRoot, file.target));
+  return renderManifestForRoot(plan, skillRoot, skillFiles);
+}
+
+function renderArchiveManifest(plan: PaiPackImportPlan): string {
+  const archiveRoot = join(plan.somaHome, "imports", "pai-packs", plan.skillName);
+  const archiveFiles = plan.files.filter((file) => isWithinPath(archiveRoot, file.target) && file.origin === "source");
+  return renderManifestForRoot(plan, archiveRoot, archiveFiles);
+}
+
+function renderManifestForRoot(plan: PaiPackImportPlan, root: string, files: PaiPackImportFile[]): string {
+  const manifest: PaiPackManifest = {
+    schema: "soma.pai-pack-import.v1",
+    skillName: plan.skillName,
+    packName: plan.packName,
+    description: plan.description,
+    files: files.map((file) => {
+      const manifestFile = {
+        target: relative(root, file.target).split(sep).join("/"),
+        classification: file.classification,
+        origin: file.origin,
+      };
+
+      if (file.origin === "source") {
+        return {
+          ...manifestFile,
+          origin: "source",
+          source: relative(plan.paiPackDir, file.source).split(sep).join("/"),
+        };
+      }
+
+      return {
+        ...manifestFile,
+        origin: "generated",
+        generator: file.generator,
+      };
+    }),
+  };
+
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+function rewriteSkillFrontmatter(content: string, skillName: string, description: string): string {
+  if (!content.startsWith("---\n")) {
+    return content;
+  }
+
+  const end = content.indexOf("\n---", 4);
+  if (end === -1) {
+    return content;
+  }
+
+  const body = content.slice(end + "\n---".length);
+  return ["---", `name: ${JSON.stringify(skillName)}`, `description: ${JSON.stringify(description || `Imported PAI pack: ${skillName}`)}`, "metadata:", "  source: pai-pack", "---", body.trimStart()].join("\n");
+}
+
+async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promise<InternalPaiPackImportPlan> {
+  const homes = resolvePackHomes(options);
+  const sourceFiles = await collectFiles(homes.paiPackDir);
+  assertSafePackPaths(sourceFiles);
+  assertRequiredPackFiles(sourceFiles);
+
+  const metadata = await readPackMetadata(homes.paiPackDir);
+  const skillName = options.skillName ? slugifySkillName(options.skillName) : slugifySkillName(metadata.name);
+  if (!skillName) {
+    throw new Error("soma import pai-pack requires a non-empty skill name after normalization.");
+  }
+  if (!NORMALIZED_SKILL_NAME_PATTERN.test(skillName)) {
+    throw new Error(`soma import pai-pack produced invalid normalized skill name '${skillName}'.`);
+  }
+  if (RESERVED_SKILL_NAMES.has(skillName)) {
+    throw new Error(`soma import pai-pack cannot overwrite reserved Soma skill '${skillName}'.`);
+  }
+  if (!options.overwrite) {
+    await access(join(homes.somaHome, "skills", skillName))
+      .then(() => {
+        throw new Error(`Soma skill '${skillName}' already exists. Re-run with --overwrite to replace it.`);
+      })
+      .catch((error: unknown) => {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+        throw error;
+      });
+    await access(join(homes.somaHome, "imports", "pai-packs", skillName))
+      .then(() => {
+        throw new Error(`Soma PAI pack archive '${skillName}' already exists. Re-run with --overwrite to replace it.`);
+      })
+      .catch((error: unknown) => {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+        throw error;
+      });
+  }
+
+  const secretFiles = sourceFiles.filter(isLikelySecretPath);
+  if (secretFiles.length > 0) {
+    throw new Error(`PAI pack import refused likely secret file(s): ${secretFiles.join(", ")}`);
+  }
+
+  const routes = sourceFiles.map((path) => ({ path, route: routePaiPackSourceFile(path) }));
+  const substrateSpecific = routes.filter(({ route }) => route.classification === "substrate-specific");
+  if (substrateSpecific.length > 0 && !options.includeSubstrateSpecific) {
+    throw new Error(
+      `PAI pack import refused substrate-specific file(s) without --include-substrate-specific: ${substrateSpecific.map(({ path }) => path).join(", ")}`,
+    );
+  }
+
+  const routedFiles: RoutedPaiPackImportFile[] = routes.map(({ path, route }) => ({
+    source: join(homes.paiPackDir, path),
+    target: join(homes.somaHome, route.root === "skill" ? "skills" : "imports/pai-packs", skillName, route.relativePath),
+    classification: route.classification,
+    renderMode: route.renderMode,
+    origin: "source",
+  }));
+
+  routedFiles.push({
+    target: join(homes.somaHome, `skills/${skillName}/soma-pack.json`),
+    classification: "portable",
+    renderMode: "manifest",
+    origin: "generated",
+    generator: "pai-pack-importer",
+  });
+  if (substrateSpecific.length > 0) {
+    routedFiles.push({
+      target: join(homes.somaHome, `imports/pai-packs/${skillName}/soma-pack-archive.json`),
+      classification: "substrate-specific",
+      renderMode: "archive-manifest",
+      origin: "generated",
+      generator: "pai-pack-importer",
+    });
+  }
+
+  const escapedTargets = routedFiles.filter((file) => !isWithinPath(homes.somaHome, file.target));
+  if (escapedTargets.length > 0) {
+    throw new Error(`PAI pack import refused target path outside Soma home: ${escapedTargets.map((file) => file.target).join(", ")}`);
+  }
+  assertUniqueTargets(routedFiles);
+
+  const files = routedFiles.map(({ renderMode: _renderMode, ...file }) => file);
+
+  return {
+    apply: false,
+    paiPackDir: homes.paiPackDir,
+    somaHome: homes.somaHome,
+    skillName,
+    packName: metadata.name,
+    description: metadata.description,
+    files,
+    routedFiles,
+  };
+}
+
+export async function planPaiPackImport(options: PaiPackImportOptions = {}): Promise<PaiPackImportPlan> {
+  const { routedFiles: _routedFiles, ...plan } = await buildPaiPackImportPlan(options);
+  return plan;
+}
+
+async function stagePaiPackFiles(plan: InternalPaiPackImportPlan, stageRoot: string): Promise<void> {
+  const realPackRoot = await realpath(plan.paiPackDir);
+
+  await mapWithConcurrency(plan.routedFiles, 8, async (file) => {
+    const target = file.target;
+    const stagedTarget = join(stageRoot, relative(plan.somaHome, target));
+    if (!isWithinPath(stageRoot, stagedTarget)) {
+      throw new Error(`PAI pack import refused staged target path outside stage root: ${target}`);
+    }
+
+    await mkdir(dirname(stagedTarget), { recursive: true });
+
+    if (file.renderMode === "manifest") {
+      await writeFile(stagedTarget, renderManifest(plan), "utf8");
+    } else if (file.renderMode === "archive-manifest") {
+      await writeFile(stagedTarget, renderArchiveManifest(plan), "utf8");
+    } else if (file.renderMode === "skill") {
+      const source = await resolveSafeSourceFile(realPackRoot, file.source);
+      const content = await readFile(source, "utf8");
+      await writeFile(stagedTarget, `${rewriteSkillFrontmatter(content, plan.skillName, plan.description).trimEnd()}\n`, "utf8");
+    } else {
+      if (!isRoutedSourceFile(file)) {
+        throw new Error(`PAI pack import cannot copy generated file: ${target}`);
+      }
+      const source = await resolveSafeSourceFile(realPackRoot, file.source);
+      await copyFile(source, stagedTarget);
+    }
+  });
+}
+
+interface PromotionContext {
+  plan: InternalPaiPackImportPlan;
+  stageRoot: string;
+  backupRoot: string;
+  skillRoot: string;
+  sourceArchiveRoot: string;
+  overwrite: boolean;
+  cleanupRoots: Set<string>;
+}
+
+async function promoteStagedImportWithRollback(context: PromotionContext): Promise<void> {
+  const { plan, stageRoot, backupRoot, skillRoot, sourceArchiveRoot, overwrite, cleanupRoots } = context;
+  const backupSkillRoot = join(backupRoot, "skills", plan.skillName);
+  const backupArchiveRoot = join(backupRoot, "imports", "pai-packs", plan.skillName);
+  const hadSkillRoot = await pathExists(skillRoot);
+  const hadArchiveRoot = await pathExists(sourceArchiveRoot);
+
+  const stagedSkillRoot = join(stageRoot, "skills", plan.skillName);
+  const stagedArchiveRoot = join(stageRoot, "imports", "pai-packs", plan.skillName);
+  let promotedSkillRoot = false;
+  let promotedArchiveRoot = false;
+
+  try {
+    if (overwrite) {
+      if (hadSkillRoot) {
+        await mkdir(dirname(backupSkillRoot), { recursive: true });
+        await rename(skillRoot, backupSkillRoot);
+      }
+      if (hadArchiveRoot) {
+        await mkdir(dirname(backupArchiveRoot), { recursive: true });
+        await rename(sourceArchiveRoot, backupArchiveRoot);
+      }
+    }
+
+    if (await pathExists(stagedSkillRoot)) {
+      await mkdir(dirname(skillRoot), { recursive: true });
+      await rename(stagedSkillRoot, skillRoot);
+      promotedSkillRoot = true;
+    }
+
+    if (await pathExists(stagedArchiveRoot)) {
+      await mkdir(dirname(sourceArchiveRoot), { recursive: true });
+      await rename(stagedArchiveRoot, sourceArchiveRoot);
+      promotedArchiveRoot = true;
+    }
+  } catch (error) {
+    try {
+      if (promotedSkillRoot) {
+        await rm(skillRoot, { recursive: true, force: true });
+      }
+      if (promotedArchiveRoot) {
+        await rm(sourceArchiveRoot, { recursive: true, force: true });
+      }
+      if (hadSkillRoot && (await pathExists(backupSkillRoot))) {
+        await mkdir(dirname(skillRoot), { recursive: true });
+        await rename(backupSkillRoot, skillRoot);
+      }
+      if (hadArchiveRoot && (await pathExists(backupArchiveRoot))) {
+        await mkdir(dirname(sourceArchiveRoot), { recursive: true });
+        await rename(backupArchiveRoot, sourceArchiveRoot);
+      }
+      await rm(backupRoot, { recursive: true, force: true }).catch(() => undefined);
+      cleanupRoots.delete(backupRoot);
+    } catch (rollbackError) {
+      cleanupRoots.delete(backupRoot);
+      const originalMessage = error instanceof Error ? error.message : String(error);
+      const rollbackMessage = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+      throw new Error(`PAI pack import failed and rollback failed. Original error: ${originalMessage}. Rollback error: ${rollbackMessage}`, {
+        cause: rollbackError,
+      });
+    }
+    throw error;
+  }
+}
+
+export async function importPaiPack(options: PaiPackImportOptions = {}): Promise<PaiPackImportResult> {
+  const plan = { ...(await buildPaiPackImportPlan(options)), apply: true };
+  const written: string[] = [];
+  const skillRoot = join(plan.somaHome, "skills", plan.skillName);
+  const sourceArchiveRoot = join(plan.somaHome, "imports", "pai-packs", plan.skillName);
+  const stageRoot = join(plan.somaHome, ".tmp", `pai-pack-${plan.skillName}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const backupRoot = join(plan.somaHome, ".tmp", `pai-pack-backup-${plan.skillName}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const cleanupRoots = new Set([stageRoot, backupRoot]);
+
+  try {
+    await mkdir(plan.somaHome, { recursive: true });
+    await assertParentWithinRealRoot(plan.somaHome, stageRoot);
+    await assertParentWithinRealRoot(plan.somaHome, skillRoot);
+    await assertParentWithinRealRoot(plan.somaHome, sourceArchiveRoot);
+
+    await stagePaiPackFiles(plan, stageRoot);
+    await promoteStagedImportWithRollback({
+      plan,
+      stageRoot,
+      backupRoot,
+      skillRoot,
+      sourceArchiveRoot,
+      overwrite: options.overwrite === true,
+      cleanupRoots,
+    });
+
+    written.push(...plan.files.map((file) => file.target));
+  } finally {
+    await Promise.allSettled(Array.from(cleanupRoots, (path) => rm(path, { recursive: true, force: true })));
+  }
+
+  return {
+    paiPackDir: plan.paiPackDir,
+    somaHome: plan.somaHome,
+    skillName: plan.skillName,
+    files: written,
+  };
+}

--- a/src/pai-pack-routing.ts
+++ b/src/pai-pack-routing.ts
@@ -1,0 +1,61 @@
+import type { PaiPackImportFile } from "./types";
+
+export type PaiPackRenderMode = "copy" | "skill" | "manifest" | "archive-manifest";
+export type PaiPackRouteRoot = "skill" | "archive";
+
+export interface PaiPackRoute {
+  classification: PaiPackImportFile["classification"];
+  root: PaiPackRouteRoot;
+  relativePath: string;
+  renderMode: Extract<PaiPackRenderMode, "copy" | "skill">;
+}
+
+const SOURCE_DOC_TARGETS: Record<string, string> = {
+  "README.md": "PAI-PACK-README.md",
+  "INSTALL.md": "PAI-PACK-INSTALL.md",
+  "VERIFY.md": "PAI-PACK-VERIFY.md",
+};
+
+const TEMPLATE_PREFIXES = ["src/DashboardTemplate/", "src/ReportTemplate/"];
+const PORTABLE_PREFIXES = ["src/Workflows/", "src/Tools/"];
+
+function stripSrcPrefix(path: string): string {
+  return path.slice("src/".length);
+}
+
+export function routePaiPackSourceFile(path: string): PaiPackRoute {
+  const sourceDocTarget = SOURCE_DOC_TARGETS[path];
+  if (sourceDocTarget) {
+    return {
+      classification: "source-doc",
+      root: "skill",
+      relativePath: `references/${sourceDocTarget}`,
+      renderMode: "copy",
+    };
+  }
+
+  if (TEMPLATE_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+    return {
+      classification: "template",
+      root: "skill",
+      relativePath: stripSrcPrefix(path),
+      renderMode: "copy",
+    };
+  }
+
+  if (path === "src/SKILL.md" || PORTABLE_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+    return {
+      classification: "portable",
+      root: "skill",
+      relativePath: stripSrcPrefix(path),
+      renderMode: path === "src/SKILL.md" ? "skill" : "copy",
+    };
+  }
+
+  return {
+    classification: "substrate-specific",
+    root: "archive",
+    relativePath: `source/${path}`,
+    renderMode: "copy",
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -286,6 +286,75 @@ export interface AlgorithmImportResult {
   files: string[];
 }
 
+export interface PaiPackImportOptions {
+  homeDir?: string;
+  paiPackDir?: string;
+  somaHome?: string;
+  skillName?: string;
+  overwrite?: boolean;
+  includeSubstrateSpecific?: boolean;
+}
+
+export interface PaiPackImportFileBase {
+  target: string;
+  classification: "portable" | "template" | "source-doc" | "substrate-specific";
+}
+
+export interface PaiPackSourceImportFile extends PaiPackImportFileBase {
+  origin: "source";
+  source: string;
+}
+
+export interface PaiPackGeneratedImportFile extends PaiPackImportFileBase {
+  origin: "generated";
+  generator: "pai-pack-importer";
+}
+
+export type PaiPackImportFile = PaiPackSourceImportFile | PaiPackGeneratedImportFile;
+
+export interface PaiPackManifestFileBase {
+  target: string;
+  classification: PaiPackImportFileBase["classification"];
+  origin: PaiPackImportFile["origin"];
+}
+
+export interface PaiPackManifestSourceFile extends PaiPackManifestFileBase {
+  origin: "source";
+  source: string;
+}
+
+export interface PaiPackManifestGeneratedFile extends PaiPackManifestFileBase {
+  origin: "generated";
+  generator: "pai-pack-importer";
+}
+
+export type PaiPackManifestFile = PaiPackManifestSourceFile | PaiPackManifestGeneratedFile;
+
+export interface PaiPackManifest {
+  schema: "soma.pai-pack-import.v1";
+  skillName: string;
+  packName: string;
+  description: string;
+  files: PaiPackManifestFile[];
+}
+
+export interface PaiPackImportPlan {
+  apply: boolean;
+  paiPackDir: string;
+  somaHome: string;
+  skillName: string;
+  packName: string;
+  description: string;
+  files: PaiPackImportFile[];
+}
+
+export interface PaiPackImportResult {
+  paiPackDir: string;
+  somaHome: string;
+  skillName: string;
+  files: string[];
+}
+
 export interface SomaMemoryEventInput {
   id?: string;
   timestamp?: string;

--- a/test/pai-pack-importer.test.ts
+++ b/test/pai-pack-importer.test.ts
@@ -1,0 +1,263 @@
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { runSomaCli } from "../src/cli";
+import { bootstrapSomaHome, importPaiPack, loadSomaHome, planPaiPackImport } from "../src/index";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-pai-pack-import-"));
+
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function writePackFixture(homeDir: string): Promise<string> {
+  const packDir = join(homeDir, "PAI/Packs/Telos");
+
+  await mkdir(join(packDir, "src/Workflows"), { recursive: true });
+  await mkdir(join(packDir, "src/Tools"), { recursive: true });
+  await mkdir(join(packDir, "src/DashboardTemplate/App"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    [
+      "---",
+      "name: Telos",
+      "description: Life OS and project analysis",
+      "---",
+      "",
+      "# Telos",
+      "",
+      "Pack docs.",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n\nClaude-oriented install guide.\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n\nChecks.\n", "utf8");
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    [
+      "---",
+      "name: Telos",
+      "description: Original PAI Telos skill",
+      "---",
+      "",
+      "# Telos",
+      "",
+      "## Triggers",
+      "",
+      "- telos",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "src/Workflows/Update.md"), "# Update\n", "utf8");
+  await writeFile(join(packDir, "src/Tools/UpdateTelos.ts"), "export const tool = true;\n", "utf8");
+  await writeFile(join(packDir, "src/DashboardTemplate/App/page.tsx"), "export default function Page() { return null; }\n", "utf8");
+  await writeFile(join(packDir, "src/DashboardTemplate/logo.png"), new Uint8Array([0, 159, 146, 150, 255]));
+
+  return packDir;
+}
+
+test("requires an explicit PAI Pack directory", async () => {
+  await expect(planPaiPackImport({ homeDir: "/tmp/soma-test-home" })).rejects.toThrow("requires --pai-pack-dir");
+});
+
+test("plans a PAI Pack import without writing files", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = await writePackFixture(homeDir);
+    const plan = await planPaiPackImport({ homeDir, paiPackDir: packDir });
+
+    expect(plan.apply).toBe(false);
+    expect(plan.skillName).toBe("telos");
+    expect(plan.files).toContainEqual(
+      expect.objectContaining({
+        source: join(packDir, "src/SKILL.md"),
+        target: join(homeDir, ".soma/skills/telos/SKILL.md"),
+        classification: "portable",
+      }),
+    );
+    expect(plan.files.some((file) => file.classification === "template" && file.target.endsWith("DashboardTemplate/App/page.tsx"))).toBe(true);
+    expect(plan.files.some((file) => file.classification === "source-doc" && file.target.endsWith("PAI-PACK-INSTALL.md"))).toBe(true);
+    const manifest = plan.files.find((file) => file.target.endsWith("soma-pack.json"));
+    expect(manifest).toMatchObject({ origin: "generated", generator: "pai-pack-importer" });
+    expect(manifest && "source" in manifest).toBe(false);
+    await expect(stat(join(homeDir, ".soma"))).rejects.toThrow();
+  });
+});
+
+test("rejects invalid, reserved, colliding, secret, and substrate-specific pack imports", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = await writePackFixture(homeDir);
+
+    await expect(planPaiPackImport({ homeDir, paiPackDir: packDir, skillName: "!!!" })).rejects.toThrow("non-empty skill name");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: packDir, skillName: "soma" })).rejects.toThrow("reserved Soma skill");
+
+    await mkdir(join(homeDir, ".soma/skills/telos"), { recursive: true });
+    await expect(planPaiPackImport({ homeDir, paiPackDir: packDir })).rejects.toThrow("already exists");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: packDir, overwrite: true })).resolves.toMatchObject({ skillName: "telos" });
+
+    const secretPackDir = await writePackFixture(join(homeDir, "secret"));
+    await writeFile(join(secretPackDir, "src/DashboardTemplate/.env"), "TOKEN=secret\n", "utf8");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: secretPackDir, overwrite: true })).rejects.toThrow("likely secret");
+    await rm(join(secretPackDir, "src/DashboardTemplate/.env"));
+    await writeFile(join(secretPackDir, "src/DashboardTemplate/.ENV"), "TOKEN=secret\n", "utf8");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: secretPackDir, overwrite: true })).rejects.toThrow("likely secret");
+    await rm(join(secretPackDir, "src/DashboardTemplate/.ENV"));
+    await writeFile(join(secretPackDir, "src/DashboardTemplate/.npmrc"), "//registry.npmjs.org/:_authToken=secret\n", "utf8");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: secretPackDir, overwrite: true })).rejects.toThrow("likely secret");
+    await rm(join(secretPackDir, "src/DashboardTemplate/.npmrc"));
+    await writeFile(join(secretPackDir, "src/Tools/config.json"), "{}", "utf8");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: secretPackDir, overwrite: true })).rejects.toThrow("likely secret");
+    await rm(join(secretPackDir, "src/Tools/config.json"));
+    await writeFile(join(secretPackDir, "src/Tools/local.settings.json"), "{}", "utf8");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: secretPackDir, overwrite: true })).rejects.toThrow("likely secret");
+    await rm(join(secretPackDir, "src/Tools/local.settings.json"));
+    await mkdir(join(secretPackDir, "src/Tools/secrets"), { recursive: true });
+    await writeFile(join(secretPackDir, "src/Tools/secrets/prod.txt"), "secret\n", "utf8");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: secretPackDir, overwrite: true })).rejects.toThrow("likely secret");
+    await rm(join(secretPackDir, "src/Tools/secrets"), { recursive: true, force: true });
+    await writeFile(join(secretPackDir, "src/Tools/github-token.txt"), "token\n", "utf8");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: secretPackDir, overwrite: true })).rejects.toThrow("likely secret");
+    await rm(join(secretPackDir, "src/Tools/github-token.txt"));
+    await mkdir(join(secretPackDir, "src/DashboardTemplate/.git"), { recursive: true });
+    await writeFile(join(secretPackDir, "src/DashboardTemplate/.git/config"), "[remote]\n", "utf8");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: secretPackDir, overwrite: true })).rejects.toThrow("VCS metadata");
+    await rm(join(secretPackDir, "src/DashboardTemplate/.git"), { recursive: true, force: true });
+    await writeFile(join(secretPackDir, "src/Tools/id_ecdsa"), "OPENSSH PRIVATE KEY\n", "utf8");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: secretPackDir, overwrite: true })).rejects.toThrow("likely secret");
+    await rm(join(secretPackDir, "src/Tools/id_ecdsa"));
+    await writeFile(join(secretPackDir, "src\\DashboardTemplate\\.env"), "TOKEN=secret\n", "utf8");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: secretPackDir, overwrite: true })).rejects.toThrow("ambiguous path separator");
+
+    const unsafePackDir = await writePackFixture(join(homeDir, "unsafe"));
+    await writeFile(join(unsafePackDir, "src\\..\\escape.md"), "# Escape\n", "utf8");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: unsafePackDir, overwrite: true })).rejects.toThrow("ambiguous path separator");
+
+    const symlinkPackDir = await writePackFixture(join(homeDir, "symlink"));
+    const outsideDir = join(homeDir, "outside");
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(join(outsideDir, "benign.md"), "# Outside\n", "utf8");
+    await symlink(outsideDir, join(symlinkPackDir, "src/Workflows/Linked"));
+    await expect(planPaiPackImport({ homeDir, paiPackDir: symlinkPackDir, overwrite: true })).rejects.toThrow("refused symlink");
+
+    const substratePackDir = await writePackFixture(join(homeDir, "substrate"));
+    await mkdir(join(substratePackDir, "claude"), { recursive: true });
+    await writeFile(join(substratePackDir, "claude/profile.md"), "# Claude profile\n", "utf8");
+    await expect(planPaiPackImport({ homeDir, paiPackDir: substratePackDir, overwrite: true })).rejects.toThrow("substrate-specific");
+    const substratePlan = await planPaiPackImport({ homeDir, paiPackDir: substratePackDir, overwrite: true, includeSubstrateSpecific: true });
+    expect(substratePlan.files).toContainEqual(
+      expect.objectContaining({
+        target: join(homeDir, ".soma/imports/pai-packs/telos/source/claude/profile.md"),
+        classification: "substrate-specific",
+      }),
+    );
+  });
+});
+
+test("rejects incomplete PAI Pack structures", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = await writePackFixture(homeDir);
+    await rm(join(packDir, "src/SKILL.md"));
+
+    await expect(planPaiPackImport({ homeDir, paiPackDir: packDir })).rejects.toThrow("requires V0 pack file(s): src/SKILL.md");
+
+    const noReadmePackDir = await writePackFixture(join(homeDir, "no-readme"));
+    await rm(join(noReadmePackDir, "README.md"));
+
+    await expect(planPaiPackImport({ homeDir, paiPackDir: noReadmePackDir, overwrite: true })).rejects.toThrow("requires V0 pack file(s): README.md");
+  });
+});
+
+test("does not treat non-src template-looking paths as templates", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = await writePackFixture(homeDir);
+    await mkdir(join(packDir, "docs/DashboardTemplate"), { recursive: true });
+    await writeFile(join(packDir, "docs/DashboardTemplate/readme.md"), "# Template docs\n", "utf8");
+
+    await expect(planPaiPackImport({ homeDir, paiPackDir: packDir })).rejects.toThrow("substrate-specific");
+  });
+});
+
+test("imports a PAI Pack as a Soma skill", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = await writePackFixture(homeDir);
+    await bootstrapSomaHome({ homeDir });
+    const result = await importPaiPack({ homeDir, paiPackDir: packDir });
+    const context = await loadSomaHome(result.somaHome);
+
+    expect(result.files).toContain(join(homeDir, ".soma/skills/telos/SKILL.md"));
+    await expect(readFile(join(homeDir, ".soma/skills/telos/SKILL.md"), "utf8")).resolves.toContain('name: "telos"');
+    await expect(readFile(join(homeDir, ".soma/skills/telos/references/PAI-PACK-INSTALL.md"), "utf8")).resolves.toContain("Claude-oriented install guide");
+    const manifest = JSON.parse(await readFile(join(homeDir, ".soma/skills/telos/soma-pack.json"), "utf8")) as {
+      files: { target: string; classification: string; origin: string; source?: string; generator?: string }[];
+    };
+    expect(manifest.files).toContainEqual(expect.objectContaining({ classification: "template", source: "src/DashboardTemplate/App/page.tsx" }));
+    expect(manifest.files).toContainEqual(expect.objectContaining({ origin: "generated", generator: "pai-pack-importer" }));
+    expect(await readFile(join(homeDir, ".soma/skills/telos/DashboardTemplate/logo.png"))).toEqual(Buffer.from([0, 159, 146, 150, 255]));
+    expect(context.profile.skills.some((skill) => skill.name === "telos")).toBe(true);
+  });
+});
+
+test("refuses existing PAI Pack archives without overwrite", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = await writePackFixture(homeDir);
+    await mkdir(join(homeDir, ".soma/imports/pai-packs/telos"), { recursive: true });
+
+    await expect(planPaiPackImport({ homeDir, paiPackDir: packDir })).rejects.toThrow("archive 'telos' already exists");
+  });
+});
+
+test("keeps substrate archives out of the skill manifest", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = await writePackFixture(homeDir);
+    await mkdir(join(packDir, "claude"), { recursive: true });
+    await writeFile(join(packDir, "claude/profile.md"), "# Claude profile\n", "utf8");
+    await importPaiPack({ homeDir, paiPackDir: packDir, includeSubstrateSpecific: true });
+
+    await expect(readFile(join(homeDir, ".soma/imports/pai-packs/telos/source/claude/profile.md"), "utf8")).resolves.toContain("# Claude profile");
+    const archiveManifest = JSON.parse(await readFile(join(homeDir, ".soma/imports/pai-packs/telos/soma-pack-archive.json"), "utf8")) as {
+      files: { target: string; classification: string; origin: string; source?: string }[];
+    };
+    expect(archiveManifest.files).toContainEqual(
+      expect.objectContaining({ target: "source/claude/profile.md", classification: "substrate-specific", origin: "source", source: "claude/profile.md" }),
+    );
+    await expect(readFile(join(homeDir, ".soma/skills/telos/soma-pack.json"), "utf8")).resolves.not.toContain("imports/pai-packs");
+    await expect(readFile(join(homeDir, ".soma/skills/telos/soma-pack.json"), "utf8")).resolves.not.toContain("claude/profile.md");
+  });
+});
+
+test("overwrites imported skills without leaving stale files", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = await writePackFixture(homeDir);
+    await importPaiPack({ homeDir, paiPackDir: packDir });
+    await writeFile(join(homeDir, ".soma/skills/telos/Workflows/Stale.md"), "# Stale\n", "utf8");
+    await mkdir(join(homeDir, ".soma/imports/pai-packs/telos/source/claude"), { recursive: true });
+    await writeFile(join(homeDir, ".soma/imports/pai-packs/telos/source/claude/settings.json"), "{}", "utf8");
+
+    await importPaiPack({ homeDir, paiPackDir: packDir, overwrite: true });
+
+    await expect(readFile(join(homeDir, ".soma/skills/telos/Workflows/Stale.md"), "utf8")).rejects.toThrow();
+    await expect(readFile(join(homeDir, ".soma/imports/pai-packs/telos/source/claude/settings.json"), "utf8")).rejects.toThrow();
+    await expect(readFile(join(homeDir, ".soma/skills/telos/Workflows/Update.md"), "utf8")).resolves.toContain("# Update");
+  });
+});
+
+test("cli dry-runs and applies a PAI Pack import", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = await writePackFixture(homeDir);
+    const dryRun = await runSomaCli(["import", "pai-pack", "--home-dir", homeDir, "--pai-pack-dir", packDir]);
+
+    expect(dryRun).toContain("Soma PAI Pack import plan");
+    expect(dryRun).toContain("skillName: telos");
+    expect(dryRun).toContain("- template: 2");
+    await expect(stat(join(homeDir, ".soma"))).rejects.toThrow();
+
+    const applied = await runSomaCli(["import", "pai-pack", "--apply", "--home-dir", homeDir, "--pai-pack-dir", packDir]);
+
+    expect(applied).toContain("Soma PAI Pack import applied");
+    await expect(readFile(join(homeDir, ".soma/skills/telos/Workflows/Update.md"), "utf8")).resolves.toContain("# Update");
+  });
+});


### PR DESCRIPTION
## Summary
- add a dry-run/apply PAI Pack importer that turns PAI packs into Soma skills
- classify pack files as portable, template, source-doc, or substrate-specific
- preserve PAI source docs as references and write a soma-pack.json manifest
- document the importer and add tests with a Telos-shaped fixture

## Verification
- bun test
- bun run typecheck
- bun run lint
- git diff --check
- real Telos dry-run: 7 portable, 63 template, 3 source-doc files