### PR TITLE
Tell users to refresh projections after PAI pack import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ dist/
 .env
 .env.*
 !.env.example
-
+*.tar.gz

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Recall commands provide deterministic file-backed memory retrieval:
 ```bash
 bun run soma memory search --query "client sovereignty agency"
 bun run soma memory promote --from-run <run-id> --store learning --title "Reusable lesson" --substrate codex
+bun run soma feedback capture --text "you missed the arc-manifest" --substrate codex
 ```
 
 Search covers Soma profile/imports plus WORK, KNOWLEDGE, LEARNING,
@@ -127,6 +128,12 @@ RELATIONSHIP, and STATE memory stores, returning source paths, line numbers, and
 short snippets. Promotion turns verified Algorithm work into concise durable
 memory notes with source run links, criteria, decisions, verification, and recall
 guidance. It refuses runs with no verification entries and no passed criteria.
+
+Feedback capture is intentionally weaker than promotion. It classifies likely
+corrections, preferences, praise, relationship notes, missed surfaces, and task
+learnings, then appends `feedback.candidate` events to
+`memory/STATE/events.jsonl`. These events are reviewable candidate learning, not
+durable memory writes.
 
 Policy commands provide the first deterministic privacy guard:
 

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,6 +1,6 @@
 schema: arc/v1
 name: soma
-version: 0.1.1
+version: 0.1.2
 type: component
 tier: community
 description: Substrate-portable Personal AI Assistant core for identity, memory, ISA, skills, learning, and adapters.
@@ -34,6 +34,7 @@ capabilities:
       - "~/work/**"
     write:
       - "~/.config/soma/**"
+      - "~/.soma/memory/STATE/**"
   bash:
     allowed: true
     restricted_to:

--- a/docs/memory-policy-v0.md
+++ b/docs/memory-policy-v0.md
@@ -39,6 +39,14 @@ because durable memory stores are source-of-truth material, not scratch space.
 Promotion requires verified source work: at least one verification entry or
 passed criterion must exist on the source Algorithm run.
 
+The first implemented feedback surface is
+`soma feedback capture --text <text> --substrate <substrate>`. It detects likely
+corrections, preferences, missed surfaces, relationship notes, and task
+learning, then appends a `feedback.candidate` event to
+`memory/STATE/events.jsonl`. Feedback capture never writes durable memory
+directly. Candidate events must be reviewed or promoted by a later explicit
+workflow.
+
 `PROMOTED/` has V0 merge semantics. Promoted notes are immutable additive
 records, keyed by sanitized title plus source run id. Creation is atomic and a
 duplicate promotion is refused rather than merged or overwritten. These notes do

--- a/docs/pai-pack-importer.md
+++ b/docs/pai-pack-importer.md
@@ -89,3 +89,10 @@ The importer does not:
 
 Projection remains the adapter's job. Import makes the capability available in
 Soma; install/projection makes it available in a substrate.
+
+After a successful applied import, refresh the substrate projection before
+expecting the skill to appear in that substrate's skill directory. For Codex:
+
+```bash
+bun run soma install codex --apply --soma-home <soma-home>
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soma",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "description": "Substrate-portable Personal AI Assistant core.",

--- a/src/adapters/codex-hook-entry.mjs
+++ b/src/adapters/codex-hook-entry.mjs
@@ -1,6 +1,14 @@
 import { spawnSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { extractWriteTargets, shouldCheckPolicyTarget } from "./codex-policy-hook.mjs";
+// __SOMA_HOOK_MODULE_IMPORTS__
+
+// __SOMA_PROMPT_SUBMIT_EXTENSION_START__
+function runSomaFeedbackCapture(config, prompt) {
+  void config;
+  void prompt;
+}
+// __SOMA_PROMPT_SUBMIT_EXTENSION_END__
 
 function readHookInput() {
   try {
@@ -150,6 +158,7 @@ function handlePreToolUse(config, input) {
 }
 
 function handlePromptSubmit(config, input) {
+  runSomaFeedbackCapture(config, input.prompt);
   const result = runSomaClassification(config, input.prompt);
   if (result.status !== 0) {
     emitAndExit({

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -2,6 +2,7 @@ import type { SomaAdapter, SomaContextBundle, SomaContextInput, SomaTask } from 
 import { defaultSomaRepoPath } from "../repo-path";
 import { readCodexHookAsset } from "./codex-hook-assets";
 import { renderCodexLifecycleHook } from "./codex-hook-runtime";
+import { renderFeedbackHookModule } from "./feedback-hook-helper";
 import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "./shared";
 
 function renderCodexPolicy(): string {
@@ -224,6 +225,55 @@ function renderCodexHooksJson(): string {
   )}\n`;
 }
 
+function renderCodexFeedbackHook(): string {
+  return renderFeedbackHookModule({
+    functionName: "runSomaFeedbackCapture",
+    leadingParameters: ["config"],
+    promptParameter: "prompt",
+    bunPathExpression: "config.bunPath",
+    cwdExpression: "config.trustedSomaRepo",
+    somaHomeExpression: "config.somaHome",
+    substrate: "codex",
+    source: "prompt-submit",
+    failureComment: "Feedback capture is best-effort and must never break prompt classification.",
+  });
+}
+
+interface CodexHookEntryExtension {
+  importLine: string;
+  fallbackStartMarker: string;
+  fallbackEndMarker: string;
+}
+
+function applyCodexHookEntryExtensions(source: string, extensions: CodexHookEntryExtension[]): string {
+  const importMarker = "// __SOMA_HOOK_MODULE_IMPORTS__";
+  if (!source.includes(importMarker)) {
+    throw new Error("Codex hook entry is missing the Soma hook module import marker.");
+  }
+
+  const imports = extensions.map((extension) => extension.importLine).join("\n");
+  let rendered = source.replace(importMarker, imports);
+  for (const extension of extensions) {
+    const fallbackStart = rendered.indexOf(extension.fallbackStartMarker);
+    const fallbackEnd = rendered.indexOf(extension.fallbackEndMarker);
+    if (fallbackStart === -1 || fallbackEnd === -1 || fallbackEnd < fallbackStart) {
+      throw new Error("Codex hook entry is missing a Soma hook extension fallback marker.");
+    }
+    rendered = `${rendered.slice(0, fallbackStart)}${rendered.slice(fallbackEnd + extension.fallbackEndMarker.length)}`;
+  }
+  return rendered;
+}
+
+function renderCodexHookEntry(): string {
+  return applyCodexHookEntryExtensions(readCodexHookAsset("codex-hook-entry.mjs"), [
+    {
+      importLine: 'import { runSomaFeedbackCapture } from "./soma-feedback-capture.mjs";',
+      fallbackStartMarker: "// __SOMA_PROMPT_SUBMIT_EXTENSION_START__",
+      fallbackEndMarker: "// __SOMA_PROMPT_SUBMIT_EXTENSION_END__",
+    },
+  ]);
+}
+
 export function buildCodexContext(input: SomaContextInput): SomaContextBundle {
   const instructions = renderInstructions(input);
 
@@ -278,7 +328,11 @@ export function buildCodexHomeContext(input: SomaContextInput, somaHome: string,
       },
       {
         path: "hooks/codex-hook-entry.mjs",
-        content: readCodexHookAsset("codex-hook-entry.mjs"),
+        content: renderCodexHookEntry(),
+      },
+      {
+        path: "hooks/soma-feedback-capture.mjs",
+        content: renderCodexFeedbackHook(),
       },
       {
         path: "hooks/codex-policy-hook.mjs",

--- a/src/adapters/feedback-hook-helper.ts
+++ b/src/adapters/feedback-hook-helper.ts
@@ -1,0 +1,81 @@
+import { SOMA_FEEDBACK_HOOK_TRIGGER_PATTERN_SOURCE, SOMA_FEEDBACK_STDIN_MAX_BYTES } from "../feedback-contract";
+
+interface FeedbackHookHelperOptions {
+  functionName: string;
+  exported?: boolean;
+  leadingParameters?: string[];
+  promptParameter: string;
+  promptType?: string;
+  bunPathExpression: string;
+  cwdExpression: string;
+  somaHomeExpression: string;
+  substrate: string;
+  source: string;
+  failureComment: string;
+}
+
+export function renderFeedbackHookHelper(options: FeedbackHookHelperOptions): string {
+  const promptDeclaration = options.promptType ? `${options.promptParameter}: ${options.promptType}` : options.promptParameter;
+  const parameters = [...(options.leadingParameters ?? []), promptDeclaration].join(", ");
+  const returnType = options.promptType ? ": void" : "";
+
+  return [
+    `const SOMA_FEEDBACK_TRIGGER_PATTERN_SOURCE = ${JSON.stringify(SOMA_FEEDBACK_HOOK_TRIGGER_PATTERN_SOURCE)};`,
+    'const SOMA_FEEDBACK_TRIGGER_PATTERN = new RegExp(SOMA_FEEDBACK_TRIGGER_PATTERN_SOURCE, "i");',
+    `const SOMA_FEEDBACK_STDIN_MAX_CHARS = ${SOMA_FEEDBACK_STDIN_MAX_BYTES};`,
+    "let somaFeedbackCaptureInFlight = false;",
+    "",
+    `${options.exported ? "export " : ""}function ${options.functionName}(${parameters})${returnType} {`,
+    `\tconst rawFeedbackText = typeof ${options.promptParameter} === "string" ? ${options.promptParameter} : "";`,
+    "\tconst feedbackText = rawFeedbackText.length > SOMA_FEEDBACK_STDIN_MAX_CHARS ? rawFeedbackText.slice(0, SOMA_FEEDBACK_STDIN_MAX_CHARS) : rawFeedbackText;",
+    "\tif (!feedbackText.trim() || !SOMA_FEEDBACK_TRIGGER_PATTERN.test(feedbackText)) return;",
+    "\tif (somaFeedbackCaptureInFlight) return;",
+    "\tconst feedbackInput = feedbackText;",
+    "\ttry {",
+    "\t\tsomaFeedbackCaptureInFlight = true;",
+    `\t\tconst child = spawn(${options.bunPathExpression}, ["run", "soma", "feedback", "capture", "--soma-home", ${options.somaHomeExpression}, "--substrate", ${JSON.stringify(options.substrate)}, "--source", ${JSON.stringify(options.source)}, "--stdin", "--no-excerpt"], {`,
+    `\t\t\tcwd: ${options.cwdExpression},`,
+    '\t\t\tstdio: ["pipe", "ignore", "ignore"]',
+    "\t\t});",
+    '\t\tchild.stdin?.on("error", () => undefined);',
+    "\t\tlet forceTimer;",
+    "\t\tlet finished = false;",
+    "\t\tconst finish = () => {",
+    "\t\t\tif (finished) return;",
+    "\t\t\tfinished = true;",
+    "\t\t\tclearTimeout(timer);",
+    "\t\t\tif (forceTimer) clearTimeout(forceTimer);",
+    "\t\t\tsomaFeedbackCaptureInFlight = false;",
+    "\t\t};",
+    "\t\tconst timer = setTimeout(() => {",
+    "\t\t\tforceTimer = setTimeout(finish, 1000);",
+    "\t\t\tforceTimer.unref?.();",
+    "\t\t\tchild.kill();",
+    "\t\t}, 3000);",
+    "\t\ttimer.unref?.();",
+    '\t\tchild.on("error", finish);',
+    '\t\tchild.on("exit", finish);',
+    "\t\ttry {",
+    "\t\t\tif (!child.stdin?.destroyed) child.stdin?.end(feedbackInput);",
+    "\t\t} catch {",
+    "\t\t\tchild.kill();",
+    "\t\t\tfinish();",
+    "\t\t}",
+    "\t\tchild.unref();",
+    "\t} catch {",
+    "\t\tsomaFeedbackCaptureInFlight = false;",
+    `\t\t// ${options.failureComment}`,
+    "\t}",
+    "}",
+  ].join("\n");
+}
+
+export function renderFeedbackHookModule(options: FeedbackHookHelperOptions): string {
+  return [
+    'import { spawn } from "node:child_process";',
+    'import { clearTimeout, setTimeout } from "node:timers";',
+    "",
+    renderFeedbackHookHelper({ ...options, exported: true }),
+    "",
+  ].join("\n");
+}

--- a/src/adapters/pi-dev.ts
+++ b/src/adapters/pi-dev.ts
@@ -1,4 +1,5 @@
 import type { SomaAdapter, SomaContextBundle, SomaContextInput, SomaTask } from "../types";
+import { renderFeedbackHookHelper } from "./feedback-hook-helper";
 import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "./shared";
 
 function renderInstructions(input: SomaContextInput): string {
@@ -22,7 +23,7 @@ function renderExtensionManifest(): string {
   return `${JSON.stringify(
     {
       name: "soma-core",
-      version: "0.1.1",
+      version: "0.1.2",
       description: "Pi.dev projection for Soma personal assistant context.",
       tools: [
         "isa_create",
@@ -82,7 +83,7 @@ function renderPaiImportIndex(somaHome: string): string {
 
 function renderHomeExtension(somaHome: string): string {
   return [
-    'import { execFile, spawnSync } from "node:child_process";',
+    'import { execFile, spawn, spawnSync } from "node:child_process";',
     'import { readFileSync, writeFileSync } from "node:fs";',
     'import { promisify } from "node:util";',
     'import { StringEnum } from "@mariozechner/pi-ai";',
@@ -149,6 +150,18 @@ function renderHomeExtension(somaHome: string): string {
     "\t});",
     '\treturn { ok: result.status === 0, output: result.stdout || result.stderr || "" };',
     "}",
+    "",
+    renderFeedbackHookHelper({
+      functionName: "captureSomaFeedback",
+      promptParameter: "prompt",
+      promptType: "string",
+      bunPathExpression: '"bun"',
+      cwdExpression: "somaRepoPath()",
+      somaHomeExpression: "SOMA_HOME",
+      substrate: "pi-dev",
+      source: "before-agent-start",
+      failureComment: "Feedback capture is best-effort and must never break prompt startup.",
+    }),
     "",
     "async function runSomaCommand(args: string[]): Promise<string> {",
     "\ttry {",
@@ -258,11 +271,13 @@ function renderHomeExtension(somaHome: string): string {
     "\t});",
     "",
     '\tpi.on("before_agent_start", async (event, ctx) => {',
+    "\t\tconst prompt = promptFromEvent(event);",
+    "\t\tcaptureSomaFeedback(prompt);",
     '\t\tconst profile = readOptional(`${PI_SOMA_HOME}/profile.md`);',
     "\t\tconst startupContext = refreshStartupContext(sessionId(ctx));",
     '\t\tconst paiImports = readOptional(`${PI_SOMA_HOME}/pai-imports.md`);',
     '\t\tconst context = readOptional(`${PI_SOMA_HOME}/context.md`);',
-    "\t\tconst promptClassification = renderPromptClassificationContext(promptFromEvent(event));",
+    "\t\tconst promptClassification = renderPromptClassificationContext(prompt);",
     '\t\tconst somaPrompt = `',
     "## Soma Personal Assistant Context",
     "",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+import { readSync } from "node:fs";
 import {
   addAlgorithmCapabilities,
   applyAlgorithmBatch,
@@ -5,6 +6,7 @@ import {
   checkSomaPolicyBatch,
   checkSomaPolicy,
   classifyAlgorithmPrompt,
+  captureSomaFeedback,
   createAlgorithmRun,
   importAlgorithm,
   importPaiIdentity,
@@ -50,6 +52,8 @@ import type {
   SomaInstallOptions,
   SomaInstallPlan,
   SomaInstallResult,
+  SomaFeedbackCaptureOptions,
+  SomaFeedbackCaptureResult,
   SomaLifecycleOptions,
   SomaLifecycleResult,
   SomaMemoryPromotionOptions,
@@ -62,6 +66,7 @@ import type {
   SomaPolicyBatchTarget,
   SubstrateId,
 } from "./types";
+import { SOMA_FEEDBACK_STDIN_MAX_BYTES } from "./feedback-contract";
 
 interface ParsedInstallArgs {
   command: "install";
@@ -133,6 +138,13 @@ interface ParsedMemoryPromoteArgs {
 
 type ParsedMemoryArgs = ParsedMemorySearchArgs | ParsedMemoryPromoteArgs;
 
+interface ParsedFeedbackArgs {
+  command: "feedback";
+  action: "capture";
+  options: SomaFeedbackCaptureOptions;
+  readTextFromStdin: boolean;
+}
+
 interface ParsedPolicyArgs {
   command: "policy";
   action: "check";
@@ -141,7 +153,7 @@ interface ParsedPolicyArgs {
   json: boolean;
 }
 
-type ParsedArgs = ParsedInstallArgs | ParsedImportArgs | ParsedAlgorithmArgs | ParsedLifecycleArgs | ParsedMemoryArgs | ParsedPolicyArgs;
+type ParsedArgs = ParsedInstallArgs | ParsedImportArgs | ParsedAlgorithmArgs | ParsedLifecycleArgs | ParsedMemoryArgs | ParsedFeedbackArgs | ParsedPolicyArgs;
 
 function readOption(args: string[], index: number, name: string): string {
   const value = args[index + 1];
@@ -757,6 +769,84 @@ function parseMemoryArgs(args: string[]): ParsedMemoryArgs {
   };
 }
 
+function parseFeedbackCaptureArgs(args: string[]): { options: SomaFeedbackCaptureOptions; readTextFromStdin: boolean } {
+  const options: Partial<SomaFeedbackCaptureOptions> = {};
+  let readTextFromStdin = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--substrate":
+        options.substrate = parseSubstrate(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--text":
+        options.text = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--stdin":
+        readTextFromStdin = true;
+        break;
+      case "--no-excerpt":
+        options.storeExcerpt = false;
+        break;
+      case "--source":
+        options.source = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--timestamp":
+        options.timestamp = readOption(args, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (!options.text && !readTextFromStdin) {
+    throw new Error("soma feedback capture is missing required option: --text or --stdin.");
+  }
+  if (options.text && readTextFromStdin) {
+    throw new Error("soma feedback capture accepts either --text or --stdin, not both.");
+  }
+
+  const parsedOptions: SomaFeedbackCaptureOptions = {
+    ...options,
+    text: options.text ?? "",
+  };
+
+  return {
+    options: parsedOptions,
+    readTextFromStdin,
+  };
+}
+
+function parseFeedbackArgs(args: string[]): ParsedFeedbackArgs {
+  const [command, action, ...rest] = args;
+
+  if (command !== "feedback" || action !== "capture") {
+    throw new Error("Usage: soma feedback capture (--text <text> | --stdin) [--substrate <id>] [--source <source>] [--no-excerpt]");
+  }
+
+  const parsed = parseFeedbackCaptureArgs(rest);
+
+  return {
+    command,
+    action,
+    options: parsed.options,
+    readTextFromStdin: parsed.readTextFromStdin,
+  };
+}
+
 function parsePolicyArgs(args: string[]): ParsedPolicyArgs {
   const [command, action, ...rest] = args;
 
@@ -861,6 +951,10 @@ function parseArgs(args: string[]): ParsedArgs {
     return parseMemoryArgs(args);
   }
 
+  if (args[0] === "feedback") {
+    return parseFeedbackArgs(args);
+  }
+
   if (args[0] === "algorithm") {
     return parseAlgorithmArgs(args);
   }
@@ -886,6 +980,7 @@ function parseArgs(args: string[]): ParsedArgs {
       "  soma algorithm <list|show|capabilities|plan|decision|change|step|verify|learn|advance> --id <run-id> [...]",
       "  soma memory search --query <text> [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
       "  soma memory promote --from-run <run-id> --store <learning|knowledge|relationship|work> --title <text> [--lesson <text>] [--applies-when <text>]",
+      "  soma feedback capture (--text <text> | --stdin) [--substrate <id>] [--source <source>] [--no-excerpt]",
       "  soma policy check --action write --destination <path> [--content <text>|--content-env <name>] [--source <path>] [--substrate <id>] [--record <all|deny|none>] [--json]",
       "  soma lifecycle <session-start|algorithm-updated|session-end> [--home-dir <dir>] [--soma-home <dir>] [--substrate <id>] [--session-id <id>]",
       "  soma install <codex|pi-dev> [--dry-run] [--apply] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
@@ -893,6 +988,24 @@ function parseArgs(args: string[]): ParsedArgs {
       "  soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
     ].join("\n"),
   );
+}
+
+function readLimitedFeedbackStdin(): string {
+  const chunks: Buffer[] = [];
+  let total = 0;
+
+  for (;;) {
+    const buffer = Buffer.alloc(Math.min(8192, SOMA_FEEDBACK_STDIN_MAX_BYTES + 1 - total));
+    const bytesRead = readSync(0, buffer, 0, buffer.length, null);
+    if (bytesRead === 0) break;
+    total += bytesRead;
+    if (total > SOMA_FEEDBACK_STDIN_MAX_BYTES) {
+      throw new Error(`soma feedback capture --stdin exceeds ${SOMA_FEEDBACK_STDIN_MAX_BYTES} byte limit.`);
+    }
+    chunks.push(buffer.subarray(0, bytesRead));
+  }
+
+  return Buffer.concat(chunks).toString("utf8");
 }
 
 function formatPlan(plan: SomaInstallPlan): string {
@@ -1086,6 +1199,19 @@ function formatMemoryPromotionResult(result: SomaMemoryPromotionResult): string 
     `sourceRunPath: ${result.sourceRunPath}`,
     `event: ${result.event.id}`,
   ].join("\n");
+}
+
+function formatFeedbackCaptureResult(result: SomaFeedbackCaptureResult): string {
+  return [
+    "Soma feedback capture",
+    `captured: ${result.captured ? "yes" : "no"}`,
+    `kind: ${result.classification.kind}`,
+    `confidence: ${result.classification.confidence}`,
+    `reason: ${result.classification.reason}`,
+    result.event ? `event: ${result.event.id}` : undefined,
+  ]
+    .filter((line) => line !== undefined)
+    .join("\n");
 }
 
 function formatPolicyCheckResult(result: SomaPolicyCheckResult): string {
@@ -1305,6 +1431,11 @@ export async function runSomaCli(args: string[]): Promise<string> {
     }
 
     return formatMemorySearchResult(await searchSomaMemory(parsed.options));
+  }
+
+  if (parsed.command === "feedback") {
+    const options = parsed.readTextFromStdin ? { ...parsed.options, text: readLimitedFeedbackStdin() } : parsed.options;
+    return formatFeedbackCaptureResult(await captureSomaFeedback(options));
   }
 
   if (parsed.command === "policy") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1127,15 +1127,29 @@ function formatPaiPackImportPlan(plan: PaiPackImportPlan): string {
 }
 
 function formatPaiPackImportResult(result: PaiPackImportResult): string {
+  const quotedSomaHome = quoteShellArg(result.somaHome);
+
   return [
     "Soma PAI Pack import applied",
     `paiPackDir: ${result.paiPackDir}`,
     `somaHome: ${result.somaHome}`,
     `skillName: ${result.skillName}`,
     "",
+    "Next step:",
+    "Import makes the skill available in Soma. Refresh the target substrate projection before expecting the skill in that substrate.",
+    `bun run soma install <substrate> --apply --soma-home ${quotedSomaHome}`,
+    "",
     "Files:",
     ...result.files.map((path) => `- ${path}`),
   ].join("\n");
+}
+
+function quoteShellArg(value: string): string {
+  if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) {
+    return value;
+  }
+
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
 }
 
 function formatAlgorithmRunResult(result: { path: string; run: { id: string; phase: string; effort: string } }): string {

--- a/src/feedback-contract.ts
+++ b/src/feedback-contract.ts
@@ -1,0 +1,45 @@
+import type { SomaFeedbackClassification, SomaFeedbackKind } from "./types";
+
+export const SOMA_FEEDBACK_STDIN_MAX_BYTES = 64 * 1024;
+
+export interface SomaFeedbackPatternSpec {
+  kind: Exclude<SomaFeedbackKind, "none">;
+  confidence: SomaFeedbackClassification["confidence"];
+  reason: string;
+  patternSources: string[];
+}
+
+export const SOMA_FEEDBACK_PATTERN_SPECS: SomaFeedbackPatternSpec[] = [
+  {
+    kind: "missed-surface",
+    confidence: "high",
+    reason: "Prompt says the assistant missed, forgot, or left out a relevant surface.",
+    patternSources: ["you missed", "missed the", "left out", "forgot", "didn'?t include"],
+  },
+  {
+    kind: "correction",
+    confidence: "high",
+    reason: "Prompt corrects prior assistant behavior or result.",
+    patternSources: ["you were wrong", "that'?s wrong", "you are wrong", "not correct", "error from", "bug in your"],
+  },
+  {
+    kind: "preference",
+    confidence: "high",
+    reason: "Prompt states a future operating preference.",
+    patternSources: ["from now on", "next time", "next time you should", "prefer", "please always", "don'?t", "do not"],
+  },
+  {
+    kind: "relationship-note",
+    confidence: "medium",
+    reason: "Prompt asks Soma to remember personal or relationship context.",
+    patternSources: ["remember (?:that|this|my|i)", "my preference", "for me"],
+  },
+  {
+    kind: "task-learning",
+    confidence: "medium",
+    reason: "Prompt reports task outcome or a reusable process observation.",
+    patternSources: ["that worked", "this worked", "works now", "root cause", "the issue was"],
+  },
+];
+
+export const SOMA_FEEDBACK_HOOK_TRIGGER_PATTERN_SOURCE = `\\b(?:${SOMA_FEEDBACK_PATTERN_SPECS.flatMap((spec) => spec.patternSources).join("|")})\\b`;

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -1,0 +1,114 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { appendSomaMemoryEvent } from "./memory";
+import { SOMA_FEEDBACK_HOOK_TRIGGER_PATTERN_SOURCE, SOMA_FEEDBACK_PATTERN_SPECS } from "./feedback-contract";
+import type { SomaFeedbackCaptureOptions, SomaFeedbackCaptureResult, SomaFeedbackClassification } from "./types";
+
+const FEEDBACK_PATTERNS = SOMA_FEEDBACK_PATTERN_SPECS.map((spec) => ({
+  ...spec,
+  patterns: spec.patternSources.map((source) => new RegExp(`\\b${source}\\b`, "i")),
+}));
+const FEEDBACK_TRIGGER_PATTERN = new RegExp(SOMA_FEEDBACK_HOOK_TRIGGER_PATTERN_SOURCE, "i");
+const FEEDBACK_EXCERPT_MAX_LENGTH = 280;
+const SECRET_EXCERPT_PATTERNS = [
+  /\b(?:sk|ghp|github_pat|xox[baprs])[-_][-_A-Za-z0-9]{12,}\b/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bBearer\s+[-._~+/A-Za-z0-9]+=*/gi,
+  /\b(?:api[_-]?key|token|secret|password|credential)\s*[:=]\s*["']?[^"'\s]+/gi,
+];
+
+export function maybeSomaFeedbackPrompt(text: string): boolean {
+  return FEEDBACK_TRIGGER_PATTERN.test(text);
+}
+
+function resolveSomaHome(options: Pick<SomaFeedbackCaptureOptions, "homeDir" | "somaHome"> = {}): string {
+  return resolve(options.somaHome ?? join(options.homeDir ?? homedir(), ".soma"));
+}
+
+function redactedFeedbackExcerpt(text: string): { text: string; truncated: boolean } {
+  const normalized = text.trim().replace(/\s+/g, " ");
+  const redacted = SECRET_EXCERPT_PATTERNS.reduce((value, pattern) => value.replace(pattern, "[redacted]"), normalized);
+  if (redacted.length <= FEEDBACK_EXCERPT_MAX_LENGTH) {
+    return { text: redacted, truncated: false };
+  }
+  return { text: `${redacted.slice(0, FEEDBACK_EXCERPT_MAX_LENGTH)}...`, truncated: true };
+}
+
+export function classifySomaFeedback(text: string): SomaFeedbackClassification {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return {
+      kind: "none",
+      confidence: "high",
+      reason: "Prompt is empty.",
+    };
+  }
+
+  if (!maybeSomaFeedbackPrompt(trimmed)) {
+    return {
+      kind: "none",
+      confidence: "high",
+      reason: "Prompt does not look like actionable feedback.",
+    };
+  }
+
+  for (const candidate of FEEDBACK_PATTERNS) {
+    if (candidate.patterns.some((pattern) => pattern.test(trimmed))) {
+      return {
+        kind: candidate.kind,
+        confidence: candidate.confidence,
+        reason: candidate.reason,
+      };
+    }
+  }
+
+  return {
+    kind: "none",
+    confidence: "high",
+    reason: "Prompt does not look like actionable feedback.",
+  };
+}
+
+export async function captureSomaFeedback(options: SomaFeedbackCaptureOptions): Promise<SomaFeedbackCaptureResult> {
+  const somaHome = resolveSomaHome(options);
+  const classification = classifySomaFeedback(options.text);
+
+  if (classification.kind === "none") {
+    return {
+      somaHome,
+      captured: false,
+      classification,
+    };
+  }
+
+  const source = options.source ?? "prompt";
+  const excerpt = options.storeExcerpt ?? true ? redactedFeedbackExcerpt(options.text) : undefined;
+
+  const event = await appendSomaMemoryEvent(somaHome, {
+    timestamp: options.timestamp,
+    substrate: options.substrate ?? "custom",
+    kind: "feedback.candidate",
+    summary: `Feedback candidate captured: ${classification.kind}.`,
+    metadata: {
+      feedbackKind: classification.kind,
+      confidence: classification.confidence,
+      reason: classification.reason,
+      source,
+      promptStored: false,
+      excerptStored: Boolean(excerpt),
+      ...(excerpt
+        ? {
+            redactedExcerpt: excerpt.text,
+            excerptTruncated: excerpt.truncated,
+          }
+        : {}),
+    },
+  });
+
+  return {
+    somaHome,
+    captured: true,
+    classification,
+    event,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,10 @@ export type {
   SomaLifecycleEventName,
   SomaLifecycleOptions,
   SomaLifecycleResult,
+  SomaFeedbackCaptureOptions,
+  SomaFeedbackCaptureResult,
+  SomaFeedbackClassification,
+  SomaFeedbackKind,
   SomaMemoryEvent,
   SomaMemoryEventInput,
   SomaMemoryPromotionOptions,
@@ -121,6 +125,7 @@ export {
   runSomaLifecycleSessionStart,
   writeAlgorithmWorkIndex,
 } from "./lifecycle";
+export { captureSomaFeedback, classifySomaFeedback, maybeSomaFeedbackPrompt } from "./feedback";
 export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from "./memory";
 export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
@@ -129,4 +134,4 @@ export { checkSomaPolicy, checkSomaPolicyBatch } from "./policy-audit";
 export { evaluateSomaPolicy } from "./policy";
 export { bootstrapSomaHome, loadSomaHome } from "./soma-home";
 
-export const SOMA_VERSION = "0.1.1";
+export const SOMA_VERSION = "0.1.2";

--- a/src/install.ts
+++ b/src/install.ts
@@ -32,6 +32,7 @@ const CODEX_HOME_FILES = [
   "hooks.json",
   "hooks/soma-lifecycle.mjs",
   "hooks/codex-hook-entry.mjs",
+  "hooks/soma-feedback-capture.mjs",
   "hooks/codex-policy-hook.mjs",
   "hooks/policy-marker.mjs",
   "skills/soma/SKILL.md",

--- a/src/types.ts
+++ b/src/types.ts
@@ -417,6 +417,31 @@ export interface SomaMemoryPromotionResult {
   event: SomaMemoryEvent;
 }
 
+export type SomaFeedbackKind = "correction" | "missed-surface" | "preference" | "relationship-note" | "task-learning" | "none";
+
+export interface SomaFeedbackClassification {
+  kind: SomaFeedbackKind;
+  confidence: "low" | "medium" | "high";
+  reason: string;
+}
+
+export interface SomaFeedbackCaptureOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate?: SubstrateId;
+  text: string;
+  source?: string;
+  storeExcerpt?: boolean;
+  timestamp?: string;
+}
+
+export interface SomaFeedbackCaptureResult {
+  somaHome: string;
+  captured: boolean;
+  classification: SomaFeedbackClassification;
+  event?: SomaMemoryEvent;
+}
+
 export type SomaPolicyDecision = "allow" | "deny";
 
 export interface SomaPolicyCheckOptions {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -267,6 +267,34 @@ test("cli searches Soma memory", async () => {
   });
 });
 
+test("cli captures feedback candidates", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);
+
+    const output = await runSomaCli([
+      "feedback",
+      "capture",
+      "--home-dir",
+      homeDir,
+      "--substrate",
+      "codex",
+      "--source",
+      "test",
+      "--text",
+      "you missed the arc-manifest",
+    ]);
+
+    expect(output).toContain("Soma feedback capture");
+    expect(output).toContain("captured: yes");
+    expect(output).toContain("kind: missed-surface");
+    await expect(readFile(join(homeDir, ".soma/memory/STATE/events.jsonl"), "utf8")).resolves.toContain("feedback.candidate");
+  });
+});
+
+test("cli rejects mixed feedback text inputs", async () => {
+  await expect(runSomaCli(["feedback", "capture", "--text", "you missed this", "--stdin"])).rejects.toThrow("either --text or --stdin");
+});
+
 test("cli promotes Algorithm run memory", async () => {
   await withTempHome(async (homeDir) => {
     await runSomaCli([

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -52,6 +52,7 @@ test("builds codex home projection bundle for default availability", () => {
     "hooks.json",
     "hooks/soma-lifecycle.mjs",
     "hooks/codex-hook-entry.mjs",
+    "hooks/soma-feedback-capture.mjs",
     "hooks/codex-policy-hook.mjs",
     "hooks/policy-marker.mjs",
     "skills/soma/SKILL.md",
@@ -67,6 +68,13 @@ test("builds codex home projection bundle for default availability", () => {
   expect(projection.bundle.files.find((file) => file.path === "hooks/soma-lifecycle.mjs")?.content).toContain("policyMarkers");
   expect(projection.bundle.files.find((file) => file.path === "hooks/codex-hook-entry.mjs")?.content).toContain("runSomaPolicyCheck");
   expect(projection.bundle.files.find((file) => file.path === "hooks/codex-hook-entry.mjs")?.content).toContain('"./codex-policy-hook.mjs"');
+  expect(projection.bundle.files.find((file) => file.path === "hooks/codex-hook-entry.mjs")?.content).toContain(
+    '"./soma-feedback-capture.mjs"',
+  );
+  expect(projection.bundle.files.find((file) => file.path === "hooks/soma-feedback-capture.mjs")?.content).toContain("--stdin");
+  expect(projection.bundle.files.find((file) => file.path === "hooks/soma-feedback-capture.mjs")?.content).not.toContain(
+    "__SOMA_FEEDBACK_TRIGGER_PATTERN_SOURCE__",
+  );
   expect(projection.bundle.files.find((file) => file.path === "hooks/codex-policy-hook.mjs")?.content).toContain('"./policy-marker.mjs"');
 });
 
@@ -113,11 +121,13 @@ test("installs codex home projection into a substrate home", async () => {
 
     expect(result.substrate).toBe("codex");
     expect(result.rootDir).toBe(join(homeDir, ".codex"));
-    expect(result.files).toHaveLength(13);
+    expect(result.files).toHaveLength(14);
 
     const rules = await readFile(join(homeDir, ".codex/rules/soma.rules"), "utf8");
     const hooks = await readFile(join(homeDir, ".codex/hooks.json"), "utf8");
     const hookScript = await readFile(join(homeDir, ".codex/hooks/soma-lifecycle.mjs"), "utf8");
+    const hookEntry = await readFile(join(homeDir, ".codex/hooks/codex-hook-entry.mjs"), "utf8");
+    const feedbackHook = await readFile(join(homeDir, ".codex/hooks/soma-feedback-capture.mjs"), "utf8");
     const policyHook = await readFile(join(homeDir, ".codex/hooks/codex-policy-hook.mjs"), "utf8");
     const skill = await readFile(join(homeDir, ".codex/skills/soma/SKILL.md"), "utf8");
     const profile = await readFile(join(homeDir, ".codex/memories/soma/profile.md"), "utf8");
@@ -132,6 +142,9 @@ test("installs codex home projection into a substrate home", async () => {
     expect(hookScript).toContain("trustedSomaRepo");
     expect(hookScript).toContain("policyMarkers");
     expect(hookScript).toContain("bunPath");
+    expect(hookEntry).toContain('"./soma-feedback-capture.mjs"');
+    expect(feedbackHook).toContain("--stdin");
+    expect(feedbackHook).not.toContain("__SOMA_FEEDBACK_TRIGGER_PATTERN_SOURCE__");
     expect(policyHook).toContain("targetExtractors");
     expect(policyHook).toContain("normalizeToolInvocation");
     expect(hookScript).not.toContain("function privateRoots");

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -16,6 +16,20 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
   }
 }
 
+async function waitForFileContaining(path: string, text: string): Promise<string> {
+  let last = "";
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    try {
+      last = await readFile(path, "utf8");
+      if (last.includes(text)) return last;
+    } catch {
+      last = "";
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return last;
+}
+
 function runCodexHook(
   hook: string,
   event: string,
@@ -60,12 +74,14 @@ test("installs soma source home and codex home projection", async () => {
     expect(result.substrate).toBe("codex");
     expect(result.somaHome.somaHome).toBe(join(homeDir, ".soma"));
     expect(result.substrateHome.rootDir).toBe(join(homeDir, ".codex"));
-    expect(result.substrateHome.files).toHaveLength(16);
+    expect(result.substrateHome.files).toHaveLength(17);
 
     const telos = await readFile(join(homeDir, ".soma/profile/telos.md"), "utf8");
     const rules = await readFile(join(homeDir, ".codex/rules/soma.rules"), "utf8");
     const config = await readFile(join(homeDir, ".codex/config.toml"), "utf8");
     const hooks = await readFile(join(homeDir, ".codex/hooks.json"), "utf8");
+    const hookEntry = await readFile(join(homeDir, ".codex/hooks/codex-hook-entry.mjs"), "utf8");
+    const feedbackHook = await readFile(join(homeDir, ".codex/hooks/soma-feedback-capture.mjs"), "utf8");
     const somaRepo = await readFile(join(homeDir, ".codex/memories/soma/soma-repo.txt"), "utf8");
     const skill = await readFile(join(homeDir, ".codex/skills/soma/SKILL.md"), "utf8");
     const startupContext = await readFile(join(homeDir, ".codex/memories/soma/startup-context.md"), "utf8");
@@ -78,6 +94,10 @@ test("installs soma source home and codex home projection", async () => {
     expect(config).not.toContain("codex_hooks");
     expect(hooks).toContain("soma-lifecycle.mjs");
     expect(hooks).toContain("UserPromptSubmit");
+    expect(hookEntry).toContain("soma-feedback-capture.mjs");
+    expect(feedbackHook).toContain("--stdin");
+    expect(hookEntry).not.toContain("__SOMA_FEEDBACK_TRIGGER_PATTERN_SOURCE__");
+    expect(hookEntry).not.toContain("__SOMA_FEEDBACK_CAPTURE_HELPER__");
     expect(somaRepo).toContain("soma");
     expect(skill).toContain("name: soma");
     expect(startupContext).toContain("Soma Startup Context");
@@ -367,6 +387,35 @@ test("installed codex lifecycle hooks ignore ambient SOMA_REPO", async () => {
   });
 });
 
+test("installed codex prompt hook captures feedback candidates quietly", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexHook(hook, "prompt-submit", homeDir, { prompt: "you missed the arc-manifest" });
+    const events = await waitForFileContaining(join(homeDir, ".soma/memory/STATE/events.jsonl"), "feedback.candidate");
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.additionalContext).toContain("Soma:");
+    expect(result.output.hookSpecificOutput?.additionalContext).not.toContain("feedback");
+    expect(events).toContain("feedback.candidate");
+    expect(events).toContain("missed-surface");
+  });
+});
+
+test("installed codex prompt hook does not persist ordinary prompts", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexHook(hook, "prompt-submit", homeDir, { prompt: "fix this failing test" });
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const events = await readFile(join(homeDir, ".soma/memory/STATE/events.jsonl"), "utf8");
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.additionalContext).toContain("Soma:");
+    expect(events).not.toContain("feedback.candidate");
+  });
+});
+
 test("installed codex session-start hook returns concise visible context", async () => {
   await withTempHome(async (homeDir) => {
     await installSomaForCodex({ homeDir });
@@ -629,6 +678,9 @@ test("installs soma source home and pi.dev home projection", async () => {
     expect(extension).toContain("Soma: ${label}");
     expect(extension).not.toContain("Operating requirement");
     expect(extension).toContain("runSomaClassification");
+    expect(extension).toContain("captureSomaFeedback");
+    expect(extension).toContain("--stdin");
+    expect(extension).toContain('spawn("bun"');
     expect(extension).toContain("soma_memory_promote");
     expect(extension).not.toContain('"memory_promote"');
     expect(extension).toContain("session_shutdown");

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -5,6 +5,8 @@ import { expect, test } from "bun:test";
 import {
   appendSomaMemoryEvent,
   bootstrapSomaHome,
+  captureSomaFeedback,
+  classifySomaFeedback,
   createAlgorithmRun,
   promoteAlgorithmRunMemory,
   searchSomaMemory,
@@ -111,6 +113,133 @@ test("rejects memory events missing required text fields", async () => {
         summary: "Missing kind.",
       }),
     ).rejects.toThrow("kind must not be empty");
+  });
+});
+
+test("classifies feedback prompts into candidate kinds", () => {
+  expect(classifySomaFeedback("you missed the arc-manifest")).toMatchObject({
+    kind: "missed-surface",
+    confidence: "high",
+  });
+  expect(classifySomaFeedback("from now on, check arc manifests on version bumps")).toMatchObject({
+    kind: "preference",
+    confidence: "high",
+  });
+  expect(classifySomaFeedback("what should I do next?")).toMatchObject({
+    kind: "none",
+  });
+  expect(classifySomaFeedback("you should add tests")).toMatchObject({
+    kind: "none",
+  });
+  expect(classifySomaFeedback("what is wrong with this bug?")).toMatchObject({
+    kind: "none",
+  });
+  expect(classifySomaFeedback("make a nice UI")).toMatchObject({
+    kind: "none",
+  });
+  expect(classifySomaFeedback("ordinary question about the repo")).toMatchObject({
+    kind: "none",
+  });
+});
+
+test("captures actionable feedback as append-only candidate event", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const result = await captureSomaFeedback({
+      homeDir,
+      substrate: "codex",
+      source: "test",
+      text: "you missed the arc-manifest",
+    });
+
+    expect(result).toMatchObject({
+      captured: true,
+      classification: {
+        kind: "missed-surface",
+      },
+    });
+
+    const events = parseEvents(await readFile(somaMemoryEventsPath(somaHome), "utf8"));
+    expect(events[0]).toMatchObject({
+      substrate: "codex",
+      kind: "feedback.candidate",
+      summary: "Feedback candidate captured: missed-surface.",
+      metadata: {
+        feedbackKind: "missed-surface",
+        source: "test",
+        promptStored: false,
+        excerptStored: true,
+        redactedExcerpt: "you missed the arc-manifest",
+        excerptTruncated: false,
+      },
+    });
+  });
+});
+
+test("automatic hook feedback omits prompt-derived excerpts", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    await captureSomaFeedback({
+      homeDir,
+      substrate: "codex",
+      source: "prompt-submit",
+      storeExcerpt: false,
+      text: "you missed this secret detail",
+    });
+
+    const events = await readFile(somaMemoryEventsPath(somaHome), "utf8");
+    expect(events).toContain('"excerptStored":false');
+    expect(events).not.toContain("secret detail");
+    expect(events).not.toContain("redactedExcerpt");
+  });
+});
+
+test("does not persist prompt text when capturing feedback", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const githubToken = ["ghp", "1234567890abcdefghijklmnop"].join("_");
+    const awsKey = ["AKIA", "1234567890ABCDEF"].join("");
+    await captureSomaFeedback({
+      homeDir,
+      substrate: "codex",
+      source: "test",
+      text: `you missed this: api_key=test-key-value-123456789 ${githubToken} ${awsKey}`,
+    });
+
+    const events = await readFile(somaMemoryEventsPath(somaHome), "utf8");
+    expect(events).toContain("promptStored");
+    expect(events).toContain("[redacted]");
+    expect(events).not.toContain("test-key-value-123456789");
+    expect(events).not.toContain(githubToken);
+    expect(events).not.toContain(awsKey);
+  });
+});
+
+test("captures standalone feedback without bootstrapping profile files", async () => {
+  await withTempHome(async (homeDir) => {
+    const result = await captureSomaFeedback({
+      homeDir,
+      substrate: "codex",
+      text: "you missed the standalone bootstrap path",
+    });
+
+    expect(result.captured).toBe(true);
+    await expect(readFile(join(homeDir, ".soma/profile/assistant.md"), "utf8")).rejects.toThrow();
+    await expect(readFile(join(homeDir, ".soma/memory/STATE/events.jsonl"), "utf8")).resolves.toContain("feedback.candidate");
+  });
+});
+
+test("does not capture non-feedback prompts", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    const result = await captureSomaFeedback({
+      homeDir,
+      substrate: "codex",
+      text: "what is the next useful thing to port?",
+    });
+
+    expect(result.captured).toBe(false);
+    expect(result.event).toBeUndefined();
   });
 });
 

--- a/test/pai-pack-importer.test.ts
+++ b/test/pai-pack-importer.test.ts
@@ -258,6 +258,18 @@ test("cli dry-runs and applies a PAI Pack import", async () => {
     const applied = await runSomaCli(["import", "pai-pack", "--apply", "--home-dir", homeDir, "--pai-pack-dir", packDir]);
 
     expect(applied).toContain("Soma PAI Pack import applied");
+    expect(applied).toContain("Import makes the skill available in Soma. Refresh the target substrate projection before expecting the skill in that substrate.");
+    expect(applied).toContain(`bun run soma install <substrate> --apply --soma-home ${join(homeDir, ".soma")}`);
     await expect(readFile(join(homeDir, ".soma/skills/telos/Workflows/Update.md"), "utf8")).resolves.toContain("# Update");
+  });
+});
+
+test("cli quotes post-import projection guidance paths when needed", async () => {
+  await withTempHome(async (rootDir) => {
+    const homeDir = join(rootDir, "home with spaces");
+    const packDir = await writePackFixture(rootDir);
+    const applied = await runSomaCli(["import", "pai-pack", "--apply", "--home-dir", homeDir, "--pai-pack-dir", packDir]);
+
+    expect(applied).toContain(`bun run soma install <substrate> --apply --soma-home '${join(homeDir, ".soma")}'`);
   });
 });

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import { SOMA_VERSION, type SomaAdapter } from "../src/index";
 
 test("exports version", () => {
-  expect(SOMA_VERSION).toBe("0.1.1");
+  expect(SOMA_VERSION).toBe("0.1.2");
 });
 
 test("adapter contract is structurally usable", async () => {


### PR DESCRIPTION
## Summary

- add post-import CLI guidance that imported PAI packs are available in Soma first
- print a follow-up substrate projection command after `soma import pai-pack --apply`
- shell-quote the displayed Soma home path when needed
- document the post-import projection step in the PAI pack importer docs

Closes #10.

## Verification

- `bun test test/pai-pack-importer.test.ts`
- `bun run typecheck`
- `bun test`
- `sage review https://github.com/the-metafactory/soma/pull/13 --substrate codex` -> approved