### PR TITLE
Fix install dry-run output fidelity

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -43,10 +43,13 @@ const CODEX_HOME_FILES = [
   "memories/soma/pai-imports.md",
   "memories/soma/skills.md",
   "memories/soma/policy.md",
+  "memories/soma/soma-repo.txt",
+  "config.toml",
 ] as const;
 
 const PI_DEV_HOME_FILES = [
   "agent/extensions/soma.ts",
+  "agent/extensions/soma-path-guard.ts",
   "agent/soma/context.md",
   "agent/soma/profile.md",
   "agent/soma/startup-context.md",
@@ -55,6 +58,7 @@ const PI_DEV_HOME_FILES = [
   "agent/soma/tools.md",
   "agent/soma/skills.md",
   "agent/soma/policy.md",
+  "agent/soma/soma-repo.txt",
   "agent/skills/soma/SKILL.md",
 ] as const;
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -3,7 +3,7 @@ import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
-import { installSomaForCodex, installSomaForPiDev } from "../src/index";
+import { installSomaForCodex, installSomaForPiDev, planSomaForCodexInstall, planSomaForPiDevInstall } from "../src/index";
 import { renderStartupContextSummary } from "../src/adapters/codex-hook-entry.mjs";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
@@ -101,6 +101,27 @@ test("installs soma source home and codex home projection", async () => {
     expect(somaRepo).toContain("soma");
     expect(skill).toContain("name: soma");
     expect(startupContext).toContain("Soma Startup Context");
+  });
+});
+
+test("codex install dry-run lists every substrate file apply reports", async () => {
+  await withTempHome(async (homeDir) => {
+    const plan = planSomaForCodexInstall({ homeDir });
+    const result = await installSomaForCodex({ homeDir });
+
+    expect(plan.substrateFiles).toContain(join(homeDir, ".codex/config.toml"));
+    expect(plan.substrateFiles).toContain(join(homeDir, ".codex/memories/soma/soma-repo.txt"));
+    expect(new Set(plan.substrateFiles)).toEqual(new Set(result.substrateHome.files));
+  });
+});
+
+test("pi.dev install dry-run lists every substrate file apply reports", async () => {
+  await withTempHome(async (homeDir) => {
+    const plan = planSomaForPiDevInstall({ homeDir });
+    const result = await installSomaForPiDev({ homeDir });
+
+    expect(plan.substrateFiles).toContain(join(homeDir, ".pi/agent/soma/soma-repo.txt"));
+    expect(new Set(plan.substrateFiles)).toEqual(new Set(result.substrateHome.files));
   });
 });
 


### PR DESCRIPTION
## Summary
- include Codex config.toml and memories/soma/soma-repo.txt in dry-run install plans
- include Pi.dev soma-repo.txt and path guard extension in dry-run install plans
- add tests that dry-run substrate files match the substrate files reported by apply

Closes #22

## Verification
- bun test test/install.test.ts test/cli.test.ts
- bun run lint
- bun run typecheck
- bun test