### PR TITLE
feat(isa): library CRUD API (#34)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -182,5 +182,28 @@ export { importPaiPack, planPaiPackImport } from "./pai-pack-importer";
 export { checkSomaPolicy, checkSomaPolicyBatch } from "./policy-audit";
 export { evaluateSomaPolicy } from "./policy";
 export { bootstrapSomaHome, loadSomaHome } from "./soma-home";
+// ISA library API (#34) — cohesive surface. Internal schema constants
+// live in `./isa-schema`; tests import path/schema helpers directly.
+export {
+  activeStatePath,
+  recordIsaDecision,
+  checkCompleteness,
+  getActiveIsa,
+  isaDir,
+  isaPath,
+  listAvailableTiers,
+  listIsas,
+  readIsa,
+  scaffoldIsa,
+  setActiveIsa,
+  writeIsa,
+  type EffortTier,
+  type IsaLibraryOptions,
+  type IsaListEntry,
+  type ScaffoldIsaInput,
+  type SetActiveIsaResult,
+  type WriteIsaResult,
+} from "./isa";
+export { type CompletenessGap, type CompletenessReport } from "./isa-schema";
 
 export const SOMA_VERSION = "0.1.3";

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,18 +182,18 @@ export { importPaiPack, planPaiPackImport } from "./pai-pack-importer";
 export { checkSomaPolicy, checkSomaPolicyBatch } from "./policy-audit";
 export { evaluateSomaPolicy } from "./policy";
 export { bootstrapSomaHome, loadSomaHome } from "./soma-home";
-// ISA library API (#34) — cohesive surface. Internal schema constants
-// live in `./isa-schema`; tests import path/schema helpers directly.
+// ISA library API (#34) — cohesive public surface only.
+// Storage-layout helpers (activeStatePath, isaDir, isaPath) stay internal
+// to `./isa` so on-disk layout can evolve without breaking consumers
+// (Sage round-2 architecture finding). Tests + adapters that need them
+// import from `./isa` directly.
 export {
-  activeStatePath,
-  recordIsaDecision,
   checkCompleteness,
   getActiveIsa,
-  isaDir,
-  isaPath,
   listAvailableTiers,
   listIsas,
   readIsa,
+  recordIsaDecision,
   scaffoldIsa,
   setActiveIsa,
   writeIsa,

--- a/src/isa-schema.ts
+++ b/src/isa-schema.ts
@@ -1,0 +1,58 @@
+import type { AlgorithmEffortTier, IdealStateArtifact } from "./types";
+import { TWELVE_SECTIONS, getSection, SECTION_NAME_MAP } from "./isa-accessors";
+
+/**
+ * Tier completeness gates — required ISA sections per effort tier.
+ * Owned by the library (#34). The unified `IdealStateArtifact` type stays
+ * section-agnostic; tier gates live here as a typed constant so schema
+ * evolution doesn't ripple through CRUD operations.
+ *
+ * The gate set is also re-exported from `src/isa.ts` for downstream
+ * consumers (#36 CLI, #38 lifecycle hooks).
+ */
+export const TIER_REQUIRED_SECTIONS: Record<AlgorithmEffortTier, readonly string[]> = {
+  E1: [SECTION_NAME_MAP.goal, SECTION_NAME_MAP.criteria],
+  E2: [
+    SECTION_NAME_MAP.problem,
+    SECTION_NAME_MAP.goal,
+    SECTION_NAME_MAP.criteria,
+    SECTION_NAME_MAP.testStrategy,
+  ],
+  E3: [
+    SECTION_NAME_MAP.problem,
+    SECTION_NAME_MAP.vision,
+    SECTION_NAME_MAP.outOfScope,
+    SECTION_NAME_MAP.constraints,
+    SECTION_NAME_MAP.goal,
+    SECTION_NAME_MAP.criteria,
+    SECTION_NAME_MAP.features,
+    SECTION_NAME_MAP.testStrategy,
+  ],
+  E4: TWELVE_SECTIONS,
+  E5: TWELVE_SECTIONS,
+};
+
+export interface CompletenessGap {
+  section: string;
+  reason: "missing" | "empty";
+}
+
+export interface CompletenessReport {
+  passed: boolean;
+  tier: AlgorithmEffortTier;
+  gaps: CompletenessGap[];
+}
+
+export function evaluateCompleteness(isa: IdealStateArtifact, tier: AlgorithmEffortTier): CompletenessReport {
+  const required = TIER_REQUIRED_SECTIONS[tier];
+  const gaps: CompletenessGap[] = [];
+  for (const name of required) {
+    const section = getSection(isa, name);
+    if (section === null) {
+      gaps.push({ section: name, reason: "missing" });
+    } else if (section.content.trim().length === 0) {
+      gaps.push({ section: name, reason: "empty" });
+    }
+  }
+  return { passed: gaps.length === 0, tier, gaps };
+}

--- a/src/isa.ts
+++ b/src/isa.ts
@@ -1,0 +1,385 @@
+import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import {
+  SECTION_NAME_MAP,
+  appendIsaDecision as appendIsaDecisionAccessor,
+  getCriteria,
+  getGoal,
+  recomputeProgress,
+  recomputeVerified,
+  renderCriteriaMarkdown,
+} from "./isa-accessors";
+import { parseIsa, serializeIsa } from "./isa-parse";
+import { appendSomaMemoryEvent } from "./memory";
+import { evaluateCompleteness, type CompletenessReport } from "./isa-schema";
+import type {
+  AlgorithmEffortTier,
+  AlgorithmPhase,
+  IdealStateArtifact,
+  IdealStateCriterion,
+  SomaActiveIsaState,
+  SubstrateId,
+} from "./types";
+
+export type EffortTier = AlgorithmEffortTier;
+
+const VALID_EFFORT_TIERS: readonly EffortTier[] = ["E1", "E2", "E3", "E4", "E5"];
+
+const VALID_SLUG_PATTERN = /^[a-z0-9][a-z0-9._-]{0,79}$/;
+
+const ACTIVE_STATE_FILENAME = "active.json";
+
+export interface IsaLibraryOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate?: SubstrateId;
+}
+
+export interface IsaListEntry {
+  slug: string;
+  phase: AlgorithmPhase;
+  progress: string;
+  updated: string;
+}
+
+export interface ScaffoldIsaInput extends IsaLibraryOptions {
+  slug: string;
+  goal: string;
+  effort: EffortTier;
+  task?: string;
+  timestamp?: string;
+  initialCriteria?: IdealStateCriterion[];
+}
+
+export interface WriteIsaResult {
+  path: string;
+  changed: boolean;
+}
+
+export interface SetActiveIsaResult {
+  previousSlug: string | null;
+  state: SomaActiveIsaState;
+}
+
+export function resolveSomaHome(options: IsaLibraryOptions = {}): string {
+  return resolve(options.somaHome ?? join(options.homeDir ?? homedir(), ".soma"));
+}
+
+export function isaDir(somaHome: string): string {
+  return join(somaHome, "isa");
+}
+
+export function isaPath(somaHome: string, slug: string): string {
+  assertValidSlug(slug);
+  return join(isaDir(somaHome), `${slug}.md`);
+}
+
+export function activeStatePath(somaHome: string): string {
+  return join(somaHome, "memory", "STATE", ACTIVE_STATE_FILENAME);
+}
+
+function assertValidSlug(slug: string): void {
+  if (!VALID_SLUG_PATTERN.test(slug)) {
+    throw new Error(`Invalid ISA slug: '${slug}'. Must match ${VALID_SLUG_PATTERN.source}.`);
+  }
+}
+
+function assertValidEffort(effort: EffortTier): void {
+  if (!VALID_EFFORT_TIERS.includes(effort)) {
+    throw new Error(`Invalid effort tier: '${effort}'. Must be one of ${VALID_EFFORT_TIERS.join(", ")}.`);
+  }
+}
+
+export function listAvailableTiers(): readonly EffortTier[] {
+  return VALID_EFFORT_TIERS;
+}
+
+export async function readIsa(slug: string, options: IsaLibraryOptions = {}): Promise<IdealStateArtifact> {
+  const somaHome = resolveSomaHome(options);
+  const path = isaPath(somaHome, slug);
+  const raw = await readFile(path, "utf8");
+  return parseIsa(raw, path);
+}
+
+export async function writeIsa(
+  slug: string,
+  isa: IdealStateArtifact,
+  options: IsaLibraryOptions = {},
+): Promise<WriteIsaResult> {
+  assertValidSlug(slug);
+  const somaHome = resolveSomaHome(options);
+  const path = isaPath(somaHome, slug);
+  const next = serializeIsa(isa);
+  let changed = true;
+  try {
+    const existing = await readFile(path, "utf8");
+    changed = existing !== next;
+  } catch (error: unknown) {
+    if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") throw error;
+  }
+  if (!changed) {
+    return { path, changed: false };
+  }
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, next, "utf8");
+  await emitEvent(somaHome, options, "isa.write", `Wrote ISA ${slug}`, { slug, path });
+  return { path, changed: true };
+}
+
+export async function listIsas(options: IsaLibraryOptions = {}): Promise<IsaListEntry[]> {
+  const somaHome = resolveSomaHome(options);
+  const dir = isaDir(somaHome);
+  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
+  const out: IsaListEntry[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".md") || entry.name === "INDEX.md") continue;
+    const slug = entry.name.slice(0, -3);
+    if (!VALID_SLUG_PATTERN.test(slug)) continue;
+    try {
+      const raw = await readFile(join(dir, entry.name), "utf8");
+      const isa = parseIsa(raw, join(dir, entry.name));
+      out.push({
+        slug,
+        phase: isa.frontmatter.phase,
+        progress: isa.frontmatter.progress,
+        updated: isa.frontmatter.updated,
+      });
+    } catch {
+      // Skip unparseable files — surface to user via separate audit, not here
+    }
+  }
+  return out.sort((a, b) => b.updated.localeCompare(a.updated));
+}
+
+export async function scaffoldIsa(input: ScaffoldIsaInput): Promise<{ path: string; isa: IdealStateArtifact }> {
+  assertValidSlug(input.slug);
+  assertValidEffort(input.effort);
+  if (input.goal.trim().length === 0) {
+    throw new Error("scaffoldIsa requires a non-empty goal.");
+  }
+  const somaHome = resolveSomaHome(input);
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const criteria = input.initialCriteria ?? [];
+  const sections = buildScaffoldSections(input.effort, input.goal, criteria);
+  const draft: IdealStateArtifact = {
+    slug: input.slug,
+    frontmatter: {
+      task: input.task ?? input.goal,
+      effort: input.effort,
+      phase: "observe",
+      progress: `0/${criteria.length}`,
+      verified: false,
+      updated: timestamp,
+      started: timestamp,
+    },
+    sections,
+  };
+  const isa: IdealStateArtifact = {
+    ...draft,
+    frontmatter: {
+      ...draft.frontmatter,
+      progress: recomputeProgress(draft),
+      verified: recomputeVerified(draft),
+    },
+  };
+  const path = isaPath(somaHome, input.slug);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, serializeIsa(isa), "utf8");
+  await emitEvent(somaHome, input, "isa.scaffold", `Scaffolded ISA ${input.slug} at ${input.effort}`, {
+    slug: input.slug,
+    effort: input.effort,
+    path,
+  });
+  return { path, isa };
+}
+
+function buildScaffoldSections(
+  effort: EffortTier,
+  goal: string,
+  initialCriteria: readonly IdealStateCriterion[],
+): { name: string; content: string }[] {
+  // Required sections per tier are pre-filled with `TODO_PLACEHOLDER` so
+  // a freshly-scaffolded ISA passes `checkCompleteness` at its own tier
+  // (AC-3). The user fills these in via Interview workflow or direct
+  // editing; the placeholder is intentionally distinct so search tools
+  // can find unfilled sections.
+  const criteriaContent = renderCriteriaMarkdown(initialCriteria) || TODO_PLACEHOLDER;
+  const out: { name: string; content: string }[] = [];
+  const required = REQUIRED_SECTIONS_FOR_TIER[effort];
+  for (const name of required) {
+    if (name === SECTION_NAME_MAP.goal) {
+      out.push({ name, content: goal });
+    } else if (name === SECTION_NAME_MAP.criteria) {
+      out.push({ name, content: criteriaContent });
+    } else {
+      out.push({ name, content: TODO_PLACEHOLDER });
+    }
+  }
+  // E4/E5 include the full twelve sections; ensure any optional sections
+  // beyond the required set also exist so authoring is symmetric.
+  if (effort === "E4" || effort === "E5") {
+    const seen = new Set(out.map((s) => s.name));
+    for (const name of TWELVE_SECTIONS_ORDER) {
+      if (!seen.has(name)) out.push({ name, content: TODO_PLACEHOLDER });
+    }
+    return reorderToCanonical(out);
+  }
+  return reorderToCanonical(out);
+}
+
+const TODO_PLACEHOLDER = "_TODO: scaffolded — fill in via Interview workflow or direct edit._";
+
+const TWELVE_SECTIONS_ORDER: readonly string[] = [
+  SECTION_NAME_MAP.problem,
+  SECTION_NAME_MAP.vision,
+  SECTION_NAME_MAP.outOfScope,
+  SECTION_NAME_MAP.principles,
+  SECTION_NAME_MAP.constraints,
+  SECTION_NAME_MAP.goal,
+  SECTION_NAME_MAP.criteria,
+  SECTION_NAME_MAP.testStrategy,
+  SECTION_NAME_MAP.features,
+  SECTION_NAME_MAP.decisions,
+  SECTION_NAME_MAP.changelog,
+  SECTION_NAME_MAP.verification,
+];
+
+const REQUIRED_SECTIONS_FOR_TIER: Record<EffortTier, readonly string[]> = {
+  E1: [SECTION_NAME_MAP.goal, SECTION_NAME_MAP.criteria],
+  E2: [
+    SECTION_NAME_MAP.problem,
+    SECTION_NAME_MAP.goal,
+    SECTION_NAME_MAP.criteria,
+    SECTION_NAME_MAP.testStrategy,
+  ],
+  E3: [
+    SECTION_NAME_MAP.problem,
+    SECTION_NAME_MAP.vision,
+    SECTION_NAME_MAP.outOfScope,
+    SECTION_NAME_MAP.constraints,
+    SECTION_NAME_MAP.goal,
+    SECTION_NAME_MAP.criteria,
+    SECTION_NAME_MAP.testStrategy,
+    SECTION_NAME_MAP.features,
+  ],
+  E4: TWELVE_SECTIONS_ORDER,
+  E5: TWELVE_SECTIONS_ORDER,
+};
+
+function reorderToCanonical(sections: { name: string; content: string }[]): { name: string; content: string }[] {
+  return [...sections].sort((a, b) => {
+    const ai = TWELVE_SECTIONS_ORDER.indexOf(a.name);
+    const bi = TWELVE_SECTIONS_ORDER.indexOf(b.name);
+    return (ai < 0 ? TWELVE_SECTIONS_ORDER.length : ai) - (bi < 0 ? TWELVE_SECTIONS_ORDER.length : bi);
+  });
+}
+
+export async function checkCompleteness(slug: string, options: IsaLibraryOptions = {}): Promise<CompletenessReport> {
+  const isa = await readIsa(slug, options);
+  return evaluateCompleteness(isa, isa.frontmatter.effort);
+}
+
+export async function getActiveIsa(options: IsaLibraryOptions = {}): Promise<SomaActiveIsaState | null> {
+  const somaHome = resolveSomaHome(options);
+  const path = activeStatePath(somaHome);
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error: unknown) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+    throw error;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Malformed JSON — treat as no active state. Callers can recover by
+    // calling `setActiveIsa(null, ...)` to reset.
+    return null;
+  }
+  return isActiveIsaState(parsed) ? parsed : null;
+}
+
+function isActiveIsaState(value: unknown): value is SomaActiveIsaState {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const candidate = value as Partial<SomaActiveIsaState>;
+  const slugOk = candidate.activeSlug === null || typeof candidate.activeSlug === "string";
+  const runOk = candidate.runId === null || typeof candidate.runId === "string";
+  const updatedOk = typeof candidate.updatedAt === "string";
+  return slugOk && runOk && updatedOk;
+}
+
+export async function setActiveIsa(
+  slug: string | null,
+  options: IsaLibraryOptions & { runId?: string | null; timestamp?: string } = {},
+): Promise<SetActiveIsaResult> {
+  if (slug !== null) assertValidSlug(slug);
+  const somaHome = resolveSomaHome(options);
+  const path = activeStatePath(somaHome);
+  const previous = await getActiveIsa({ homeDir: options.homeDir, somaHome: options.somaHome });
+  const next: SomaActiveIsaState = {
+    activeSlug: slug,
+    runId: options.runId ?? null,
+    updatedAt: options.timestamp ?? new Date().toISOString(),
+  };
+  await writeActiveStateAtomic(path, next);
+  await emitEvent(
+    somaHome,
+    options,
+    "isa.active_changed",
+    slug ? `Active ISA set to ${slug}` : "Active ISA cleared",
+    { slug, runId: next.runId },
+  );
+  return { previousSlug: previous?.activeSlug ?? null, state: next };
+}
+
+async function writeActiveStateAtomic(path: string, state: SomaActiveIsaState): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmpPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmpPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await rename(tmpPath, path);
+}
+
+/**
+ * File-backed companion to the pure `appendIsaDecision` accessor (#41).
+ * Reads slug → appends entry → writes back. Used by Algorithm integration
+ * (#39); kept here so #34 ships a complete I/O surface for callers that
+ * don't want to manage parse/serialize themselves.
+ */
+export async function recordIsaDecision(
+  slug: string,
+  text: string,
+  options: IsaLibraryOptions & { timestamp?: string; phase?: AlgorithmPhase } = {},
+): Promise<WriteIsaResult> {
+  if (text.trim().length === 0) {
+    throw new Error("recordIsaDecision requires non-empty text.");
+  }
+  const isa = await readIsa(slug, options);
+  const phase = options.phase ?? isa.frontmatter.phase;
+  const timestamp = options.timestamp ?? new Date().toISOString();
+  const updated = appendIsaDecisionAccessor(isa, { timestamp, phase, text });
+  return writeIsa(slug, { ...updated, frontmatter: { ...updated.frontmatter, updated: timestamp } }, options);
+}
+
+// Re-export schema surface for downstream consumers (CLI #36, lifecycle #38).
+export { evaluateCompleteness, TIER_REQUIRED_SECTIONS, type CompletenessReport, type CompletenessGap } from "./isa-schema";
+
+// Re-export the criteria/goal accessors so callers don't need to import
+// from two places for the common cases.
+export { getCriteria, getGoal };
+
+async function emitEvent(
+  somaHome: string,
+  options: IsaLibraryOptions,
+  kind: string,
+  summary: string,
+  metadata: Record<string, unknown>,
+): Promise<void> {
+  await appendSomaMemoryEvent(somaHome, {
+    substrate: options.substrate ?? "custom",
+    kind,
+    summary,
+    metadata,
+  });
+}

--- a/src/isa.ts
+++ b/src/isa.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdir, readdir, readFile, rename, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -335,7 +336,9 @@ export async function setActiveIsa(
 
 async function writeActiveStateAtomic(path: string, state: SomaActiveIsaState): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
-  const tmpPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  // randomUUID guarantees temp path uniqueness across concurrent calls in
+  // the same process and same millisecond — Sage round-3 suggestion.
+  const tmpPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
   await writeFile(tmpPath, `${JSON.stringify(state, null, 2)}\n`, "utf8");
   await rename(tmpPath, path);
 }

--- a/src/isa.ts
+++ b/src/isa.ts
@@ -12,7 +12,7 @@ import {
 } from "./isa-accessors";
 import { parseIsa, serializeIsa } from "./isa-parse";
 import { appendSomaMemoryEvent } from "./memory";
-import { evaluateCompleteness, type CompletenessReport } from "./isa-schema";
+import { TIER_REQUIRED_SECTIONS, evaluateCompleteness, type CompletenessReport } from "./isa-schema";
 import type {
   AlgorithmEffortTier,
   AlgorithmPhase,
@@ -130,26 +130,41 @@ export async function writeIsa(
 export async function listIsas(options: IsaLibraryOptions = {}): Promise<IsaListEntry[]> {
   const somaHome = resolveSomaHome(options);
   const dir = isaDir(somaHome);
-  const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
-  const out: IsaListEntry[] = [];
-  for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".md") || entry.name === "INDEX.md") continue;
-    const slug = entry.name.slice(0, -3);
-    if (!VALID_SLUG_PATTERN.test(slug)) continue;
-    try {
-      const raw = await readFile(join(dir, entry.name), "utf8");
-      const isa = parseIsa(raw, join(dir, entry.name));
-      out.push({
-        slug,
-        phase: isa.frontmatter.phase,
-        progress: isa.frontmatter.progress,
-        updated: isa.frontmatter.updated,
-      });
-    } catch {
-      // Skip unparseable files — surface to user via separate audit, not here
-    }
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (error: unknown) {
+    // Only ENOENT (no isa dir yet) is a quiet empty list. Permission errors,
+    // ENOTDIR, etc. are real failures and must surface to the caller.
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+    throw error;
   }
-  return out.sort((a, b) => b.updated.localeCompare(a.updated));
+  const candidates = entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md") && entry.name !== "INDEX.md")
+    .map((entry) => ({ slug: entry.name.slice(0, -3), path: join(dir, entry.name) }))
+    .filter((entry) => VALID_SLUG_PATTERN.test(entry.slug));
+  // Parallelize reads — listIsas was serializing per-file I/O. Bounded
+  // by candidate count; ISA libraries are small (≤ low hundreds) so a
+  // full Promise.all here is safe.
+  const parsed = await Promise.all(
+    candidates.map(async ({ slug, path }) => {
+      try {
+        const raw = await readFile(path, "utf8");
+        const isa = parseIsa(raw, path);
+        return {
+          slug,
+          phase: isa.frontmatter.phase,
+          progress: isa.frontmatter.progress,
+          updated: isa.frontmatter.updated,
+        } satisfies IsaListEntry;
+      } catch {
+        return null;
+      }
+    }),
+  );
+  return parsed
+    .filter((entry): entry is IsaListEntry => entry !== null)
+    .sort((a, b) => b.updated.localeCompare(a.updated));
 }
 
 export async function scaffoldIsa(input: ScaffoldIsaInput): Promise<{ path: string; isa: IdealStateArtifact }> {
@@ -206,7 +221,7 @@ function buildScaffoldSections(
   // can find unfilled sections.
   const criteriaContent = renderCriteriaMarkdown(initialCriteria) || TODO_PLACEHOLDER;
   const out: { name: string; content: string }[] = [];
-  const required = REQUIRED_SECTIONS_FOR_TIER[effort];
+  const required = TIER_REQUIRED_SECTIONS[effort];
   for (const name of required) {
     if (name === SECTION_NAME_MAP.goal) {
       out.push({ name, content: goal });
@@ -230,6 +245,10 @@ function buildScaffoldSections(
 
 const TODO_PLACEHOLDER = "_TODO: scaffolded — fill in via Interview workflow or direct edit._";
 
+// Canonical output order — single source of truth for "what order do
+// sections appear on disk?". Tier gates (TIER_REQUIRED_SECTIONS from
+// isa-schema) define WHICH sections must exist; this list defines
+// THE ORDER. Distinct concerns, single owners — Sage round-1 dedup.
 const TWELVE_SECTIONS_ORDER: readonly string[] = [
   SECTION_NAME_MAP.problem,
   SECTION_NAME_MAP.vision,
@@ -244,28 +263,6 @@ const TWELVE_SECTIONS_ORDER: readonly string[] = [
   SECTION_NAME_MAP.changelog,
   SECTION_NAME_MAP.verification,
 ];
-
-const REQUIRED_SECTIONS_FOR_TIER: Record<EffortTier, readonly string[]> = {
-  E1: [SECTION_NAME_MAP.goal, SECTION_NAME_MAP.criteria],
-  E2: [
-    SECTION_NAME_MAP.problem,
-    SECTION_NAME_MAP.goal,
-    SECTION_NAME_MAP.criteria,
-    SECTION_NAME_MAP.testStrategy,
-  ],
-  E3: [
-    SECTION_NAME_MAP.problem,
-    SECTION_NAME_MAP.vision,
-    SECTION_NAME_MAP.outOfScope,
-    SECTION_NAME_MAP.constraints,
-    SECTION_NAME_MAP.goal,
-    SECTION_NAME_MAP.criteria,
-    SECTION_NAME_MAP.testStrategy,
-    SECTION_NAME_MAP.features,
-  ],
-  E4: TWELVE_SECTIONS_ORDER,
-  E5: TWELVE_SECTIONS_ORDER,
-};
 
 function reorderToCanonical(sections: { name: string; content: string }[]): { name: string; content: string }[] {
   return [...sections].sort((a, b) => {

--- a/src/isa.ts
+++ b/src/isa.ts
@@ -157,14 +157,16 @@ export async function listIsas(options: IsaLibraryOptions = {}): Promise<IsaList
           progress: isa.frontmatter.progress,
           updated: isa.frontmatter.updated,
         } satisfies IsaListEntry;
-      } catch {
-        return null;
+      } catch (error: unknown) {
+        // Sage round 2: don't silently hide invalid ISA files. Rethrow
+        // with slug/path context so callers see the real library error
+        // rather than an incomplete-but-successful list.
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(`listIsas: failed to read or parse '${slug}' at ${path}: ${message}`, { cause: error });
       }
     }),
   );
-  return parsed
-    .filter((entry): entry is IsaListEntry => entry !== null)
-    .sort((a, b) => b.updated.localeCompare(a.updated));
+  return parsed.sort((a, b) => b.updated.localeCompare(a.updated));
 }
 
 export async function scaffoldIsa(input: ScaffoldIsaInput): Promise<{ path: string; isa: IdealStateArtifact }> {

--- a/test/isa.test.ts
+++ b/test/isa.test.ts
@@ -131,6 +131,32 @@ test("AC-6: writeIsa serializes to semantic-equivalent content on round-trip", a
   });
 });
 
+test("listIsas surfaces real filesystem errors (not silent empty list)", async () => {
+  // Replace the isa dir with a regular file → readdir throws ENOTDIR. Must
+  // propagate, not silently return [].
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-isa-list-err-"));
+  try {
+    await bootstrapSomaHome({ homeDir });
+    const { rm: rmf, writeFile: wf } = await import("node:fs/promises");
+    await rmf(join(homeDir, ".soma", "isa"), { recursive: true, force: true });
+    await wf(join(homeDir, ".soma", "isa"), "not a directory", "utf8");
+    await expect(listIsas({ homeDir })).rejects.toThrow();
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
+test("listIsas returns [] for missing isa dir (ENOENT only)", async () => {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-isa-noenoent-"));
+  try {
+    // Don't bootstrap — isa dir doesn't exist at all
+    const entries = await listIsas({ homeDir });
+    expect(entries).toEqual([]);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+});
+
 test("listIsas returns entries sorted by updated desc, ignoring INDEX.md", async () => {
   await withSomaHome(async (homeDir) => {
     await scaffoldIsa({

--- a/test/isa.test.ts
+++ b/test/isa.test.ts
@@ -1,0 +1,241 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import {
+  activeStatePath,
+  bootstrapSomaHome,
+  checkCompleteness,
+  getActiveIsa,
+  getCriteria,
+  getGoal,
+  isaPath,
+  listAvailableTiers,
+  listIsas,
+  readIsa,
+  recordIsaDecision,
+  scaffoldIsa,
+  setActiveIsa,
+  writeIsa,
+  somaMemoryEventsPath,
+} from "../src/index";
+import { parseIsa, serializeIsa } from "../src/isa-parse";
+
+async function withSomaHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-isa-lib-"));
+  try {
+    await bootstrapSomaHome({ homeDir });
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function readEvents(homeDir: string): Promise<{ kind: string; metadata?: Record<string, unknown> }[]> {
+  const path = somaMemoryEventsPath(join(homeDir, ".soma"));
+  const raw = await readFile(path, "utf8").catch(() => "");
+  return raw.split("\n").filter((line) => line.length > 0).map((line) => JSON.parse(line) as { kind: string; metadata?: Record<string, unknown> });
+}
+
+test("AC-1: library exports the seven core functions", () => {
+  expect(typeof readIsa).toBe("function");
+  expect(typeof writeIsa).toBe("function");
+  expect(typeof listIsas).toBe("function");
+  expect(typeof scaffoldIsa).toBe("function");
+  expect(typeof checkCompleteness).toBe("function");
+  expect(typeof setActiveIsa).toBe("function");
+  expect(typeof getActiveIsa).toBe("function");
+});
+
+test("AC-7 Anti: reconcileIsa is NOT exported from the library", () => {
+  // Import the namespace object and assert reconcileIsa is absent
+  // (it lives in deferred issue #35 only).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const lib = require("../src/isa") as Record<string, unknown>;
+  expect(lib.reconcileIsa).toBeUndefined();
+});
+
+test("scaffoldIsa produces an ISA that passes checkCompleteness at the same tier", async () => {
+  await withSomaHome(async (homeDir) => {
+    for (const tier of listAvailableTiers()) {
+      const slug = `scaffold-${tier.toLowerCase()}`;
+      await scaffoldIsa({
+        homeDir,
+        slug,
+        goal: `Demo goal for ${tier}`,
+        effort: tier,
+        timestamp: "2026-05-17T00:00:00.000Z",
+        initialCriteria: [{ id: "C1", text: "Demo criterion", status: "open" }],
+      });
+      const report = await checkCompleteness(slug, { homeDir });
+      expect(report.passed).toBe(true);
+      expect(report.tier).toBe(tier);
+      expect(report.gaps).toHaveLength(0);
+    }
+  });
+});
+
+test("readIsa returns parsed IdealStateArtifact with sourcePath", async () => {
+  await withSomaHome(async (homeDir) => {
+    await scaffoldIsa({ homeDir, slug: "demo", goal: "Test goal", effort: "E1" });
+    const isa = await readIsa("demo", { homeDir });
+    expect(isa.slug).toBe("demo");
+    expect(getGoal(isa)).toBe("Test goal");
+    expect(isa.sourcePath).toContain("/isa/demo.md");
+  });
+});
+
+test("writeIsa returns changed=false when content is byte-equivalent", async () => {
+  await withSomaHome(async (homeDir) => {
+    await scaffoldIsa({ homeDir, slug: "demo", goal: "Test goal", effort: "E1" });
+    const isa = await readIsa("demo", { homeDir });
+    const result = await writeIsa("demo", isa, { homeDir });
+    expect(result.changed).toBe(false);
+  });
+});
+
+test("writeIsa returns changed=true after structural mutation", async () => {
+  await withSomaHome(async (homeDir) => {
+    await scaffoldIsa({ homeDir, slug: "demo", goal: "Test goal", effort: "E1" });
+    const isa = await readIsa("demo", { homeDir });
+    const mutated = {
+      ...isa,
+      sections: [...isa.sections, { name: "Extra", content: "extra body" }],
+    };
+    const result = await writeIsa("demo", mutated, { homeDir });
+    expect(result.changed).toBe(true);
+  });
+});
+
+test("AC-6: writeIsa serializes to semantic-equivalent content on round-trip", async () => {
+  await withSomaHome(async (homeDir) => {
+    await scaffoldIsa({
+      homeDir,
+      slug: "rtrip",
+      goal: "Round-trip goal",
+      effort: "E2",
+      initialCriteria: [
+        { id: "C1", text: "First", status: "passed", verification: "evidence" },
+        { id: "C2", text: "Second", status: "open" },
+      ],
+    });
+    const original = await readFile(join(homeDir, ".soma", "isa", "rtrip.md"), "utf8");
+    const reparsed = parseIsa(original);
+    const reserialized = serializeIsa(reparsed);
+    // Same identity: raw input WeakMap hit
+    expect(reserialized).toBe(original);
+    // After parse → access → serialize, derived fields match
+    const isa = await readIsa("rtrip", { homeDir });
+    expect(getCriteria(isa)).toHaveLength(2);
+    expect(getCriteria(isa)[0]?.status).toBe("passed");
+  });
+});
+
+test("listIsas returns entries sorted by updated desc, ignoring INDEX.md", async () => {
+  await withSomaHome(async (homeDir) => {
+    await scaffoldIsa({
+      homeDir, slug: "alpha", goal: "G", effort: "E1", timestamp: "2026-05-01T00:00:00.000Z",
+    });
+    await scaffoldIsa({
+      homeDir, slug: "bravo", goal: "G", effort: "E1", timestamp: "2026-05-17T00:00:00.000Z",
+    });
+    const entries = await listIsas({ homeDir });
+    expect(entries.map((e) => e.slug)).toEqual(["bravo", "alpha"]);
+    expect(entries[0]?.phase).toBe("observe");
+  });
+});
+
+test("AC-4: setActiveIsa writes active.json atomically and returns previous", async () => {
+  await withSomaHome(async (homeDir) => {
+    expect(await getActiveIsa({ homeDir })).toBeNull();
+    const first = await setActiveIsa("demo", { homeDir, runId: "run-1", timestamp: "2026-05-17T00:00:00.000Z" });
+    expect(first.previousSlug).toBeNull();
+    expect(first.state.activeSlug).toBe("demo");
+    expect(first.state.runId).toBe("run-1");
+
+    const stateOnDisk = JSON.parse(await readFile(activeStatePath(join(homeDir, ".soma")), "utf8"));
+    expect(stateOnDisk.activeSlug).toBe("demo");
+
+    const second = await setActiveIsa("other", { homeDir, timestamp: "2026-05-17T01:00:00.000Z" });
+    expect(second.previousSlug).toBe("demo");
+
+    const cleared = await setActiveIsa(null, { homeDir, timestamp: "2026-05-17T02:00:00.000Z" });
+    expect(cleared.previousSlug).toBe("other");
+    expect(cleared.state.activeSlug).toBeNull();
+  });
+});
+
+test("getActiveIsa returns null for missing or malformed active.json", async () => {
+  await withSomaHome(async (homeDir) => {
+    expect(await getActiveIsa({ homeDir })).toBeNull();
+    // Write malformed content
+    const path = activeStatePath(join(homeDir, ".soma"));
+    const { mkdir, writeFile: wf } = await import("node:fs/promises");
+    await mkdir(join(homeDir, ".soma", "memory", "STATE"), { recursive: true });
+    await wf(path, "not json", "utf8");
+    expect(await getActiveIsa({ homeDir })).toBeNull();
+    // Write valid JSON but wrong shape
+    await wf(path, JSON.stringify({ foo: "bar" }), "utf8");
+    expect(await getActiveIsa({ homeDir })).toBeNull();
+  });
+});
+
+test("AC-5: every mutation appends a structured event to events.jsonl", async () => {
+  await withSomaHome(async (homeDir) => {
+    await scaffoldIsa({ homeDir, slug: "ev", goal: "G", effort: "E1" });
+    const isa = await readIsa("ev", { homeDir });
+    await writeIsa("ev", { ...isa, sections: [...isa.sections, { name: "Extra", content: "x" }] }, { homeDir });
+    await setActiveIsa("ev", { homeDir });
+    await recordIsaDecision("ev", "Test decision", { homeDir });
+
+    const events = await readEvents(homeDir);
+    const kinds = events.map((e) => e.kind);
+    expect(kinds).toContain("isa.scaffold");
+    expect(kinds).toContain("isa.write");
+    expect(kinds).toContain("isa.active_changed");
+  });
+});
+
+test("scaffoldIsa rejects invalid slug / empty goal / unknown tier", async () => {
+  await withSomaHome(async (homeDir) => {
+    await expect(scaffoldIsa({ homeDir, slug: "Bad Slug", goal: "g", effort: "E1" })).rejects.toThrow("Invalid ISA slug");
+    await expect(scaffoldIsa({ homeDir, slug: "good", goal: "   ", effort: "E1" })).rejects.toThrow("non-empty goal");
+    await expect(
+      scaffoldIsa({ homeDir, slug: "good", goal: "g", effort: "E9" as unknown as "E1" }),
+    ).rejects.toThrow("Invalid effort tier");
+  });
+});
+
+test("writeIsa rejects unsafe slugs", async () => {
+  await withSomaHome(async (homeDir) => {
+    const sample = await scaffoldIsa({ homeDir, slug: "ok", goal: "g", effort: "E1" });
+    expect(() => isaPath(join(homeDir, ".soma"), "../etc/passwd")).toThrow("Invalid ISA slug");
+    expect(() => isaPath(join(homeDir, ".soma"), "Bad Slug")).toThrow("Invalid ISA slug");
+    void sample;
+  });
+});
+
+test("checkCompleteness reports gaps for tier-required sections that are missing", async () => {
+  await withSomaHome(async (homeDir) => {
+    await scaffoldIsa({ homeDir, slug: "incomplete", goal: "G", effort: "E3" });
+    // Manually remove the Vision section to introduce a gap. (Serialize drops
+    // empty sections, so on round-trip an empty section becomes "missing".)
+    const isa = await readIsa("incomplete", { homeDir });
+    const cleared = { ...isa, sections: isa.sections.filter((s) => s.name !== "Vision") };
+    await writeIsa("incomplete", cleared, { homeDir });
+    const report = await checkCompleteness("incomplete", { homeDir });
+    expect(report.passed).toBe(false);
+    expect(report.gaps.some((g) => g.section === "Vision" && g.reason === "missing")).toBe(true);
+  });
+});
+
+test("recordIsaDecision appends to Decisions section and updates timestamp", async () => {
+  await withSomaHome(async (homeDir) => {
+    await scaffoldIsa({ homeDir, slug: "dec", goal: "G", effort: "E4", timestamp: "2026-05-17T00:00:00.000Z" });
+    await recordIsaDecision("dec", "Chose path A", { homeDir, timestamp: "2026-05-17T10:00:00.000Z" });
+    const isa = await readIsa("dec", { homeDir });
+    expect(isa.frontmatter.updated).toBe("2026-05-17T10:00:00.000Z");
+    const decisions = isa.sections.find((s) => s.name === "Decisions");
+    expect(decisions?.content).toContain("Chose path A");
+  });
+});

--- a/test/isa.test.ts
+++ b/test/isa.test.ts
@@ -3,13 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
 import {
-  activeStatePath,
   bootstrapSomaHome,
   checkCompleteness,
   getActiveIsa,
   getCriteria,
   getGoal,
-  isaPath,
   listAvailableTiers,
   listIsas,
   readIsa,
@@ -19,6 +17,9 @@ import {
   writeIsa,
   somaMemoryEventsPath,
 } from "../src/index";
+// Path helpers are intentionally internal (#34 Sage round-2 finding) —
+// tests import them directly from the implementation module.
+import { activeStatePath, isaPath } from "../src/isa";
 import { parseIsa, serializeIsa } from "../src/isa-parse";
 
 async function withSomaHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
@@ -128,6 +129,23 @@ test("AC-6: writeIsa serializes to semantic-equivalent content on round-trip", a
     const isa = await readIsa("rtrip", { homeDir });
     expect(getCriteria(isa)).toHaveLength(2);
     expect(getCriteria(isa)[0]?.status).toBe("passed");
+  });
+});
+
+test("listIsas surfaces per-file read errors with slug/path context", async () => {
+  await withSomaHome(async (homeDir) => {
+    await scaffoldIsa({ homeDir, slug: "good", goal: "G", effort: "E1" });
+    // Plant an unreadable .md file by removing read permission.
+    const { writeFile: wf, chmod: ch } = await import("node:fs/promises");
+    const unreadable = join(homeDir, ".soma", "isa", "unreadable.md");
+    await wf(unreadable, "---\ntask: x\neffort: E1\nphase: observe\n---\n\n## Goal\n\nx\n", "utf8");
+    await ch(unreadable, 0o000);
+    try {
+      await expect(listIsas({ homeDir })).rejects.toThrow(/unreadable/);
+    } finally {
+      // Restore so afterAll cleanup can rm the file
+      await ch(unreadable, 0o644).catch(() => undefined);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Sprint 2 main course — library CRUD on top of #41 (type) + #32 (storage) + #33 (skills).

- `src/isa-schema.ts` — tier completeness gate config + evaluateCompleteness
- `src/isa.ts` — 7 core functions: readIsa, writeIsa, listIsas, scaffoldIsa, checkCompleteness, setActiveIsa, getActiveIsa + recordIsaDecision file-backed helper

Audit: every mutation appends a structured event to events.jsonl.
Atomicity: setActiveIsa uses write-rename for active.json.
Round-trip: writeIsa returns changed=false on byte-equivalent content via parseIsa/serializeIsa.

## ACs

- [x] AC-1: src/isa.ts exports seven functions
- [x] AC-2: each function has unit tests
- [x] AC-3: scaffoldIsa at E1..E5 produces ISA that passes checkCompleteness at same tier (placeholder-filled skeletons)
- [x] AC-4: setActiveIsa write-rename atomic
- [x] AC-5: every mutation appends events.jsonl entry (isa.scaffold, isa.write, isa.active_changed)
- [x] AC-6: writeIsa changed=false on byte-equivalent round-trip
- [x] AC-7 Anti: reconcileIsa NOT in src/isa.ts (deferred to #35)

## Test plan

- [x] `bun test` — 300 pass, 0 fail (15 new tests covering all 7 functions + edge cases)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean

Unblocks #36 (CLI), #37 (adapters), #38 (lifecycle), #39 (Algorithm advisory), #35 (reconcile — after 2-week stability gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)