### PR TITLE
Quiet Soma lifecycle hook output

### DIFF
--- a/src/adapters/codex-hook-entry.mjs
+++ b/src/adapters/codex-hook-entry.mjs
@@ -113,6 +113,17 @@ function readProjectedStartupContext() {
   }
 }
 
+export function renderStartupContextSummary(context) {
+  if (!context) return "Soma: startup context unavailable; read the projected Soma startup context when needed.";
+  const assistant = context.match(/^Assistant:\s*(.+)$/m)?.[1]?.trim();
+  const principal = context.match(/^Principal:\s*(.+)$/m)?.[1]?.trim();
+  const activeRunsSection = context.match(/(?:^|\n)## Active Algorithm Runs\n(?<section>[\s\S]*?)(?=\n## |$)/)?.groups?.section ?? "";
+  const activeRuns = [...activeRunsSection.matchAll(/^- [^\n]+$/gm)].length;
+  const identity = assistant && principal ? `${assistant} for ${principal}` : assistant || "startup context";
+  const runText = activeRuns === 1 ? "1 active run" : `${activeRuns} active runs`;
+  return `Soma: ${identity}; ${runText}. Full context is in the projected startup-context.md.`;
+}
+
 function handlePreToolUse(config, input) {
   if (input.__somaParseError) {
     denyPreToolUse(`Soma policy check failed closed: malformed hook input (${input.__somaParseError})`);
@@ -167,15 +178,15 @@ function handleLifecycleEvent(config, event, input) {
       const context = readProjectedStartupContext();
       emitAndExit({
         continue: true,
-        systemMessage: `Soma lifecycle hook fell back to projected context: ${result.stderr || result.stdout || "unknown error"}`,
+        systemMessage: "Soma lifecycle hook fell back to projected startup context.",
         hookSpecificOutput: {
           hookEventName: "SessionStart",
-          additionalContext: context || "Soma lifecycle context is unavailable; read ~/.codex/memories/soma/ when needed.",
+          additionalContext: renderStartupContextSummary(context),
         },
       });
     }
 
-    emitAndExit({ continue: true, systemMessage: `Soma lifecycle hook failed: ${result.stderr || result.stdout || "unknown error"}` });
+    emitAndExit({ continue: true, systemMessage: `Soma lifecycle hook failed for ${event}; read projected Soma context when needed.` });
   }
 
   if (event === "session-start") {
@@ -184,12 +195,12 @@ function handleLifecycleEvent(config, event, input) {
       continue: true,
       hookSpecificOutput: {
         hookEventName: "SessionStart",
-        additionalContext: context || result.stdout,
+        additionalContext: renderStartupContextSummary(context || result.stdout),
       },
     });
   }
 
-  emitAndExit({ continue: true, systemMessage: result.stdout.trim() });
+  emitAndExit({ continue: true, systemMessage: `Soma lifecycle ${event} handled.` });
 }
 
 export function runCodexHook(config, event = process.argv[2], input = readHookInput()) {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import { installSomaForCodex, installSomaForPiDev } from "../src/index";
+import { renderStartupContextSummary } from "../src/adapters/codex-hook-entry.mjs";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-install-"));
@@ -364,6 +365,46 @@ test("installed codex lifecycle hooks ignore ambient SOMA_REPO", async () => {
     expect(result.output.hookSpecificOutput?.additionalContext).not.toContain("Operating requirement");
     expect(result.output.hookSpecificOutput?.additionalContext).not.toContain("malicious");
   });
+});
+
+test("installed codex session-start hook returns concise visible context", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexHook(hook, "session-start", homeDir, { session_id: "session-1" });
+    const startupContext = await readFile(join(homeDir, ".codex/memories/soma/startup-context.md"), "utf8");
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.additionalContext).toContain("Soma:");
+    expect(result.output.hookSpecificOutput?.additionalContext).toContain("Full context is in the projected startup-context.md");
+    expect(result.output.hookSpecificOutput?.additionalContext).not.toContain("Soma Startup Context");
+    expect(result.output.hookSpecificOutput?.additionalContext).not.toContain("## Active Algorithm Runs");
+    expect(startupContext).toContain("Soma Startup Context");
+  });
+});
+
+test("codex session-start summary only counts active Algorithm runs", () => {
+  const summary = renderStartupContextSummary(
+    [
+      "# Soma Startup Context",
+      "Assistant: Ivy",
+      "Principal: Jens-Christian",
+      "Mission: Keep portable context concise.",
+      "",
+      "## Active Algorithm Runs",
+      "- 20260515_one: OBSERVE 1/1 E1 - One active run.",
+      "- 20260515_two: OBSERVE 2/2 E1 - Another active run.",
+      "",
+      "## Recent Learning",
+      "- This is a learning note, not an active run.",
+      "- This is another learning note.",
+      "",
+    ].join("\n"),
+  );
+
+  expect(summary).toContain("Ivy for Jens-Christian");
+  expect(summary).toContain("2 active runs");
+  expect(summary).not.toContain("4 active runs");
 });
 
 test("installed codex hook uses explicit soma repo path", async () => {


### PR DESCRIPTION
## Summary
- summarize Codex SessionStart visible hook context instead of emitting the full startup markdown
- keep the full startup context in the projected startup-context.md file
- make other lifecycle hook messages concise status lines

## Verification
- bun test
- bun run lint
- bun run typecheck
- git diff --check