### PR TITLE
fix(skills): keep imported descriptions Codex-safe

### DIFF
--- a/docs/pai-pack-importer.md
+++ b/docs/pai-pack-importer.md
@@ -54,6 +54,12 @@ lowercase Soma skill name. Source docs are preserved under `references/` so
 Claude-specific installation guidance remains available without becoming the
 Soma install procedure.
 
+Soma skill descriptions are compact runtime metadata. Imported descriptions are
+normalized to the portable Soma skill metadata limit of 1024 characters; longer
+routing doctrine belongs in the skill body, references, or generated routing
+metadata rather than frontmatter. The importer records this as a normalization
+action when it compacts an oversized description.
+
 ## Classification
 
 The import plan classifies each file:

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -5,6 +5,7 @@ import { routePaiPackSourceFile, type PaiPackRenderMode } from "./pai-pack-routi
 import {
   generateSomaSkillManifest,
   mergeNormalizationReports,
+  normalizeSkillDescription,
   normalizeSkillContent,
 } from "./pai-pack-normalizer";
 import type {
@@ -420,7 +421,14 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
   // report actions and warnings without writing. The Map is also re-used by
   // the apply path (no second read+normalize pass) — Sage round 1 finding.
   const normalizedSkillFiles = await normalizeSkillFiles(homes.paiPackDir, routedFiles);
-  const normalization = reportFromNormalizedFiles(normalizedSkillFiles.values());
+  const normalizedDescription = normalizeSkillDescription(metadata.description, {
+    file: "README.md",
+    fallback: `Imported PAI pack: ${metadata.name}`,
+  });
+  const normalization = mergeNormalizationReports([
+    reportFromNormalizedFiles(normalizedSkillFiles.values()),
+    { actions: normalizedDescription.action ? [normalizedDescription.action] : [], warnings: [] },
+  ]);
 
   routedFiles.push({
     target: join(homes.somaHome, `skills/${skillName}/soma-pack.json`),
@@ -462,7 +470,7 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
     somaHome: homes.somaHome,
     skillName,
     packName: metadata.name,
-    description: metadata.description,
+    description: normalizedDescription.description,
     files,
     routedFiles,
     normalization,

--- a/src/pai-pack-normalizer.ts
+++ b/src/pai-pack-normalizer.ts
@@ -29,6 +29,8 @@ export interface NormalizeContentResult {
   warnings: PaiPackNormalizationWarning[];
 }
 
+export const SOMA_SKILL_DESCRIPTION_MAX_LENGTH = 1024;
+
 // Patterns that mark "must execute" runtime blocks in PAI skill bodies. We
 // strip the *executable instruction* (curl notification calls + the
 // "MANDATORY" framing) but keep neutral prose.
@@ -219,6 +221,54 @@ export function mergeNormalizationReports(
   };
 }
 
+export interface NormalizeSkillDescriptionResult {
+  description: string;
+  action?: PaiPackNormalizationAction;
+}
+
+export function normalizeSkillDescription(
+  description: string,
+  options: {
+    file: string;
+    fallback: string;
+    maxLength?: number;
+  },
+): NormalizeSkillDescriptionResult {
+  const maxLength = options.maxLength ?? SOMA_SKILL_DESCRIPTION_MAX_LENGTH;
+  const source = (description || options.fallback).replace(/\s+/g, " ").trim();
+  const fallback = options.fallback.replace(/\s+/g, " ").trim();
+  const initial = source || fallback;
+  if (initial.length <= maxLength) {
+    return { description: initial };
+  }
+
+  const sentences = initial.match(/[^.!?]+[.!?]+(?=\s|$)|[^.!?]+$/g)?.map((sentence) => sentence.trim()) ?? [];
+  let compact = "";
+  for (const sentence of sentences) {
+    const next = compact ? `${compact} ${sentence}` : sentence;
+    if (next.length > maxLength) break;
+    compact = next;
+  }
+
+  if (!compact) {
+    compact = initial.slice(0, maxLength).trimEnd();
+    compact = compact.replace(/[,;:\s-]+$/u, "");
+  }
+
+  if (!compact) {
+    compact = fallback.slice(0, maxLength).trimEnd();
+  }
+
+  return {
+    description: compact,
+    action: {
+      file: options.file,
+      kind: "compacted-skill-description",
+      detail: `Compacted skill description from ${initial.length} to ${compact.length} characters for Soma's portable ${maxLength}-character skill metadata limit.`,
+    },
+  };
+}
+
 export interface GenerateSomaSkillManifestInput {
   skillName: string;
   description: string;
@@ -230,10 +280,15 @@ export interface GenerateSomaSkillManifestInput {
 }
 
 export function generateSomaSkillManifest(input: GenerateSomaSkillManifestInput): SomaSkillManifest {
+  const { description } = normalizeSkillDescription(input.description, {
+    file: "soma-skill.json",
+    fallback: `Imported PAI pack: ${input.packName}`,
+  });
+
   return {
     schema: "soma.skill.v1",
     name: input.skillName,
-    description: input.description || `Imported PAI pack: ${input.packName}`,
+    description,
     packId: input.packId,
     source: { kind: "pai-pack", packName: input.packName },
     entrypoint: input.entrypoint,

--- a/src/skills/ISA/SKILL.md
+++ b/src/skills/ISA/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ISA
-description: "Owns the Ideal State Artifact — the universal primitive that holds the articulated ideal state of any thing (project, task, application, library, infrastructure, work session) as a hard-to-vary explanation. The ISA is a single document that articulates the ideal state, drives the build, verifies the build, and records the evolution of understanding. Five workflows: Scaffold (generate a fresh ISA from a prompt at a specified effort tier), Interview (adaptive question-and-answer to fill in or deepen sections), CheckCompleteness (score an existing ISA against the tier completeness gate and report gaps), Reconcile (deterministic merge of an ephemeral feature-file excerpt back into the master ISA, keyed on stable ISC IDs), Seed (bootstrap a draft project ISA from an existing repository's README, code structure, and recent commits). Examples directory contains canonical-isa.md (the showpiece reference, fully populated across all twelve sections), e1-minimal.md (90-second task — Goal + Criteria only), e3-project.md (mid-size project with eight sections), e5-enterprise.md / e5-desktop-app.md / e5-album.md (full applications with all twelve sections plus a populated changelog history). Twelve-section body order is locked: Problem, Vision, Out of Scope, Principles, Constraints, Goal, Criteria, Test Strategy, Features, Decisions, Changelog, Verification. The skill is invoked automatically by the Algorithm at OBSERVE for any non-trivial task and may also be invoked directly by the user to scaffold or audit an ISA outside an Algorithm run. USE WHEN: any prompt mentions ideal state, ISA, ISC, ideal state criteria, ideal state artifact, project specification, hill-climb on a task, articulating done, scaffolding an ISA, interviewing for an ISA, checking ISA completeness, reconciling an ephemeral feature file back to a master ISA, or seeding an ISA from an existing project. NOT FOR creating new skills (use CreateSkill), running the Algorithm itself (the Algorithm invokes this skill), generating non-ISA artifacts (this skill owns the ISA primitive only), or after-the-fact write-ups like postmortems, decision logs, or engineering journals (those are retrospective; the ISA is a commitment-time scaffold for ideal state)."
+description: "Owns the Ideal State Artifact: the commitment-time scaffold for articulating done, deriving ISC criteria, planning features, recording decisions, and verifying work. Use for ideal state, ISA/ISC criteria, project specs, scaffolding, completeness checks, reconciliation, or seeding an ISA from a repo."
 effort: medium
 version: 1.0.1
 pack-id: pai-isa-v1.0.0
@@ -30,6 +30,31 @@ pack-id: pai-isa-v1.0.0
 The ISA is the single document that articulates "done" for any thing whose ideal state we are pursuing — a project, an application, a library, infrastructure, a work session, an art piece, a strategic decision. It serves five identities simultaneously: ideal state articulation, test harness, build verification, done condition, system of record.
 
 This skill owns the canonical template, the workflows that generate and refine ISAs, and the example library.
+
+---
+
+## Routing Details
+
+The ISA is the universal primitive that holds the articulated ideal state of any thing (project, task, application, library, infrastructure, work session) as a hard-to-vary explanation. It drives the build, verifies the build, and records the evolution of understanding.
+
+Five workflows:
+
+- Scaffold: generate a fresh ISA from a prompt at a specified effort tier.
+- Interview: adaptive question-and-answer to fill in or deepen sections.
+- CheckCompleteness: score an existing ISA against the tier completeness gate and report gaps.
+- Reconcile: deterministic merge of an ephemeral feature-file excerpt back into the master ISA, keyed on stable ISC IDs.
+- Seed: bootstrap a draft project ISA from an existing repository's README, code structure, and recent commits.
+
+Examples directory:
+
+- `canonical-isa.md`: showpiece reference, fully populated across all twelve sections.
+- `e1-minimal.md`: 90-second task with Goal and Criteria only.
+- `e3-project.md`: mid-size project with eight sections.
+- `e5-enterprise.md`, `e5-desktop-app.md`, and `e5-album.md`: full applications with all twelve sections plus populated changelog history.
+
+Use when any prompt mentions ideal state, ISA, ISC, ideal state criteria, ideal state artifact, project specification, hill-climb on a task, articulating done, scaffolding an ISA, interviewing for an ISA, checking ISA completeness, reconciling an ephemeral feature file back to a master ISA, or seeding an ISA from an existing project.
+
+Not for creating new skills, running the Algorithm itself, generating non-ISA artifacts, or after-the-fact write-ups like postmortems, decision logs, or engineering journals. Those are retrospective; the ISA is a commitment-time scaffold for ideal state.
 
 ---
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -426,7 +426,8 @@ export interface PaiPackNormalizationAction {
   kind:
     | "removed-substrate-notification-hook"
     | "rewrote-claude-home-path"
-    | "stripped-mandatory-runtime-block";
+    | "stripped-mandatory-runtime-block"
+    | "compacted-skill-description";
   detail: string;
 }
 

--- a/test/isa-skill-installer.test.ts
+++ b/test/isa-skill-installer.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { expect, test } from "bun:test";
 import { installIsaSkill } from "../src/index";
 import type { SomaSkillBaselines } from "../src/index";
+import { SOMA_SKILL_DESCRIPTION_MAX_LENGTH } from "../src/pai-pack-normalizer";
 import {
   compareSkillVersions,
   isaSkillRuntimeDir,
@@ -306,4 +307,13 @@ test("ship config: real src/skills/ISA carries version + pack-id frontmatter", a
   expect(fm).not.toBeNull();
   expect(fm?.version).toMatch(/^\d+\.\d+\.\d+/);
   expect(fm?.packId).toMatch(/^pai-isa/);
+});
+
+test("ship config: real src/skills/ISA description fits portable metadata limit", async () => {
+  const repoSkill = join(import.meta.dirname, "..", "src", "skills", "ISA", "SKILL.md");
+  const content = await readFile(repoSkill, "utf8");
+  const description = /^description:\s*"([\s\S]*?)"$/m.exec(content)?.[1];
+  expect(description).toBeDefined();
+  expect(description!.length).toBeLessThanOrEqual(SOMA_SKILL_DESCRIPTION_MAX_LENGTH);
+  expect(content).toContain("## Routing Details");
 });

--- a/test/pai-pack-normalizer.test.ts
+++ b/test/pai-pack-normalizer.test.ts
@@ -3,11 +3,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
 import {
+  SOMA_SKILL_DESCRIPTION_MAX_LENGTH,
   generateSomaSkillManifest,
   mergeNormalizationReports,
+  normalizeSkillDescription,
   normalizeSkillContent,
 } from "../src/pai-pack-normalizer";
 import { importPaiPack, planPaiPackImport } from "../src/index";
+
+function makeLongDescription(count = 80, detail = "explains routing details"): string {
+  return Array.from({ length: count }, (_, index) => `Sentence ${index} ${detail}.`).join(" ");
+}
 
 async function withFakePack<T>(fn: (paiPackDir: string, somaHome: string, homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-pack-norm-"));
@@ -233,6 +239,30 @@ test("generateSomaSkillManifest extracts triggers from USE WHEN clause", () => {
   expect(manifest.source).toEqual({ kind: "pai-pack", packName: "Demo" });
 });
 
+test("normalizeSkillDescription compacts descriptions for portable metadata limit", () => {
+  const longDescription = makeLongDescription();
+  const result = normalizeSkillDescription(longDescription, {
+    file: "README.md",
+    fallback: "Imported PAI pack: Demo",
+  });
+
+  expect(result.description.length).toBeLessThanOrEqual(SOMA_SKILL_DESCRIPTION_MAX_LENGTH);
+  expect(result.action?.kind).toBe("compacted-skill-description");
+});
+
+test("generateSomaSkillManifest keeps generated descriptions within portable limit", () => {
+  const manifest = generateSomaSkillManifest({
+    skillName: "demo",
+    description: makeLongDescription(),
+    packName: "Demo",
+    entrypoint: "SKILL.md",
+    references: [],
+    workflowFiles: [],
+  });
+
+  expect(manifest.description.length).toBeLessThanOrEqual(SOMA_SKILL_DESCRIPTION_MAX_LENGTH);
+});
+
 test("AC-1: dry-run plan reports normalization actions + warnings", async () => {
   await withFakePack(async (paiPackDir, somaHome, homeDir) => {
     const plan = await planPaiPackImport({ homeDir, somaHome, paiPackDir });
@@ -240,6 +270,27 @@ test("AC-1: dry-run plan reports normalization actions + warnings", async () => 
     expect(plan.normalization.warnings.length).toBeGreaterThan(0);
     // No files written under somaHome
     await expect(readFile(join(somaHome, "skills", "test-pack", "SKILL.md"), "utf8")).rejects.toThrow();
+  });
+});
+
+test("PAI pack import compacts oversized skill descriptions in frontmatter and manifest", async () => {
+  await withFakePack(async (paiPackDir, somaHome, homeDir) => {
+    const longDescription = makeLongDescription(90, "explains imported routing details");
+    await writeFile(
+      join(paiPackDir, "README.md"),
+      `---\nname: TestPack\ndescription: ${JSON.stringify(longDescription)}\n---\n\n# TestPack\n`,
+      "utf8",
+    );
+
+    const result = await importPaiPack({ homeDir, somaHome, paiPackDir });
+    expect(result.normalization.actions.some((action) => action.kind === "compacted-skill-description")).toBe(true);
+
+    const skillMd = await readFile(join(somaHome, "skills", "test-pack", "SKILL.md"), "utf8");
+    const description = /^description:\s*"([\s\S]*?)"$/m.exec(skillMd)?.[1] ?? "";
+    expect(description.length).toBeLessThanOrEqual(SOMA_SKILL_DESCRIPTION_MAX_LENGTH);
+
+    const somaSkill = JSON.parse(await readFile(join(somaHome, "skills", "test-pack", "soma-skill.json"), "utf8"));
+    expect(somaSkill.description.length).toBeLessThanOrEqual(SOMA_SKILL_DESCRIPTION_MAX_LENGTH);
   });
 });
 


### PR DESCRIPTION
## Summary
- shorten the bundled ISA skill frontmatter description to fit Codex's 1024-character skill metadata limit
- move the detailed ISA routing/workflow guidance into the ISA skill body
- add importer normalization for oversized PAI pack descriptions, recording a compacted-skill-description action
- keep generated soma-skill.json descriptions within the same Codex limit

Closes #57

## Verification
- bun test test/pai-pack-normalizer.test.ts test/isa-skill-installer.test.ts
- bun run typecheck
- bun run lint
- bun test
