### PR TITLE
Tune Algorithm classifier native fast paths

### DIFF
--- a/src/algorithm-classifier.ts
+++ b/src/algorithm-classifier.ts
@@ -10,12 +10,28 @@ const MINIMAL_PROMPTS = new Set([
   "thanks",
   "thank you",
   "works",
+  "worked",
+  "working",
   "great",
+  "great works",
+  "great that works",
+  "great that works nicely",
+  "nice",
+  "excellent",
+  "cool",
+  "perfect",
+  "looks good",
+  "sounds good",
+  "that works",
+  "that worked",
   "go for it",
   "do it",
 ]);
 
 const NATIVE_PATTERNS = [
+  /\b(what'?s next|next step|status|is that installed|does that work|what changed|what did you change)\b/i,
+  /^(what|who|when|where) (is|are|was|were)\b/i,
+  /^how (does|do|did|is|are)\b/i,
   /\b(run|execute)\b.+\b(tests?|command|script|lint|typecheck|date|pwd|ls)\b/i,
   /\b(read|show|summarize|inspect|check)\b.+\b(file|output|log|diff|status)\b/i,
   /\b(fix|change|rename|update)\b.+\b(typo|spelling|one line|single line)\b/i,
@@ -60,7 +76,11 @@ function classifyAlgorithmTier(prompt: string): AlgorithmEffortTier {
 
 function classifyMode(prompt: string): AlgorithmMode {
   const text = prompt.trim();
-  const normalized = text.toLowerCase().replace(/[.!?]+$/g, "");
+  const normalized = text
+    .toLowerCase()
+    .replace(/[.!?,'"]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
 
   if (MINIMAL_PROMPTS.has(normalized)) {
     return "minimal";
@@ -105,7 +125,7 @@ export function classifyAlgorithmPrompt(prompt: string): AlgorithmPromptClassifi
     return {
       mode,
       source: "auto",
-      reason: mode === "minimal" ? "Prompt is a minimal acknowledgement." : "Prompt is a narrow native substrate action.",
+      reason: mode === "minimal" ? "Prompt is a minimal acknowledgement." : "Prompt can be handled by the native substrate without Algorithm harness.",
     };
   }
 

--- a/test/algorithm.test.ts
+++ b/test/algorithm.test.ts
@@ -27,7 +27,7 @@ test("creates deterministic Algorithm runs around ISA criteria", () => {
   const run = createAlgorithmRun({
     id: "ledger-update",
     timestamp: "2026-05-14T10:00:00.000Z",
-    prompt: "Update the ledger",
+    prompt: "Create a verified ledger update",
     intent: "Bring ledger state current.",
     currentState: "Ledger is stale.",
     goal: "Ledger is current and verified.",
@@ -61,7 +61,19 @@ test("classifies prompts into Algorithm mode and effort tiers", () => {
     mode: "minimal",
     source: "auto",
   });
+  expect(classifyAlgorithmPrompt("great, that works nicely")).toMatchObject({
+    mode: "minimal",
+    source: "auto",
+  });
+  expect(classifyAlgorithmPrompt("what's next?")).toMatchObject({
+    mode: "native",
+    source: "auto",
+  });
   expect(classifyAlgorithmPrompt("run the tests")).toMatchObject({
+    mode: "native",
+    source: "auto",
+  });
+  expect(classifyAlgorithmPrompt("how does PAI handle the classification?")).toMatchObject({
     mode: "native",
     source: "auto",
   });


### PR DESCRIPTION
## Summary
- normalize simple acknowledgement prompts so punctuation does not prevent minimal classification
- add native fast paths for simple status/fact/Q&A prompts
- keep substantial build, migration, telos, and strategy prompts in Algorithm mode

## Verification
- bun test
- bun run lint
- bun run typecheck
- git diff --check
- CLI probes for minimal, native, and Algorithm classifications