### PR TITLE
Show normal help when soma runs without arguments

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -153,7 +153,19 @@ interface ParsedPolicyArgs {
   json: boolean;
 }
 
-type ParsedArgs = ParsedInstallArgs | ParsedImportArgs | ParsedAlgorithmArgs | ParsedLifecycleArgs | ParsedMemoryArgs | ParsedFeedbackArgs | ParsedPolicyArgs;
+interface ParsedHelpArgs {
+  command: "help";
+}
+
+type ParsedArgs =
+  | ParsedHelpArgs
+  | ParsedInstallArgs
+  | ParsedImportArgs
+  | ParsedAlgorithmArgs
+  | ParsedLifecycleArgs
+  | ParsedMemoryArgs
+  | ParsedFeedbackArgs
+  | ParsedPolicyArgs;
 
 function readOption(args: string[], index: number, name: string): string {
   const value = args[index + 1];
@@ -946,6 +958,10 @@ function parsePolicyArgs(args: string[]): ParsedPolicyArgs {
 }
 
 function parseArgs(args: string[]): ParsedArgs {
+  if (args.length === 0) {
+    return { command: "help" };
+  }
+
   if (args[0] === "lifecycle") {
     return parseLifecycleArgs(args);
   }
@@ -974,23 +990,25 @@ function parseArgs(args: string[]): ParsedArgs {
     return parseImportArgs(args);
   }
 
-  throw new Error(
-    [
-      "Usage:",
-      "  soma algorithm new --prompt <text> --intent <text> --current-state <text> --goal <text> --criterion <id:text> [--effort <E1|E2|E3|E4|E5>] [--home-dir <dir>] [--soma-home <dir>]",
-      "  soma algorithm classify --prompt <text>",
-      "  soma algorithm batch --id <run-id> --op <kind:...> [--op <kind:...>]",
-      "  soma algorithm <list|show|capabilities|plan|decision|change|step|verify|learn|advance> --id <run-id> [...]",
-      "  soma memory search --query <text> [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
-      "  soma memory promote --from-run <run-id> --store <learning|knowledge|relationship|work> --title <text> [--lesson <text>] [--applies-when <text>]",
-      "  soma feedback capture (--text <text> | --stdin) [--substrate <id>] [--source <source>] [--store-excerpt]",
-      "  soma policy check --action write --destination <path> [--content <text>|--content-env <name>] [--source <path>] [--substrate <id>] [--record <all|deny|none>] [--json]",
-      "  soma lifecycle <session-start|algorithm-updated|session-end> [--home-dir <dir>] [--soma-home <dir>] [--substrate <id>] [--session-id <id>]",
-      "  soma install <codex|pi-dev> [--dry-run] [--apply] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      "  soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>]",
-      "  soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
-    ].join("\n"),
-  );
+  throw new Error(renderUsage());
+}
+
+function renderUsage(): string {
+  return [
+    "Usage:",
+    "  soma algorithm new --prompt <text> --intent <text> --current-state <text> --goal <text> --criterion <id:text> [--effort <E1|E2|E3|E4|E5>] [--home-dir <dir>] [--soma-home <dir>]",
+    "  soma algorithm classify --prompt <text>",
+    "  soma algorithm batch --id <run-id> --op <kind:...> [--op <kind:...>]",
+    "  soma algorithm <list|show|capabilities|plan|decision|change|step|verify|learn|advance> --id <run-id> [...]",
+    "  soma memory search --query <text> [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
+    "  soma memory promote --from-run <run-id> --store <learning|knowledge|relationship|work> --title <text> [--lesson <text>] [--applies-when <text>]",
+    "  soma feedback capture (--text <text> | --stdin) [--substrate <id>] [--source <source>] [--store-excerpt]",
+    "  soma policy check --action write --destination <path> [--content <text>|--content-env <name>] [--source <path>] [--substrate <id>] [--record <all|deny|none>] [--json]",
+    "  soma lifecycle <session-start|algorithm-updated|session-end> [--home-dir <dir>] [--soma-home <dir>] [--substrate <id>] [--session-id <id>]",
+    "  soma install <codex|pi-dev> [--dry-run] [--apply] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+    "  soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>]",
+    "  soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
+  ].join("\n");
 }
 
 function readLimitedFeedbackStdin(): string {
@@ -1414,6 +1432,10 @@ async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<string> {
 
 export async function runSomaCli(args: string[]): Promise<string> {
   const parsed = parseArgs(args);
+
+  if (parsed.command === "help") {
+    return renderUsage();
+  }
 
   if (parsed.command === "lifecycle") {
     if (parsed.event === "session-start") {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -24,6 +25,22 @@ test("cli dry-runs codex install without writing files", async () => {
     await expect(stat(join(homeDir, ".soma"))).rejects.toThrow();
     await expect(stat(join(homeDir, ".codex"))).rejects.toThrow();
   });
+});
+
+test("cli shows no-argument usage as normal help", async () => {
+  const output = await runSomaCli([]);
+
+  expect(output).toContain("Usage:");
+  expect(output).toContain("soma install <codex|pi-dev>");
+
+  const result = spawnSync(process.execPath, ["run", "soma"], {
+    cwd: join(import.meta.dir, ".."),
+    encoding: "utf8",
+  });
+
+  expect(result.status).toBe(0);
+  expect(result.stdout).toContain("Usage:");
+  expect(result.stderr).not.toContain("error: script");
 });
 
 test("cli creates persisted Algorithm runs", async () => {


### PR DESCRIPTION
## Summary

- treat no-argument CLI invocation as normal help instead of an error
- reuse the top-level usage renderer for both help and unsupported-command errors
- add subprocess coverage proving `bun run soma` exits 0 and writes help to stdout

Closes #11.

## Verification

- `bun test test/cli.test.ts`
- `bun run soma`
- `bun run soma nope` exits 1
- `bun run typecheck`
- `bun test`
- `sage review https://github.com/the-metafactory/soma/pull/14 --substrate codex` -> approved on same diff before retargeting to main