### PR TITLE
fix(isa): bump bundled skill after metadata fix

### DIFF
--- a/src/skills/ISA/SKILL.md
+++ b/src/skills/ISA/SKILL.md
@@ -2,7 +2,7 @@
 name: ISA
 description: "Owns the Ideal State Artifact: the commitment-time scaffold for articulating done, deriving ISC criteria, planning features, recording decisions, and verifying work. Use for ideal state, ISA/ISC criteria, project specs, scaffolding, completeness checks, reconciliation, or seeding an ISA from a repo."
 effort: medium
-version: 1.0.1
+version: 1.0.2
 pack-id: pai-isa-v1.0.0
 ---
 


### PR DESCRIPTION
## Summary
- bump bundled ISA skill version from 1.0.1 to 1.0.2 so existing Soma homes upgrade to the Codex-safe metadata from #59

Follow-up to #57 / #59.

## Verification
- bun test test/isa-skill-installer.test.ts
- verified src/skills/ISA/SKILL.md description length is 300 characters
