### PR TITLE
fix(codex): keep PreToolUse success output minimal

### DIFF
--- a/src/adapters/codex/hooks/codex-hook-entry.mjs
+++ b/src/adapters/codex/hooks/codex-hook-entry.mjs
@@ -129,40 +129,6 @@ function algorithmPromptHookOutput(classification) {
   };
 }
 
-const PHASE_LABELS = {
-  observe: "Phase 1/7 — OBSERVE",
-  think: "Phase 2/7 — THINK",
-  plan: "Phase 3/7 — PLAN",
-  build: "Phase 4/7 — BUILD",
-  execute: "Phase 5/7 — EXECUTE",
-  verify: "Phase 6/7 — VERIFY",
-  learn: "Phase 7/7 — LEARN",
-  complete: "Phase 7/7 — SUMMARY",
-};
-
-function readActiveAlgorithmPhase(config) {
-  try {
-    const state = JSON.parse(readFileSync(`${config.somaHome}/memory/STATE/active-algorithm-run.json`, "utf8"));
-    const phase = state.phase || state.run?.phase;
-    return typeof phase === "string" ? phase : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function phaseStatusOutput(config) {
-  const phase = readActiveAlgorithmPhase(config);
-  const label = phase ? PHASE_LABELS[phase] : undefined;
-  if (!label) return {};
-
-  return {
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      statusMessage: `Soma: ${label}`,
-    },
-  };
-}
-
 function writeProjectedStartupContext(output) {
   const marker = "# Soma Startup Context";
   const index = output.indexOf(marker);
@@ -213,7 +179,7 @@ function handlePreToolUse(config, input) {
       denyPreToolUse(reason);
     }
   }
-  emitAndExit({ continue: true, ...phaseStatusOutput(config) });
+  emitAndExit({ continue: true });
 }
 
 function handlePromptSubmit(config, input) {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -399,7 +399,7 @@ test("installed codex hook handles null tool input", async () => {
   });
 });
 
-test("installed codex hook reports active Algorithm phase on pre-tool use", async () => {
+test("installed codex hook keeps successful pre-tool use output schema-minimal", async () => {
   await withTempHome(async (homeDir) => {
     await installSomaForCodex({ homeDir });
     await writeFile(join(homeDir, ".soma/memory/STATE/active-algorithm-run.json"), JSON.stringify({ id: "run-1", phase: "execute" }), "utf8");
@@ -411,7 +411,7 @@ test("installed codex hook reports active Algorithm phase on pre-tool use", asyn
 
     expect(result.status).toBe(0);
     expect(result.output.continue).toBe(true);
-    expect(result.output.hookSpecificOutput?.statusMessage).toBe("Soma: Phase 5/7 — EXECUTE");
+    expect(result.output.hookSpecificOutput).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- remove active Algorithm phase status output from successful Codex PreToolUse hook responses
- keep PreToolUse success responses schema-minimal as { continue: true }
- update the install test to prevent reintroducing hookSpecificOutput/statusMessage on successful PreToolUse

## Verification
- bun test test/install.test.ts
- bun run typecheck
- bun run lint
- bun test

## Live projection
- ran bun run soma install codex --apply
- verified: printf '{"tool_name":"Write","tool_input":null}' | node /Users/fischer/.codex/hooks/soma-lifecycle.mjs pre-tool-use -> {"continue":true}
