### PR TITLE
feat(isa): unify IdealStateArtifact + SomaIsa into one type (#41)

### DIFF
--- a/src/adapters/shared/index.ts
+++ b/src/adapters/shared/index.ts
@@ -1,4 +1,5 @@
 import type { SomaContextInput } from "../../types";
+import { getCriteria, getGoal } from "../../isa-accessors";
 
 export function formatList(items: string[]): string {
   return items.length === 0 ? "- None declared" : items.map((item) => `- ${item}`).join("\n");
@@ -19,7 +20,7 @@ export function renderActiveIsa(input: SomaContextInput): string {
     return "No active ISA was provided.";
   }
 
-  const criteria = input.activeIsa.criteria
+  const criteria = getCriteria(input.activeIsa)
     .map((criterion) => {
       const verification = criterion.verification ? ` Verification: ${criterion.verification}` : "";
       return `- [${criterion.status}] ${criterion.id}: ${criterion.text}${verification}`;
@@ -28,8 +29,8 @@ export function renderActiveIsa(input: SomaContextInput): string {
 
   return [
     `Slug: ${input.activeIsa.slug}`,
-    `Phase: ${input.activeIsa.phase}`,
-    `Goal: ${input.activeIsa.goal}`,
+    `Phase: ${input.activeIsa.frontmatter.phase}`,
+    `Goal: ${getGoal(input.activeIsa) ?? ""}`,
     "",
     "Criteria:",
     criteria || "- None declared",

--- a/src/algorithm-lifecycle.ts
+++ b/src/algorithm-lifecycle.ts
@@ -9,22 +9,28 @@ export function getRunPhase(run: AlgorithmRun): AlgorithmPhase {
 }
 
 /**
- * Terminal transition — completes the run.
+ * Pure terminal phase transition — sets phase to `complete`.
  *
- * Composes phase advancement to `complete` plus side effects that belong to
- * end-of-run (active.json clearing, completion event emission). Until #32+#34
- * land, the active.json clearing is a no-op stub — callers wanting just the
- * pure phase transition continue to use `advanceAlgorithmRun`.
+ * This helper does NOT touch active.json, NOT emit lifecycle events, NOT
+ * persist to disk. It is a pure function over an in-memory `AlgorithmRun`.
+ *
+ * The end-of-run service (active.json clearing, `algorithm.completed`
+ * event emission, persistence) will live in `algorithm-lifecycle-service.ts`
+ * shipped by #32+#34 — a separate API that accepts the store/event-emitter
+ * context as constructor arguments. That service composes this pure helper
+ * with the IO side effects, so the public surface for IO is added at the
+ * service boundary, not retrofitted onto this pure function.
  */
 export function completeAlgorithmRun(run: AlgorithmRun, timestamp = new Date().toISOString()): AlgorithmRun {
   return setRunPhase(run, "complete", timestamp);
 }
 
 /**
- * Terminal transition — abandons the run with a reason.
+ * Pure terminal phase transition — sets phase to `abandoned` and records
+ * the reason in the run's `decisions` log so the abandonment is auditable.
  *
- * Mirror of `completeAlgorithmRun`. Records the reason in the run's
- * `decisions` log so the abandonment is auditable.
+ * Mirror of `completeAlgorithmRun` — no IO, no events, no store dependency.
+ * The IO composition lives in the end-of-run service (see above).
  */
 export function abandonAlgorithmRun(run: AlgorithmRun, reason: string, timestamp = new Date().toISOString()): AlgorithmRun {
   if (reason.trim().length === 0) {

--- a/src/algorithm-lifecycle.ts
+++ b/src/algorithm-lifecycle.ts
@@ -1,0 +1,52 @@
+import type { AlgorithmPhase, AlgorithmRun } from "./types";
+
+/**
+ * Phase accessor — `AlgorithmRun.phase` was removed in #41.
+ * `run.isa.frontmatter.phase` is the only source of truth.
+ */
+export function getRunPhase(run: AlgorithmRun): AlgorithmPhase {
+  return run.isa.frontmatter.phase;
+}
+
+/**
+ * Terminal transition — completes the run.
+ *
+ * Composes phase advancement to `complete` plus side effects that belong to
+ * end-of-run (active.json clearing, completion event emission). Until #32+#34
+ * land, the active.json clearing is a no-op stub — callers wanting just the
+ * pure phase transition continue to use `advanceAlgorithmRun`.
+ */
+export function completeAlgorithmRun(run: AlgorithmRun, timestamp = new Date().toISOString()): AlgorithmRun {
+  return setRunPhase(run, "complete", timestamp);
+}
+
+/**
+ * Terminal transition — abandons the run with a reason.
+ *
+ * Mirror of `completeAlgorithmRun`. Records the reason in the run's
+ * `decisions` log so the abandonment is auditable.
+ */
+export function abandonAlgorithmRun(run: AlgorithmRun, reason: string, timestamp = new Date().toISOString()): AlgorithmRun {
+  if (reason.trim().length === 0) {
+    throw new Error("abandonAlgorithmRun reason must not be empty.");
+  }
+  const abandoned = setRunPhase(run, "abandoned", timestamp);
+  return {
+    ...abandoned,
+    decisions: [
+      ...abandoned.decisions,
+      { timestamp, phase: "abandoned", text: `Abandoned: ${reason}` },
+    ],
+  };
+}
+
+function setRunPhase(run: AlgorithmRun, phase: AlgorithmPhase, timestamp: string): AlgorithmRun {
+  return {
+    ...run,
+    updatedAt: timestamp,
+    isa: {
+      ...run.isa,
+      frontmatter: { ...run.isa.frontmatter, phase, updated: timestamp },
+    },
+  };
+}

--- a/src/algorithm-store.ts
+++ b/src/algorithm-store.ts
@@ -11,14 +11,7 @@ import type {
   IdealStateArtifact,
   IdealStateCriterion,
 } from "./types";
-import {
-  SECTION_NAME_MAP,
-  getCriteria,
-  getGoal,
-  recomputeProgress,
-  recomputeVerified,
-  renderCriteriaMarkdown,
-} from "./isa-accessors";
+import { buildIsaArtifact, getCriteria, getGoal } from "./isa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
 
 export interface AlgorithmStoreOptions {
@@ -140,27 +133,20 @@ function migrateRunV1toV2(legacy: LegacyAlgorithmRun): AlgorithmRun {
   const criteria = Array.isArray(legacy.isa.criteria) ? legacy.isa.criteria : [];
   const goal = typeof legacy.isa.goal === "string" ? legacy.isa.goal : "";
   const intent = legacy.intent ?? legacy.id;
-  const sections = [
-    { name: SECTION_NAME_MAP.goal, content: goal },
-    { name: SECTION_NAME_MAP.criteria, content: renderCriteriaMarkdown(criteria) },
-  ];
-
-  const isa: IdealStateArtifact = {
+  const built = buildIsaArtifact({
     slug: legacy.isa.slug,
-    frontmatter: {
-      task: intent,
-      effort: legacy.effort,
-      mode: legacy.mode,
-      phase: legacyPhase,
-      progress: `0/${criteria.length}`,
-      verified: false,
-      updated: legacy.updatedAt,
-      started: legacy.createdAt,
-    },
-    sections,
+    task: intent,
+    goal,
+    criteria,
+    effort: legacy.effort,
+    mode: legacy.mode,
+    phase: legacyPhase,
+    timestamp: legacy.createdAt,
+  });
+  const isa: IdealStateArtifact = {
+    ...built,
+    frontmatter: { ...built.frontmatter, updated: legacy.updatedAt },
   };
-  isa.frontmatter.progress = recomputeProgress(isa);
-  isa.frontmatter.verified = recomputeVerified(isa);
 
   return {
     schemaVersion: 2,

--- a/src/algorithm-store.ts
+++ b/src/algorithm-store.ts
@@ -147,19 +147,14 @@ function migrateRunV1toV2(legacy: LegacyAlgorithmRun): AlgorithmRun {
     frontmatter: { ...built.frontmatter, updated: legacy.updatedAt },
   };
 
+  // Spread legacy first, then override divergent fields. New AlgorithmRun
+  // fields with default-safe optionality will propagate automatically.
+  const { phase: _legacyPhaseField, ...legacyFields } = legacy;
+  void _legacyPhaseField;
   return {
+    ...legacyFields,
     schemaVersion: 2,
-    id: legacy.id,
-    createdAt: legacy.createdAt,
-    updatedAt: legacy.updatedAt,
-    substrate: legacy.substrate,
-    prompt: legacy.prompt,
     intent,
-    effort: legacy.effort,
-    effortSource: legacy.effortSource,
-    mode: legacy.mode,
-    classificationReason: legacy.classificationReason,
-    currentState: legacy.currentState,
     isa,
     antiCriteria: legacy.antiCriteria ?? [],
     capabilities: legacy.capabilities ?? [],

--- a/src/algorithm-store.ts
+++ b/src/algorithm-store.ts
@@ -78,11 +78,17 @@ interface LegacyIsa {
   criteria: IdealStateCriterion[];
 }
 
-interface LegacyAlgorithmRun {
+// LegacyAlgorithmRun = pre-#41 on-disk shape. Derived from AlgorithmRun so
+// field additions propagate; only the diverging fields (`phase` lived at
+// the top level, `isa` carried embedded `{ phase, goal, criteria }`,
+// `intent` was required) are overridden.
+type LegacyAlgorithmRun = Omit<
+  Partial<AlgorithmRun>,
+  "schemaVersion" | "isa" | "phase" | "intent"
+> & {
   id: string;
   createdAt: string;
   updatedAt: string;
-  substrate?: AlgorithmRun["substrate"];
   prompt: string;
   intent?: string;
   effort: AlgorithmEffortTier;
@@ -92,15 +98,8 @@ interface LegacyAlgorithmRun {
   currentState: string;
   phase?: AlgorithmPhase;
   isa: LegacyIsa;
-  antiCriteria?: IdealStateCriterion[];
-  capabilities?: string[];
-  planSteps?: AlgorithmRun["planSteps"];
-  decisions?: AlgorithmRun["decisions"];
-  changelog?: AlgorithmRun["changelog"];
-  verification?: AlgorithmRun["verification"];
-  learning?: AlgorithmRun["learning"];
   schemaVersion?: 1 | 2;
-}
+};
 
 /**
  * Compat shim — accepts both pre-#41 (schemaVersion 1, embedded `{ goal, criteria }`)

--- a/src/algorithm-store.ts
+++ b/src/algorithm-store.ts
@@ -1,7 +1,25 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import type { AlgorithmRun, AlgorithmRunSummary } from "./types";
+import type {
+  AlgorithmEffortSource,
+  AlgorithmEffortTier,
+  AlgorithmMode,
+  AlgorithmPhase,
+  AlgorithmRun,
+  AlgorithmRunSummary,
+  IdealStateArtifact,
+  IdealStateCriterion,
+} from "./types";
+import {
+  SECTION_NAME_MAP,
+  getCriteria,
+  getGoal,
+  recomputeProgress,
+  recomputeVerified,
+  renderCriteriaMarkdown,
+} from "./isa-accessors";
+import { getRunPhase } from "./algorithm-lifecycle";
 
 export interface AlgorithmStoreOptions {
   homeDir?: string;
@@ -56,7 +74,116 @@ export async function writeAlgorithmRun(run: AlgorithmRun, options: AlgorithmSto
 }
 
 export async function readAlgorithmRun(path: string): Promise<AlgorithmRun> {
-  return JSON.parse(await readFile(path, "utf8")) as AlgorithmRun;
+  const raw = JSON.parse(await readFile(path, "utf8")) as unknown;
+  return loadAlgorithmRun(raw);
+}
+
+interface LegacyIsa {
+  slug: string;
+  phase: AlgorithmPhase;
+  goal: string;
+  criteria: IdealStateCriterion[];
+}
+
+interface LegacyAlgorithmRun {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  substrate?: AlgorithmRun["substrate"];
+  prompt: string;
+  intent?: string;
+  effort: AlgorithmEffortTier;
+  effortSource: AlgorithmEffortSource;
+  mode: AlgorithmMode;
+  classificationReason: string;
+  currentState: string;
+  phase?: AlgorithmPhase;
+  isa: LegacyIsa;
+  antiCriteria?: IdealStateCriterion[];
+  capabilities?: string[];
+  planSteps?: AlgorithmRun["planSteps"];
+  decisions?: AlgorithmRun["decisions"];
+  changelog?: AlgorithmRun["changelog"];
+  verification?: AlgorithmRun["verification"];
+  learning?: AlgorithmRun["learning"];
+  schemaVersion?: 1 | 2;
+}
+
+/**
+ * Compat shim — accepts both pre-#41 (schemaVersion 1, embedded `{ goal, criteria }`)
+ * and post-#41 (schemaVersion 2, unified `IdealStateArtifact`) on-disk shapes.
+ * Always returns the unified schema-2 shape.
+ */
+export function loadAlgorithmRun(raw: unknown): AlgorithmRun {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("AlgorithmRun JSON is not an object.");
+  }
+  const candidate = raw as Partial<AlgorithmRun & LegacyAlgorithmRun>;
+  if (candidate.schemaVersion === 2 && isUnifiedShape(candidate.isa)) {
+    return candidate as AlgorithmRun;
+  }
+  return migrateRunV1toV2(candidate as LegacyAlgorithmRun);
+}
+
+function isUnifiedShape(isa: unknown): boolean {
+  return (
+    typeof isa === "object" &&
+    isa !== null &&
+    "frontmatter" in isa &&
+    "sections" in isa &&
+    Array.isArray((isa as { sections: unknown }).sections)
+  );
+}
+
+function migrateRunV1toV2(legacy: LegacyAlgorithmRun): AlgorithmRun {
+  const legacyPhase: AlgorithmPhase = legacy.phase ?? legacy.isa.phase;
+  const criteria = Array.isArray(legacy.isa.criteria) ? legacy.isa.criteria : [];
+  const goal = typeof legacy.isa.goal === "string" ? legacy.isa.goal : "";
+  const intent = legacy.intent ?? legacy.id;
+  const sections = [
+    { name: SECTION_NAME_MAP.goal, content: goal },
+    { name: SECTION_NAME_MAP.criteria, content: renderCriteriaMarkdown(criteria) },
+  ];
+
+  const isa: IdealStateArtifact = {
+    slug: legacy.isa.slug,
+    frontmatter: {
+      task: intent,
+      effort: legacy.effort,
+      mode: legacy.mode,
+      phase: legacyPhase,
+      progress: `0/${criteria.length}`,
+      verified: false,
+      updated: legacy.updatedAt,
+      started: legacy.createdAt,
+    },
+    sections,
+  };
+  isa.frontmatter.progress = recomputeProgress(isa);
+  isa.frontmatter.verified = recomputeVerified(isa);
+
+  return {
+    schemaVersion: 2,
+    id: legacy.id,
+    createdAt: legacy.createdAt,
+    updatedAt: legacy.updatedAt,
+    substrate: legacy.substrate,
+    prompt: legacy.prompt,
+    intent,
+    effort: legacy.effort,
+    effortSource: legacy.effortSource,
+    mode: legacy.mode,
+    classificationReason: legacy.classificationReason,
+    currentState: legacy.currentState,
+    isa,
+    antiCriteria: legacy.antiCriteria ?? [],
+    capabilities: legacy.capabilities ?? [],
+    planSteps: legacy.planSteps ?? [],
+    decisions: legacy.decisions ?? [],
+    changelog: legacy.changelog ?? [],
+    verification: legacy.verification ?? [],
+    learning: legacy.learning ?? [],
+  };
 }
 
 export async function readAlgorithmRunById(id: string, options: AlgorithmStoreOptions = {}): Promise<{ path: string; run: AlgorithmRun }> {
@@ -84,20 +211,21 @@ export function summarizeAlgorithmRun(run: AlgorithmRun, path: string): Algorith
     dropped: 0,
   };
 
-  for (const criterion of run.isa.criteria) {
+  const criteria = getCriteria(run.isa);
+  for (const criterion of criteria) {
     counts[criterion.status] += 1;
   }
 
-  const total = run.isa.criteria.length;
+  const total = criteria.length;
   const completed = counts.passed + counts.dropped;
 
   return {
     id: run.id,
     path,
     updatedAt: run.updatedAt,
-    phase: run.phase,
+    phase: getRunPhase(run),
     effort: run.effort,
-    goal: run.isa.goal,
+    goal: getGoal(run.isa) ?? "",
     openCriteria: counts.open,
     passedCriteria: counts.passed,
     failedCriteria: counts.failed,

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -10,12 +10,10 @@ import type {
 } from "./types";
 import { classifyAlgorithmPrompt } from "./algorithm-classifier";
 import {
-  SECTION_NAME_MAP,
   buildIsaArtifact,
   getCriteria,
   progressFromCriteria,
-  renderCriteriaMarkdown,
-  setSection,
+  updateCriterionWithResult,
   verifiedFromCriteria,
 } from "./isa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
@@ -221,14 +219,12 @@ export function verifyAlgorithmCriterion(
 ): AlgorithmRun {
   assertNonEmpty(evidence, "verification evidence");
 
-  const criteria = getCriteria(run.isa);
-  if (!criteria.some((c) => c.id === criterionId)) {
-    throw new Error(`Algorithm criterion not found: ${criterionId}`);
-  }
-  const updatedCriteria = criteria.map((c) =>
-    c.id === criterionId ? { ...c, status, verification: evidence } : c,
+  const { isa: isaWithSection, criteria: updatedCriteria } = updateCriterionWithResult(
+    run.isa,
+    criterionId,
+    status,
+    evidence,
   );
-  const isaWithSection = setSection(run.isa, SECTION_NAME_MAP.criteria, renderCriteriaMarkdown(updatedCriteria));
   const entry = logEntry(getRunPhase(run), `${criterionId}: ${status}. ${evidence}`, timestamp);
   const isaWithRecompute: IdealStateArtifact = {
     ...isaWithSection,
@@ -292,12 +288,18 @@ function assertGate(run: AlgorithmRun, target: AlgorithmPhase): void {
     case "observe":
       throw new Error("Algorithm cannot transition back to OBSERVE.");
     case "abandoned":
-      break;
+      // abandoned is terminal — only reachable through abandonAlgorithmRun, never via advanceAlgorithmRun.
+      throw new Error("Algorithm cannot advance to ABANDONED; use abandonAlgorithmRun.");
   }
 }
 
 export function advanceAlgorithmRun(run: AlgorithmRun, timestamp = new Date().toISOString()): AlgorithmRun {
-  const target = nextAlgorithmPhase(getRunPhase(run));
+  const current = getRunPhase(run);
+  if (current === "abandoned") {
+    throw new Error("Algorithm run was abandoned and cannot advance.");
+  }
+
+  const target = nextAlgorithmPhase(current);
 
   if (!target) {
     throw new Error("Algorithm run is already complete.");

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -10,11 +10,10 @@ import type {
 } from "./types";
 import { classifyAlgorithmPrompt } from "./algorithm-classifier";
 import {
-  SECTION_NAME_MAP,
+  buildIsaArtifact,
   getCriteria,
   recomputeProgress,
   recomputeVerified,
-  renderCriteriaMarkdown,
   updateCriterion,
 } from "./isa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
@@ -69,43 +68,6 @@ function logEntry(phase: AlgorithmPhase, text: string, timestamp = new Date().to
   };
 }
 
-function buildInitialIsa(input: {
-  slug: string;
-  task: string;
-  goal: string;
-  criteria: IdealStateCriterion[];
-  effort: AlgorithmRun["effort"];
-  mode: AlgorithmRun["mode"];
-  timestamp: string;
-}): IdealStateArtifact {
-  const sections = [
-    { name: SECTION_NAME_MAP.goal, content: input.goal },
-    { name: SECTION_NAME_MAP.criteria, content: renderCriteriaMarkdown(input.criteria) },
-  ];
-  const draft: IdealStateArtifact = {
-    slug: input.slug,
-    frontmatter: {
-      task: input.task,
-      effort: input.effort,
-      mode: input.mode,
-      phase: "observe",
-      progress: `0/${input.criteria.length}`,
-      verified: false,
-      updated: input.timestamp,
-      started: input.timestamp,
-    },
-    sections,
-  };
-  return {
-    ...draft,
-    frontmatter: {
-      ...draft.frontmatter,
-      progress: recomputeProgress(draft),
-      verified: recomputeVerified(draft),
-    },
-  };
-}
-
 export function createAlgorithmRun(input: AlgorithmRunInput): AlgorithmRun {
   assertNonEmpty(input.prompt, "prompt");
   assertNonEmpty(input.intent, "intent");
@@ -141,7 +103,7 @@ export function createAlgorithmRun(input: AlgorithmRunInput): AlgorithmRun {
     mode,
     classificationReason,
     currentState: input.currentState,
-    isa: buildInitialIsa({
+    isa: buildIsaArtifact({
       slug,
       task: input.intent,
       goal: input.goal,

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -5,9 +5,19 @@ import type {
   AlgorithmPlanStep,
   AlgorithmRun,
   AlgorithmRunInput,
+  IdealStateArtifact,
   IdealStateCriterion,
 } from "./types";
 import { classifyAlgorithmPrompt } from "./algorithm-classifier";
+import {
+  SECTION_NAME_MAP,
+  getCriteria,
+  recomputeProgress,
+  recomputeVerified,
+  renderCriteriaMarkdown,
+  updateCriterion,
+} from "./isa-accessors";
+import { getRunPhase } from "./algorithm-lifecycle";
 
 const PHASES: AlgorithmPhase[] = ["observe", "think", "plan", "build", "execute", "verify", "learn", "complete"];
 
@@ -59,6 +69,43 @@ function logEntry(phase: AlgorithmPhase, text: string, timestamp = new Date().to
   };
 }
 
+function buildInitialIsa(input: {
+  slug: string;
+  task: string;
+  goal: string;
+  criteria: IdealStateCriterion[];
+  effort: AlgorithmRun["effort"];
+  mode: AlgorithmRun["mode"];
+  timestamp: string;
+}): IdealStateArtifact {
+  const sections = [
+    { name: SECTION_NAME_MAP.goal, content: input.goal },
+    { name: SECTION_NAME_MAP.criteria, content: renderCriteriaMarkdown(input.criteria) },
+  ];
+  const draft: IdealStateArtifact = {
+    slug: input.slug,
+    frontmatter: {
+      task: input.task,
+      effort: input.effort,
+      mode: input.mode,
+      phase: "observe",
+      progress: `0/${input.criteria.length}`,
+      verified: false,
+      updated: input.timestamp,
+      started: input.timestamp,
+    },
+    sections,
+  };
+  return {
+    ...draft,
+    frontmatter: {
+      ...draft.frontmatter,
+      progress: recomputeProgress(draft),
+      verified: recomputeVerified(draft),
+    },
+  };
+}
+
 export function createAlgorithmRun(input: AlgorithmRunInput): AlgorithmRun {
   assertNonEmpty(input.prompt, "prompt");
   assertNonEmpty(input.intent, "intent");
@@ -79,8 +126,10 @@ export function createAlgorithmRun(input: AlgorithmRunInput): AlgorithmRun {
   const effortSource = input.effortSource ?? (input.effort ? "explicit" : classification.source);
   const mode = input.mode ?? "algorithm";
   const classificationReason = input.classificationReason ?? classification.reason;
+  const slug = input.id ?? "algorithm-run";
 
   return {
+    schemaVersion: 2,
     id: input.id ?? createRunId(timestamp),
     createdAt: timestamp,
     updatedAt: timestamp,
@@ -92,13 +141,15 @@ export function createAlgorithmRun(input: AlgorithmRunInput): AlgorithmRun {
     mode,
     classificationReason,
     currentState: input.currentState,
-    phase: "observe",
-    isa: {
-      slug: input.id ?? "algorithm-run",
-      phase: "observe",
+    isa: buildInitialIsa({
+      slug,
+      task: input.intent,
       goal: input.goal,
       criteria,
-    },
+      effort,
+      mode,
+      timestamp,
+    }),
     antiCriteria: (input.antiCriteria ?? []).map(criterionFromInput),
     capabilities: [],
     planSteps: [],
@@ -142,6 +193,8 @@ export function setAlgorithmPlan(run: AlgorithmRun, planSteps: AlgorithmPlanStep
 
   uniqueIds(planSteps, "plan step");
 
+  const criteria = getCriteria(run.isa);
+
   for (const step of planSteps) {
     assertNonEmpty(step.text, `plan step ${step.id} text`);
 
@@ -150,7 +203,7 @@ export function setAlgorithmPlan(run: AlgorithmRun, planSteps: AlgorithmPlanStep
     }
 
     for (const criterionId of step.criteriaIds) {
-      const exists = run.isa.criteria.some((criterion) => criterion.id === criterionId);
+      const exists = criteria.some((criterion) => criterion.id === criterionId);
 
       if (!exists) {
         throw new Error(`Algorithm plan step ${step.id} references unknown criterion: ${criterionId}`);
@@ -166,7 +219,7 @@ export function setAlgorithmPlan(run: AlgorithmRun, planSteps: AlgorithmPlanStep
 }
 
 export function recordAlgorithmChange(run: AlgorithmRun, text: string, timestamp?: string): AlgorithmRun {
-  const entry = logEntry(run.phase, text, timestamp);
+  const entry = logEntry(getRunPhase(run), text, timestamp);
 
   return {
     ...run,
@@ -176,7 +229,7 @@ export function recordAlgorithmChange(run: AlgorithmRun, text: string, timestamp
 }
 
 export function recordAlgorithmDecision(run: AlgorithmRun, text: string, timestamp?: string): AlgorithmRun {
-  const entry = logEntry(run.phase, text, timestamp);
+  const entry = logEntry(getRunPhase(run), text, timestamp);
 
   return {
     ...run,
@@ -186,7 +239,7 @@ export function recordAlgorithmDecision(run: AlgorithmRun, text: string, timesta
 }
 
 export function recordAlgorithmLearning(run: AlgorithmRun, text: string, timestamp?: string): AlgorithmRun {
-  const entry = logEntry(run.phase, text, timestamp);
+  const entry = logEntry(getRunPhase(run), text, timestamp);
 
   return {
     ...run,
@@ -204,42 +257,35 @@ export function verifyAlgorithmCriterion(
 ): AlgorithmRun {
   assertNonEmpty(evidence, "verification evidence");
 
-  const criteria = run.isa.criteria.map((criterion) => {
-    if (criterion.id !== criterionId) {
-      return criterion;
-    }
-
-    return {
-      ...criterion,
-      status,
-      verification: evidence,
-    };
-  });
-
-  if (!criteria.some((criterion) => criterion.id === criterionId)) {
-    throw new Error(`Algorithm criterion not found: ${criterionId}`);
-  }
-
-  const entry = logEntry(run.phase, `${criterionId}: ${status}. ${evidence}`, timestamp);
+  const updatedIsa = updateCriterion(run.isa, criterionId, status, evidence);
+  const entry = logEntry(getRunPhase(run), `${criterionId}: ${status}. ${evidence}`, timestamp);
+  const isaWithRecompute: IdealStateArtifact = {
+    ...updatedIsa,
+    frontmatter: {
+      ...updatedIsa.frontmatter,
+      progress: recomputeProgress(updatedIsa),
+      verified: recomputeVerified(updatedIsa),
+      updated: entry.timestamp,
+    },
+  };
 
   return {
     ...run,
     updatedAt: entry.timestamp,
-    isa: {
-      ...run.isa,
-      criteria,
-    },
+    isa: isaWithRecompute,
     verification: [...run.verification, entry],
   };
 }
 
 function assertGate(run: AlgorithmRun, target: AlgorithmPhase): void {
   switch (target) {
-    case "think":
-      if (run.isa.criteria.length === 0) {
+    case "think": {
+      const criteria = getCriteria(run.isa);
+      if (criteria.length === 0) {
         throw new Error("Algorithm cannot enter THINK without criteria.");
       }
       break;
+    }
     case "plan":
       if (run.capabilities.length === 0) {
         throw new Error("Algorithm cannot enter PLAN without selected capabilities.");
@@ -260,11 +306,13 @@ function assertGate(run: AlgorithmRun, target: AlgorithmPhase): void {
         throw new Error("Algorithm cannot enter VERIFY until every plan step is done or blocked.");
       }
       break;
-    case "learn":
-      if (!run.isa.criteria.every((criterion) => criterion.status === "passed" || criterion.status === "dropped")) {
+    case "learn": {
+      const criteria = getCriteria(run.isa);
+      if (!criteria.every((criterion) => criterion.status === "passed" || criterion.status === "dropped")) {
         throw new Error("Algorithm cannot enter LEARN until every criterion is passed or dropped.");
       }
       break;
+    }
     case "complete":
       if (run.learning.length === 0) {
         throw new Error("Algorithm cannot COMPLETE without a learning entry.");
@@ -272,11 +320,13 @@ function assertGate(run: AlgorithmRun, target: AlgorithmPhase): void {
       break;
     case "observe":
       throw new Error("Algorithm cannot transition back to OBSERVE.");
+    case "abandoned":
+      break;
   }
 }
 
 export function advanceAlgorithmRun(run: AlgorithmRun, timestamp = new Date().toISOString()): AlgorithmRun {
-  const target = nextAlgorithmPhase(run.phase);
+  const target = nextAlgorithmPhase(getRunPhase(run));
 
   if (!target) {
     throw new Error("Algorithm run is already complete.");
@@ -287,10 +337,13 @@ export function advanceAlgorithmRun(run: AlgorithmRun, timestamp = new Date().to
   return {
     ...run,
     updatedAt: timestamp,
-    phase: target,
     isa: {
       ...run.isa,
-      phase: target,
+      frontmatter: {
+        ...run.isa.frontmatter,
+        phase: target,
+        updated: timestamp,
+      },
     },
   };
 }

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -10,11 +10,13 @@ import type {
 } from "./types";
 import { classifyAlgorithmPrompt } from "./algorithm-classifier";
 import {
+  SECTION_NAME_MAP,
   buildIsaArtifact,
   getCriteria,
-  recomputeProgress,
-  recomputeVerified,
-  updateCriterion,
+  progressFromCriteria,
+  renderCriteriaMarkdown,
+  setSection,
+  verifiedFromCriteria,
 } from "./isa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
 
@@ -219,14 +221,21 @@ export function verifyAlgorithmCriterion(
 ): AlgorithmRun {
   assertNonEmpty(evidence, "verification evidence");
 
-  const updatedIsa = updateCriterion(run.isa, criterionId, status, evidence);
+  const criteria = getCriteria(run.isa);
+  if (!criteria.some((c) => c.id === criterionId)) {
+    throw new Error(`Algorithm criterion not found: ${criterionId}`);
+  }
+  const updatedCriteria = criteria.map((c) =>
+    c.id === criterionId ? { ...c, status, verification: evidence } : c,
+  );
+  const isaWithSection = setSection(run.isa, SECTION_NAME_MAP.criteria, renderCriteriaMarkdown(updatedCriteria));
   const entry = logEntry(getRunPhase(run), `${criterionId}: ${status}. ${evidence}`, timestamp);
   const isaWithRecompute: IdealStateArtifact = {
-    ...updatedIsa,
+    ...isaWithSection,
     frontmatter: {
-      ...updatedIsa.frontmatter,
-      progress: recomputeProgress(updatedIsa),
-      verified: recomputeVerified(updatedIsa),
+      ...isaWithSection.frontmatter,
+      progress: progressFromCriteria(updatedCriteria),
+      verified: verifiedFromCriteria(updatedCriteria),
       updated: entry.timestamp,
     },
   };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,6 +67,8 @@ import type {
   SubstrateId,
 } from "./types";
 import { SOMA_FEEDBACK_STDIN_MAX_BYTES } from "./feedback-contract";
+import { getCriteria, getGoal } from "./isa-accessors";
+import { getRunPhase } from "./algorithm-lifecycle";
 
 interface ParsedInstallArgs {
   command: "install";
@@ -1337,11 +1339,11 @@ function quoteShellArg(value: string): string {
   return `'${value.replaceAll("'", "'\"'\"'")}'`;
 }
 
-function formatAlgorithmRunResult(result: { path: string; run: { id: string; phase: string; effort: string } }): string {
+function formatAlgorithmRunResult(result: { path: string; run: AlgorithmRun }): string {
   return [
     "Soma Algorithm run created",
     `id: ${result.run.id}`,
-    `phase: ${result.run.phase}`,
+    `phase: ${getRunPhase(result.run)}`,
     `effort: ${result.run.effort}`,
     `path: ${result.path}`,
   ].join("\n");
@@ -1465,16 +1467,16 @@ function formatAlgorithmRun(run: AlgorithmRun, path: string): string {
   return [
     "Soma Algorithm run",
     `id: ${run.id}`,
-    `phase: ${run.phase}`,
+    `phase: ${getRunPhase(run)}`,
     `effort: ${run.effort}`,
     `effortSource: ${run.effortSource}`,
     `mode: ${run.mode}`,
     `classificationReason: ${run.classificationReason}`,
     `path: ${path}`,
-    `goal: ${run.isa.goal}`,
+    `goal: ${getGoal(run.isa) ?? ""}`,
     "",
     "Criteria:",
-    ...run.isa.criteria.map((criterion) => `- [${criterion.status}] ${criterion.id}: ${criterion.text}${criterion.verification ? ` | ${criterion.verification}` : ""}`),
+    ...getCriteria(run.isa).map((criterion) => `- [${criterion.status}] ${criterion.id}: ${criterion.text}${criterion.verification ? ` | ${criterion.verification}` : ""}`),
     "",
     "Plan:",
     ...(run.planSteps.length > 0 ? run.planSteps.map((step) => `- [${step.status}] ${step.id}: ${step.text} (${step.criteriaIds.join(",")})`) : ["- none"]),

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,6 @@ export {
   algorithmRunPathById,
   listAlgorithmRunSummaries,
   listAlgorithmRuns,
-  loadAlgorithmRun,
   readAlgorithmRunById,
   readAlgorithmRun,
   resolveAlgorithmRunsDir,

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,9 +91,12 @@ export {
   verifyAlgorithmCriterion,
 } from "./algorithm";
 export { classifyAlgorithmPrompt } from "./algorithm-classifier";
+// Public ISA API — cohesive surface: semantic accessors + mutators + parse/serialize.
+// Renderer details (SECTION_NAME_MAP, TWELVE_SECTIONS, renderCriteriaMarkdown,
+// renderLogEntries, parseCriteriaMarkdown, progressFromCriteria,
+// verifiedFromCriteria, buildIsaArtifact) stay internal — import from
+// `./isa-accessors` directly if you need them from within the package.
 export {
-  SECTION_NAME_MAP,
-  TWELVE_SECTIONS,
   appendCriterion,
   appendIsaChangelog,
   appendIsaDecision,
@@ -104,11 +107,8 @@ export {
   getGoal,
   getSection,
   getVerification,
-  parseCriteriaMarkdown,
   recomputeProgress,
   recomputeVerified,
-  renderCriteriaMarkdown,
-  renderLogEntries,
   setSection,
   updateCriterion,
 } from "./isa-accessors";

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,12 @@ export type {
   AlgorithmRunSummary,
   AlgorithmWorkIndex,
   AssistantIdentity,
+  AuthoredFrontmatter,
+  DerivedFrontmatter,
   IdealStateArtifact,
   IdealStateCriterion,
+  IsaFrontmatter,
+  IsaSection,
   PrincipalIdentity,
   SomaAdapter,
   SomaContextBundle,
@@ -88,10 +92,38 @@ export {
 } from "./algorithm";
 export { classifyAlgorithmPrompt } from "./algorithm-classifier";
 export {
+  SECTION_NAME_MAP,
+  TWELVE_SECTIONS,
+  appendCriterion,
+  appendIsaChangelog,
+  appendIsaDecision,
+  appendIsaVerification,
+  getChangelog,
+  getCriteria,
+  getDecisions,
+  getGoal,
+  getSection,
+  getVerification,
+  parseCriteriaMarkdown,
+  recomputeProgress,
+  recomputeVerified,
+  renderCriteriaMarkdown,
+  renderLogEntries,
+  setSection,
+  updateCriterion,
+} from "./isa-accessors";
+export { parseIsa, serializeIsa } from "./isa-parse";
+export {
+  abandonAlgorithmRun,
+  completeAlgorithmRun,
+  getRunPhase,
+} from "./algorithm-lifecycle";
+export {
   algorithmRunPath,
   algorithmRunPathById,
   listAlgorithmRunSummaries,
   listAlgorithmRuns,
+  loadAlgorithmRun,
   readAlgorithmRunById,
   readAlgorithmRun,
   resolveAlgorithmRunsDir,

--- a/src/isa-accessors.ts
+++ b/src/isa-accessors.ts
@@ -78,23 +78,40 @@ export function setSection(isa: IdealStateArtifact, name: string, content: strin
   return { ...isa, sections };
 }
 
+export function setCriteria(isa: IdealStateArtifact, criteria: readonly IdealStateCriterion[]): IdealStateArtifact {
+  return setSection(isa, SECTION_NAME_MAP.criteria, renderCriteriaMarkdown(criteria));
+}
+
+export interface UpdateCriterionResult {
+  isa: IdealStateArtifact;
+  criteria: IdealStateCriterion[];
+}
+
+export function updateCriterionWithResult(
+  isa: IdealStateArtifact,
+  criterionId: string,
+  status: IdealStateCriterion["status"],
+  verification?: string,
+): UpdateCriterionResult {
+  const criteria = getCriteria(isa);
+  if (!criteria.some((criterion) => criterion.id === criterionId)) {
+    throw new Error(`Algorithm criterion not found: ${criterionId}`);
+  }
+  const updated = criteria.map((criterion) =>
+    criterion.id === criterionId
+      ? { ...criterion, status, verification: verification ?? criterion.verification }
+      : criterion,
+  );
+  return { isa: setCriteria(isa, updated), criteria: updated };
+}
+
 export function updateCriterion(
   isa: IdealStateArtifact,
   criterionId: string,
   status: IdealStateCriterion["status"],
   verification?: string,
 ): IdealStateArtifact {
-  const criteria = getCriteria(isa);
-  if (!criteria.some((criterion) => criterion.id === criterionId)) {
-    throw new Error(`Algorithm criterion not found: ${criterionId}`);
-  }
-
-  const updated = criteria.map((criterion) => {
-    if (criterion.id !== criterionId) return criterion;
-    return { ...criterion, status, verification: verification ?? criterion.verification };
-  });
-
-  return setSection(isa, SECTION_NAME_MAP.criteria, renderCriteriaMarkdown(updated));
+  return updateCriterionWithResult(isa, criterionId, status, verification).isa;
 }
 
 export function appendCriterion(isa: IdealStateArtifact, criterion: IdealStateCriterion): IdealStateArtifact {

--- a/src/isa-accessors.ts
+++ b/src/isa-accessors.ts
@@ -273,14 +273,20 @@ export function buildIsaArtifact(input: BuildIsaInput): IdealStateArtifact {
 }
 
 export function recomputeProgress(isa: IdealStateArtifact): string {
-  const criteria = getCriteria(isa);
+  return progressFromCriteria(getCriteria(isa));
+}
+
+export function recomputeVerified(isa: IdealStateArtifact): boolean {
+  return verifiedFromCriteria(getCriteria(isa));
+}
+
+export function progressFromCriteria(criteria: readonly IdealStateCriterion[]): string {
   if (criteria.length === 0) return "0/0";
   const completed = criteria.filter((c) => c.status === "passed" || c.status === "dropped").length;
   return `${completed}/${criteria.length}`;
 }
 
-export function recomputeVerified(isa: IdealStateArtifact): boolean {
-  const criteria = getCriteria(isa);
+export function verifiedFromCriteria(criteria: readonly IdealStateCriterion[]): boolean {
   if (criteria.length === 0) return false;
   return criteria.every((c) => c.status === "passed" || c.status === "dropped");
 }

--- a/src/isa-accessors.ts
+++ b/src/isa-accessors.ts
@@ -154,29 +154,34 @@ function canonicalInsertIndex(sections: readonly IsaSection[], name: string): nu
   return sections.length;
 }
 
-const CRITERION_LINE = /^- \[([ x\-_!])\]\s+([^:]+):\s*(.+?)(?:\s+\|\s+Evidence:\s*(.+))?$/;
+const CRITERION_LINE = /^- \[([ x\-_!])\]\s+([^:]+):\s*(.+)$/;
+const EVIDENCE_LINE = /^\s{2,}Evidence:\s*(.+)$/;
 
 export function parseCriteriaMarkdown(content: string): IdealStateCriterion[] {
-  return content
-    .split("\n")
-    .map((line) => parseCriterionLine(line.trim()))
-    .filter((entry): entry is IdealStateCriterion => entry !== null);
+  const out: IdealStateCriterion[] = [];
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.replace(/\s+$/, "");
+    const evidenceMatch = EVIDENCE_LINE.exec(rawLine);
+    const last = out.at(-1);
+    if (evidenceMatch !== null && last !== undefined) {
+      last.verification = evidenceMatch[1].trim();
+      continue;
+    }
+    const criterion = parseCriterionLine(line.trim());
+    if (criterion !== null) out.push(criterion);
+  }
+  return out;
 }
 
 function parseCriterionLine(line: string): IdealStateCriterion | null {
   const match = CRITERION_LINE.exec(line);
   if (match === null) return null;
-  const [, mark, idRaw, textRaw, evidence] = match;
-  const status = criterionStatusFromMark(mark);
-  const criterion: IdealStateCriterion = {
+  const [, mark, idRaw, textRaw] = match;
+  return {
     id: idRaw.trim(),
     text: textRaw.trim(),
-    status,
+    status: criterionStatusFromMark(mark),
   };
-  if (typeof evidence === "string") {
-    criterion.verification = evidence.trim();
-  }
-  return criterion;
 }
 
 function criterionStatusFromMark(mark: string): IdealStateCriterion["status"] {
@@ -210,8 +215,11 @@ export function renderCriteriaMarkdown(criteria: readonly IdealStateCriterion[])
   return criteria
     .map((criterion) => {
       const mark = criterionStatusMark(criterion.status);
-      const evidence = criterion.verification ? ` | Evidence: ${criterion.verification}` : "";
-      return `- [${mark}] ${criterion.id}: ${criterion.text}${evidence}`;
+      const head = `- [${mark}] ${criterion.id}: ${criterion.text}`;
+      if (criterion.verification === undefined || criterion.verification.length === 0) {
+        return head;
+      }
+      return `${head}\n  Evidence: ${criterion.verification}`;
     })
     .join("\n");
 }

--- a/src/isa-accessors.ts
+++ b/src/isa-accessors.ts
@@ -44,10 +44,19 @@ export function getGoal(isa: IdealStateArtifact): string | null {
   return trimmed.length === 0 ? null : trimmed;
 }
 
+const CRITERIA_CACHE = new WeakMap<IsaSection, IdealStateCriterion[]>();
+
 export function getCriteria(isa: IdealStateArtifact): IdealStateCriterion[] {
   const section = getSection(isa, SECTION_NAME_MAP.criteria);
   if (section === null) return [];
-  return parseCriteriaMarkdown(section.content);
+  // Section objects are frozen in the type as readonly content fields; mutators
+  // in this file always create a new section object via setSection, so identity
+  // changes whenever content changes.
+  const cached = CRITERIA_CACHE.get(section);
+  if (cached !== undefined) return cached.slice();
+  const parsed = parseCriteriaMarkdown(section.content);
+  CRITERIA_CACHE.set(section, parsed);
+  return parsed.slice();
 }
 
 export function getDecisions(isa: IdealStateArtifact): AlgorithmLogEntry[] {

--- a/src/isa-accessors.ts
+++ b/src/isa-accessors.ts
@@ -1,5 +1,7 @@
 import type {
+  AlgorithmEffortTier,
   AlgorithmLogEntry,
+  AlgorithmMode,
   AlgorithmPhase,
   IdealStateArtifact,
   IdealStateCriterion,
@@ -222,6 +224,52 @@ function parseLogEntryLine(line: string): AlgorithmLogEntry | null {
 export function renderLogEntries(entries: readonly AlgorithmLogEntry[]): string {
   if (entries.length === 0) return "";
   return entries.map((entry) => `- ${entry.timestamp} [${entry.phase}] ${entry.text}`).join("\n");
+}
+
+export interface BuildIsaInput {
+  slug: string;
+  task: string;
+  goal: string;
+  criteria: IdealStateCriterion[];
+  effort: AlgorithmEffortTier;
+  mode?: AlgorithmMode;
+  phase?: AlgorithmPhase;
+  timestamp: string;
+}
+
+/**
+ * Single source of truth for constructing a fresh IdealStateArtifact from
+ * primitive inputs. Used by both `createAlgorithmRun` (new runs) and the
+ * legacy v1 → v2 compat shim in `algorithm-store`. Keeps section + frontmatter
+ * shape consistent across both paths.
+ */
+export function buildIsaArtifact(input: BuildIsaInput): IdealStateArtifact {
+  const sections: IsaSection[] = [
+    { name: SECTION_NAME_MAP.goal, content: input.goal },
+    { name: SECTION_NAME_MAP.criteria, content: renderCriteriaMarkdown(input.criteria) },
+  ];
+  const draft: IdealStateArtifact = {
+    slug: input.slug,
+    frontmatter: {
+      task: input.task,
+      effort: input.effort,
+      mode: input.mode,
+      phase: input.phase ?? "observe",
+      progress: `0/${input.criteria.length}`,
+      verified: false,
+      updated: input.timestamp,
+      started: input.timestamp,
+    },
+    sections,
+  };
+  return {
+    ...draft,
+    frontmatter: {
+      ...draft.frontmatter,
+      progress: recomputeProgress(draft),
+      verified: recomputeVerified(draft),
+    },
+  };
 }
 
 export function recomputeProgress(isa: IdealStateArtifact): string {

--- a/src/isa-accessors.ts
+++ b/src/isa-accessors.ts
@@ -44,19 +44,10 @@ export function getGoal(isa: IdealStateArtifact): string | null {
   return trimmed.length === 0 ? null : trimmed;
 }
 
-const CRITERIA_CACHE = new WeakMap<IsaSection, IdealStateCriterion[]>();
-
 export function getCriteria(isa: IdealStateArtifact): IdealStateCriterion[] {
   const section = getSection(isa, SECTION_NAME_MAP.criteria);
   if (section === null) return [];
-  // Section objects are frozen in the type as readonly content fields; mutators
-  // in this file always create a new section object via setSection, so identity
-  // changes whenever content changes.
-  const cached = CRITERIA_CACHE.get(section);
-  if (cached !== undefined) return cached.slice();
-  const parsed = parseCriteriaMarkdown(section.content);
-  CRITERIA_CACHE.set(section, parsed);
-  return parsed.slice();
+  return parseCriteriaMarkdown(section.content);
 }
 
 export function getDecisions(isa: IdealStateArtifact): AlgorithmLogEntry[] {
@@ -266,7 +257,14 @@ function parseLogEntryLine(line: string): AlgorithmLogEntry | null {
 
 export function renderLogEntries(entries: readonly AlgorithmLogEntry[]): string {
   if (entries.length === 0) return "";
-  return entries.map((entry) => `- ${entry.timestamp} [${entry.phase}] ${entry.text}`).join("\n");
+  return entries
+    .map((entry) => {
+      assertSingleLine("timestamp", entry.timestamp, entry.timestamp);
+      assertSingleLine("phase", entry.phase, entry.phase);
+      assertSingleLine("text", entry.timestamp, entry.text);
+      return `- ${entry.timestamp} [${entry.phase}] ${entry.text}`;
+    })
+    .join("\n");
 }
 
 export interface BuildIsaInput {

--- a/src/isa-accessors.ts
+++ b/src/isa-accessors.ts
@@ -210,15 +210,24 @@ function criterionStatusMark(status: IdealStateCriterion["status"]): string {
   }
 }
 
+function assertSingleLine(field: string, criterionId: string, value: string): void {
+  if (/[\r\n]/.test(value)) {
+    throw new Error(`Algorithm criterion ${criterionId} ${field} must not contain newlines.`);
+  }
+}
+
 export function renderCriteriaMarkdown(criteria: readonly IdealStateCriterion[]): string {
   if (criteria.length === 0) return "";
   return criteria
     .map((criterion) => {
+      assertSingleLine("id", criterion.id, criterion.id);
+      assertSingleLine("text", criterion.id, criterion.text);
       const mark = criterionStatusMark(criterion.status);
       const head = `- [${mark}] ${criterion.id}: ${criterion.text}`;
       if (criterion.verification === undefined || criterion.verification.length === 0) {
         return head;
       }
+      assertSingleLine("verification", criterion.id, criterion.verification);
       return `${head}\n  Evidence: ${criterion.verification}`;
     })
     .join("\n");

--- a/src/isa-accessors.ts
+++ b/src/isa-accessors.ts
@@ -1,0 +1,238 @@
+import type {
+  AlgorithmLogEntry,
+  AlgorithmPhase,
+  IdealStateArtifact,
+  IdealStateCriterion,
+  IsaSection,
+} from "./types";
+
+/**
+ * Canonical section names for the twelve-section ISA schema.
+ * The unified `IdealStateArtifact` type itself is section-agnostic; lifecycle
+ * hooks and validators operate on these well-known names.
+ *
+ * Order matters: when a missing section needs to be inserted, it is placed
+ * at the index implied by this list.
+ */
+export const SECTION_NAME_MAP = {
+  problem: "Problem",
+  vision: "Vision",
+  outOfScope: "Out of Scope",
+  principles: "Principles",
+  constraints: "Constraints",
+  goal: "Goal",
+  criteria: "Criteria",
+  testStrategy: "Test Strategy",
+  features: "Features",
+  decisions: "Decisions",
+  changelog: "Changelog",
+  verification: "Verification",
+} as const;
+
+export const TWELVE_SECTIONS = Object.values(SECTION_NAME_MAP);
+
+export function getSection(isa: IdealStateArtifact, name: string): IsaSection | null {
+  return isa.sections.find((section) => section.name === name) ?? null;
+}
+
+export function getGoal(isa: IdealStateArtifact): string | null {
+  const section = getSection(isa, SECTION_NAME_MAP.goal);
+  if (section === null) return null;
+  const trimmed = section.content.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+export function getCriteria(isa: IdealStateArtifact): IdealStateCriterion[] {
+  const section = getSection(isa, SECTION_NAME_MAP.criteria);
+  if (section === null) return [];
+  return parseCriteriaMarkdown(section.content);
+}
+
+export function getDecisions(isa: IdealStateArtifact): AlgorithmLogEntry[] {
+  return parseLogEntries(isa, SECTION_NAME_MAP.decisions);
+}
+
+export function getChangelog(isa: IdealStateArtifact): AlgorithmLogEntry[] {
+  return parseLogEntries(isa, SECTION_NAME_MAP.changelog);
+}
+
+export function getVerification(isa: IdealStateArtifact): AlgorithmLogEntry[] {
+  return parseLogEntries(isa, SECTION_NAME_MAP.verification);
+}
+
+export function setSection(isa: IdealStateArtifact, name: string, content: string): IdealStateArtifact {
+  const existingIndex = isa.sections.findIndex((section) => section.name === name);
+  const next: IsaSection = { name, content };
+
+  if (existingIndex >= 0) {
+    const sections = isa.sections.slice();
+    sections[existingIndex] = next;
+    return { ...isa, sections };
+  }
+
+  const insertIndex = canonicalInsertIndex(isa.sections, name);
+  const sections = isa.sections.slice();
+  sections.splice(insertIndex, 0, next);
+  return { ...isa, sections };
+}
+
+export function updateCriterion(
+  isa: IdealStateArtifact,
+  criterionId: string,
+  status: IdealStateCriterion["status"],
+  verification?: string,
+): IdealStateArtifact {
+  const criteria = getCriteria(isa);
+  if (!criteria.some((criterion) => criterion.id === criterionId)) {
+    throw new Error(`Algorithm criterion not found: ${criterionId}`);
+  }
+
+  const updated = criteria.map((criterion) => {
+    if (criterion.id !== criterionId) return criterion;
+    return { ...criterion, status, verification: verification ?? criterion.verification };
+  });
+
+  return setSection(isa, SECTION_NAME_MAP.criteria, renderCriteriaMarkdown(updated));
+}
+
+export function appendCriterion(isa: IdealStateArtifact, criterion: IdealStateCriterion): IdealStateArtifact {
+  const criteria = getCriteria(isa);
+  if (criteria.some((existing) => existing.id === criterion.id)) {
+    throw new Error(`Algorithm criterion already exists: ${criterion.id}`);
+  }
+  return setSection(isa, SECTION_NAME_MAP.criteria, renderCriteriaMarkdown([...criteria, criterion]));
+}
+
+export function appendIsaDecision(isa: IdealStateArtifact, entry: AlgorithmLogEntry): IdealStateArtifact {
+  return appendLogEntry(isa, SECTION_NAME_MAP.decisions, entry);
+}
+
+export function appendIsaChangelog(isa: IdealStateArtifact, entry: AlgorithmLogEntry): IdealStateArtifact {
+  return appendLogEntry(isa, SECTION_NAME_MAP.changelog, entry);
+}
+
+export function appendIsaVerification(isa: IdealStateArtifact, entry: AlgorithmLogEntry): IdealStateArtifact {
+  return appendLogEntry(isa, SECTION_NAME_MAP.verification, entry);
+}
+
+function appendLogEntry(isa: IdealStateArtifact, sectionName: string, entry: AlgorithmLogEntry): IdealStateArtifact {
+  const existing = parseLogEntries(isa, sectionName);
+  return setSection(isa, sectionName, renderLogEntries([...existing, entry]));
+}
+
+function canonicalInsertIndex(sections: readonly IsaSection[], name: string): number {
+  const canonicalOrder = TWELVE_SECTIONS as readonly string[];
+  const targetIndex = canonicalOrder.indexOf(name);
+  if (targetIndex < 0) {
+    return sections.length;
+  }
+  for (let i = 0; i < sections.length; i++) {
+    const sectionRank = canonicalOrder.indexOf(sections[i].name);
+    if (sectionRank < 0 || sectionRank > targetIndex) {
+      return i;
+    }
+  }
+  return sections.length;
+}
+
+const CRITERION_LINE = /^- \[([ x\-_!])\]\s+([^:]+):\s*(.+?)(?:\s+\|\s+Evidence:\s*(.+))?$/;
+
+export function parseCriteriaMarkdown(content: string): IdealStateCriterion[] {
+  return content
+    .split("\n")
+    .map((line) => parseCriterionLine(line.trim()))
+    .filter((entry): entry is IdealStateCriterion => entry !== null);
+}
+
+function parseCriterionLine(line: string): IdealStateCriterion | null {
+  const match = CRITERION_LINE.exec(line);
+  if (match === null) return null;
+  const [, mark, idRaw, textRaw, evidence] = match;
+  const status = criterionStatusFromMark(mark);
+  const criterion: IdealStateCriterion = {
+    id: idRaw.trim(),
+    text: textRaw.trim(),
+    status,
+  };
+  if (typeof evidence === "string") {
+    criterion.verification = evidence.trim();
+  }
+  return criterion;
+}
+
+function criterionStatusFromMark(mark: string): IdealStateCriterion["status"] {
+  switch (mark) {
+    case "x":
+      return "passed";
+    case "-":
+      return "dropped";
+    case "!":
+      return "failed";
+    default:
+      return "open";
+  }
+}
+
+function criterionStatusMark(status: IdealStateCriterion["status"]): string {
+  switch (status) {
+    case "passed":
+      return "x";
+    case "dropped":
+      return "-";
+    case "failed":
+      return "!";
+    default:
+      return " ";
+  }
+}
+
+export function renderCriteriaMarkdown(criteria: readonly IdealStateCriterion[]): string {
+  if (criteria.length === 0) return "";
+  return criteria
+    .map((criterion) => {
+      const mark = criterionStatusMark(criterion.status);
+      const evidence = criterion.verification ? ` | Evidence: ${criterion.verification}` : "";
+      return `- [${mark}] ${criterion.id}: ${criterion.text}${evidence}`;
+    })
+    .join("\n");
+}
+
+const LOG_LINE = /^- (\S+)\s+\[(observe|think|plan|build|execute|verify|learn|complete|abandoned)\]\s+(.+)$/;
+
+function parseLogEntries(isa: IdealStateArtifact, sectionName: string): AlgorithmLogEntry[] {
+  const section = getSection(isa, sectionName);
+  if (section === null) return [];
+  return section.content
+    .split("\n")
+    .map((line) => parseLogEntryLine(line.trim()))
+    .filter((entry): entry is AlgorithmLogEntry => entry !== null);
+}
+
+function parseLogEntryLine(line: string): AlgorithmLogEntry | null {
+  const match = LOG_LINE.exec(line);
+  if (match === null) return null;
+  const [, timestamp, phase, text] = match;
+  return {
+    timestamp: timestamp,
+    phase: phase as AlgorithmPhase,
+    text: text.trim(),
+  };
+}
+
+export function renderLogEntries(entries: readonly AlgorithmLogEntry[]): string {
+  if (entries.length === 0) return "";
+  return entries.map((entry) => `- ${entry.timestamp} [${entry.phase}] ${entry.text}`).join("\n");
+}
+
+export function recomputeProgress(isa: IdealStateArtifact): string {
+  const criteria = getCriteria(isa);
+  if (criteria.length === 0) return "0/0";
+  const completed = criteria.filter((c) => c.status === "passed" || c.status === "dropped").length;
+  return `${completed}/${criteria.length}`;
+}
+
+export function recomputeVerified(isa: IdealStateArtifact): boolean {
+  const criteria = getCriteria(isa);
+  if (criteria.length === 0) return false;
+  return criteria.every((c) => c.status === "passed" || c.status === "dropped");
+}

--- a/src/isa-parse.ts
+++ b/src/isa-parse.ts
@@ -172,11 +172,22 @@ function renderFrontmatter(frontmatter: IsaFrontmatter): string {
   }
   if (frontmatter.custom) {
     for (const [key, value] of Object.entries(frontmatter.custom)) {
-      lines.push(`${key}: ${renderYamlScalar(value)}`);
+      if (isPlainObject(value)) {
+        lines.push(`${key}:`);
+        for (const [nestedKey, nestedValue] of Object.entries(value)) {
+          lines.push(`  ${nestedKey}: ${renderYamlScalar(nestedValue)}`);
+        }
+      } else {
+        lines.push(`${key}: ${renderYamlScalar(value)}`);
+      }
     }
   }
   lines.push("---");
   return lines.join("\n");
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function renderYamlScalar(value: unknown): string {

--- a/src/isa-parse.ts
+++ b/src/isa-parse.ts
@@ -8,7 +8,7 @@ import type {
   IsaFrontmatter,
   IsaSection,
 } from "./types";
-import { recomputeProgress, recomputeVerified } from "./isa-accessors";
+import { getCriteria, progressFromCriteria, verifiedFromCriteria } from "./isa-accessors";
 
 /**
  * Round-trip contract: parseIsa → serializeIsa produces **semantic equivalence**
@@ -98,12 +98,11 @@ function renderSection(section: IsaSection): string {
 }
 
 function withRecomputedDerived(isa: IdealStateArtifact): IsaFrontmatter {
-  const progress = recomputeProgress(isa);
-  const verified = recomputeVerified(isa);
+  const criteria = getCriteria(isa);
   return {
     ...isa.frontmatter,
-    progress,
-    verified,
+    progress: progressFromCriteria(criteria),
+    verified: verifiedFromCriteria(criteria),
   };
 }
 

--- a/src/isa-parse.ts
+++ b/src/isa-parse.ts
@@ -1,0 +1,295 @@
+import type {
+  AlgorithmEffortTier,
+  AlgorithmMode,
+  AlgorithmPhase,
+  AuthoredFrontmatter,
+  DerivedFrontmatter,
+  IdealStateArtifact,
+  IsaFrontmatter,
+  IsaSection,
+} from "./types";
+import { recomputeProgress, recomputeVerified } from "./isa-accessors";
+
+/**
+ * Round-trip contract: parseIsa → serializeIsa produces **semantic equivalence**
+ * with the original markdown. Byte preservation is a best-effort optimization
+ * — when no structural mutation has occurred between parse and serialize,
+ * the raw input buffer is reused so whitespace is byte-identical.
+ *
+ * In-flight Algorithm runs that go through `{ ...isa, ... }` spreads create
+ * a new object identity, orphaning the raw-spans cache. Those runs will
+ * always get semantic equivalence, never byte preservation. This is expected.
+ */
+
+const RAW_INPUT = new WeakMap<IdealStateArtifact, string>();
+
+const AUTHORED_KEYS: ReadonlySet<keyof AuthoredFrontmatter> = new Set([
+  "task",
+  "effort",
+  "mode",
+  "iteration",
+  "started",
+  "algorithm_config",
+  "custom",
+]);
+
+const DERIVED_KEYS: ReadonlySet<keyof DerivedFrontmatter> = new Set([
+  "phase",
+  "progress",
+  "verified",
+  "updated",
+]);
+
+const EFFORT_TIERS: readonly AlgorithmEffortTier[] = ["E1", "E2", "E3", "E4", "E5"];
+const PHASES: readonly AlgorithmPhase[] = [
+  "observe",
+  "think",
+  "plan",
+  "build",
+  "execute",
+  "verify",
+  "learn",
+  "complete",
+  "abandoned",
+];
+const MODES: readonly AlgorithmMode[] = ["minimal", "native", "algorithm"];
+
+export function parseIsa(markdown: string, sourcePath?: string): IdealStateArtifact {
+  const { frontmatterRaw, body } = splitFrontmatter(markdown);
+  const frontmatter = parseFrontmatter(frontmatterRaw);
+  const slug = typeof frontmatter.custom?.slug === "string" ? frontmatter.custom.slug : (sourcePath ? slugFromPath(sourcePath) : frontmatter.task || "isa");
+  const sections = parseSections(body);
+  const isa: IdealStateArtifact = { slug, frontmatter, sections, sourcePath };
+  RAW_INPUT.set(isa, markdown);
+  return isa;
+}
+
+export function serializeIsa(isa: IdealStateArtifact): string {
+  const previous = RAW_INPUT.get(isa);
+  const frontmatter = withRecomputedDerived(isa);
+  const rendered = renderIsa({ ...isa, frontmatter });
+  if (previous !== undefined && previous === rendered) {
+    return previous;
+  }
+  return rendered;
+}
+
+function renderIsa(isa: IdealStateArtifact): string {
+  const fm = renderFrontmatter(isa.frontmatter);
+  const body = isa.sections
+    .filter((section) => section.content.trim().length > 0)
+    .map((section) => renderSection(section))
+    .join("\n\n");
+  return body.length > 0 ? `${fm}\n\n${body}\n` : `${fm}\n`;
+}
+
+function renderSection(section: IsaSection): string {
+  const content = section.content.replace(/\s+$/, "");
+  return `## ${section.name}\n\n${content}`;
+}
+
+function withRecomputedDerived(isa: IdealStateArtifact): IsaFrontmatter {
+  const progress = recomputeProgress(isa);
+  const verified = recomputeVerified(isa);
+  return {
+    ...isa.frontmatter,
+    progress,
+    verified,
+  };
+}
+
+interface FrontmatterSplit {
+  frontmatterRaw: string;
+  body: string;
+}
+
+function splitFrontmatter(markdown: string): FrontmatterSplit {
+  if (!markdown.startsWith("---\n")) {
+    return { frontmatterRaw: "", body: markdown };
+  }
+  const end = markdown.indexOf("\n---", 4);
+  if (end < 0) {
+    return { frontmatterRaw: "", body: markdown };
+  }
+  const frontmatterRaw = markdown.slice(4, end);
+  let body = markdown.slice(end + 4);
+  if (body.startsWith("\n")) {
+    body = body.slice(1);
+  }
+  return { frontmatterRaw, body };
+}
+
+function parseFrontmatter(raw: string): IsaFrontmatter {
+  const yaml = parseYamlObject(raw);
+  const authored: AuthoredFrontmatter = {
+    task: stringOrEmpty(yaml.task),
+    effort: coerceEffort(yaml.effort),
+  };
+  if (typeof yaml.mode === "string" && (MODES as readonly string[]).includes(yaml.mode)) {
+    authored.mode = yaml.mode as AlgorithmMode;
+  }
+  if (typeof yaml.iteration === "number") authored.iteration = yaml.iteration;
+  if (typeof yaml.started === "string") authored.started = yaml.started;
+  if (typeof yaml.algorithm_config === "object" && yaml.algorithm_config !== null) {
+    authored.algorithm_config = yaml.algorithm_config as Record<string, unknown>;
+  }
+  if (typeof yaml.custom === "object" && yaml.custom !== null) {
+    authored.custom = yaml.custom as Record<string, unknown>;
+  }
+
+  const customExtras: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(yaml)) {
+    if (AUTHORED_KEYS.has(key as keyof AuthoredFrontmatter)) continue;
+    if (DERIVED_KEYS.has(key as keyof DerivedFrontmatter)) continue;
+    customExtras[key] = value;
+  }
+  if (Object.keys(customExtras).length > 0) {
+    authored.custom = { ...(authored.custom ?? {}), ...customExtras };
+  }
+
+  const derived: DerivedFrontmatter = {
+    phase: coercePhase(yaml.phase),
+    progress: typeof yaml.progress === "string" ? yaml.progress : "0/0",
+    verified: yaml.verified === true,
+    updated: typeof yaml.updated === "string" ? yaml.updated : new Date().toISOString(),
+  };
+
+  return { ...authored, ...derived };
+}
+
+function renderFrontmatter(frontmatter: IsaFrontmatter): string {
+  const lines: string[] = ["---"];
+  for (const key of ["task", "effort", "phase", "progress", "mode", "iteration", "started", "updated", "verified"] as const) {
+    const value = frontmatter[key];
+    if (value === undefined) continue;
+    lines.push(`${key}: ${renderYamlScalar(value)}`);
+  }
+  if (frontmatter.algorithm_config && Object.keys(frontmatter.algorithm_config).length > 0) {
+    lines.push("algorithm_config:");
+    for (const [key, value] of Object.entries(frontmatter.algorithm_config)) {
+      lines.push(`  ${key}: ${renderYamlScalar(value)}`);
+    }
+  }
+  if (frontmatter.custom) {
+    for (const [key, value] of Object.entries(frontmatter.custom)) {
+      lines.push(`${key}: ${renderYamlScalar(value)}`);
+    }
+  }
+  lines.push("---");
+  return lines.join("\n");
+}
+
+function renderYamlScalar(value: unknown): string {
+  if (typeof value === "string") {
+    if (/^[A-Za-z0-9_./:+-]+$/.test(value) && !/^(true|false|null)$/i.test(value)) {
+      return value;
+    }
+    return `"${value.replaceAll("\\", "\\\\").replaceAll("\"", "\\\"")}"`;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return JSON.stringify(value);
+}
+
+function parseYamlObject(raw: string): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  let currentBlockKey: string | null = null;
+  let currentBlock: Record<string, unknown> | null = null;
+
+  for (const rawLine of raw.split("\n")) {
+    if (rawLine.trim().length === 0) continue;
+    if (rawLine.startsWith("  ") && currentBlock !== null) {
+      const match = /^\s+([A-Za-z0-9_]+)\s*:\s*(.*)$/.exec(rawLine);
+      if (match) currentBlock[match[1]] = parseYamlScalar(match[2]);
+      continue;
+    }
+    const match = /^([A-Za-z0-9_]+)\s*:\s*(.*)$/.exec(rawLine);
+    if (!match) continue;
+    const [, key, valueRaw] = match;
+    if (valueRaw === "") {
+      currentBlockKey = key;
+      currentBlock = {};
+      result[key] = currentBlock;
+      continue;
+    }
+    currentBlockKey = null;
+    currentBlock = null;
+    result[key] = parseYamlScalar(valueRaw);
+  }
+  void currentBlockKey;
+  return result;
+}
+
+function parseYamlScalar(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return "";
+  if (/^"(.*)"$/.test(trimmed)) {
+    return trimmed.slice(1, -1).replaceAll("\\\"", "\"").replaceAll("\\\\", "\\");
+  }
+  if (/^-?\d+$/.test(trimmed)) return Number.parseInt(trimmed, 10);
+  if (/^-?\d+\.\d+$/.test(trimmed)) return Number.parseFloat(trimmed);
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (trimmed === "null") return null;
+  return trimmed;
+}
+
+function stringOrEmpty(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function coerceEffort(value: unknown): AlgorithmEffortTier {
+  if (typeof value === "string") {
+    const normalized = value.toUpperCase();
+    if ((EFFORT_TIERS as readonly string[]).includes(normalized)) {
+      return normalized as AlgorithmEffortTier;
+    }
+  }
+  return "E1";
+}
+
+function coercePhase(value: unknown): AlgorithmPhase {
+  if (typeof value === "string" && (PHASES as readonly string[]).includes(value)) {
+    return value as AlgorithmPhase;
+  }
+  return "observe";
+}
+
+function parseSections(body: string): readonly IsaSection[] {
+  const sections: IsaSection[] = [];
+  const lines = body.split("\n");
+  let currentName: string | null = null;
+  let currentContent: string[] = [];
+
+  for (const line of lines) {
+    const match = /^## (.+)$/.exec(line);
+    if (match) {
+      if (currentName !== null) {
+        sections.push({ name: currentName, content: stripBlock(currentContent) });
+      }
+      currentName = match[1].trim();
+      currentContent = [];
+    } else if (currentName !== null) {
+      currentContent.push(line);
+    }
+  }
+  if (currentName !== null) {
+    sections.push({ name: currentName, content: stripBlock(currentContent) });
+  }
+  return sections;
+}
+
+function stripBlock(lines: string[]): string {
+  while (lines.length > 0 && lines[0].trim().length === 0) lines.shift();
+  while (lines.length > 0 && lines[lines.length - 1].trim().length === 0) lines.pop();
+  return lines.join("\n");
+}
+
+function slugFromPath(path: string): string {
+  const filename = path.split("/").at(-1) ?? "isa";
+  return filename.replace(/\.md$/, "");
+}

--- a/src/isa-parse.ts
+++ b/src/isa-parse.ts
@@ -64,14 +64,23 @@ export function parseIsa(markdown: string, sourcePath?: string): IdealStateArtif
   return isa;
 }
 
+/**
+ * If `isa` is the exact identity returned by `parseIsa`, return the raw input
+ * verbatim — no structural mutation occurred (the helpers in `isa-accessors`
+ * that mutate sections — setSection, updateCriterion, etc. — return a NEW
+ * object identity via spread, so the raw cache is only hit for true round-trip
+ * read-then-serialize calls).
+ *
+ * Otherwise (new identity from a spread or hand-constructed), render fresh
+ * with derived frontmatter recomputed.
+ */
 export function serializeIsa(isa: IdealStateArtifact): string {
   const previous = RAW_INPUT.get(isa);
-  const frontmatter = withRecomputedDerived(isa);
-  const rendered = renderIsa({ ...isa, frontmatter });
-  if (previous !== undefined && previous === rendered) {
+  if (previous !== undefined) {
     return previous;
   }
-  return rendered;
+  const frontmatter = withRecomputedDerived(isa);
+  return renderIsa({ ...isa, frontmatter });
 }
 
 function renderIsa(isa: IdealStateArtifact): string {

--- a/src/isa-parse.ts
+++ b/src/isa-parse.ts
@@ -115,16 +115,21 @@ function splitFrontmatter(markdown: string): FrontmatterSplit {
   if (!markdown.startsWith("---\n")) {
     return { frontmatterRaw: "", body: markdown };
   }
-  const end = markdown.indexOf("\n---", 4);
-  if (end < 0) {
-    return { frontmatterRaw: "", body: markdown };
+  // Scan line by line for a literal "---" closing delimiter line; "---foo"
+  // or "------" must NOT match.
+  let cursor = 4;
+  while (cursor < markdown.length) {
+    const lineEnd = markdown.indexOf("\n", cursor);
+    const line = lineEnd === -1 ? markdown.slice(cursor) : markdown.slice(cursor, lineEnd);
+    if (line === "---") {
+      const frontmatterRaw = markdown.slice(4, cursor === 4 ? 4 : cursor - 1);
+      const bodyStart = lineEnd === -1 ? markdown.length : lineEnd + 1;
+      return { frontmatterRaw, body: markdown.slice(bodyStart) };
+    }
+    if (lineEnd === -1) break;
+    cursor = lineEnd + 1;
   }
-  const frontmatterRaw = markdown.slice(4, end);
-  let body = markdown.slice(end + 4);
-  if (body.startsWith("\n")) {
-    body = body.slice(1);
-  }
-  return { frontmatterRaw, body };
+  return { frontmatterRaw: "", body: markdown };
 }
 
 function parseFrontmatter(raw: string): IsaFrontmatter {
@@ -214,22 +219,32 @@ function renderYamlScalar(value: unknown): string {
   return JSON.stringify(value);
 }
 
+const DANGEROUS_YAML_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
+function isSafeYamlKey(key: string): boolean {
+  return !DANGEROUS_YAML_KEYS.has(key);
+}
+
 function parseYamlObject(raw: string): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
+  const result = Object.create(null) as Record<string, unknown>;
   let currentBlock: Record<string, unknown> | null = null;
 
   for (const rawLine of raw.split("\n")) {
     if (rawLine.trim().length === 0) continue;
     if (rawLine.startsWith("  ") && currentBlock !== null) {
       const match = /^\s+([^:\s][^:]*?)\s*:\s*(.*)$/.exec(rawLine);
-      if (match) currentBlock[match[1]] = parseYamlScalar(match[2]);
+      if (match && isSafeYamlKey(match[1])) currentBlock[match[1]] = parseYamlScalar(match[2]);
       continue;
     }
     const match = /^([^:\s][^:]*?)\s*:\s*(.*)$/.exec(rawLine);
     if (!match) continue;
     const [, key, valueRaw] = match;
+    if (!isSafeYamlKey(key)) {
+      currentBlock = null;
+      continue;
+    }
     if (valueRaw === "") {
-      currentBlock = {};
+      currentBlock = Object.create(null) as Record<string, unknown>;
       result[key] = currentBlock;
       continue;
     }

--- a/src/isa-parse.ts
+++ b/src/isa-parse.ts
@@ -197,30 +197,26 @@ function renderYamlScalar(value: unknown): string {
 
 function parseYamlObject(raw: string): Record<string, unknown> {
   const result: Record<string, unknown> = {};
-  let currentBlockKey: string | null = null;
   let currentBlock: Record<string, unknown> | null = null;
 
   for (const rawLine of raw.split("\n")) {
     if (rawLine.trim().length === 0) continue;
     if (rawLine.startsWith("  ") && currentBlock !== null) {
-      const match = /^\s+([A-Za-z0-9_]+)\s*:\s*(.*)$/.exec(rawLine);
+      const match = /^\s+([^:\s][^:]*?)\s*:\s*(.*)$/.exec(rawLine);
       if (match) currentBlock[match[1]] = parseYamlScalar(match[2]);
       continue;
     }
-    const match = /^([A-Za-z0-9_]+)\s*:\s*(.*)$/.exec(rawLine);
+    const match = /^([^:\s][^:]*?)\s*:\s*(.*)$/.exec(rawLine);
     if (!match) continue;
     const [, key, valueRaw] = match;
     if (valueRaw === "") {
-      currentBlockKey = key;
       currentBlock = {};
       result[key] = currentBlock;
       continue;
     }
-    currentBlockKey = null;
     currentBlock = null;
     result[key] = parseYamlScalar(valueRaw);
   }
-  void currentBlockKey;
   return result;
 }
 

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -4,6 +4,8 @@ import { dirname, join, resolve } from "node:path";
 import { listAlgorithmRunSummaries, listAlgorithmRuns } from "./algorithm-store";
 import { appendSomaMemoryEvent } from "./memory";
 import { loadSomaHome } from "./soma-home";
+import { getCriteria, getGoal } from "./isa-accessors";
+import { getRunPhase } from "./algorithm-lifecycle";
 import type {
   AlgorithmRun,
   AlgorithmRunSummary,
@@ -138,11 +140,11 @@ function completedLearningContent(run: AlgorithmRun, timestamp: string): string 
     "",
     `Captured: ${timestamp}`,
     `Run: ${run.id}`,
-    `Goal: ${run.isa.goal}`,
+    `Goal: ${getGoal(run.isa) ?? ""}`,
     `Effort: ${run.effort}`,
     "",
     "## Criteria",
-    ...run.isa.criteria.map((criterion) => `- [${criterion.status === "passed" ? "x" : " "}] ${criterion.id}: ${criterion.text}`),
+    ...getCriteria(run.isa).map((criterion) => `- [${criterion.status === "passed" ? "x" : " "}] ${criterion.id}: ${criterion.text}`),
     "",
     "## Verification",
     ...(run.verification.length > 0 ? run.verification.map((entry) => `- ${entry.timestamp} ${entry.text}`) : ["No verification entries recorded."]),
@@ -159,7 +161,7 @@ export async function captureCompletedAlgorithmLearnings(options: SomaLifecycleO
   const written: string[] = [];
 
   for (const { run } of runs) {
-    if (run.phase !== "complete") {
+    if (getRunPhase(run) !== "complete") {
       continue;
     }
 

--- a/src/memory-promotion.ts
+++ b/src/memory-promotion.ts
@@ -3,6 +3,8 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { readAlgorithmRunById } from "./algorithm-store";
 import { appendSomaMemoryEvent } from "./memory";
+import { getCriteria, getGoal } from "./isa-accessors";
+import { getRunPhase } from "./algorithm-lifecycle";
 import type { AlgorithmRun, SomaMemoryPromotionOptions, SomaMemoryPromotionResult } from "./types";
 
 const PROMOTION_STORE_DIRS = {
@@ -33,7 +35,7 @@ function slugify(value: string): string {
 }
 
 function checkedCriteria(run: AlgorithmRun): string[] {
-  return run.isa.criteria.map((criterion) => {
+  return getCriteria(run.isa).map((criterion) => {
     const mark = criterion.status === "passed" ? "x" : criterion.status === "dropped" ? "-" : " ";
     const verification = criterion.verification ? ` Evidence: ${criterion.verification}` : "";
     return `- [${mark}] ${criterion.id}: ${criterion.text}${verification}`;
@@ -49,11 +51,11 @@ function promotionLesson(run: AlgorithmRun, explicitLesson?: string): string {
   const decision = run.decisions.at(-1)?.text;
   if (decision) return decision;
 
-  return run.isa.goal;
+  return getGoal(run.isa) ?? "";
 }
 
 function hasPromotionVerification(run: AlgorithmRun): boolean {
-  return run.verification.length > 0 || run.isa.criteria.some((criterion) => criterion.status === "passed");
+  return run.verification.length > 0 || getCriteria(run.isa).some((criterion) => criterion.status === "passed");
 }
 
 function renderPromotionContent(input: {
@@ -72,7 +74,7 @@ function renderPromotionContent(input: {
     `Store: ${input.store}`,
     `Source run: ${input.run.id}`,
     `Source path: ${input.runPath}`,
-    `Phase: ${input.run.phase}`,
+    `Phase: ${getRunPhase(input.run)}`,
     `Effort: ${input.run.effort}`,
     "",
     "## Durable Lesson",
@@ -85,7 +87,7 @@ function renderPromotionContent(input: {
     "",
     "## Source Goal",
     "",
-    input.run.isa.goal,
+    getGoal(input.run.isa) ?? "",
     "",
     "## Source Criteria",
     "",

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,20 +27,57 @@ export interface IdealStateCriterion {
   verification?: string;
 }
 
-export interface IdealStateArtifact {
-  slug: string;
-  phase: "observe" | "think" | "plan" | "build" | "execute" | "verify" | "learn" | "complete";
-  goal: string;
-  criteria: IdealStateCriterion[];
-}
-
-export type AlgorithmPhase = IdealStateArtifact["phase"];
+export type AlgorithmPhase = "observe" | "think" | "plan" | "build" | "execute" | "verify" | "learn" | "complete" | "abandoned";
 
 export type AlgorithmEffortTier = "E1" | "E2" | "E3" | "E4" | "E5";
 
 export type AlgorithmMode = "minimal" | "native" | "algorithm";
 
 export type AlgorithmEffortSource = "explicit" | "classifier" | "context-override" | "auto" | "fail-safe";
+
+export interface AuthoredFrontmatter {
+  task: string;
+  effort: AlgorithmEffortTier;
+  mode?: AlgorithmMode;
+  iteration?: number;
+  started?: string;
+  algorithm_config?: Record<string, unknown>;
+  custom?: Record<string, unknown>;
+}
+
+export interface DerivedFrontmatter {
+  phase: AlgorithmPhase;
+  progress: string;
+  verified: boolean;
+  updated: string;
+}
+
+export interface IsaFrontmatter extends AuthoredFrontmatter, DerivedFrontmatter {}
+
+export interface IsaSection {
+  name: string;
+  content: string;
+}
+
+/**
+ * Mutable working document — NOT a static artifact despite the name.
+ * Accumulates Decisions, Changelog, and Verification entries over its lifetime.
+ * The name is historical (predates the section-based model).
+ *
+ * Identity: `slug`. Source of truth when file-backed: `~/.soma/isa/<slug>.md`.
+ * In-memory ephemeral ISAs (Algorithm runs that never touch disk) leave
+ * `sourcePath` undefined.
+ *
+ * Storage model is section-agnostic at the type level — derived accessors
+ * (getGoal, getCriteria, etc.) and the SECTION_NAME_MAP are what give the
+ * twelve-section schema its meaning.
+ */
+export interface IdealStateArtifact {
+  slug: string;
+  frontmatter: IsaFrontmatter;
+  sections: readonly IsaSection[];
+  sourcePath?: string;
+}
 
 export interface AlgorithmPromptClassification {
   mode: AlgorithmMode;
@@ -64,6 +101,7 @@ export interface AlgorithmLogEntry {
 }
 
 export interface AlgorithmRun {
+  schemaVersion: 2;
   id: string;
   createdAt: string;
   updatedAt: string;
@@ -75,7 +113,6 @@ export interface AlgorithmRun {
   mode: AlgorithmMode;
   classificationReason: string;
   currentState: string;
-  phase: AlgorithmPhase;
   isa: IdealStateArtifact;
   antiCriteria: IdealStateCriterion[];
   capabilities: string[];

--- a/test/algorithm-compat.test.ts
+++ b/test/algorithm-compat.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test";
+import { loadAlgorithmRun, getCriteria, getGoal, getRunPhase } from "../src/index";
+
+const LEGACY_V1_RUN = {
+  id: "legacy-run-1",
+  createdAt: "2026-04-01T10:00:00.000Z",
+  updatedAt: "2026-04-02T10:00:00.000Z",
+  prompt: "Pre-#41 run",
+  intent: "Test legacy migration",
+  effort: "E2",
+  effortSource: "auto",
+  mode: "algorithm",
+  classificationReason: "Pre-#41 fixture",
+  currentState: "ISA was embedded JSON",
+  phase: "verify",
+  isa: {
+    slug: "legacy-run-1",
+    phase: "verify",
+    goal: "Migrate cleanly",
+    criteria: [
+      { id: "C1", text: "Legacy parses", status: "passed", verification: "test" },
+      { id: "C2", text: "Frontmatter populated", status: "open" },
+    ],
+  },
+  antiCriteria: [],
+  capabilities: ["test"],
+  planSteps: [],
+  decisions: [{ timestamp: "2026-04-01T10:00:00.000Z", phase: "observe", text: "Intent: Test legacy migration" }],
+  changelog: [],
+  verification: [],
+  learning: [],
+};
+
+test("loadAlgorithmRun migrates legacy v1 JSON to unified schema 2", () => {
+  const run = loadAlgorithmRun(LEGACY_V1_RUN);
+  expect(run.schemaVersion).toBe(2);
+  expect(run.id).toBe("legacy-run-1");
+  expect(run.isa.frontmatter.phase).toBe("verify");
+  expect(run.isa.frontmatter.task).toBe("Test legacy migration");
+  expect(run.isa.sections.find((s) => s.name === "Goal")?.content).toBe("Migrate cleanly");
+});
+
+test("loadAlgorithmRun preserves criteria status from legacy JSON", () => {
+  const run = loadAlgorithmRun(LEGACY_V1_RUN);
+  const criteria = getCriteria(run.isa);
+  expect(criteria).toHaveLength(2);
+  expect(criteria[0]).toMatchObject({ id: "C1", status: "passed", verification: "test" });
+  expect(criteria[1]).toMatchObject({ id: "C2", status: "open" });
+});
+
+test("loadAlgorithmRun recomputes progress and verified from legacy criteria", () => {
+  const run = loadAlgorithmRun(LEGACY_V1_RUN);
+  expect(run.isa.frontmatter.progress).toBe("1/2");
+  expect(run.isa.frontmatter.verified).toBe(false);
+});
+
+test("loadAlgorithmRun passes through schema 2 runs unchanged", () => {
+  const v2Run = {
+    schemaVersion: 2,
+    id: "modern-run",
+    createdAt: "2026-05-16T10:00:00.000Z",
+    updatedAt: "2026-05-16T10:00:00.000Z",
+    prompt: "Modern run",
+    intent: "Modern intent",
+    effort: "E1",
+    effortSource: "auto",
+    mode: "algorithm",
+    classificationReason: "Modern",
+    currentState: "ISA is unified",
+    isa: {
+      slug: "modern-run",
+      frontmatter: {
+        task: "Modern intent",
+        effort: "E1",
+        mode: "algorithm",
+        phase: "observe",
+        progress: "0/1",
+        verified: false,
+        updated: "2026-05-16T10:00:00.000Z",
+      },
+      sections: [
+        { name: "Goal", content: "Already unified" },
+        { name: "Criteria", content: "- [ ] C1: Modern criterion" },
+      ],
+    },
+    antiCriteria: [],
+    capabilities: [],
+    planSteps: [],
+    decisions: [],
+    changelog: [],
+    verification: [],
+    learning: [],
+  };
+  const run = loadAlgorithmRun(v2Run);
+  expect(run.schemaVersion).toBe(2);
+  expect(getGoal(run.isa)).toBe("Already unified");
+  expect(getRunPhase(run)).toBe("observe");
+});
+
+test("AlgorithmRun has no top-level phase field (AC-11)", () => {
+  const run = loadAlgorithmRun(LEGACY_V1_RUN);
+  // The migrated run object should NOT carry a top-level phase field; phase is in frontmatter only.
+  expect((run as unknown as { phase?: unknown }).phase).toBeUndefined();
+  // The accessor is the single source of truth.
+  expect(getRunPhase(run)).toBe("verify");
+});
+
+test("loadAlgorithmRun rejects non-object input", () => {
+  expect(() => loadAlgorithmRun(null)).toThrow();
+  expect(() => loadAlgorithmRun("not-an-object")).toThrow();
+});

--- a/test/algorithm-compat.test.ts
+++ b/test/algorithm-compat.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { loadAlgorithmRun, getCriteria, getGoal, getRunPhase } from "../src/index";
+import { getCriteria, getGoal, getRunPhase } from "../src/index";
+import { loadAlgorithmRun } from "../src/algorithm-store";
 
 const LEGACY_V1_RUN = {
   id: "legacy-run-1",

--- a/test/algorithm.test.ts
+++ b/test/algorithm.test.ts
@@ -153,6 +153,22 @@ test("enforces Algorithm phase gates", () => {
   expect(getRunPhase(run)).toBe("complete");
 });
 
+test("abandoned runs cannot advance", async () => {
+  const { abandonAlgorithmRun } = await import("../src/index");
+  const run = createAlgorithmRun({
+    id: "abandoned-test",
+    timestamp: "2026-05-16T10:00:00.000Z",
+    prompt: "Test abandonment",
+    intent: "Verify terminal state",
+    currentState: "Run starts fresh",
+    goal: "Run cannot advance after abandonment",
+    criteria: [{ id: "C1", text: "Abandonment is terminal" }],
+  });
+  const abandoned = abandonAlgorithmRun(run, "intentional test abort", "2026-05-16T10:01:00.000Z");
+  expect(getRunPhase(abandoned)).toBe("abandoned");
+  expect(() => advanceAlgorithmRun(abandoned)).toThrow("abandoned");
+});
+
 test("persists Algorithm runs under Soma WORK memory", async () => {
   await withTempHome(async (homeDir) => {
     const run = createAlgorithmRun({

--- a/test/algorithm.test.ts
+++ b/test/algorithm.test.ts
@@ -7,6 +7,8 @@ import {
   advanceAlgorithmRun,
   classifyAlgorithmPrompt,
   createAlgorithmRun,
+  getCriteria,
+  getRunPhase,
   setAlgorithmPlan,
   updateAlgorithmPlanStep,
   verifyAlgorithmCriterion,
@@ -34,12 +36,12 @@ test("creates deterministic Algorithm runs around ISA criteria", () => {
     criteria: [{ id: "C1", text: "Ledger contains the new entry." }],
   });
 
-  expect(run.phase).toBe("observe");
+  expect(getRunPhase(run)).toBe("observe");
   expect(run.effort).toBe("E1");
   expect(run.effortSource).toBe("auto");
   expect(run.classificationReason).toContain("E1");
-  expect(run.isa.phase).toBe("observe");
-  expect(run.isa.criteria[0]?.status).toBe("open");
+  expect(run.isa.frontmatter.phase).toBe("observe");
+  expect(getCriteria(run.isa)[0]?.status).toBe("open");
   expect(run.decisions[0]?.text).toContain("Bring ledger state current");
 });
 
@@ -110,12 +112,12 @@ test("enforces Algorithm phase gates", () => {
   });
 
   run = advanceAlgorithmRun(run, "2026-05-14T10:01:00.000Z");
-  expect(run.phase).toBe("think");
+  expect(getRunPhase(run)).toBe("think");
 
   expect(() => advanceAlgorithmRun(run)).toThrow("selected capabilities");
   run = addAlgorithmCapabilities(run, ["sequential-analysis"], "2026-05-14T10:02:00.000Z");
   run = advanceAlgorithmRun(run, "2026-05-14T10:03:00.000Z");
-  expect(run.phase).toBe("plan");
+  expect(getRunPhase(run)).toBe("plan");
 
   expect(() => advanceAlgorithmRun(run)).toThrow("criterion-mapped plan");
   run = setAlgorithmPlan(
@@ -124,31 +126,31 @@ test("enforces Algorithm phase gates", () => {
     "2026-05-14T10:04:00.000Z",
   );
   run = advanceAlgorithmRun(run, "2026-05-14T10:05:00.000Z");
-  expect(run.phase).toBe("build");
+  expect(getRunPhase(run)).toBe("build");
 
   run = {
     ...run,
     changelog: [{ timestamp: "2026-05-14T10:06:00.000Z", phase: "build", text: "Added harness." }],
   };
   run = advanceAlgorithmRun(run, "2026-05-14T10:07:00.000Z");
-  expect(run.phase).toBe("execute");
+  expect(getRunPhase(run)).toBe("execute");
 
   expect(() => advanceAlgorithmRun(run)).toThrow("plan step");
   run = updateAlgorithmPlanStep(run, "P1", "done", "Harness tests pass.", "2026-05-14T10:08:00.000Z");
   run = advanceAlgorithmRun(run, "2026-05-14T10:09:00.000Z");
-  expect(run.phase).toBe("verify");
+  expect(getRunPhase(run)).toBe("verify");
 
   expect(() => advanceAlgorithmRun(run)).toThrow("criterion");
   run = verifyAlgorithmCriterion(run, "C1", "passed", "Test asserted gate failures and success path.", "2026-05-14T10:10:00.000Z");
   run = advanceAlgorithmRun(run, "2026-05-14T10:11:00.000Z");
-  expect(run.phase).toBe("learn");
+  expect(getRunPhase(run)).toBe("learn");
 
   run = {
     ...run,
     learning: [{ timestamp: "2026-05-14T10:12:00.000Z", phase: "learn", text: "Harness gates doctrine." }],
   };
   run = advanceAlgorithmRun(run, "2026-05-14T10:13:00.000Z");
-  expect(run.phase).toBe("complete");
+  expect(getRunPhase(run)).toBe("complete");
 });
 
 test("persists Algorithm runs under Soma WORK memory", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -131,7 +131,9 @@ test("cli creates persisted Algorithm runs", async () => {
       ?.slice("path: ".length);
 
     expect(path?.startsWith(join(homeDir, ".soma/memory/WORK/algorithm-runs"))).toBe(true);
-    await expect(readFile(path ?? "", "utf8")).resolves.toContain('"goal": "Harness exists."');
+    const persisted = await readFile(path ?? "", "utf8");
+    expect(persisted).toContain('"schemaVersion": 2');
+    expect(persisted).toContain('"content": "Harness exists."');
   });
 });
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,4 +1,5 @@
 import type { SomaContextInput } from "../src/index";
+import { SECTION_NAME_MAP, renderCriteriaMarkdown } from "../src/index";
 
 export const portableContextInput: SomaContextInput = {
   profile: {
@@ -41,14 +42,27 @@ export const portableContextInput: SomaContextInput = {
   },
   activeIsa: {
     slug: "portable-context",
-    phase: "build",
-    goal: "Build substrate context projections from one Soma input.",
-    criteria: [
+    frontmatter: {
+      task: "Build substrate context projections from one Soma input.",
+      effort: "E3",
+      mode: "algorithm",
+      phase: "build",
+      progress: "0/1",
+      verified: false,
+      updated: "2026-05-14T10:00:00.000Z",
+    },
+    sections: [
+      { name: SECTION_NAME_MAP.goal, content: "Build substrate context projections from one Soma input." },
       {
-        id: "ISC-PORTABLE-1",
-        text: "Adapters receive assistant identity, telos, memory, skills, and ISA.",
-        status: "open",
-        verification: "bun test",
+        name: SECTION_NAME_MAP.criteria,
+        content: renderCriteriaMarkdown([
+          {
+            id: "ISC-PORTABLE-1",
+            text: "Adapters receive assistant identity, telos, memory, skills, and ISA.",
+            status: "open",
+            verification: "bun test",
+          },
+        ]),
       },
     ],
   },

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,5 +1,5 @@
 import type { SomaContextInput } from "../src/index";
-import { SECTION_NAME_MAP, renderCriteriaMarkdown } from "../src/index";
+import { SECTION_NAME_MAP, renderCriteriaMarkdown } from "../src/isa-accessors";
 
 export const portableContextInput: SomaContextInput = {
   profile: {

--- a/test/isa-accessors.test.ts
+++ b/test/isa-accessors.test.ts
@@ -123,6 +123,13 @@ test("appendIsaDecision / Changelog / Verification round-trip", () => {
   expect(getSection(withVerify, SECTION_NAME_MAP.decisions)?.content).toContain("did the thing");
 });
 
+test("renderLogEntries rejects newlines to prevent log-entry injection", async () => {
+  const { renderLogEntries: renderLogs } = await import("../src/isa-accessors");
+  expect(() => renderLogs([
+    { timestamp: "2026-05-16T10:00:00.000Z", phase: "execute", text: "real entry\n- 2026-01-01T00:00:00.000Z [verify] forged" },
+  ])).toThrow("must not contain newlines");
+});
+
 test("renderCriteriaMarkdown rejects newlines in id, text, and verification", () => {
   expect(() => renderCriteriaMarkdown([
     { id: "C1\n- [x] C2: forged", text: "bad", status: "open" },

--- a/test/isa-accessors.test.ts
+++ b/test/isa-accessors.test.ts
@@ -123,6 +123,18 @@ test("appendIsaDecision / Changelog / Verification round-trip", () => {
   expect(getSection(withVerify, SECTION_NAME_MAP.decisions)?.content).toContain("did the thing");
 });
 
+test("renderCriteriaMarkdown rejects newlines in id, text, and verification", () => {
+  expect(() => renderCriteriaMarkdown([
+    { id: "C1\n- [x] C2: forged", text: "bad", status: "open" },
+  ])).toThrow("must not contain newlines");
+  expect(() => renderCriteriaMarkdown([
+    { id: "C1", text: "first line\nsecond line", status: "open" },
+  ])).toThrow("must not contain newlines");
+  expect(() => renderCriteriaMarkdown([
+    { id: "C1", text: "ok", status: "passed", verification: "evidence\n- [x] FORGED: injected" },
+  ])).toThrow("must not contain newlines");
+});
+
 test("criterion text containing pipe-and-evidence-like content survives round-trip", () => {
   // Regression: previous inline `| Evidence: ...` delimiter could swallow
   // ordinary criterion text containing those characters as verification.

--- a/test/isa-accessors.test.ts
+++ b/test/isa-accessors.test.ts
@@ -17,7 +17,7 @@ import {
   renderCriteriaMarkdown,
   setSection,
   updateCriterion,
-} from "../src/index";
+} from "../src/isa-accessors";
 
 function buildIsa(): IdealStateArtifact {
   return {

--- a/test/isa-accessors.test.ts
+++ b/test/isa-accessors.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import type { IdealStateArtifact } from "../src/index";
+import type { IdealStateArtifact, IdealStateCriterion } from "../src/index";
 import {
   SECTION_NAME_MAP,
   appendCriterion,
@@ -12,6 +12,7 @@ import {
   getGoal,
   getSection,
   getVerification,
+  parseCriteriaMarkdown,
   recomputeProgress,
   recomputeVerified,
   renderCriteriaMarkdown,
@@ -120,6 +121,21 @@ test("appendIsaDecision / Changelog / Verification round-trip", () => {
   expect(getChangelog(withVerify)).toEqual([entry]);
   expect(getVerification(withVerify)).toEqual([entry]);
   expect(getSection(withVerify, SECTION_NAME_MAP.decisions)?.content).toContain("did the thing");
+});
+
+test("criterion text containing pipe-and-evidence-like content survives round-trip", () => {
+  // Regression: previous inline `| Evidence: ...` delimiter could swallow
+  // ordinary criterion text containing those characters as verification.
+  const original: IdealStateCriterion[] = [
+    { id: "C1", text: "mention | Evidence: literally", status: "open" },
+    { id: "C2", text: "regular criterion", status: "passed", verification: "actual evidence" },
+  ];
+  const md = renderCriteriaMarkdown(original);
+  const parsed = parseCriteriaMarkdown(md);
+  expect(parsed).toHaveLength(2);
+  expect(parsed[0]).toMatchObject({ id: "C1", text: "mention | Evidence: literally", status: "open" });
+  expect(parsed[0]?.verification).toBeUndefined();
+  expect(parsed[1]).toMatchObject({ id: "C2", text: "regular criterion", status: "passed", verification: "actual evidence" });
 });
 
 test("derived accessors are pure functions (no memoization side effects)", () => {

--- a/test/isa-accessors.test.ts
+++ b/test/isa-accessors.test.ts
@@ -1,0 +1,131 @@
+import { expect, test } from "bun:test";
+import type { IdealStateArtifact } from "../src/index";
+import {
+  SECTION_NAME_MAP,
+  appendCriterion,
+  appendIsaChangelog,
+  appendIsaDecision,
+  appendIsaVerification,
+  getChangelog,
+  getCriteria,
+  getDecisions,
+  getGoal,
+  getSection,
+  getVerification,
+  recomputeProgress,
+  recomputeVerified,
+  renderCriteriaMarkdown,
+  setSection,
+  updateCriterion,
+} from "../src/index";
+
+function buildIsa(): IdealStateArtifact {
+  return {
+    slug: "demo",
+    frontmatter: {
+      task: "demo task",
+      effort: "E2",
+      mode: "algorithm",
+      phase: "observe",
+      progress: "0/2",
+      verified: false,
+      updated: "2026-05-16T10:00:00.000Z",
+    },
+    sections: [
+      { name: SECTION_NAME_MAP.goal, content: "Demo derived accessors." },
+      {
+        name: SECTION_NAME_MAP.criteria,
+        content: renderCriteriaMarkdown([
+          { id: "C1", text: "First", status: "open" },
+          { id: "C2", text: "Second", status: "open" },
+        ]),
+      },
+    ],
+  };
+}
+
+test("getGoal returns trimmed goal section content", () => {
+  const isa = buildIsa();
+  expect(getGoal(isa)).toBe("Demo derived accessors.");
+});
+
+test("getGoal returns null when section is missing", () => {
+  const isa: IdealStateArtifact = { ...buildIsa(), sections: [] };
+  expect(getGoal(isa)).toBeNull();
+});
+
+test("getCriteria parses checkbox markdown back into typed criteria", () => {
+  const isa = buildIsa();
+  const criteria = getCriteria(isa);
+  expect(criteria).toHaveLength(2);
+  expect(criteria[0]).toMatchObject({ id: "C1", text: "First", status: "open" });
+  expect(criteria[1]).toMatchObject({ id: "C2", text: "Second", status: "open" });
+});
+
+test("updateCriterion rewrites the Criteria section content", () => {
+  const isa = buildIsa();
+  const next = updateCriterion(isa, "C1", "passed", "Test evidence");
+  const criteria = getCriteria(next);
+  expect(criteria[0]).toMatchObject({ id: "C1", status: "passed", verification: "Test evidence" });
+  expect(criteria[1]?.status).toBe("open");
+});
+
+test("updateCriterion throws for unknown criterion id", () => {
+  const isa = buildIsa();
+  expect(() => updateCriterion(isa, "CX", "passed")).toThrow("Algorithm criterion not found: CX");
+});
+
+test("appendCriterion adds a new criterion at the end", () => {
+  const isa = buildIsa();
+  const next = appendCriterion(isa, { id: "C3", text: "Third", status: "open" });
+  expect(getCriteria(next)).toHaveLength(3);
+});
+
+test("appendCriterion refuses duplicate id", () => {
+  const isa = buildIsa();
+  expect(() => appendCriterion(isa, { id: "C1", text: "dup", status: "open" })).toThrow("already exists");
+});
+
+test("recomputeProgress reflects passed and dropped criteria", () => {
+  const isa = updateCriterion(buildIsa(), "C1", "passed", "ok");
+  expect(recomputeProgress(isa)).toBe("1/2");
+  const isaAll = updateCriterion(isa, "C2", "dropped");
+  expect(recomputeProgress(isaAll)).toBe("2/2");
+});
+
+test("recomputeVerified true only when every criterion is passed or dropped", () => {
+  const isa = buildIsa();
+  expect(recomputeVerified(isa)).toBe(false);
+  const partial = updateCriterion(isa, "C1", "passed", "ok");
+  expect(recomputeVerified(partial)).toBe(false);
+  const both = updateCriterion(partial, "C2", "passed", "ok");
+  expect(recomputeVerified(both)).toBe(true);
+});
+
+test("setSection inserts a missing canonical section at the right index", () => {
+  const isa: IdealStateArtifact = {
+    ...buildIsa(),
+    sections: [{ name: SECTION_NAME_MAP.goal, content: "g" }],
+  };
+  const next = setSection(isa, SECTION_NAME_MAP.problem, "Problem statement");
+  expect(next.sections.map((s) => s.name)).toEqual([SECTION_NAME_MAP.problem, SECTION_NAME_MAP.goal]);
+});
+
+test("appendIsaDecision / Changelog / Verification round-trip", () => {
+  const entry = { timestamp: "2026-05-16T10:00:00.000Z", phase: "execute" as const, text: "did the thing" };
+  const withDecision = appendIsaDecision(buildIsa(), entry);
+  const withChangelog = appendIsaChangelog(withDecision, entry);
+  const withVerify = appendIsaVerification(withChangelog, entry);
+  expect(getDecisions(withVerify)).toEqual([entry]);
+  expect(getChangelog(withVerify)).toEqual([entry]);
+  expect(getVerification(withVerify)).toEqual([entry]);
+  expect(getSection(withVerify, SECTION_NAME_MAP.decisions)?.content).toContain("did the thing");
+});
+
+test("derived accessors are pure functions (no memoization side effects)", () => {
+  const isa = buildIsa();
+  const first = getCriteria(isa);
+  const second = getCriteria(isa);
+  expect(first).toEqual(second);
+  expect(first).not.toBe(second); // each call returns a fresh array
+});

--- a/test/isa-parse.test.ts
+++ b/test/isa-parse.test.ts
@@ -58,6 +58,33 @@ test("serializeIsa reuses raw input when no structural mutation occurred", () =>
   expect(first).toBe(second);
 });
 
+test("serializeIsa preserves raw input verbatim even when renderer would normalize", () => {
+  // Different key order, no derived defaults, comment-like whitespace — renderer
+  // would reorder/normalize, but the raw round-trip must return the exact input.
+  const oddOrderInput = `---
+phase: build
+task: Odd order
+effort: E3
+custom_key: value
+---
+
+## Goal
+
+Something
+`;
+  const isa = parseIsa(oddOrderInput);
+  expect(serializeIsa(isa)).toBe(oddOrderInput);
+});
+
+test("serializeIsa re-renders after structural mutation via accessor", async () => {
+  const { setSection: setSectionFn, SECTION_NAME_MAP: SNM } = await import("../src/isa-accessors");
+  const isa = parseIsa(SAMPLE);
+  const mutated = setSectionFn(isa, SNM.goal, "Different goal text");
+  const serialized = serializeIsa(mutated);
+  expect(serialized).toContain("Different goal text");
+  expect(serialized).not.toBe(SAMPLE);
+});
+
 test("serializeIsa recomputes derived frontmatter fields from sections", () => {
   const isa = parseIsa(SAMPLE);
   const serialized = serializeIsa(isa);

--- a/test/isa-parse.test.ts
+++ b/test/isa-parse.test.ts
@@ -74,6 +74,40 @@ test("authored frontmatter fields survive round-trip verbatim", () => {
   expect(reparsed.frontmatter.custom).toMatchObject({ project: "soma" });
 });
 
+test("hyphenated custom YAML keys round-trip through parse and serialize", () => {
+  const markdown = `---
+task: Demo
+effort: E1
+phase: observe
+project-id: soma
+foo_bar: baz
+nested-thing: hello
+---
+
+## Goal
+
+Test broader YAML key support.
+
+## Criteria
+
+- [ ] C1: hyphenated key survives
+`;
+  const isa = parseIsa(markdown);
+  expect(isa.frontmatter.custom).toMatchObject({
+    "project-id": "soma",
+    foo_bar: "baz",
+    "nested-thing": "hello",
+  });
+  const serialized = serializeIsa(isa);
+  expect(serialized).toContain("project-id: soma");
+  expect(serialized).toContain("nested-thing: hello");
+  const reparsed = parseIsa(serialized);
+  expect(reparsed.frontmatter.custom).toMatchObject({
+    "project-id": "soma",
+    "nested-thing": "hello",
+  });
+});
+
 test("derived frontmatter fields are recomputed on serialize", () => {
   const isa = parseIsa(SAMPLE);
   const mutated = {

--- a/test/isa-parse.test.ts
+++ b/test/isa-parse.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { parseIsa, serializeIsa, SECTION_NAME_MAP } from "../src/index";
+import { parseIsa, serializeIsa } from "../src/index";
+import { SECTION_NAME_MAP } from "../src/isa-accessors";
 
 const SAMPLE = `---
 task: Build the Algorithm
@@ -106,6 +107,32 @@ Test broader YAML key support.
     "project-id": "soma",
     "nested-thing": "hello",
   });
+});
+
+test("nested custom YAML objects round-trip as objects, not JSON-stringified", () => {
+  const markdown = `---
+task: Demo
+effort: E1
+phase: observe
+metadata:
+  owner: jc
+  team: soma
+---
+
+## Goal
+
+Test nested custom YAML round-trip.
+
+## Criteria
+
+- [ ] C1: nested round-trips
+`;
+  const isa = parseIsa(markdown);
+  expect(isa.frontmatter.custom?.metadata).toEqual({ owner: "jc", team: "soma" });
+  const serialized = serializeIsa(isa);
+  expect(serialized).toContain("metadata:\n  owner: jc\n  team: soma");
+  const reparsed = parseIsa(serialized);
+  expect(reparsed.frontmatter.custom?.metadata).toEqual({ owner: "jc", team: "soma" });
 });
 
 test("derived frontmatter fields are recomputed on serialize", () => {

--- a/test/isa-parse.test.ts
+++ b/test/isa-parse.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test";
+import { parseIsa, serializeIsa, SECTION_NAME_MAP } from "../src/index";
+
+const SAMPLE = `---
+task: Build the Algorithm
+effort: E3
+phase: build
+progress: 1/2
+mode: algorithm
+started: 2026-05-16T10:00:00.000Z
+updated: 2026-05-16T10:05:00.000Z
+verified: false
+project: soma
+---
+
+## Goal
+
+Ship the unified ISA type.
+
+## Criteria
+
+- [x] C1: Type exported
+- [ ] C2: Tests pass
+`;
+
+test("parseIsa extracts frontmatter, sections, and slug from sourcePath", () => {
+  const isa = parseIsa(SAMPLE, "/tmp/foo/demo-slug.md");
+  expect(isa.slug).toBe("demo-slug");
+  expect(isa.frontmatter.task).toBe("Build the Algorithm");
+  expect(isa.frontmatter.effort).toBe("E3");
+  expect(isa.frontmatter.phase).toBe("build");
+  expect(isa.frontmatter.verified).toBe(false);
+  expect(isa.sourcePath).toBe("/tmp/foo/demo-slug.md");
+  expect(isa.sections).toHaveLength(2);
+  expect(isa.sections[0]?.name).toBe(SECTION_NAME_MAP.goal);
+});
+
+test("parseIsa buckets unknown YAML keys into frontmatter.custom", () => {
+  const isa = parseIsa(SAMPLE);
+  expect(isa.frontmatter.custom).toMatchObject({ project: "soma" });
+});
+
+test("serializeIsa round-trips parsed ISA via semantic equivalence", () => {
+  const isa = parseIsa(SAMPLE);
+  const serialized = serializeIsa(isa);
+  const reparsed = parseIsa(serialized);
+  expect(reparsed.frontmatter.task).toBe(isa.frontmatter.task);
+  expect(reparsed.frontmatter.phase).toBe(isa.frontmatter.phase);
+  expect(reparsed.frontmatter.custom).toEqual(isa.frontmatter.custom);
+  expect(reparsed.sections).toEqual(isa.sections);
+});
+
+test("serializeIsa reuses raw input when no structural mutation occurred", () => {
+  const isa = parseIsa(SAMPLE);
+  const first = serializeIsa(isa);
+  const second = serializeIsa(isa);
+  expect(first).toBe(second);
+});
+
+test("serializeIsa recomputes derived frontmatter fields from sections", () => {
+  const isa = parseIsa(SAMPLE);
+  const serialized = serializeIsa(isa);
+  // The frontmatter `progress` in SAMPLE says "1/2" — recomputed should match parsed criteria (1 passed of 2)
+  expect(serialized).toContain("progress: 1/2");
+  expect(serialized).toContain("verified: false");
+});
+
+test("authored frontmatter fields survive round-trip verbatim", () => {
+  const isa = parseIsa(SAMPLE);
+  const serialized = serializeIsa(isa);
+  const reparsed = parseIsa(serialized);
+  expect(reparsed.frontmatter.task).toBe("Build the Algorithm");
+  expect(reparsed.frontmatter.started).toBe("2026-05-16T10:00:00.000Z");
+  expect(reparsed.frontmatter.custom).toMatchObject({ project: "soma" });
+});
+
+test("derived frontmatter fields are recomputed on serialize", () => {
+  const isa = parseIsa(SAMPLE);
+  const mutated = {
+    ...isa,
+    sections: [
+      { name: SECTION_NAME_MAP.goal, content: "Different goal" },
+      { name: SECTION_NAME_MAP.criteria, content: "- [x] C1: done\n- [x] C2: done" },
+    ],
+  };
+  const serialized = serializeIsa(mutated);
+  expect(serialized).toContain("progress: 2/2");
+  expect(serialized).toContain("verified: true");
+});

--- a/test/isa-parse.test.ts
+++ b/test/isa-parse.test.ts
@@ -136,6 +136,45 @@ Test broader YAML key support.
   });
 });
 
+test("parser rejects __proto__ / prototype / constructor keys to prevent pollution", () => {
+  const markdown = `---
+task: pollution test
+effort: E1
+phase: observe
+__proto__:
+  polluted: true
+constructor: { polluted: true }
+prototype: yes
+---
+
+## Goal
+
+Test prototype safety.
+`;
+  const isa = parseIsa(markdown);
+  // Object.prototype must not be polluted
+  const probe = {};
+  expect((probe as Record<string, unknown>).polluted).toBeUndefined();
+  expect(isa.frontmatter.custom?.__proto__).toBeUndefined();
+});
+
+test("frontmatter delimiter requires a full --- line, not a prefix", () => {
+  const markdown = `---
+task: edge case
+effort: E1
+phase: observe
+---not-a-delimiter: still part of frontmatter? no, this is invalid yaml ignored
+---
+
+## Goal
+
+After real delimiter
+`;
+  const isa = parseIsa(markdown);
+  expect(isa.frontmatter.task).toBe("edge case");
+  expect(isa.sections[0]?.content).toContain("After real delimiter");
+});
+
 test("nested custom YAML objects round-trip as objects, not JSON-stringified", () => {
   const markdown = `---
 task: Demo

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -300,7 +300,7 @@ test("promotes an Algorithm run into durable Soma memory", async () => {
             { name: "Goal", content: "Consulting lesson becomes durable memory." },
             {
               name: "Criteria",
-              content: "- [x] C1: Lesson is promoted. | Evidence: Promotion evidence is present.",
+              content: "- [x] C1: Lesson is promoted.\n  Evidence: Promotion evidence is present.",
             },
           ],
         },
@@ -385,7 +385,7 @@ test("sanitizes Algorithm run ids in promotion filenames", async () => {
           },
           sections: [
             { name: "Goal", content: "Promotion filename is path-safe." },
-            { name: "Criteria", content: "- [x] C1: Filename is safe. | Evidence: Path is flat." },
+            { name: "Criteria", content: "- [x] C1: Filename is safe.\n  Evidence: Path is flat." },
           ],
         },
       },

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -287,14 +287,20 @@ test("promotes an Algorithm run into durable Soma memory", async () => {
         }),
         isa: {
           slug: "consulting-lesson",
-          phase: "complete",
-          goal: "Consulting lesson becomes durable memory.",
-          criteria: [
+          frontmatter: {
+            task: "Capture a reusable consulting insight.",
+            effort: "E1",
+            mode: "algorithm",
+            phase: "complete",
+            progress: "1/1",
+            verified: true,
+            updated: "2026-05-14T12:05:00.000Z",
+          },
+          sections: [
+            { name: "Goal", content: "Consulting lesson becomes durable memory." },
             {
-              id: "C1",
-              text: "Lesson is promoted.",
-              status: "passed",
-              verification: "Promotion evidence is present.",
+              name: "Criteria",
+              content: "- [x] C1: Lesson is promoted. | Evidence: Promotion evidence is present.",
             },
           ],
         },
@@ -368,9 +374,19 @@ test("sanitizes Algorithm run ids in promotion filenames", async () => {
         }),
         isa: {
           slug: "nested-run-id",
-          phase: "complete",
-          goal: "Promotion filename is path-safe.",
-          criteria: [{ id: "C1", text: "Filename is safe.", status: "passed", verification: "Path is flat." }],
+          frontmatter: {
+            task: "Keep promotion paths flat.",
+            effort: "E1",
+            mode: "algorithm",
+            phase: "complete",
+            progress: "1/1",
+            verified: true,
+            updated: "2026-05-14T12:05:00.000Z",
+          },
+          sections: [
+            { name: "Goal", content: "Promotion filename is path-safe." },
+            { name: "Criteria", content: "- [x] C1: Filename is safe. | Evidence: Path is flat." },
+          ],
         },
       },
       { homeDir },


### PR DESCRIPTION
## Summary

- Unifies `IdealStateArtifact` (Algorithm in-memory JSON) and the proposed `SomaIsa` (markdown-backed) into one type — resolves Holly's cross-cutting finding on #32-#39
- Adds `frontmatter` (authored + derived sub-types) and `sections` (section-agnostic storage); removes parallel `goal`/`criteria` fields on the type, routes them through derived accessors
- Removes `AlgorithmRun.phase` field; `getRunPhase(run)` reads from `run.isa.frontmatter.phase` (Holly Blocker 5)
- Adds `schemaVersion: 2` and compat shim in `algorithm-store` so legacy v1 runs on disk deserialize cleanly (Holly Blocker 1)

Implements spec at #41 (Reconciliation v3). Blocks #32, #34, #36, #37, #38, #39.

## AC checklist

- [x] AC-1: `IdealStateArtifact` extended with `frontmatter` + `sections`; `goal`/`criteria` fields removed
- [x] AC-2: `IsaFrontmatter`, `IsaSection`, `AuthoredFrontmatter`, `DerivedFrontmatter` exported
- [x] AC-3: All derived accessors in `src/isa-accessors.ts`
- [x] AC-4: `parseIsa` / `serializeIsa` round-trip via semantic equivalence (raw-spans internal WeakMap optimization)
- [x] AC-5: Every `isa.goal` / `isa.criteria` reference migrated to accessors — grep clean
- [x] AC-6: `SomaContextInput.activeIsa` field name unchanged, type still `IdealStateArtifact | undefined`
- [x] AC-7: Anti: no `SomaIsa`, `SomaDocument`, `SomaSpec`, `SomaBlueprint` types exist
- [x] AC-8: Issues #32, #34, #36, #37, #38, #39 already updated via resolution comments to reference unified type
- [x] AC-9 (revised v3): derived accessors are pure functions, no memoization (per Holly v3 finding #1)
- [x] AC-10: Compat shim deserializes legacy `AlgorithmRun` JSON; test fixture exercises pre-#41 shape
- [x] AC-11: `AlgorithmRun.phase` field removed; `getRunPhase(run)` is sole accessor (grep + test)
- [x] AC-12: Authored vs derived frontmatter boundary tested (manual edits to `task` survive, `progress` recomputed)
- [x] AC-13 (NEW v3): YAML with mixed known + unknown keys preserves all keys via `custom` subfield round-trip
- [x] AC-14 (NEW v3): `completeAlgorithmRun` transitions phase to `complete`; active.json clearing stubbed pending #32+#34 land
- [x] AC-15 (NEW v3): `abandonAlgorithmRun` mirrors with `phase: abandoned` + reason in decisions log

## Test plan

- [x] `bun test` — 233 pass, 0 fail (25 new tests added across `isa-accessors.test.ts`, `isa-parse.test.ts`, `algorithm-compat.test.ts`)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [ ] Sage review

## Holly findings — disposition

Reconciliation v3 (posted on #41) addressed all 6 v1 findings + 3 v2/v3 follow-ups. This PR implements that spec verbatim. Notable carry-forwards documented inline:
- In-flight Algorithm runs always get semantic-equivalence round-trips (never byte preservation) due to immutable spreads — documented at the top of `isa-parse.ts`
- Single-writer `events.jsonl` contract continues from pre-PR baseline; concurrent-write protection deferred to follow-up if usage demands

🤖 Generated with [Claude Code](https://claude.com/claude-code)