### PR TITLE
feat(soma-home): ISA storage layout + SomaActiveIsaState schema (#32)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export type {
   IsaSkillInstallOptions,
   IsaSkillInstallResult,
   PrincipalIdentity,
+  SomaActiveIsaState,
   SomaSkillBaseline,
   SomaSkillBaselines,
   SomaAdapter,

--- a/src/soma-home.ts
+++ b/src/soma-home.ts
@@ -238,6 +238,10 @@ export async function bootstrapSomaHome(options: SomaHomeBootstrapOptions = {}):
       path: "projections/README.md",
       content: "# Soma Projections\n\nGenerated substrate projections can be cached here. Substrate homes remain projections, not source of truth.",
     },
+    {
+      path: "isa/INDEX.md",
+      content: "# Soma ISAs\n\nOne ISA per project or task lives in this directory as `<slug>.md`.\nThe active ISA slug is recorded in `memory/STATE/active.json`.\nTemplates seeded by the ISA skill live under `.templates/`.\n",
+    },
   ];
   const writtenFiles: string[] = [];
 
@@ -250,6 +254,13 @@ export async function bootstrapSomaHome(options: SomaHomeBootstrapOptions = {}):
   for (const projection of ["codex", "pi-dev", "claude-code"]) {
     await mkdir(join(somaHome, "projections", projection), { recursive: true });
   }
+
+  // ISA storage layout (#32). Library CRUD (#34) owns reads/writes;
+  // bootstrap only ensures the canonical directories exist. `.templates/`
+  // is left empty here — Layer 2 (#33) populates skill assets; future
+  // template seeding lives outside bootstrap to avoid Layer 1 → Layer 2
+  // coupling.
+  await mkdir(join(somaHome, "isa", ".templates"), { recursive: true });
 
   for (const file of files) {
     const target = join(somaHome, file.path);

--- a/src/types.ts
+++ b/src/types.ts
@@ -283,6 +283,24 @@ export interface SomaInstallPlan {
   substrateFiles: string[];
 }
 
+/**
+ * Schema for `~/.soma/memory/STATE/active.json` — canonical active-ISA
+ * state file shipped by #32. Layer 3 (#34) library CRUD is the sole
+ * owner of reads/writes; `bootstrapSomaHome()` only declares the schema
+ * and creates the containing directory.
+ *
+ * - `activeSlug` — slug of the currently-active ISA, or `null` when none.
+ * - `runId`      — `AlgorithmRun.id` currently operating on the active
+ *                  ISA; cleared by `completeAlgorithmRun` /
+ *                  `abandonAlgorithmRun` (per #41 reconciliation v3).
+ * - `updatedAt`  — ISO 8601 timestamp of the last mutation.
+ */
+export interface SomaActiveIsaState {
+  activeSlug: string | null;
+  runId: string | null;
+  updatedAt: string;
+}
+
 export interface SomaSkillBaseline {
   version: string;
   files: Record<string, string>;

--- a/test/soma-home.test.ts
+++ b/test/soma-home.test.ts
@@ -73,3 +73,59 @@ test("bootstrap does not overwrite existing profile files", async () => {
     expect(second.context.profile.assistant.name).toBe("custom");
   });
 });
+
+test("AC-1: bootstrap creates ~/.soma/isa/ + .templates/ + INDEX.md + memory/STATE/", async () => {
+  const { stat } = await import("node:fs/promises");
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const isaDir = await stat(join(somaHome, "isa"));
+    expect(isaDir.isDirectory()).toBe(true);
+    const templatesDir = await stat(join(somaHome, "isa", ".templates"));
+    expect(templatesDir.isDirectory()).toBe(true);
+    const stateDir = await stat(join(somaHome, "memory", "STATE"));
+    expect(stateDir.isDirectory()).toBe(true);
+    const indexFile = await stat(join(somaHome, "isa", "INDEX.md"));
+    expect(indexFile.isFile()).toBe(true);
+  });
+});
+
+test("AC-6: bootstrap is idempotent for ISA storage layout", async () => {
+  const { stat, readFile } = await import("node:fs/promises");
+  await withTempHome(async (homeDir) => {
+    const first = await bootstrapSomaHome({ homeDir });
+    const firstIndex = await readFile(join(first.somaHome, "isa", "INDEX.md"), "utf8");
+
+    // User edits INDEX.md — second bootstrap must not overwrite
+    await writeFile(join(first.somaHome, "isa", "INDEX.md"), "# Custom Index\n\nMy entries.\n", "utf8");
+
+    const second = await bootstrapSomaHome({ homeDir });
+    const secondIndex = await readFile(join(second.somaHome, "isa", "INDEX.md"), "utf8");
+
+    expect(secondIndex).toBe("# Custom Index\n\nMy entries.\n");
+    expect(firstIndex).not.toBe(secondIndex);
+    // Directories still present
+    expect((await stat(join(second.somaHome, "isa", ".templates"))).isDirectory()).toBe(true);
+  });
+});
+
+test("AC-3: SomaActiveIsaState type exported with correct shape", () => {
+  // Type-only export — verify usable shape via type-checked literal.
+  const sample: import("../src/index").SomaActiveIsaState = {
+    activeSlug: null,
+    runId: null,
+    updatedAt: "2026-05-17T00:00:00.000Z",
+  };
+  expect(sample.activeSlug).toBeNull();
+  expect(sample.runId).toBeNull();
+  expect(sample.updatedAt).toContain("2026");
+});
+
+test("AC-5: SomaContextInput.activeIsa unchanged shape after bootstrap", async () => {
+  await withTempHome(async (homeDir) => {
+    const { context } = await bootstrapSomaHome({ homeDir });
+    // No activeIsa expected on fresh bootstrap — bootstrap doesn't seed one
+    expect(context.activeIsa).toBeUndefined();
+    // Bootstrap returns the same shape callers always saw
+    expect(context.profile).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 2 Layer 1 per `Plans/2026-05-isa-rollout.md`. Smallest of the ISA chain — bootstrap-side scaffolding for the on-disk ISA store.

- `bootstrapSomaHome()` creates `~/.soma/isa/`, `~/.soma/isa/.templates/`, and `~/.soma/isa/INDEX.md` (idempotently)
- `SomaActiveIsaState` type added to `types.ts` as canonical schema for `~/.soma/memory/STATE/active.json` — Layer 3 (#34) will own all reads/writes; bootstrap only declares the schema and the directory layout

## ACs (post-resolution)

- [x] AC-1: `~/.soma/isa/` + `~/.soma/memory/STATE/` created idempotently
- [x] AC-2: `.templates/` empty (Layer 2 populates separately)
- [x] AC-3: `SomaActiveIsaState` exported (replaces "new SomaIsa type" AC — collapsed into #41 unified IdealStateArtifact)
- AC-4 CUT — `loadSomaHome()` does NOT read `active.json` (Holly review rejected scope creep)
- [x] AC-5: existing `SomaContextInput.activeIsa` callers unchanged
- [x] AC-6: bootstrap idempotency tested (user edits to INDEX.md survive re-run)

## Test plan

- [x] `bun test` — 285 pass, 0 fail (4 new tests for ISA storage layout + active-state schema)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean

## Resolution notes

See #32 comment trail for the scope amendments. Key: this is now a pure storage-contract issue — no library code, no read paths, no active-ISA mutations. All of those live in #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)