### PR TITLE
fix(policy): allow memory writes while guarding destructive roots

### DIFF
--- a/docs/private-source-guard-v0.md
+++ b/docs/private-source-guard-v0.md
@@ -8,8 +8,13 @@ Soma separates the public code repo from private installed context.
 - substrate projections such as `~/.codex/memories/soma/` and
   `~/.pi/agent/soma/` are also private context surfaces.
 
-V0 protects the narrow mistake class that matters first: moving private Soma
-source material into a public destination.
+V0 protects the mistake classes that matter first:
+
+- moving private Soma/source material into a public destination
+- destructively deleting or moving private memory/configuration roots
+
+Memory roots are protected assets, not forbidden destinations. Normal memory
+writes stay allowed.
 
 ## CLI
 
@@ -25,8 +30,8 @@ on the result.
 
 ## Deny Conditions
 
-A write is denied when the destination is outside private Soma/projection roots
-and either:
+A write is denied when the destination is outside private Soma/projection/memory
+roots and either:
 
 - `--source` points under a private Soma/projection root, or
 - the proposed content contains a private Soma/projection root marker.
@@ -35,27 +40,39 @@ Private roots include:
 
 - `~/.soma/profile`
 - `~/.soma/memory`
+- `<codex-home>/memories`
 - `~/.codex/memories/soma`
 - `~/.codex/skills/soma`
+- Claude memory roots such as `<claude-home>/memory`,
+  `<claude-home>/memories`, and `<claude-home>/PAI/MEMORY`
 - `~/.pi/agent/soma`
 - `~/.pi/agent/skills/soma`
 
 Writes inside those roots are allowed. This avoids blocking normal memory,
 profile, and projection maintenance.
 
+Delete and destructive move operations are stricter. The path guard blocks
+destructive operations that target protected memory/configuration roots, such as
+removing the Codex memory directory, removing the Soma home, or a patch
+`Delete File` inside a protected memory root. This is separate from ordinary
+write checks so memory can remain writable without allowing directory-removal
+accidents.
+
 ## Codex Projection
 
 The Codex home projection installs a `PreToolUse` hook for `Write`, `Edit`,
-`MultiEdit`, and `apply_patch`. The hook calls:
+`MultiEdit`, `apply_patch`, and shell tools. The hook calls:
 
 ```bash
-bun run soma policy check --soma-home <home> --substrate codex --action write --destination <path> --content-env SOMA_POLICY_CONTENT
+SOMA_POLICY_TARGETS='[{"filePath":"<path>","content":"<content>","action":"write"}]' \
+  bun run soma policy check --soma-home <home> --substrate codex --action write --targets-env SOMA_POLICY_TARGETS --private-root <adapter-memory-root> --record deny --json
 ```
 
-The hook first performs a cheap in-process marker precheck. If the proposed
-write does not mention private Soma/projection roots, it does not start the CLI
-or write an audit event. If a private marker is present, it calls the checker in
-JSON mode with `--record deny`. Denials and checker failures both return a Codex
+The hook first performs a cheap in-process precheck. If the proposed write does
+not mention private Soma/projection roots and is not a destructive protected-path
+operation, it does not start the CLI or write an audit event. If a private marker
+or protected destructive operation is present, it calls the checker in JSON mode
+with `--record deny`. Denials and checker failures both return a Codex
 `PreToolUse` `permissionDecision: deny`.
 
 ## Non-Goals

--- a/src/adapters/codex/hooks/codex-hook-entry.mjs
+++ b/src/adapters/codex/hooks/codex-hook-entry.mjs
@@ -44,7 +44,7 @@ function runSomaClassification(config, prompt) {
   return runSomaCommand(config, ["run", "soma", "algorithm", "classify", "--prompt", prompt || "", "--json"]);
 }
 
-function runSomaPolicyCheck(config, targets) {
+function runSomaPolicyCheck(config, targets, action = "write") {
   const args = [
     "run",
     "soma",
@@ -55,13 +55,16 @@ function runSomaPolicyCheck(config, targets) {
     "--substrate",
     "codex",
     "--action",
-    "write",
+    action,
     "--targets-env",
     "SOMA_POLICY_TARGETS",
     "--record",
     "deny",
     "--json",
   ];
+  for (const privateRoot of config.privateRoots || []) {
+    args.push("--private-root", privateRoot);
+  }
 
   return runSomaCommand(config, args, { SOMA_POLICY_TARGETS: JSON.stringify(targets) });
 }

--- a/src/adapters/codex/hooks/codex-policy-hook.mjs
+++ b/src/adapters/codex/hooks/codex-policy-hook.mjs
@@ -28,6 +28,14 @@ function resolveShellPath(config, path, cwd) {
     return `${config.somaHome}${path.slice("~/.soma".length)}`;
   }
 
+  const home = config.somaHome.endsWith("/.soma") ? config.somaHome.slice(0, -"/.soma".length) : process.env.HOME || "";
+  if (home && path.startsWith("$HOME/")) {
+    return `${home}/${path.slice("$HOME/".length)}`;
+  }
+  if (home && path.startsWith("${HOME}/")) {
+    return `${home}/${path.slice("${HOME}/".length)}`;
+  }
+
   if (path.startsWith("~/") && config.somaHome.endsWith("/.soma")) {
     return `${config.somaHome.slice(0, -"/.soma".length)}/${path.slice(2)}`;
   }
@@ -49,7 +57,7 @@ function hasPrivatePathReference(config, token, cwd) {
   if (token === ".soma" || token.startsWith(".soma/") || token.startsWith("./.soma/")) return true;
   if (token.startsWith(".codex/memories/soma/") || token.startsWith("./.codex/memories/soma/")) return true;
   if (token.startsWith(".pi/agent/soma/") || token.startsWith("./.pi/agent/soma/")) return true;
-  const resolved = resolveToolPath(token, cwd);
+  const resolved = resolveShellPath(config, token, cwd);
   return config.policyMarkers.some((marker) => {
     if (!marker.startsWith("/")) return false;
     const root = marker.endsWith("/") ? marker.slice(0, -1) : marker;
@@ -57,8 +65,24 @@ function hasPrivatePathReference(config, token, cwd) {
   });
 }
 
+function isProtectedPathReference(config, token, cwd) {
+  if (!token) return false;
+  if (hasPrivatePathReference(config, token, cwd)) return true;
+  if (token === ".codex/memories" || token.startsWith(".codex/memories/") || token.startsWith("./.codex/memories/")) return true;
+  if (token === ".claude" || token.startsWith(".claude/") || token.startsWith("./.claude/")) return true;
+  return false;
+}
+
 function firstPrivatePathToken(config, tokens, cwd) {
   return tokens.find((token) => hasPrivatePathReference(config, token, cwd));
+}
+
+function protectedPathTokens(config, tokens, cwd) {
+  return tokens.filter((token) => isProtectedPathReference(config, token, cwd));
+}
+
+function absoluteProtectedRoots(config) {
+  return Array.from(new Set(config.policyMarkers.filter((marker) => marker.startsWith("/")).map((marker) => resolve(marker))));
 }
 
 function lastPathToken(tokens) {
@@ -70,6 +94,296 @@ function redirectionTarget(tokens) {
   if (redirectIndex !== -1) return tokens[redirectIndex + 1];
   const redirectToken = tokens.find((token) => token.startsWith(">") && token.length > 1);
   return redirectToken ? redirectToken.replace(/^>+/, "") : undefined;
+}
+
+function isShellOperator(token) {
+  return token === "&&" || token === "||" || token === "|" || token === ";";
+}
+
+function shellSegments(tokens) {
+  const segments = [];
+  let current = [];
+  for (const token of tokens) {
+    if (isShellOperator(token)) {
+      if (current.length > 0) segments.push(current);
+      current = [];
+    } else {
+      current.push(token);
+    }
+  }
+  if (current.length > 0) segments.push(current);
+  return segments;
+}
+
+function shellSegmentsWithOperators(tokens) {
+  const segments = [];
+  let current = [];
+  for (const token of tokens) {
+    if (isShellOperator(token)) {
+      if (current.length > 0) segments.push({ tokens: current, operatorAfter: token });
+      current = [];
+    } else {
+      current.push(token);
+    }
+  }
+  if (current.length > 0) segments.push({ tokens: current, operatorAfter: undefined });
+  return segments;
+}
+
+function shellCommandName(token) {
+  return (token || "").split("/").pop() || "";
+}
+
+function skipShellPrefixes(tokens) {
+  let index = 0;
+  while (index < tokens.length) {
+    const token = tokens[index];
+    if (/^[A-Za-z_][A-Za-z0-9_]*=.*$/.test(token) || ["command", "exec", "time", "nice", "nohup"].includes(token)) {
+      index += 1;
+      continue;
+    }
+    if (token === "sudo") {
+      index += 1;
+      while (index < tokens.length && tokens[index].startsWith("-")) {
+        const option = tokens[index];
+        index += 1;
+        if (["-u", "--user", "-g", "--group", "-h", "--host", "-p", "--prompt", "-C", "--close-from", "-T", "--command-timeout"].includes(option)) {
+          index += 1;
+        }
+      }
+      continue;
+    }
+    if (token === "env") {
+      index += 1;
+      while (index < tokens.length && (tokens[index].startsWith("-") || /^[A-Za-z_][A-Za-z0-9_]*=.*$/.test(tokens[index]))) {
+        index += 1;
+      }
+      continue;
+    }
+    break;
+  }
+  return index;
+}
+
+function shellPathArguments(tokens, startIndex) {
+  const args = [];
+  let parseFlags = true;
+  for (let i = startIndex; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (parseFlags && token === "--") {
+      parseFlags = false;
+      continue;
+    }
+    if (parseFlags && token.startsWith("-") && token.length > 1) continue;
+    if (token === ">" || token === ">>") {
+      i += 1;
+      continue;
+    }
+    args.push(token);
+  }
+  return args;
+}
+
+function findSearchRoots(tokens, startIndex) {
+  const roots = [];
+  for (let i = startIndex; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token === "-H" || token === "-L" || token === "-P") continue;
+    if (token === "(" || token === "!" || token.startsWith("-")) break;
+    roots.push(token);
+  }
+  return roots.length > 0 ? roots : ["."];
+}
+
+function findNamePredicates(tokens) {
+  const names = [];
+  for (let i = 0; i < tokens.length; i += 1) {
+    if (tokens[i] === "-name" || tokens[i] === "-iname") {
+      const name = tokens[i + 1];
+      if (name) names.push(name);
+      i += 1;
+    }
+  }
+  return names;
+}
+
+function findDeleteParentTargets(config, segment, commandIndex, cwd) {
+  const names = findNamePredicates(segment);
+  const roots = absoluteProtectedRoots(config);
+  const targets = [];
+
+  for (const searchRoot of findSearchRoots(segment, commandIndex + 1)) {
+    const resolvedSearchRoot = resolveShellPath(config, searchRoot, cwd);
+    for (const root of roots) {
+      if (root === resolvedSearchRoot || !root.startsWith(`${resolvedSearchRoot}/`)) continue;
+      const basename = root.slice(root.lastIndexOf("/") + 1);
+      if (names.length === 0 || names.includes(basename)) {
+        targets.push(root);
+      }
+    }
+  }
+
+  return targets;
+}
+
+function shellPayload(tokens, commandIndex) {
+  const shellOptionsWithValues = new Set(["--command-timeout"]);
+  for (let i = commandIndex + 1; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token === "-c" || token === "--command") return tokens[i + 1];
+    if (shellOptionsWithValues.has(token)) {
+      i += 1;
+      continue;
+    }
+    if (token.startsWith("--")) continue;
+    if (/^-[A-Za-z]+$/.test(token) && token.includes("c")) return tokens[i + 1];
+  }
+  return undefined;
+}
+
+function extractDestructiveShellTargets(config, tokens, cwd, depth = 0) {
+  const destructiveTargets = [];
+  for (const segment of shellSegments(tokens)) {
+    const commandIndex = skipShellPrefixes(segment);
+    const command = shellCommandName(segment[commandIndex]);
+
+    if (depth < 4 && (command === "bash" || command === "sh" || command === "zsh")) {
+      const payload = shellPayload(segment, commandIndex);
+      if (payload) destructiveTargets.push(...extractDestructiveShellTargets(config, tokenizeShellCommand(payload), cwd, depth + 1));
+      continue;
+    }
+
+    if (depth < 4 && command === "eval") {
+      destructiveTargets.push(...extractDestructiveShellTargets(config, segment.slice(commandIndex + 1), cwd, depth + 1));
+      continue;
+    }
+
+    if (command === "rm" || command === "rmdir" || command === "trash" || command === "trash-put" || command === "gtrash") {
+      destructiveTargets.push(
+        ...protectedPathTokens(config, shellPathArguments(segment, commandIndex + 1), cwd).map((token) => ({
+          action: "delete",
+          filePath: resolveShellPath(config, token, cwd),
+          content: "",
+        })),
+      );
+    }
+    if (command === "find" && segment.includes("-delete")) {
+      destructiveTargets.push(
+        ...[
+          ...protectedPathTokens(config, shellPathArguments(segment, commandIndex + 1), cwd).map((token) => resolveShellPath(config, token, cwd)),
+          ...findDeleteParentTargets(config, segment, commandIndex, cwd),
+        ].map((path) => ({
+          action: "delete",
+          filePath: path,
+          content: "",
+        })),
+      );
+    }
+    if (command === "mv") {
+      const args = shellPathArguments(segment, commandIndex + 1);
+      const sourceArgs = args.length > 1 ? args.slice(0, -1) : args;
+      destructiveTargets.push(
+        ...protectedPathTokens(config, sourceArgs, cwd).map((token) => ({
+          action: "modify",
+          filePath: resolveShellPath(config, token, cwd),
+          content: "",
+        })),
+      );
+    }
+  }
+  return destructiveTargets;
+}
+
+function extractPrivateShellTransferTargets(config, tokens, cwd, depth = 0) {
+  const transferTargets = [];
+  for (const segment of shellSegments(tokens)) {
+    const commandIndex = skipShellPrefixes(segment);
+    const command = shellCommandName(segment[commandIndex]);
+
+    if (depth < 4 && (command === "bash" || command === "sh" || command === "zsh")) {
+      const payload = shellPayload(segment, commandIndex);
+      if (payload) transferTargets.push(...extractPrivateShellTransferTargets(config, tokenizeShellCommand(payload), cwd, depth + 1));
+      continue;
+    }
+
+    if (depth < 4 && command === "eval") {
+      transferTargets.push(...extractPrivateShellTransferTargets(config, segment.slice(commandIndex + 1), cwd, depth + 1));
+      continue;
+    }
+
+    const privateSource = firstPrivatePathToken(config, segment, cwd);
+    if (!privateSource) {
+      const redirectedDestination = redirectionTarget(segment);
+      if (redirectedDestination) {
+        const markerSource = segment.find((token) => hasPrivatePathReference(config, token, cwd));
+        if (markerSource) {
+          transferTargets.push({ filePath: resolveShellPath(config, redirectedDestination, cwd), sourcePath: resolveShellPath(config, markerSource, cwd), content: "" });
+        }
+      }
+      continue;
+    }
+
+    if (command === "cp" || command === "mv" || command === "rsync") {
+      const destination = lastPathToken(segment.slice(commandIndex + 1));
+      if (destination && destination !== privateSource) {
+        transferTargets.push({ filePath: resolveShellPath(config, destination, cwd), sourcePath: resolveShellPath(config, privateSource, cwd), content: "" });
+      }
+      continue;
+    }
+
+    const redirectedDestination = redirectionTarget(segment);
+    if (redirectedDestination) {
+      transferTargets.push({ filePath: resolveShellPath(config, redirectedDestination, cwd), sourcePath: resolveShellPath(config, privateSource, cwd), content: "" });
+      continue;
+    }
+
+    if (command === "tee") {
+      const destination = lastPathToken(segment.slice(commandIndex + 1));
+      if (destination && destination !== privateSource) {
+        transferTargets.push({ filePath: resolveShellPath(config, destination, cwd), sourcePath: resolveShellPath(config, privateSource, cwd), content: "" });
+      }
+    }
+  }
+  return transferTargets;
+}
+
+function extractPipedPrivateShellTransferTargets(config, tokens, cwd, depth = 0) {
+  const transferTargets = [];
+  let pipedPrivateSource;
+
+  for (const { tokens: segment, operatorAfter } of shellSegmentsWithOperators(tokens)) {
+    const commandIndex = skipShellPrefixes(segment);
+    const command = shellCommandName(segment[commandIndex]);
+
+    if (depth < 4 && (command === "bash" || command === "sh" || command === "zsh")) {
+      const payload = shellPayload(segment, commandIndex);
+      if (payload) transferTargets.push(...extractPipedPrivateShellTransferTargets(config, tokenizeShellCommand(payload), cwd, depth + 1));
+      pipedPrivateSource = operatorAfter === "|" ? pipedPrivateSource : undefined;
+      continue;
+    }
+
+    if (depth < 4 && command === "eval") {
+      transferTargets.push(...extractPipedPrivateShellTransferTargets(config, segment.slice(commandIndex + 1), cwd, depth + 1));
+      pipedPrivateSource = operatorAfter === "|" ? pipedPrivateSource : undefined;
+      continue;
+    }
+
+    if (pipedPrivateSource && command === "tee") {
+      const destination = lastPathToken(segment.slice(commandIndex + 1));
+      if (destination) {
+        transferTargets.push({ filePath: resolveShellPath(config, destination, cwd), sourcePath: resolveShellPath(config, pipedPrivateSource, cwd), content: "" });
+      }
+    }
+
+    const privateSource = firstPrivatePathToken(config, segment, cwd);
+    if (operatorAfter === "|") {
+      pipedPrivateSource = privateSource || pipedPrivateSource;
+    } else {
+      pipedPrivateSource = undefined;
+    }
+  }
+
+  return transferTargets;
 }
 
 function normalizeToolInvocation(input) {
@@ -94,6 +408,7 @@ function normalizeToolInvocation(input) {
 function pushPatchTarget(config, targets, target) {
   if (!target) return;
   targets.push({
+    action: target.action,
     filePath: target.filePath,
     sourcePath: target.sourcePath,
     content: target.lines.filter((line) => hasSomaPolicyMarker(config, line)).join("\n"),
@@ -103,7 +418,7 @@ function pushPatchTarget(config, targets, target) {
 function extractPatchTargets(config, patch, cwd) {
   const targets = [];
   let current;
-  const pattern = /^\*\*\* (?:Add|Update|Delete) File: (.+)$/;
+  const pattern = /^\*\*\* (Add|Update|Delete) File: (.+)$/;
   const movePattern = /^\*\*\* Move to: (.+)$/;
 
   for (const line of (patch || "").split("\n")) {
@@ -122,7 +437,12 @@ function extractPatchTargets(config, patch, cwd) {
     const fileMatch = line.match(pattern);
     if (fileMatch) {
       pushPatchTarget(config, targets, current);
-      current = { filePath: resolveToolPath(fileMatch[1].trim(), cwd), lines: [] };
+      const operation = fileMatch[1];
+      current = {
+        filePath: resolveToolPath(fileMatch[2].trim(), cwd),
+        action: operation === "Delete" ? "delete" : "write",
+        lines: [],
+      };
       continue;
     }
 
@@ -164,30 +484,10 @@ function extractApplyPatchTargets(config, context) {
 
 function extractShellTarget(config, context) {
   const tokens = tokenizeShellCommand(context.command);
-  const privateSource = firstPrivatePathToken(config, tokens, context.cwd);
-  if (!privateSource) return [];
-
-  const command = tokens[0] || "";
-  if (command === "cp" || command === "mv" || command === "rsync") {
-    const destination = lastPathToken(tokens.slice(1));
-    if (destination && destination !== privateSource) {
-      return [{ filePath: resolveShellPath(config, destination, context.cwd), sourcePath: resolveShellPath(config, privateSource, context.cwd), content: "" }];
-    }
-  }
-
-  const redirectedDestination = redirectionTarget(tokens);
-  if (redirectedDestination) {
-    return [{ filePath: resolveShellPath(config, redirectedDestination, context.cwd), sourcePath: resolveShellPath(config, privateSource, context.cwd), content: "" }];
-  }
-
-  if (command === "tee") {
-    const destination = lastPathToken(tokens.slice(1));
-    if (destination && destination !== privateSource) {
-      return [{ filePath: resolveShellPath(config, destination, context.cwd), sourcePath: resolveShellPath(config, privateSource, context.cwd), content: "" }];
-    }
-  }
-
-  return [];
+  const destructiveTargets = extractDestructiveShellTargets(config, tokens, context.cwd);
+  const transferTargets = extractPrivateShellTransferTargets(config, tokens, context.cwd);
+  const pipedTransferTargets = extractPipedPrivateShellTransferTargets(config, tokens, context.cwd);
+  return [...destructiveTargets, ...transferTargets, ...pipedTransferTargets];
 }
 
 const targetExtractors = {
@@ -207,5 +507,5 @@ export function extractWriteTargets(config, input) {
 }
 
 export function shouldCheckPolicyTarget(config, target) {
-  return Boolean(target.sourcePath) || hasSomaPolicyMarker(config, target.content);
+  return target.action === "delete" || target.action === "modify" || Boolean(target.sourcePath) || hasSomaPolicyMarker(config, target.content);
 }

--- a/src/adapters/codex/hooks/runtime.ts
+++ b/src/adapters/codex/hooks/runtime.ts
@@ -1,6 +1,8 @@
 import { spawnSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
 import { somaPolicyPrivateMarkers } from "../../../policy";
-import { somaProjectionPrivateRoots } from "../../../projection-private-roots";
+import { somaMemoryPrivateRoots, somaProjectionPrivateRoots } from "../../../projection-private-roots";
 import { defaultSomaRepoPath } from "../../../repo-path";
 
 export function resolveBunExecutable(explicitBunPath = process.env.SOMA_BUN_PATH): string {
@@ -22,7 +24,8 @@ export function resolveBunExecutable(explicitBunPath = process.env.SOMA_BUN_PATH
 }
 
 export function renderCodexLifecycleHook(somaHome: string, homeDir?: string, somaRepoPath = defaultSomaRepoPath(), bunPath = resolveBunExecutable()): string {
-  const policyMarkers = somaPolicyPrivateMarkers(somaHome, homeDir, somaProjectionPrivateRoots({ homeDir, substrate: "codex" }));
+  const privateRoots = [...somaProjectionPrivateRoots({ homeDir, substrate: "codex" }), ...codexAdapterMemoryPrivateRoots(homeDir)];
+  const policyMarkers = somaPolicyPrivateMarkers(somaHome, homeDir, privateRoots);
 
   return [
     "#!/usr/bin/env node",
@@ -32,7 +35,18 @@ export function renderCodexLifecycleHook(somaHome: string, homeDir?: string, som
     `  somaHome: ${JSON.stringify(somaHome)},`,
     `  trustedSomaRepo: ${JSON.stringify(somaRepoPath)},`,
     `  bunPath: ${JSON.stringify(bunPath)},`,
+    `  privateRoots: ${JSON.stringify(privateRoots)},`,
     `  policyMarkers: ${JSON.stringify(policyMarkers)},`,
     "});",
   ].join("\n");
+}
+
+function codexAdapterMemoryPrivateRoots(homeDir?: string): string[] {
+  const home = resolve(homeDir ?? homedir());
+  return [
+    ...somaMemoryPrivateRoots({ homeDir, substrate: "codex" }),
+    join(home, ".claude", "memory"),
+    join(home, ".claude", "memories"),
+    join(home, ".claude", "PAI", "MEMORY"),
+  ].map((path) => resolve(path));
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1010,6 +1010,11 @@ function parsePolicyArgs(args: string[]): ParsedPolicyArgs {
         index += 1;
         break;
       }
+      case "--private-root": {
+        (options.privateRoots ??= []).push(readOption(rest, index, arg));
+        index += 1;
+        break;
+      }
       case "--json":
         json = true;
         break;
@@ -1461,11 +1466,15 @@ function readPolicyTargetsEnv(envName: string): SomaPolicyBatchTarget[] {
         !target ||
         typeof target !== "object" ||
         typeof (target as SomaPolicyBatchTarget).filePath !== "string" ||
+        ((target as SomaPolicyBatchTarget).action !== undefined &&
+          (typeof (target as SomaPolicyBatchTarget).action !== "string" || !["write", "delete", "modify"].includes((target as SomaPolicyBatchTarget).action ?? ""))) ||
         ((target as SomaPolicyBatchTarget).content !== undefined && typeof (target as SomaPolicyBatchTarget).content !== "string") ||
         ((target as SomaPolicyBatchTarget).sourcePath !== undefined && typeof (target as SomaPolicyBatchTarget).sourcePath !== "string"),
     )
   ) {
-    throw new Error(`--targets-env ${envName} must contain an array of targets with string filePath values and optional string content/sourcePath values.`);
+    throw new Error(
+      `--targets-env ${envName} must contain an array of targets with string filePath values and optional string content/sourcePath values. Optional action must be one of write, delete, or modify.`,
+    );
   }
 
   return targets as SomaPolicyBatchTarget[];
@@ -1664,6 +1673,8 @@ export async function runSomaCli(args: string[]): Promise<string> {
         action: parsed.options.action,
         record: parsed.options.record,
         timestamp: parsed.options.timestamp,
+        privateRoots: parsed.options.privateRoots,
+        protectedPaths: parsed.options.protectedPaths,
         targets,
       });
 

--- a/src/policy-audit.ts
+++ b/src/policy-audit.ts
@@ -1,6 +1,6 @@
 import { appendSomaMemoryEvent } from "./memory";
 import { evaluateSomaPolicyBatch, evaluateSomaPolicyWithFilesystem, normalizeSomaPolicyPath, policyOptionsForTarget } from "./policy";
-import { somaProjectionPrivateRoots } from "./projection-private-roots";
+import { somaMemoryPrivateRoots, somaProjectionPrivateRoots } from "./projection-private-roots";
 import type { SomaPolicyBatchCheckOptions, SomaPolicyBatchCheckResult, SomaPolicyCheckOptions, SomaPolicyCheckResult } from "./types";
 
 export async function checkSomaPolicy(options: SomaPolicyCheckOptions): Promise<SomaPolicyCheckResult> {
@@ -29,7 +29,7 @@ export async function checkSomaPolicyBatch(options: SomaPolicyBatchCheckOptions)
 function withProjectionPrivateRoots<T extends SomaPolicyCheckOptions | SomaPolicyBatchCheckOptions>(options: T): T {
   return {
     ...options,
-    privateRoots: [...(options.privateRoots ?? []), ...somaProjectionPrivateRoots(options)],
+    privateRoots: [...(options.privateRoots ?? []), ...somaProjectionPrivateRoots(options), ...somaMemoryPrivateRoots(options)],
   };
 }
 

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -231,7 +231,7 @@ export function policyOptionsForTarget(options: Omit<SomaPolicyBatchCheckOptions
     protectedPaths: options.protectedPaths,
     cwd: options.cwd,
     substrate: options.substrate,
-    action: options.action,
+    action: target.action ?? options.action,
     destinationPath: target.filePath,
     sourcePath: target.sourcePath,
     content: target.content,

--- a/src/projection-private-roots.ts
+++ b/src/projection-private-roots.ts
@@ -4,11 +4,20 @@ import type { SubstrateId } from "./types";
 
 export function somaProjectionPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
   const home = resolve(options.homeDir ?? homedir());
-  const codexRoots = [join(home, ".codex", "memories", "soma"), join(home, ".codex", "skills", "soma")];
+  const codexRoots = [join(home, ".codex", "skills", "soma")];
   const piDevRoots = [join(home, ".pi", "agent", "soma"), join(home, ".pi", "agent", "skills", "soma")];
 
   if (options.substrate === "codex") return codexRoots.map((path) => resolve(path));
   if (options.substrate === "pi-dev") return piDevRoots.map((path) => resolve(path));
 
   return [...codexRoots, ...piDevRoots].map((path) => resolve(path));
+}
+
+export function somaMemoryPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
+  const home = resolve(options.homeDir ?? homedir());
+  const codexMemoryRoots = [join(home, ".codex", "memories")];
+
+  if (options.substrate === undefined || options.substrate === "codex") return codexMemoryRoots.map((path) => resolve(path));
+
+  return [];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -543,6 +543,7 @@ export interface SomaPolicyCheckOptions {
 
 export interface SomaPolicyBatchTarget {
   filePath: string;
+  action?: SomaPolicyAction;
   content?: string;
   sourcePath?: string;
 }

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -35,6 +35,7 @@ interface CodexHookTestOutput {
   hookSpecificOutput?: {
     additionalContext?: string;
     permissionDecision?: string;
+    permissionDecisionReason?: string;
     statusMessage?: string;
   };
 }
@@ -642,6 +643,243 @@ test("installed codex hook allows mixed apply_patch when only private destinatio
   });
 });
 
+test("installed codex hook allows memory writes that reference private memory paths", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const target = join(homeDir, ".codex/memories/MEMORY.md");
+    const projectedContext = join(homeDir, ".codex/memories/soma/startup-context.md");
+    const input = {
+      tool_name: "Write",
+      tool_input: {
+        file_path: target,
+        content: `Operational memory note: read ${projectedContext} before Soma work.`,
+      },
+    };
+    const result = runCodexPreToolUseHook(hook, homeDir, input);
+
+    expect(result.status).toBe(0);
+    expect(result.output.continue).toBe(true);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBeUndefined();
+  });
+});
+
+test("installed codex hook denies destructive shell deletes of memory roots", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: homeDir,
+      tool_name: "Shell",
+      tool_input: {
+        command: "rm -rf ~/.codex/memories",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(result.output.hookSpecificOutput?.permissionDecisionReason).toContain("delete blocked");
+  });
+});
+
+test("installed codex hook denies relative deletes from memory root parents", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: join(homeDir, ".codex"),
+      tool_name: "Shell",
+      tool_input: {
+        command: "rm -rf memories",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(result.output.hookSpecificOutput?.permissionDecisionReason).toContain("delete blocked");
+  });
+});
+
+test("installed codex hook denies HOME-variable deletes of memory roots", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: homeDir,
+      tool_name: "Shell",
+      tool_input: {
+        command: "rm -rf $HOME/" + ".codex/memories",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(result.output.hookSpecificOutput?.permissionDecisionReason).toContain("delete blocked");
+  });
+});
+
+test("installed codex hook denies destructive shell wrapper deletes of memory roots", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: homeDir,
+      tool_name: "Shell",
+      tool_input: {
+        command: 'zsh -lc "rm -rf ~/.codex/memories"',
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(result.output.hookSpecificOutput?.permissionDecisionReason).toContain("delete blocked");
+  });
+});
+
+test("installed codex hook denies separated shell flag wrapper deletes of memory roots", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: homeDir,
+      tool_name: "Shell",
+      tool_input: {
+        command: 'zsh -l -c "rm -rf ~/' + '.codex/memories"',
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(result.output.hookSpecificOutput?.permissionDecisionReason).toContain("delete blocked");
+  });
+});
+
+test("installed codex hook denies clustered shell flag wrapper deletes of memory roots", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: homeDir,
+      tool_name: "Shell",
+      tool_input: {
+        command: 'zsh -elc "rm -rf ~/' + '.codex/memories"',
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(result.output.hookSpecificOutput?.permissionDecisionReason).toContain("delete blocked");
+  });
+});
+
+test("installed codex hook denies find-delete of memory roots", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: homeDir,
+      tool_name: "Shell",
+      tool_input: {
+        command: "find ~/" + ".codex/memories -delete",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(result.output.hookSpecificOutput?.permissionDecisionReason).toContain("delete blocked");
+  });
+});
+
+test("installed codex hook denies parent find-delete of memory roots", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: homeDir,
+      tool_name: "Shell",
+      tool_input: {
+        command: "find ~/" + ".codex -name memories -delete",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(result.output.hookSpecificOutput?.permissionDecisionReason).toContain("delete blocked");
+  });
+});
+
+test("installed codex hook ignores unrelated shell flags before command payload", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: homeDir,
+      tool_name: "Shell",
+      tool_input: {
+        command: "zsh --command-timeout 10 -c \"rm -rf ~/" + ".codex/memories\"",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(result.output.hookSpecificOutput?.permissionDecisionReason).toContain("delete blocked");
+  });
+});
+
+test("installed codex hook denies sudo-option destructive deletes of memory roots", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: homeDir,
+      tool_name: "Shell",
+      tool_input: {
+        command: "sudo -n rm -rf ~/" + ".codex/memories",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(result.output.hookSpecificOutput?.permissionDecisionReason).toContain("delete blocked");
+  });
+});
+
+test("installed codex hook allows shell moves into memory roots", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: homeDir,
+      tool_name: "Shell",
+      tool_input: {
+        command: "mv ./note ~/" + ".codex/memories/note",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.continue).toBe(true);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBeUndefined();
+  });
+});
+
+test("installed codex hook denies apply_patch deletes inside memory roots", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const target = join(homeDir, ".codex/memories/MEMORY.md");
+    const patch = ["*** Begin Patch", `*** Delete File: ${target}`, "*** End Patch"].join("\n");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: homeDir,
+      tool_name: "apply_patch",
+      tool_input: patch,
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(result.output.hookSpecificOutput?.permissionDecisionReason).toContain("delete blocked");
+  });
+});
+
 test("installed codex hook checks explicit soma home markers", async () => {
   await withTempHome(async (homeDir) => {
     const somaHome = join(homeDir, "private-soma-home");
@@ -712,6 +950,43 @@ test("installed codex hook denies shell copies from relative private Soma paths"
 
     expect(result.status).toBe(0);
     expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+});
+
+test("installed codex hook denies private shell copies in later command segments", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, homeDir, {
+      cwd: homeDir,
+      tool_name: "Shell",
+      tool_input: {
+        command: "echo ok && cp ~/" + ".soma/memory/WORK/private.md ./README.md",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+});
+
+test("installed codex hook denies piped private shell writes", async () => {
+  await withTempHome(async (homeDir) => {
+    const somaHome = join(homeDir, "private-soma-home");
+    const substrateHome = join(homeDir, "codex-home");
+    await installSomaForCodex({ somaHome, substrateHome });
+    const hook = join(substrateHome, "hooks/soma-lifecycle.mjs");
+    const result = runCodexPreToolUseHook(hook, substrateHome, {
+      cwd: homeDir,
+      tool_name: "Shell",
+      tool_input: {
+        command: "cat " + join(somaHome, "memory/WORK/private.md") + " | tee ./public.md",
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.output.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(result.output.hookSpecificOutput?.permissionDecisionReason).toContain("Private Soma context");
   });
 });
 

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -136,6 +136,7 @@ test("uses home-dir when detecting projected Codex private markers", async () =>
     await bootstrapSomaHome({ homeDir });
     const result = await checkSomaPolicy({
       homeDir,
+      substrate: "codex",
       action: "write",
       destinationPath: join(homeDir, "work/public/summary.md"),
       content: `${join(homeDir, ".codex/memories/soma/profile.md")} is projected private context.`,
@@ -145,6 +146,39 @@ test("uses home-dir when detecting projected Codex private markers", async () =>
     expect(result.findings[0]).toMatchObject({
       kind: "private-marker",
     });
+  });
+});
+
+test("allows private markers in approved Codex memory destinations", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    const result = await checkSomaPolicy({
+      homeDir,
+      substrate: "codex",
+      action: "write",
+      destinationPath: join(homeDir, ".codex/memories/MEMORY.md"),
+      content: `${join(homeDir, ".codex/memories/soma/startup-context.md")} is operational memory metadata.`,
+      record: "none",
+    });
+
+    expect(result.decision).toBe("allow");
+  });
+});
+
+test("allows private markers in approved Claude memory destinations", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    const result = await checkSomaPolicy({
+      homeDir,
+      substrate: "claude-code",
+      privateRoots: [join(homeDir, ".claude/memories")],
+      action: "write",
+      destinationPath: join(homeDir, ".claude/memories/session.md"),
+      content: `${join(homeDir, ".soma/memory/WORK/private.md")} is allowed inside managed memory.`,
+      record: "none",
+    });
+
+    expect(result.decision).toBe("allow");
   });
 });
 


### PR DESCRIPTION
## Summary
- treat Codex memory and Claude memory roots as private destinations so legitimate memory writes can mention private memory paths
- keep private-to-public leakage blocked through the existing write policy
- extend the Codex PreToolUse hook to check destructive shell deletes/moves and patch deletes as path-guard actions
- document memory roots as protected assets rather than forbidden destinations

Closes #48

## Verification
- bun install
- bun test test/policy.test.ts
- bun test test/install.test.ts
- bun test test/policy-path-guard.test.ts
- bun test test/cli.test.ts
- bun run lint
- bun run typecheck
- bun test (272 pass, 0 fail)
