### PR TITLE
docs: align all docs + ISA with CONTEXT.md glossary

### DIFF
--- a/ISA.md
+++ b/ISA.md
@@ -22,10 +22,10 @@ learning.
 
 ## Vision
 
-Soma becomes the portable body of a personal AI assistant. The same assistant
-context can run inside Codex, Pi.dev, Claude Code, or as a Cortex/Myelin daemon.
-The substrate changes; the assistant's identity, memory, goals, skills, and
-work artifacts remain stable.
+Soma becomes the portable body of a personal AI assistant. The same Soma can
+run inside Codex, Pi.dev, Claude Code, or as a Cortex/Myelin daemon. The
+substrate changes; the assistant's identity, memory, goals, skills, and work
+artifacts remain stable.
 
 ## Out of Scope
 
@@ -56,7 +56,7 @@ work artifacts remain stable.
 
 ## Goal
 
-Define and scaffold Soma as a substrate-portable Personal AI Assistant core with
+Define and scaffold Soma as a portable Personal AI Assistant core with
 clear boundaries, initial storage contracts, and an adapter path for Codex,
 Pi.dev, Claude Code, and Cortex/Myelin.
 
@@ -68,7 +68,7 @@ Pi.dev, Claude Code, and Cortex/Myelin.
 - [x] ISC-4: Substrate adapter doc covers Codex, Pi.dev, Claude Code, and Cortex.
 - [x] ISC-5: Initial TypeScript types model identity, telos, ISA, memory, skills, and adapters.
 - [x] ISC-6: Arc manifest declares Soma as a Meta Factory component.
-- [x] ISC-7: Skill stub explains when an agent should use Soma.
+- [x] ISC-7: Skill stub explains when an assistant should use Soma.
 - [x] ISC-8: Package metadata supports Bun-based development.
 - [x] ISC-9: Anti: Soma does not claim to replace Cortex or Myelin.
 - [x] ISC-10: Anti: Soma does not bind the core to one model provider.
@@ -80,11 +80,11 @@ Pi.dev, Claude Code, and Cortex/Myelin.
 - [x] ISC-16: Boundary ownership rules define what Soma owns versus references.
 - [x] ISC-17: Portability proof defines the first same-input, two-substrate workflow.
 - [x] ISC-18: Memory and policy v0 are scoped before richer stores or enforcement.
-- [x] ISC-19: Codex adapter builds a deterministic context bundle from a Soma profile.
-- [x] ISC-20: Pi.dev adapter builds an extension-shaped context bundle from the same Soma input.
-- [x] ISC-21: Claude Code adapter builds a Claude-shaped context bundle from the same Soma input.
+- [x] ISC-19: Codex adapter builds a deterministic projection from a Soma profile.
+- [x] ISC-20: Pi.dev adapter builds an extension-shaped projection from the same Soma input.
+- [x] ISC-21: Claude Code adapter builds a Claude-shaped projection from the same Soma input.
 - [x] ISC-22: ESLint setup follows the Arc/Myelin flat-config pattern and passes on Soma.
-- [x] ISC-23: Context bundles can be written to disk with path escape protection.
+- [x] ISC-23: Projections can be written to disk with path escape protection.
 - [x] ISC-24: Default availability is defined as home installation with workspace overlays.
 - [x] ISC-25: Codex home projection resolves `~/.soma` and materializes into `~/.codex`.
 - [x] ISC-26: Soma home bootstrap creates `~/.soma` source files and loads them into context.
@@ -115,11 +115,11 @@ Pi.dev, Claude Code, and Cortex/Myelin.
 | ISC-16 | file | boundary doc declares sources of truth | read |
 | ISC-17 | file | portability proof names workflow and pass conditions | read |
 | ISC-18 | file | memory/policy v0 separates file memory from enforcement | read |
-| ISC-19 | unit | Codex context bundle contains profile, telos, memory, skills, and ISA | bun test |
-| ISC-20 | unit | Pi.dev context bundle contains profile, telos, memory, skills, ISA, and tool contract | bun test |
-| ISC-21 | unit | Claude Code context bundle contains profile, telos, memory, skills, ISA, and hook plan | bun test |
+| ISC-19 | unit | Codex projection contains profile, telos, memory, skills, and ISA | bun test |
+| ISC-20 | unit | Pi.dev projection contains profile, telos, memory, skills, ISA, and tool contract | bun test |
+| ISC-21 | unit | Claude Code projection contains profile, telos, memory, skills, ISA, and hook plan | bun test |
 | ISC-22 | static | ESLint flat config and package scripts are installed | bun run lint |
-| ISC-23 | unit | Bundle writer creates substrate files and rejects unsafe paths | bun test |
+| ISC-23 | unit | Projection writer creates substrate files and rejects unsafe paths | bun test |
 | ISC-24 | file | Default availability doc distinguishes home projection from workspace overlay | read |
 | ISC-25 | unit | Codex home projection resolves paths and writes rules, skill, memory, and policy files | bun test |
 | ISC-26 | unit | Soma home bootstrap creates profile, memory, skill, policy, and projection layout | bun test |
@@ -145,9 +145,9 @@ Pi.dev, Claude Code, and Cortex/Myelin.
 | Pi.dev context adapter | ISC-20 | type contracts | yes |
 | Claude Code context adapter | ISC-21 | type contracts | yes |
 | ESLint baseline | ISC-22 | package metadata | no |
-| Context bundle writer | ISC-23 | context adapters | no |
+| Projection writer | ISC-23 | context adapters | no |
 | Default availability design | ISC-24 | PAI integration review | no |
-| Codex home projection | ISC-25 | context bundle writer | no |
+| Codex home projection | ISC-25 | projection writer | no |
 | Soma home bootstrap | ISC-26 | default availability design | no |
 | Codex install flow | ISC-27 | Soma home bootstrap, Codex home projection | no |
 | Memory event writeback | ISC-28 | Soma home bootstrap | no |
@@ -164,15 +164,14 @@ Pi.dev, Claude Code, and Cortex/Myelin.
   a dedicated Codex adapter.
 - 2026-05-14: Accepted Luna's concept review as design pressure: boundary
   ownership, portability proof, memory v0, and policy v0 are now explicit.
-- 2026-05-14: Implemented Codex as context generation first. Running Codex tasks
-  remains out of scope until context projection is proven across a second
-  substrate.
-- 2026-05-14: Implemented Pi.dev and Claude Code as context generation first.
-  The same Soma input is now projected into three substrate-specific bundles.
+- 2026-05-14: Implemented Codex as projection first. Running Codex tasks remains
+  out of scope until projection is proven across a second substrate.
+- 2026-05-14: Implemented Pi.dev and Claude Code as projection first. The same
+  Soma input is now projected into three substrate-specific projections.
 - 2026-05-14: Adopted the Arc/Myelin ESLint flat-config pattern using
   `@eslint/js`, `typescript-eslint`, type-aware rules, and test overrides.
-- 2026-05-14: Added a filesystem writer for materializing generated context
-  bundles into a workspace root.
+- 2026-05-14: Added a filesystem writer for materializing generated projections
+  into a workspace root.
 - 2026-05-14: Reframed installation around default substrate-home availability,
   using PAI's `~/.claude/` integration as the reference pattern.
 - 2026-05-14: Implemented Codex as the first home projection target:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,13 +21,13 @@ SomaCore
 
 Identity stores who the principal is and who the assistant is. It includes
 profile facts, communication preferences, personality metadata, and optional
-voice metadata. Identity is loaded into substrate context but is not owned by
+voice metadata. Identity is projected into the substrate but is not owned by
 the substrate.
 
 ### Telos
 
 Telos stores goals, principles, commitments, strategies, and desired state. It
-is the steering context for assistant recommendations and prioritization.
+is the steering source for assistant recommendations and prioritization.
 
 ### ISA
 
@@ -38,7 +38,7 @@ Soma memory.
 ### Algorithm Harness
 
 The Algorithm harness is the deterministic execution layer around ISA. PAI used
-TheAlgorithm mostly as doctrine inside Claude context; Soma keeps that doctrine
+TheAlgorithm mostly as doctrine projected into Claude; Soma keeps that doctrine
 as a portable skill, but also exposes typed run state and phase gates that a
 substrate or daemon can call directly.
 
@@ -97,51 +97,59 @@ but deterministic enforcement is the target.
 
 ## Adapters
 
-Adapters translate Soma into substrate-native primitives.
+Adapters project Soma into substrate-native primitives. One adapter per
+substrate. See [CONTEXT.md](../CONTEXT.md) for glossary.
 
 ```ts
 interface SomaAdapter {
   name: string;
   detect(): Promise<boolean>;
-  buildContext(input: SomaContextInput): Promise<SomaContextBundle>;
+  project(input: ProjectionInput): Promise<Projection>;
   run(task: SomaTask): Promise<SomaRunResult>;
 }
 ```
 
+> Note: existing code still uses `buildContext` / `SomaContextInput` /
+> `SomaContextBundle`. Rename tracked in #52.
+
 Examples:
 
-- Codex adapter writes instructions into a Codex-friendly context package.
+- Codex adapter projects Soma into Codex-readable instruction files.
 - Pi.dev adapter exposes tools through Pi extensions.
-- Claude Code adapter maps Soma into system prompt, CLAUDE.md, hooks, and skills.
-- Cortex adapter registers Soma as a daemon or in-process agent consuming Myelin envelopes.
+- Claude Code adapter projects Soma into system prompt, CLAUDE.md, hooks, and skills.
+- Cortex adapter registers Soma as a Cortex agent daemon consuming Myelin envelopes.
 
 ## Runtime Modes
 
-### Home Install Mode
+Five modes name where the projection lives or runs from. One-word names; the
+`Mode` suffix is omitted in glossary use.
 
-Used to make Soma available by default in a substrate. Soma writes or updates
-user-level substrate projections from `~/.soma/` into homes such as `~/.codex/`,
-`~/.claude/`, Pi.dev's extension home, or Cortex's agent registry. This is the
-primary install path.
+### home
 
-### Library Mode
+Primary mode. Soma writes its projection into the substrate's home directory:
+`~/.codex/`, `~/.claude/`, Pi.dev's extension home, or Cortex's agent registry.
+Available by default in every session.
 
-Used by a substrate CLI. Soma builds context and exposes tools, but the substrate
-owns the process.
+### workspace
 
-### Daemon Mode
+Workspace mode projects into the current workspace (`./.codex/soma/`,
+`./.claude/soma/`). Only present when the principal is in that workspace.
+Overlays the home projection if both exist.
 
-Used by Cortex/Myelin. Soma runs as a long-lived process, subscribes to work
-subjects, owns state, and publishes envelopes.
+### library
 
-### Export Mode
+A substrate CLI loads Soma as code and exposes tools. No projection on disk.
+The substrate owns the process.
 
-Used to generate substrate-specific configuration without running anything.
+### daemon
 
-### Workspace Overlay Mode
+Soma runs as a long-lived process, subscribes to Myelin subjects, owns state,
+and publishes envelopes. No substrate involved.
 
-Used to add project-local context to a workspace. Workspace overlays complement
-the home install; they are not the primary way Soma becomes available.
+### export
+
+Generate projection bytes (stdout or a tarball) without writing anywhere or
+running anything. Dry-run / inspection shape.
 
 ## Relationship To Meta Factory
 
@@ -161,9 +169,10 @@ The detailed source-of-truth contract lives in [boundaries.md](./boundaries.md).
 When a concept appears in more than one repo or substrate, the other copy must
 be treated as a projection unless a sync contract says otherwise.
 
-Default availability is specified in [default-availability.md](./default-availability.md).
-Soma should follow PAI's lesson that the assistant needs a durable substrate
-home, while avoiding PAI's Claude-only coupling.
+Eager-projection behaviour for the home mode is specified in
+[default-availability.md](./default-availability.md). Soma should follow PAI's
+lesson that the assistant needs a protected substrate home, while avoiding
+PAI's Claude-only coupling.
 
 ## Lifecycle Harness
 

--- a/docs/boundaries.md
+++ b/docs/boundaries.md
@@ -1,22 +1,23 @@
 # Ownership Boundaries
 
 Soma is the portable personal assistant kernel. It should reference nearby Meta
-Factory systems without absorbing their responsibilities.
+Factory systems without absorbing their responsibilities. Glossary lives in
+[CONTEXT.md](../CONTEXT.md).
 
 ## Source Of Truth
 
 | Concept | Source of truth | Soma role |
 | --- | --- | --- |
-| Personal assistant identity | Soma | Owns portable identity schema and context rendering. |
-| Principal profile | Soma | Owns personal profile shape and substrate-safe projection. |
-| Telos | Soma | Owns personal goals, principles, commitments, and prioritization context. |
+| Personal assistant identity | Soma | Owns portable identity schema and projection. |
+| Principal profile | Soma | Owns personal profile shape and its projection (scrubbed so private data does not leak between substrates). |
+| Telos | Soma | Owns personal goals, principles, commitments, and prioritization. |
 | Project ISA | Project repository | Reads and summarizes local `ISA.md`; does not centralize every project task. |
 | Personal/task ISA | Soma memory | Owns personal assistant tasks that do not belong to one project repo. |
 | Skills as portable capability folders | Soma | Owns portable skill metadata and discovery contract. |
-| Claude Code skills | Claude Code adapter | Projection of Soma skills into Claude-native layout. |
-| Codex instructions | Codex adapter | Projection of Soma context into Codex-readable files. |
+| Claude Code skills | Claude Code adapter | A Soma skill's Claude Code projection. |
+| Codex instructions | Codex adapter | A Soma skill's Codex projection (Codex instruction). |
 | SOPs and governance | Compass | Soma references Compass rules; it does not redefine org process. |
-| Daemon, bus, and envelopes | Cortex / Myelin | Soma can run as an agent, but Myelin owns protocol semantics. |
+| Daemon, bus, and envelopes | Cortex / Myelin | Soma can run as a Cortex agent, but Myelin owns protocol semantics. |
 | Installation and distribution | Arc | Soma ships manifests; Arc owns package lifecycle. |
 | Observability | Signal | Soma emits events; Signal owns telemetry systems. |
 | Isolated execution | Spawn | Soma requests execution; Spawn owns sandbox lifecycle. |
@@ -24,22 +25,29 @@ Factory systems without absorbing their responsibilities.
 ## Boundary Rules
 
 - Soma owns portable personal assistant concepts.
-- Adapters own substrate translation only.
+- Adapters own substrate projection only. One adapter per substrate.
 - Nearby systems own ecosystem-level mechanics.
 - A duplicated concept must declare one source of truth and one or more
   projections.
-- A projection can cache, summarize, or render source data, but it must not
-  become an independent editing surface without a sync contract.
+- A projection can cache, summarize, or project source data, but it must not
+  become an independent editing surface without a writeback contract.
+- Substrate → Soma flow is **writeback** only, gated by Policy
+  (see [writeback-and-policy.md](./writeback-and-policy.md)). Substrate-side
+  state Soma does not author is **mirrored** into `MEMORY/STATE/`.
 
 ## Naming Rules
 
-Use `Skill` in Soma only for portable capability folders. When referring to a
-substrate-specific skill system, qualify it:
+Use `skill` in Soma only for portable capability folders. When referring to a
+substrate-specific capability primitive, qualify it:
 
-- `Soma skill`
-- `Claude Code skill projection`
-- `Codex instruction projection`
+- `Soma skill` (or bare `skill` in Soma docs — unqualified always means Soma)
+- `Claude Code skill` (the substrate's native capability primitive)
+- `Pi.dev skill`
+- `Codex instruction` (Codex has no native skill primitive)
 - `Compass SOP`
+
+To name the projected output, use the possessive: "the skill's Claude Code
+projection" — not "Claude Code skill projection", which is ambiguous.
 
 If a capability is only meaningful inside one substrate, it belongs in that
 adapter and should not be named a Soma skill.

--- a/docs/default-availability.md
+++ b/docs/default-availability.md
@@ -1,7 +1,9 @@
-# Default Availability
+# Home Projection Defaults
 
 Soma must be available by default, not only inside individual project
-repositories.
+repositories. This doc describes the **home** mode (the primary projection
+target) and the **workspace** overlay. See [CONTEXT.md](../CONTEXT.md) for
+glossary; modes are `home`, `workspace`, `library`, `daemon`, `export`.
 
 PAI proves the pattern in Claude Code: it installs into `~/.claude/` so the
 assistant is present whenever Claude starts. Project-local `CLAUDE.md` files are
@@ -9,38 +11,39 @@ overlays; they do not carry the whole assistant.
 
 ## Principle
 
-Soma has two projection layers:
+Soma supports two projection placements relevant to default availability:
 
-1. **Home projection**: installed into the substrate's user-level configuration
-   directory. This makes the assistant available by default.
-2. **Workspace projection**: installed into a project directory. This adds
-   project-specific context, ISA, skills, and policy overlays.
+1. **home** mode: the projection is installed into the substrate's user-level
+   configuration directory. This makes the assistant available by default.
+2. **workspace** mode: the projection is installed into a project directory.
+   This adds project-specific ISA, skills, and policy overlays.
 
-The home projection is the primary install target. Workspace projection is a
-secondary overlay.
+The home projection is the primary install target. The workspace projection is
+a secondary overlay that takes precedence inside that workspace.
 
-A projection is a generated snapshot, not a symlink, live synchronized overlay,
-or authoritative copy. Refresh is currently on demand through install commands;
-substrate startup does not auto-refresh projections in V0. See
-[writeback-and-policy.md](./writeback-and-policy.md) for writeback and conflict
-semantics.
+A projection is a generated snapshot, not a symlink, live overlay, or
+authoritative copy. The Identity compartment projects eagerly; Skills project
+as an indexed registry; Memory archives are on-demand. Refresh is on demand
+through `soma install` / `soma reproject`; substrate startup does not
+auto-refresh projections in V0. See [writeback-and-policy.md](./writeback-and-policy.md)
+for writeback semantics.
 
 ## PAI Reference Shape
 
 PAI's Claude integration uses:
 
-- `~/.claude/CLAUDE.md` for always-loaded context routing and operating rules.
+- `~/.claude/CLAUDE.md` for the eagerly-loaded routing and operating rules.
 - `~/.claude/settings.json` for environment, permissions, hooks, and statusline.
 - `~/.claude/hooks/` for lifecycle integration.
-- `~/.claude/skills/` for globally available skills.
-- `~/.claude/agents/` for globally available specialists.
+- `~/.claude/skills/` for globally available Claude Code skills.
+- `~/.claude/agents/` for globally available Claude Code sub-agents.
 - `~/.claude/commands/` for slash commands.
-- `~/.claude/PAI/USER/` for principal identity, DA identity, and TELOS.
-- `~/.claude/PAI/MEMORY/` for durable memory.
+- `~/.claude/PAI/USER/` for principal identity, assistant identity, and TELOS.
+- `~/.claude/PAI/MEMORY/` for protected memory.
 - `~/.claude/PAI/PULSE/` for daemon behavior, notifications, and dashboards.
 
 That shape is Claude-specific, but the design lesson is portable: the assistant
-has a durable home, and project-local files only specialize it.
+has a protected home, and project-local files only specialize it.
 
 ## Soma Home Layout
 
@@ -70,7 +73,8 @@ Soma's substrate-neutral home should be:
 
 The implemented bootstrap slice is `bootstrapSomaHome`, which creates the
 starter profile files, memory directories, skill/policy directories, projection
-directories, and returns a `SomaContextInput` loaded from those files.
+directories, and returns a `SomaContextInput` loaded from those files. (Type
+rename to `ProjectionInput` is tracked in #52.)
 
 ## Substrate Home Projections
 
@@ -81,8 +85,8 @@ Observed Codex user-level surfaces include `~/.codex/config.toml`,
 
 Codex `*.rules` files are parsed as Starlark permission rules, not Markdown
 assistant instructions. Soma therefore keeps `rules/soma.rules` comment-only as
-a parse-safe projection marker. Natural-language assistant context lives in the
-projected skill and memory files.
+a parse-safe projection marker. The eager Soma content lives in the projected
+Codex instruction and memory files.
 
 Initial Soma projection target:
 
@@ -96,14 +100,14 @@ Initial Soma projection target:
   memories/soma/policy.md
 ```
 
-Codex project overlays may still write `.codex/soma/` into a workspace.
+Codex workspace overlays may still write `.codex/soma/` into a workspace.
 
 The implemented first slice is `buildCodexHomeProjection`, which resolves
-`~/.soma` and `~/.codex`, builds the Codex home bundle, and can materialize it
-with `installCodexHomeProjection`.
+`~/.soma` and `~/.codex`, builds the Codex home projection, and can materialize
+it with `installCodexHomeProjection`.
 
 The first end-to-end install function is `installSomaForCodex`. It bootstraps
-`~/.soma`, loads that source context, then projects it into `~/.codex`.
+`~/.soma`, loads that source, then projects it into `~/.codex`.
 
 ### Claude Code
 
@@ -126,8 +130,8 @@ Claude home; Soma should be less invasive.
 
 ### Pi.dev
 
-Pi.dev receives a user-level extension projection under the observed Pi.dev home
-layout:
+Pi.dev receives a user-level extension projection under the observed Pi.dev
+home layout:
 
 ```text
 ~/.pi/
@@ -142,39 +146,41 @@ layout:
   agent/skills/soma/SKILL.md
 ```
 
-The extension registers a `soma_context` tool for reading the projected profile,
-memory layout, PAI import index, and selected source files under `~/.soma`.
-It also appends Soma identity context to Pi.dev's system prompt during
+The extension registers a `soma_context` tool for reading the projected
+profile, memory layout, PAI import index, and selected source files under
+`~/.soma`. It also appends Soma identity to Pi.dev's system prompt during
 `before_agent_start`, because tools alone are not enough for default identity
-behavior. The context files remain generated snapshots; `~/.soma` is still
+behaviour. The projection files remain generated snapshots; `~/.soma` is still
 authoritative.
 
 ### Cortex / Myelin
 
-Cortex default availability should be daemon registration, not copied prompt
-files:
+Cortex default availability should be Cortex agent registration, not copied
+prompt files:
 
 ```text
 ~/.config/cortex/agents.d/soma.json
 ~/.soma/
 ```
 
-The daemon consumes Myelin envelopes and reads the same `~/.soma/` source data.
+The Cortex agent daemon consumes Myelin envelopes and reads the same
+`~/.soma/` source data.
 
 ## Install Commands
 
-The CLI should reflect this split:
+The CLI should reflect the home/workspace split:
 
 ```bash
-soma install --substrate codex
-soma install --substrate claude-code
-soma install --substrate pi-dev
-soma install --substrate cortex
+soma install codex
+soma install claude-code
+soma install pi-dev
+soma install cortex
 
-soma project install --substrate codex --root .
+soma install codex --workspace
 ```
 
-`install` targets the substrate home. `project install` targets a workspace.
+`install` targets the substrate home by default. `--workspace` targets the
+current workspace overlay. (CLI alignment tracked in #54.)
 
 ## Safety Rules
 

--- a/docs/naming.md
+++ b/docs/naming.md
@@ -2,15 +2,16 @@
 
 ## Chosen Name: Soma
 
-Soma is the substrate-portable body of a personal AI assistant.
+Soma is the portable body of a personal AI assistant. See
+[CONTEXT.md](../CONTEXT.md) for the full glossary.
 
 The Meta Factory ecosystem already has a strong neural and biological metaphor:
 
 - `myelin` carries transport and connective protocol layers.
 - `cortex` is the layer-7 collaboration surface.
 - `signal` captures activity and observability.
-- botanical agent names such as `sage`, `cedar`, `fern`, and `gorse` identify
-  specific worker personas.
+- botanical names such as `sage`, `cedar`, `fern`, and `gorse` identify
+  specific Cortex agents (worker personas).
 
 Soma fits the neural side of the taxonomy. In biology, the soma is the cell body.
 In this project, Soma is the assistant body: identity, memory, goals, skills,
@@ -30,6 +31,6 @@ policy, and work state. A substrate can change without changing the body.
 ## Naming Boundary
 
 Soma is not a bot persona. Names like Sage, Cedar, Fern, Alpha, and Gorse should
-remain specific agents. Soma is a portable core that such agents or personal
-assistants can consume.
+remain specific Cortex agents. Soma is a portable core that such agents — or
+named assistants like Ivy — can consume.
 

--- a/docs/pai-pack-importer.md
+++ b/docs/pai-pack-importer.md
@@ -49,7 +49,7 @@ skills/telos/
   soma-pack.json
 ```
 
-The importer rewrites `SKILL.md` frontmatter to use a substrate-portable,
+The importer rewrites `SKILL.md` frontmatter to use a portable,
 lowercase Soma skill name. Source docs are preserved under `references/` so
 Claude-specific installation guidance remains available without becoming the
 Soma install procedure.

--- a/docs/pai-pack-normalization-research.md
+++ b/docs/pai-pack-normalization-research.md
@@ -234,7 +234,7 @@ Unsafe without review:
 - rewriting skill doctrine
 - changing workflow intent
 - inventing Soma equivalents for ambiguous Claude paths
-- translating personal/private context conventions
+- projecting personal/private content conventions
 - executing installers or embedded commands
 - resolving symlinks without an explicit policy
 

--- a/docs/portability-proof.md
+++ b/docs/portability-proof.md
@@ -1,8 +1,8 @@
 # Portability Proof
 
 Substrate portability is Soma's load-bearing claim. The first proof is not a
-large feature set; it is one unchanged assistant bundle projected into two
-substrates with comparable behavior.
+large feature set; it is one unchanged Soma projected into two substrates with
+comparable behavior. See [CONTEXT.md](../CONTEXT.md) for glossary.
 
 ## Week-One Workflow
 
@@ -11,8 +11,8 @@ The first workflow is a ledger update:
 1. Load one `SomaProfile`.
 2. Load one active `IdealStateArtifact`.
 3. Load one memory layout rooted on files.
-4. Build a Codex context bundle.
-5. Build a Claude Code context bundle.
+4. Project Soma into Codex.
+5. Project Soma into Claude Code.
 6. Run the same task prompt in both substrates.
 7. Verify both runs update the same project-facing artifact or produce the same
    proposed patch.
@@ -20,8 +20,8 @@ The first workflow is a ledger update:
 ## Pass Conditions
 
 - The same profile, telos, skill list, memory layout, and ISA are used unchanged.
-- Substrate adapters may change only rendering, file names, and host-specific
-  invocation.
+- Substrate adapters may change only projection shape, file names, and
+  host-specific invocation.
 - The workflow has a shared verification criterion that does not depend on chat
   transcript style.
 - Any divergence is recorded as an adapter limitation, not solved by changing
@@ -29,9 +29,10 @@ The first workflow is a ledger update:
 
 ## First Implementation Slice
 
-The first implemented slice is context generation:
+The first implemented slice is projection:
 
-- `src/adapters/codex.ts` renders a Codex context bundle.
-- `src/adapters/pi-dev.ts` renders a Pi.dev extension-shaped context bundle.
-- `src/adapters/claude-code.ts` renders a Claude Code context bundle.
-- Tests compare shared bundle semantics before any daemon or plugin work begins.
+- `src/adapters/codex.ts` projects Soma into Codex shape.
+- `src/adapters/pi-dev.ts` projects Soma into a Pi.dev extension shape.
+- `src/adapters/claude-code.ts` projects Soma into Claude Code shape.
+- Tests compare shared projection semantics before any daemon or plugin work
+  begins.

--- a/docs/private-source-guard-v0.md
+++ b/docs/private-source-guard-v0.md
@@ -6,7 +6,7 @@ Soma separates the public code repo from private installed context.
 - `~/.soma` is private by design: identity, telos, imported PAI context, memory,
   and work state live there.
 - substrate projections such as `~/.codex/memories/soma/` and
-  `~/.pi/agent/soma/` are also private context surfaces.
+  `~/.pi/agent/soma/` are also private projections.
 
 V0 protects the mistake classes that matter first:
 

--- a/docs/progressive-skill-loading.md
+++ b/docs/progressive-skill-loading.md
@@ -1,14 +1,15 @@
 # Progressive Skill Loading
 
 Progressive skill loading keeps Soma's capability surface broad without putting
-every capability into every model context.
+every capability into every model context. See [CONTEXT.md](../CONTEXT.md) for
+glossary; this document uses the eager / indexed / on-demand loading tiers.
 
 ## Problem
 
 PAI already selects skills and capabilities during work. The failure mode is not
 missing selection. The failure mode is that selection can happen after a large
 amount of routing doctrine, capability descriptions, and skill material has
-already entered the substrate context.
+already entered the LLM context.
 
 That is especially costly in Claude Code, where global instructions, hooks,
 skills, commands, agents, and project context all compete for the same context
@@ -73,8 +74,8 @@ The kernel is the maximum context that should be loaded by default:
 - skill registry location and loading protocol
 
 The kernel must not include full skill bodies unless the substrate has a native
-lazy skill mechanism that guarantees those bodies are not inserted into model
-context until invoked.
+on-demand skill mechanism that guarantees those bodies are not inserted into
+the LLM context until invoked.
 
 ### Skill Registry
 
@@ -188,7 +189,7 @@ add embeddings or BM25-style indexing without changing the contract.
 
 ## Adapter Behavior
 
-Adapters translate the same route into substrate-native behavior.
+Adapters project the same route into substrate-native behavior.
 
 ### Codex
 
@@ -234,8 +235,8 @@ right context shape.
 
 ## Context Budget Rules
 
-- Every projected context bundle should report estimated token cost for kernel,
-  registry, and selected skills.
+- Every projection should report estimated token cost for kernel, registry, and
+  selected skills.
 - A selected skill should have a reason and a budget estimate.
 - If selected skills exceed budget, the router should prefer entrypoints over
   references and references over examples.
@@ -307,10 +308,10 @@ own skill semantics.
 
 ### Substrates Without Native File Loading
 
-If a substrate cannot read selected files on demand, the adapter should generate
-a route bundle before the task starts. The bundle contains the kernel, registry
-entry subset, and selected entrypoints or references. This preserves progressive
-loading even on static substrates.
+If a substrate cannot read selected files on demand, the adapter should
+materialize a route projection before the task starts. The projection contains
+the kernel, registry entry subset, and selected entrypoints or references. This
+preserves progressive loading even on static substrates.
 
 ```text
 tool-capable substrate -> read selected skill files on demand
@@ -346,8 +347,8 @@ or route contracts.
 
 ## Verification Criteria
 
-- A substrate startup context can be generated without including full bodies for
-  unrelated skills.
+- A substrate startup projection can be generated without including full bodies
+  for unrelated skills.
 - A task that names or clearly triggers a skill loads that skill entrypoint.
 - A task with no matching skill keeps only the kernel and registry context.
 - Anti-triggers prevent irrelevant but lexically similar skills from loading.

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -1,30 +1,32 @@
 # Substrate Adapters
 
-Soma treats execution environments as adapters. Each adapter maps the same
-assistant core into different host primitives.
+Soma treats execution environments as substrates. One adapter per substrate
+projects the same Soma into different substrate-native primitives. See
+[CONTEXT.md](../CONTEXT.md) for glossary.
 
 ## Codex
 
-Codex is a coding-agent substrate. The adapter should package:
+Codex is a coding-agent substrate. The Codex projection should carry:
 
 - system/developer instruction fragments
-- Soma identity and telos context
+- Soma identity and telos
 - active ISA summary
 - relevant skills as local instructions
 - memory readback
 - verification policy
 
 Open question: whether Codex plugins should carry the adapter or whether Soma
-should generate a workspace-local instruction bundle consumed by Codex.
+should project a workspace-local instruction set consumed by Codex.
 
-Initial answer: start with workspace-local context generation. `buildCodexContext`
-returns deterministic files under `.codex/soma/` plus an instruction string.
-Codex execution and plugins come later, after the same input can be projected
-into at least one second substrate.
+Initial answer: start with a workspace projection. `projectCodex` (currently
+named `buildCodexContext`, rename tracked in #52) returns deterministic files
+under `.codex/soma/` plus an instruction string. Codex execution and plugins
+come later, after the same input can be projected into at least one second
+substrate.
 
 Next answer: add a home projection for `~/.codex/` so Soma is available by
-default. Workspace-local `.codex/soma/` files should become project overlays,
-not the main install surface.
+default. Workspace projections under `.codex/soma/` overlay the home projection,
+they are not the main install surface.
 
 ## Pi.dev
 
@@ -44,18 +46,19 @@ The first useful Pi adapter can be a `soma-core` extension with:
 - `capture_learning`
 - `policy_check`
 
-Initial implementation: `buildPiDevContext` generates a workspace-shaped
-`soma-core` extension projection under `.pi/extensions/soma-core/`. It includes
-an extension manifest, portable context, tool contract, memory layout, skills,
-and policy projection. The tools are named as the adapter contract; execution is
-not wired yet.
+Initial implementation: `projectPiDev` (currently `buildPiDevContext`) generates
+a workspace-shaped `soma-core` extension projection under
+`.pi/extensions/soma-core/`. It includes an extension manifest, portable
+content, tool contract, memory layout, skills, and policy projection. The tools
+are named as the adapter contract; execution is not wired yet.
 
-Home implementation: `buildPiDevHomeContext` projects into `~/.pi/agent/`:
-`agent/extensions/soma.ts` registers the `soma_context` tool, while
-`agent/soma/` holds generated context snapshots and `agent/skills/soma/SKILL.md`
-advertises the Soma skill. The extension appends Soma identity context to the
-system prompt on `before_agent_start`; the tool can read projected
-profile/context files and detailed imported PAI source files under `~/.soma`.
+Home implementation: `projectPiDevHome` (currently `buildPiDevHomeContext`)
+projects into `~/.pi/agent/`: `agent/extensions/soma.ts` registers the
+`soma_context` tool, while `agent/soma/` holds the generated projection
+snapshot and `agent/skills/soma/SKILL.md` advertises the Soma skill as a Pi.dev
+skill. The extension appends Soma identity to the LLM context on
+`before_agent_start`; the tool can read projection files and detailed imported
+PAI source files under `~/.soma`.
 
 ## Claude Code
 
@@ -64,36 +67,37 @@ Claude Code has the richest native surface:
 - system prompt append
 - `CLAUDE.md`
 - hooks
-- skills
-- agents
+- Claude Code skills
+- Claude Code sub-agents
 - slash commands
 - statusline
 
-The Claude adapter can be the highest-fidelity implementation, but the core must
-not depend on Claude-only primitives. Hooks should improve behavior; they should
-not be required for the storage contract to function.
+The Claude Code adapter can be the highest-fidelity implementation, but the
+core must not depend on Claude-only primitives. Hooks should improve behavior;
+they should not be required for the storage contract to function.
 
-Initial implementation: `buildClaudeCodeContext` generates a Claude-shaped
-projection with `CLAUDE.md` plus `.claude/soma/` context files. Hooks are
-documented as optional enhancements, not requirements for the portable core.
+Initial implementation: `projectClaudeCode` (currently `buildClaudeCodeContext`)
+generates a Claude-shaped projection with `CLAUDE.md` plus `.claude/soma/`
+projection files. Hooks are documented as optional enhancements, not
+requirements for the portable core.
 
 The Claude Code adapter should support a home projection into `~/.claude/`.
 This is how PAI is deeply integrated: global `CLAUDE.md`, settings, hooks,
-skills, agents, commands, user identity, memory, and daemon support are available
-at every Claude Code startup. Soma should project into that shape without making
-Claude Code the source of truth.
+Claude Code skills, sub-agents, commands, principal identity, memory, and
+daemon support are available at every Claude Code startup. Soma should project
+into that shape without making Claude Code the source of truth.
 
 ## Cortex / Myelin
 
 Cortex is the Meta Factory collaboration surface. Myelin is the protocol stack.
 Soma can integrate in two ways:
 
-1. **In-process assistant profile**: Cortex uses Soma context when spawning a
-   substrate session.
-2. **Standalone daemon**: Soma subscribes to Myelin subjects, claims personal
-   assistant tasks, updates its own memory, and publishes envelopes.
+1. **In-process assistant profile**: Cortex uses Soma when spawning a substrate
+   session.
+2. **Standalone Cortex agent**: Soma subscribes to Myelin subjects, claims
+   personal assistant tasks, updates its own memory, and publishes envelopes.
 
-The daemon shape should follow the existing standalone agent pattern:
+The daemon shape should follow the existing standalone Cortex agent pattern:
 
 - `type: agent`
 - `targets: [cortex, darwin-launchd]`
@@ -104,8 +108,8 @@ The daemon shape should follow the existing standalone agent pattern:
 ## Adapter Contract
 
 Adapters should be thin. They do not own identity, memory, ISA, skill schemas, or
-policy semantics. They only translate those contracts into a substrate's native
-mechanisms.
+policy semantics. They only project those contracts into a substrate's native
+mechanisms, and write back substrate-side events through the writeback gate.
 
 The first portability proof is documented in
 [portability-proof.md](./portability-proof.md). Memory and policy v0 are

--- a/docs/writeback-and-policy.md
+++ b/docs/writeback-and-policy.md
@@ -1,7 +1,9 @@
 # Writeback And Policy Semantics
 
-Soma's hardest problem is not rendering context into substrates. It is safe
-return traffic from several substrates into one durable home.
+Soma's hardest problem is not projecting into substrates. It is safe return
+traffic from several substrates into one protected home. See
+[CONTEXT.md](../CONTEXT.md) for glossary (`writeback`, `write back`,
+`writeback gate`, `mirror`).
 
 ## Current Decision
 
@@ -35,22 +37,29 @@ A projection is a generated snapshot.
 - It is not generated on every substrate startup unless a substrate adapter
   explicitly implements that later.
 
-Projection refresh is currently **on demand**:
+Projection refresh is currently **on demand** (via the `reproject` lifecycle
+verb):
 
-- `soma install <substrate>` plans or refreshes the substrate-home projection.
-- Workspace overlays are refreshed by the future `soma project install` flow.
-- Substrate launch does not automatically refresh projections in V0.
+- `soma install <substrate>` plans or refreshes the home projection.
+- Workspace overlays are refreshed via the future `soma install <substrate>
+  --workspace` flow.
+- Substrate launch does not automatically reproject in V0.
 
 This intentionally favors clear failure modes over clever sync. If a projection
 is stale, refresh it from `~/.soma`.
 
 ## Writeback V0
 
-The only approved substrate-to-Soma write path is:
+The only approved writeback path is:
 
 ```text
 ~/.soma/memory/STATE/events.jsonl
 ```
+
+The writeback gate (Policy) admits an event only if it matches the V0 contract
+(see schema below) and lands in the append-only events log. Substrate-side
+state that Soma does not author — e.g., Cortex task status, Signal events — is
+**mirrored** into `MEMORY/STATE/`, not written back.
 
 Each line is one event:
 


### PR DESCRIPTION
Closes #56.

## Summary

Rewrites `docs/` and `ISA.md` to use the canonical vocabulary locked in [CONTEXT.md](./CONTEXT.md) during the `/grill-with-docs` session.

## Substitutions applied

- `translate` → `project`; `render` / `rendering` → `project` / `projection`
- `context bundle` / `context generation` / `context rendering` → `projection`
- Runtime modes renamed: `Home Install Mode` → `home`, `Workspace Overlay Mode` → `workspace`, `Library Mode` → `library`, `Daemon Mode` → `daemon`, `Export Mode` → `export`
- `substrate-portable` → `portable`; `substrate-safe` → explicit phrase
- `lazy` → `on-demand`; "default availability" prose → eager / indexed / on-demand tiers
- Bare `agent` qualified (`Cortex agent`, `Claude Code sub-agent`, etc.)
- "Claude Code skill projection" disambiguated to "skill's Claude Code projection"
- `docs/writeback-and-policy.md` introduces `mirror` and `writeback gate`
- "private context surface" → "private projection"
- ISA criteria preserved (terminology updated; ISC numbers and meaning unchanged)

## Files touched

- `docs/architecture.md`
- `docs/boundaries.md`
- `docs/default-availability.md`
- `docs/naming.md`
- `docs/pai-pack-importer.md`
- `docs/pai-pack-normalization-research.md`
- `docs/portability-proof.md`
- `docs/private-source-guard-v0.md`
- `docs/progressive-skill-loading.md`
- `docs/substrate-adapters.md`
- `docs/writeback-and-policy.md`
- `ISA.md`

## Out of scope (tracked separately)

- #52 — type / function renames in `src/` and `test/`
- #54 — CLI alignment with locked modes and lifecycle verbs

## Test plan

- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `grep -rn "translate\|render\|context bundle\|substrate-portable\|substrate-safe\|Home Install Mode" docs/ ISA.md` returns no hits
- [ ] Reviewer scans rewritten prose for any new fuzzy synonyms

🤖 Generated with [Claude Code](https://claude.com/claude-code)