### PR TITLE
feat(adapter): ISA Layer 6 projections for Codex, Pi.dev, Claude Code (#37)

### DIFF
--- a/src/adapter-active-isa.ts
+++ b/src/adapter-active-isa.ts
@@ -1,0 +1,75 @@
+/**
+ * Adapter active-ISA projection (#37).
+ *
+ * Single source of truth for the active-ISA file that every substrate
+ * projects into its own home. Using `serializeIsa` guarantees the file
+ * is BYTE-identical across substrates — that's AC-4's portability
+ * contract (run a scaffold once, install for all three substrates,
+ * the resulting active-isa.md files are exact byte equals).
+ *
+ * When no active ISA is set the file is OMITTED from the bundle
+ * entirely (AC-2) rather than written empty — adapters must filter the
+ * `null` result before adding to their files list.
+ */
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { getActiveIsa, readIsa } from "./isa";
+import { serializeIsa } from "./isa-parse";
+import type { IdealStateArtifact, SubstrateId } from "./types";
+
+export interface LoadActiveIsaOptions {
+  homeDir?: string;
+  somaHome?: string;
+}
+
+/**
+ * Resolve the active ISA from the Soma home, or null when no slug is
+ * set. Used by per-substrate installers to populate `input.activeIsa`
+ * before invoking the adapter's `build*HomeContext`.
+ */
+export async function loadActiveIsaForBundle(
+  options: LoadActiveIsaOptions = {},
+): Promise<IdealStateArtifact | null> {
+  const somaHome = resolve(options.somaHome ?? join(options.homeDir ?? homedir(), ".soma"));
+  const state = await getActiveIsa({ somaHome });
+  if (state?.activeSlug == null) return null;
+  return readIsa(state.activeSlug, { somaHome });
+}
+
+/**
+ * The byte-portable rendering of an active ISA — `serializeIsa` is the
+ * same renderer used to write the on-disk file, so every substrate
+ * projection ends up with identical bytes when scaffolded from the same
+ * ISA. Adapters MUST call this (not their own serializer) to satisfy
+ * AC-4 portability.
+ */
+export function renderActiveIsaFile(isa: IdealStateArtifact): string {
+  return serializeIsa(isa);
+}
+
+/**
+ * Per-substrate relative path inside the substrate home for the active
+ * ISA file. Aligned with the #37 issue specification table.
+ *
+ * | Substrate    | Path                              |
+ * |--------------|-----------------------------------|
+ * | codex        | memories/soma/active-isa.md       |
+ * | pi-dev       | agent/soma/active-isa.md          |
+ * | claude-code  | PAI/ACTIVE_ISA.md                 |
+ *
+ * Throws on unsupported substrates so a new substrate must be added
+ * here explicitly rather than silently picking a default.
+ */
+export function activeIsaProjectionPath(substrate: SubstrateId): string {
+  switch (substrate) {
+    case "codex":
+      return "memories/soma/active-isa.md";
+    case "pi-dev":
+      return "agent/soma/active-isa.md";
+    case "claude-code":
+      return "PAI/ACTIVE_ISA.md";
+    case "cortex":
+    case "custom":
+      throw new Error(`activeIsaProjectionPath: unsupported substrate '${substrate}'`);
+  }
+}

--- a/src/adapter-active-isa.ts
+++ b/src/adapter-active-isa.ts
@@ -73,3 +73,28 @@ export function activeIsaProjectionPath(substrate: SubstrateId): string {
       throw new Error(`activeIsaProjectionPath: unsupported substrate '${substrate}'`);
   }
 }
+
+/**
+ * Convenience for adapter `build*HomeContext` functions (#37 sage r1):
+ * returns the single-entry bundle file array when `activeIsa` is set,
+ * empty array otherwise. Lets adapters spread `...activeIsaBundleFile(...)`
+ * instead of re-implementing the conditional and path lookup.
+ */
+export function activeIsaBundleFile(
+  substrate: SubstrateId,
+  activeIsa: IdealStateArtifact | undefined,
+): { path: string; content: string }[] {
+  if (!activeIsa) return [];
+  return [{ path: activeIsaProjectionPath(substrate), content: renderActiveIsaFile(activeIsa) }];
+}
+
+/**
+ * Per-substrate default home directory name (used by both installer
+ * and home-projection modules — kept here so adding a substrate is a
+ * one-file change). Sage r1 finding.
+ */
+export const DEFAULT_SUBSTRATE_HOMES: Record<"codex" | "pi-dev" | "claude-code", string> = {
+  codex: ".codex",
+  "pi-dev": ".pi",
+  "claude-code": ".claude",
+};

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -1,5 +1,6 @@
 import type { SomaAdapter, SomaContextBundle, SomaContextInput, SomaTask } from "../types";
 import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "./shared";
+import { activeIsaProjectionPath, renderActiveIsaFile } from "../adapter-active-isa";
 
 function renderInstructions(input: SomaContextInput): string {
   return [
@@ -78,7 +79,28 @@ export function buildClaudeCodeContext(input: SomaContextInput): SomaContextBund
           "Verification reporting when hooks are absent",
         ]),
       },
+      // Active-ISA projection (#37). OMITTED when no active ISA — AC-2.
+      ...(input.activeIsa
+        ? [{ path: ".claude/soma/active-isa.md", content: renderActiveIsaFile(input.activeIsa) }]
+        : []),
     ],
+  };
+}
+
+/**
+ * Claude Code home projection (#37 minimal — full home install lands
+ * in #29 with the `.claude/rules/` pivot). For now we only project
+ * the active ISA at `~/.claude/PAI/ACTIVE_ISA.md` per the #37 spec
+ * table. When no active ISA is set the bundle has zero files (callers
+ * skip the writer).
+ */
+export function buildClaudeCodeHomeContext(input: SomaContextInput): SomaContextBundle {
+  return {
+    substrate: "claude-code",
+    instructions: renderInstructions(input),
+    files: input.activeIsa
+      ? [{ path: activeIsaProjectionPath("claude-code"), content: renderActiveIsaFile(input.activeIsa) }]
+      : [],
   };
 }
 

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -1,6 +1,6 @@
 import type { SomaAdapter, SomaContextBundle, SomaContextInput, SomaTask } from "../types";
 import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "./shared";
-import { activeIsaProjectionPath, renderActiveIsaFile } from "../adapter-active-isa";
+import { activeIsaBundleFile } from "../adapter-active-isa";
 
 function renderInstructions(input: SomaContextInput): string {
   return [
@@ -80,8 +80,11 @@ export function buildClaudeCodeContext(input: SomaContextInput): SomaContextBund
         ]),
       },
       // Active-ISA projection (#37). OMITTED when no active ISA — AC-2.
+      // Note: project bundle uses `.claude/soma/active-isa.md` (workspace
+      // overlay path), not `PAI/ACTIVE_ISA.md` (the home path used by
+      // buildClaudeCodeHomeContext + activeIsaProjectionPath).
       ...(input.activeIsa
-        ? [{ path: ".claude/soma/active-isa.md", content: renderActiveIsaFile(input.activeIsa) }]
+        ? [{ path: ".claude/soma/active-isa.md", content: activeIsaBundleFile("claude-code", input.activeIsa)[0].content }]
         : []),
     ],
   };
@@ -98,9 +101,7 @@ export function buildClaudeCodeHomeContext(input: SomaContextInput): SomaContext
   return {
     substrate: "claude-code",
     instructions: renderInstructions(input),
-    files: input.activeIsa
-      ? [{ path: activeIsaProjectionPath("claude-code"), content: renderActiveIsaFile(input.activeIsa) }]
-      : [],
+    files: activeIsaBundleFile("claude-code", input.activeIsa),
   };
 }
 

--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -4,7 +4,7 @@ import { readCodexHookAsset } from "./hooks/assets";
 import { renderCodexLifecycleHook } from "./hooks/runtime";
 import { renderFeedbackHookModule } from "../shared/feedback-helper";
 import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
-import { activeIsaProjectionPath, renderActiveIsaFile } from "../../adapter-active-isa";
+import { activeIsaBundleFile } from "../../adapter-active-isa";
 
 function renderCodexPolicy(): string {
   return renderPolicyProjection("codex", ["Filesystem sandbox and approval model when Codex exposes it"], [
@@ -456,9 +456,7 @@ export function buildCodexHomeContext(input: SomaContextInput, somaHome: string,
         content: renderAlgorithmRenderingContract(),
       },
       // Active-ISA projection (#37). OMITTED when no active ISA — AC-2.
-      ...(input.activeIsa
-        ? [{ path: activeIsaProjectionPath("codex"), content: renderActiveIsaFile(input.activeIsa) }]
-        : []),
+      ...activeIsaBundleFile("codex", input.activeIsa),
     ],
   };
 }

--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -4,6 +4,7 @@ import { readCodexHookAsset } from "./hooks/assets";
 import { renderCodexLifecycleHook } from "./hooks/runtime";
 import { renderFeedbackHookModule } from "../shared/feedback-helper";
 import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
+import { activeIsaProjectionPath, renderActiveIsaFile } from "../../adapter-active-isa";
 
 function renderCodexPolicy(): string {
   return renderPolicyProjection("codex", ["Filesystem sandbox and approval model when Codex exposes it"], [
@@ -454,6 +455,10 @@ export function buildCodexHomeContext(input: SomaContextInput, somaHome: string,
         path: "skills/the-algorithm/SKILL.md",
         content: renderAlgorithmRenderingContract(),
       },
+      // Active-ISA projection (#37). OMITTED when no active ISA — AC-2.
+      ...(input.activeIsa
+        ? [{ path: activeIsaProjectionPath("codex"), content: renderActiveIsaFile(input.activeIsa) }]
+        : []),
     ],
   };
 }

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,3 +1,3 @@
-export { buildClaudeCodeContext, claudeCodeAdapter } from "./claude-code";
+export { buildClaudeCodeContext, buildClaudeCodeHomeContext, claudeCodeAdapter } from "./claude-code";
 export { buildCodexContext, buildCodexHomeContext, codexAdapter } from "./codex";
 export { buildPiDevContext, buildPiDevHomeContext, piDevAdapter } from "./pi-dev";

--- a/src/adapters/pi-dev/adapter.ts
+++ b/src/adapters/pi-dev/adapter.ts
@@ -2,6 +2,7 @@ import type { SomaAdapter, SomaContextBundle, SomaContextInput, SomaTask } from 
 import { renderFeedbackHookHelper } from "../shared/feedback-helper";
 import { renderPathGuardExtension } from "./path-guard";
 import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
+import { activeIsaProjectionPath, renderActiveIsaFile } from "../../adapter-active-isa";
 
 function renderInstructions(input: SomaContextInput): string {
   return [
@@ -520,6 +521,10 @@ export function buildPiDevHomeContext(input: SomaContextInput, somaHome: string)
         content: renderHomeSkill(input, somaHome),
       },
       ...portableSkillFiles,
+      // Active-ISA projection (#37). OMITTED when no active ISA — AC-2.
+      ...(input.activeIsa
+        ? [{ path: activeIsaProjectionPath("pi-dev"), content: renderActiveIsaFile(input.activeIsa) }]
+        : []),
     ],
   };
 }

--- a/src/adapters/pi-dev/adapter.ts
+++ b/src/adapters/pi-dev/adapter.ts
@@ -2,7 +2,7 @@ import type { SomaAdapter, SomaContextBundle, SomaContextInput, SomaTask } from 
 import { renderFeedbackHookHelper } from "../shared/feedback-helper";
 import { renderPathGuardExtension } from "./path-guard";
 import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
-import { activeIsaProjectionPath, renderActiveIsaFile } from "../../adapter-active-isa";
+import { activeIsaBundleFile } from "../../adapter-active-isa";
 
 function renderInstructions(input: SomaContextInput): string {
   return [
@@ -522,9 +522,7 @@ export function buildPiDevHomeContext(input: SomaContextInput, somaHome: string)
       },
       ...portableSkillFiles,
       // Active-ISA projection (#37). OMITTED when no active ISA — AC-2.
-      ...(input.activeIsa
-        ? [{ path: activeIsaProjectionPath("pi-dev"), content: renderActiveIsaFile(input.activeIsa) }]
-        : []),
+      ...activeIsaBundleFile("pi-dev", input.activeIsa),
     ],
   };
 }

--- a/src/home-projection.ts
+++ b/src/home-projection.ts
@@ -1,20 +1,26 @@
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { buildCodexHomeContext, buildPiDevHomeContext } from "./adapters";
+import { buildClaudeCodeHomeContext, buildCodexHomeContext, buildPiDevHomeContext } from "./adapters";
 import { writeContextBundle } from "./context-bundle";
 import { defaultSomaRepoPath } from "./repo-path";
 import type { SomaContextInput, SomaHomeProjection, SomaHomeProjectionOptions, SubstrateId, WrittenContextBundle } from "./types";
+
+const DEFAULT_SUBSTRATE_HOMES: Record<"codex" | "pi-dev" | "claude-code", string> = {
+  codex: ".codex",
+  "pi-dev": ".pi",
+  "claude-code": ".claude",
+};
 
 export function resolveHomeProjectionPaths(
   substrate: SubstrateId,
   options: SomaHomeProjectionOptions = {},
 ): Omit<SomaHomeProjection, "bundle"> {
-  if (substrate !== "codex" && substrate !== "pi-dev") {
+  if (substrate !== "codex" && substrate !== "pi-dev" && substrate !== "claude-code") {
     throw new Error(`Home projection is not implemented for substrate: ${substrate}`);
   }
 
   const homeDir = resolve(options.homeDir ?? homedir());
-  const defaultSubstrateHome = substrate === "codex" ? ".codex" : ".pi";
+  const defaultSubstrateHome = DEFAULT_SUBSTRATE_HOMES[substrate];
 
   return {
     substrate,
@@ -56,5 +62,30 @@ export async function installPiDevHomeProjection(
   options: SomaHomeProjectionOptions = {},
 ): Promise<WrittenContextBundle> {
   const projection = buildPiDevHomeProjection(input, options);
+  return writeContextBundle(projection.bundle, projection.substrateHome);
+}
+
+/**
+ * Claude Code home projection (#37 minimal). For now this bundle is
+ * just the active-ISA file at `PAI/ACTIVE_ISA.md`; the full home
+ * install lands in #29 with the `.claude/rules/` pivot.
+ */
+export function buildClaudeCodeHomeProjection(
+  input: SomaContextInput,
+  options: SomaHomeProjectionOptions = {},
+): SomaHomeProjection {
+  const paths = resolveHomeProjectionPaths("claude-code", options);
+
+  return {
+    ...paths,
+    bundle: buildClaudeCodeHomeContext(input),
+  };
+}
+
+export async function installClaudeCodeHomeProjection(
+  input: SomaContextInput,
+  options: SomaHomeProjectionOptions = {},
+): Promise<WrittenContextBundle> {
+  const projection = buildClaudeCodeHomeProjection(input, options);
   return writeContextBundle(projection.bundle, projection.substrateHome);
 }

--- a/src/home-projection.ts
+++ b/src/home-projection.ts
@@ -3,13 +3,8 @@ import { join, resolve } from "node:path";
 import { buildClaudeCodeHomeContext, buildCodexHomeContext, buildPiDevHomeContext } from "./adapters";
 import { writeContextBundle } from "./context-bundle";
 import { defaultSomaRepoPath } from "./repo-path";
+import { DEFAULT_SUBSTRATE_HOMES } from "./adapter-active-isa";
 import type { SomaContextInput, SomaHomeProjection, SomaHomeProjectionOptions, SubstrateId, WrittenContextBundle } from "./types";
-
-const DEFAULT_SUBSTRATE_HOMES: Record<"codex" | "pi-dev" | "claude-code", string> = {
-  codex: ".codex",
-  "pi-dev": ".pi",
-  "claude-code": ".claude",
-};
 
 export function resolveHomeProjectionPaths(
   substrate: SubstrateId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,22 +145,40 @@ export {
 } from "./algorithm-store";
 export {
   buildClaudeCodeContext,
+  buildClaudeCodeHomeContext,
   buildCodexContext,
   buildCodexHomeContext,
   buildPiDevContext,
+  buildPiDevHomeContext,
   claudeCodeAdapter,
   codexAdapter,
   piDevAdapter,
 } from "./adapters";
 export { writeContextBundle } from "./context-bundle";
 export {
+  buildClaudeCodeHomeProjection,
   buildCodexHomeProjection,
   buildPiDevHomeProjection,
+  installClaudeCodeHomeProjection,
   installCodexHomeProjection,
   installPiDevHomeProjection,
   resolveHomeProjectionPaths,
 } from "./home-projection";
-export { installSomaForCodex, installSomaForPiDev, planSomaForCodexInstall, planSomaForPiDevInstall } from "./install";
+export {
+  installSomaForClaudeCode,
+  installSomaForCodex,
+  installSomaForPiDev,
+  planSomaForClaudeCodeInstall,
+  planSomaForCodexInstall,
+  planSomaForPiDevInstall,
+} from "./install";
+// Adapter active-ISA projection helpers (#37).
+export {
+  activeIsaProjectionPath,
+  loadActiveIsaForBundle,
+  renderActiveIsaFile,
+  type LoadActiveIsaOptions,
+} from "./adapter-active-isa";
 // Public ISA-skill installer API — cohesive surface only.
 // Implementation details (isaSkillRuntimeDir, isaSkillSourceDir,
 // parseSkillFrontmatter, skillBaselinesPath, compareSkillVersions) stay in

--- a/src/install.ts
+++ b/src/install.ts
@@ -7,7 +7,7 @@ import { buildSomaStartupContext, runSomaLifecycleAlgorithmUpdated } from "./lif
 import { defaultSomaRepoPath } from "./repo-path";
 import { bootstrapSomaHome } from "./soma-home";
 import { installIsaSkill } from "./isa-skill-installer";
-import { loadActiveIsaForBundle } from "./adapter-active-isa";
+import { DEFAULT_SUBSTRATE_HOMES, loadActiveIsaForBundle } from "./adapter-active-isa";
 import type { SomaContextInput, SomaInstallOptions, SomaInstallPlan, SomaInstallResult } from "./types";
 
 const SOMA_BOOTSTRAP_FILES = [
@@ -70,12 +70,6 @@ const PI_DEV_HOME_FILES = [
 ] as const;
 
 const CLAUDE_CODE_HOME_FILES = ["PAI/ACTIVE_ISA.md"] as const;
-
-const DEFAULT_SUBSTRATE_HOMES: Record<InstallSubstrate, string> = {
-  codex: ".codex",
-  "pi-dev": ".pi",
-  "claude-code": ".claude",
-};
 
 const SKILL_SUBPATHS: Record<InstallSubstrate, string> = {
   codex: "skills/ISA",

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,12 +1,14 @@
+import { homedir } from "node:os";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { configureCodexInstall } from "./adapters/codex";
-import { installCodexHomeProjection, installPiDevHomeProjection } from "./home-projection";
+import { installClaudeCodeHomeProjection, installCodexHomeProjection, installPiDevHomeProjection } from "./home-projection";
 import { buildSomaStartupContext, runSomaLifecycleAlgorithmUpdated } from "./lifecycle";
 import { defaultSomaRepoPath } from "./repo-path";
 import { bootstrapSomaHome } from "./soma-home";
 import { installIsaSkill } from "./isa-skill-installer";
-import type { SomaInstallOptions, SomaInstallPlan, SomaInstallResult } from "./types";
+import { loadActiveIsaForBundle } from "./adapter-active-isa";
+import type { SomaContextInput, SomaInstallOptions, SomaInstallPlan, SomaInstallResult } from "./types";
 
 const SOMA_BOOTSTRAP_FILES = [
   "profile/assistant.md",
@@ -67,9 +69,25 @@ const PI_DEV_HOME_FILES = [
   "agent/skills/soma/SKILL.md",
 ] as const;
 
-function resolveInstallHomes(substrate: "codex" | "pi-dev", options: SomaInstallOptions): { somaHome: string; substrateHome: string } {
+const CLAUDE_CODE_HOME_FILES = ["PAI/ACTIVE_ISA.md"] as const;
+
+const DEFAULT_SUBSTRATE_HOMES: Record<InstallSubstrate, string> = {
+  codex: ".codex",
+  "pi-dev": ".pi",
+  "claude-code": ".claude",
+};
+
+const SKILL_SUBPATHS: Record<InstallSubstrate, string> = {
+  codex: "skills/ISA",
+  "pi-dev": "agent/skills/ISA",
+  "claude-code": "skills/ISA",
+};
+
+type InstallSubstrate = "codex" | "pi-dev" | "claude-code";
+
+function resolveInstallHomes(substrate: InstallSubstrate, options: SomaInstallOptions): { somaHome: string; substrateHome: string } {
   const homeDir = options.homeDir;
-  const defaultSubstrateHome = substrate === "codex" ? ".codex" : ".pi";
+  const defaultSubstrateHome = DEFAULT_SUBSTRATE_HOMES[substrate];
   const somaHome = options.somaHome ?? `${homeDir ?? "~"}/.soma`;
   const substrateHome = options.substrateHome ?? `${homeDir ?? "~"}/${defaultSubstrateHome}`;
 
@@ -79,8 +97,12 @@ function resolveInstallHomes(substrate: "codex" | "pi-dev", options: SomaInstall
   };
 }
 
+function resolveSubstrateSkillDir(substrate: InstallSubstrate, substrateHome: string): string {
+  return resolve(substrateHome, SKILL_SUBPATHS[substrate]);
+}
+
 function planSomaInstall(
-  substrate: "codex" | "pi-dev",
+  substrate: InstallSubstrate,
   substrateFiles: readonly string[],
   options: SomaInstallOptions = {},
 ): SomaInstallPlan {
@@ -105,34 +127,59 @@ export function planSomaForPiDevInstall(options: SomaInstallOptions = {}): SomaI
   return planSomaInstall("pi-dev", PI_DEV_HOME_FILES, options);
 }
 
+export function planSomaForClaudeCodeInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
+  return planSomaInstall("claude-code", CLAUDE_CODE_HOME_FILES, options);
+}
+
 async function installSomaForSubstrate(
-  substrate: "codex" | "pi-dev",
+  substrate: InstallSubstrate,
   options: SomaInstallOptions = {},
 ): Promise<SomaInstallResult> {
   const somaHome = await bootstrapSomaHome(options);
+  const somaRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();
+  // Install ISA skill into Soma home (canonical baseline) so other
+  // tooling reading <somaHome>/skills/ISA continues to work.
   await installIsaSkill({
     homeDir: options.homeDir,
     somaHome: somaHome.somaHome,
-    somaRepoPath: options.somaRepoPath ?? defaultSomaRepoPath(),
+    somaRepoPath,
   });
   const projectionOptions = {
     homeDir: options.homeDir,
     somaHome: options.somaHome,
     substrateHome: options.substrateHome,
-    somaRepoPath: options.somaRepoPath ?? defaultSomaRepoPath(),
+    somaRepoPath,
   };
-  const substrateHome =
-    substrate === "codex"
-      ? await installCodexHomeProjection(somaHome.context, projectionOptions)
-      : await installPiDevHomeProjection(somaHome.context, projectionOptions);
-  const configFiles = substrate === "codex" ? [await configureCodexInstall(substrateHome.rootDir, somaHome.somaHome)] : [];
-  const agentsFiles = substrate === "codex" ? [await configureCodexAgentsImport(substrateHome.rootDir)] : [];
-  const lifecycleFiles = await installLifecycleProjection(substrate, substrateHome.rootDir, {
+  // Per-substrate skill projection (#37 AC-3). Each substrate gets the
+  // versioned ISA skill under its native skills dir, with independent
+  // baseline tracking via `skillDestinationDir`. AC-5: drift detection
+  // inherits installIsaSkill's local-edits-preserved contract.
+  const resolvedHomeDir = resolve(options.homeDir ?? homedir());
+  const substrateRoot = resolve(options.substrateHome ?? join(resolvedHomeDir, DEFAULT_SUBSTRATE_HOMES[substrate]));
+  await installIsaSkill({
     homeDir: options.homeDir,
     somaHome: somaHome.somaHome,
-    somaRepoPath: projectionOptions.somaRepoPath,
-    substrate,
+    somaRepoPath,
+    skillDestinationDir: resolveSubstrateSkillDir(substrate, substrateRoot),
   });
+  // Populate the projection input with the active ISA so each
+  // substrate writes its `active-isa.md` file (#37 AC-1/AC-2).
+  const contextWithActiveIsa: SomaContextInput = {
+    ...somaHome.context,
+    activeIsa: (await loadActiveIsaForBundle({ somaHome: somaHome.somaHome })) ?? undefined,
+  };
+  const substrateHome = await installHomeProjectionFor(substrate, contextWithActiveIsa, projectionOptions);
+  const configFiles = substrate === "codex" ? [await configureCodexInstall(substrateHome.rootDir, somaHome.somaHome)] : [];
+  const agentsFiles = substrate === "codex" ? [await configureCodexAgentsImport(substrateHome.rootDir)] : [];
+  const lifecycleFiles =
+    substrate === "claude-code"
+      ? []
+      : await installLifecycleProjection(substrate, substrateHome.rootDir, {
+          homeDir: options.homeDir,
+          somaHome: somaHome.somaHome,
+          somaRepoPath: projectionOptions.somaRepoPath,
+          substrate,
+        });
 
   return {
     substrate,
@@ -142,6 +189,21 @@ async function installSomaForSubstrate(
       files: [...substrateHome.files, ...agentsFiles, ...configFiles, ...lifecycleFiles],
     },
   };
+}
+
+async function installHomeProjectionFor(
+  substrate: InstallSubstrate,
+  context: SomaContextInput,
+  options: { homeDir?: string; somaHome?: string; substrateHome?: string; somaRepoPath: string },
+) {
+  switch (substrate) {
+    case "codex":
+      return installCodexHomeProjection(context, options);
+    case "pi-dev":
+      return installPiDevHomeProjection(context, options);
+    case "claude-code":
+      return installClaudeCodeHomeProjection(context, options);
+  }
 }
 
 async function configureCodexAgentsImport(codexHome: string): Promise<string> {
@@ -169,9 +231,9 @@ async function writeProjectionFile(root: string, relativePath: string, content: 
 }
 
 async function installLifecycleProjection(
-  substrate: "codex" | "pi-dev",
+  substrate: Exclude<InstallSubstrate, "claude-code">,
   substrateHome: string,
-  options: { homeDir?: string; somaHome: string; somaRepoPath: string; substrate: "codex" | "pi-dev" },
+  options: { homeDir?: string; somaHome: string; somaRepoPath: string; substrate: Exclude<InstallSubstrate, "claude-code"> },
 ): Promise<string[]> {
   await runSomaLifecycleAlgorithmUpdated(options);
   const startup = await buildSomaStartupContext(options);
@@ -195,4 +257,15 @@ export async function installSomaForCodex(options: SomaInstallOptions = {}): Pro
 
 export async function installSomaForPiDev(options: SomaInstallOptions = {}): Promise<SomaInstallResult> {
   return installSomaForSubstrate("pi-dev", options);
+}
+
+/**
+ * Claude Code substrate installer (#37 minimal). Bootstraps Soma home,
+ * installs the ISA skill into `~/.claude/skills/ISA/`, and writes the
+ * active-ISA projection at `~/.claude/PAI/ACTIVE_ISA.md` when one is
+ * set. Full Claude Code home install lands in #29 with the
+ * `.claude/rules/` pivot.
+ */
+export async function installSomaForClaudeCode(options: SomaInstallOptions = {}): Promise<SomaInstallResult> {
+  return installSomaForSubstrate("claude-code", options);
 }

--- a/src/isa-skill-installer.ts
+++ b/src/isa-skill-installer.ts
@@ -17,6 +17,15 @@ const BASELINES_SUBPATH = "memory/STATE/skill-baselines.json";
 const UPGRADE_MARKER_NAME = ".upgrade-available";
 const SKILL_MD = "SKILL.md";
 
+/**
+ * Baselines are keyed by destination so multi-substrate installs (#37)
+ * track their own drift independently. Default destination uses the
+ * unqualified "ISA" key for backwards-compat with pre-#37 baselines.
+ */
+function baselineKey(destinationDir: string, defaultDir: string): string {
+  return resolve(destinationDir) === resolve(defaultDir) ? SKILL_NAME : `${SKILL_NAME}@${resolve(destinationDir)}`;
+}
+
 function resolveSomaHome(options: Pick<IsaSkillInstallOptions, "homeDir" | "somaHome"> = {}): string {
   return resolve(options.somaHome ?? join(options.homeDir ?? homedir(), ".soma"));
 }
@@ -215,7 +224,12 @@ export async function installIsaSkill(options: IsaSkillInstallOptions = {}): Pro
   const somaHome = resolveSomaHome(options);
   const somaRepoPath = resolveSomaRepoPath(options);
   const sourceDir = isaSkillSourceDir(somaRepoPath);
-  const runtimeDir = isaSkillRuntimeDir(somaHome);
+  // Substrate adapters (#37) install the skill under their own root
+  // (e.g. ~/.codex/skills/ISA). The baseline file still lives under
+  // ~/.soma so drift and version tracking remain centralized.
+  const runtimeDir = options.skillDestinationDir
+    ? resolve(options.skillDestinationDir)
+    : isaSkillRuntimeDir(somaHome);
   const markerPath = join(runtimeDir, UPGRADE_MARKER_NAME);
 
   if (!(await exists(sourceDir))) {
@@ -244,10 +258,11 @@ export async function installIsaSkill(options: IsaSkillInstallOptions = {}): Pro
   const runtimeFrontmatter = await readSkillFrontmatter(join(runtimeDir, SKILL_MD));
   const baselinesRead = await readBaselines(somaHome);
   const baselines = baselinesRead.baselines;
-  const baseline = baselines[SKILL_NAME];
 
   const runtimeFiles = await listSkillFiles(runtimeDir);
   const userAdditions = runtimeFiles.filter((rel) => !sourceFiles.includes(rel) && rel !== UPGRADE_MARKER_NAME);
+  const skillKey = baselineKey(runtimeDir, isaSkillRuntimeDir(somaHome));
+  const baselineForDest = baselines[skillKey];
 
   if (runtimeFrontmatter === null || options.force === true) {
     return freshInstall({
@@ -261,6 +276,7 @@ export async function installIsaSkill(options: IsaSkillInstallOptions = {}): Pro
       baselines,
       markerPath,
       userAdditions,
+      skillKey,
     });
   }
 
@@ -276,12 +292,13 @@ export async function installIsaSkill(options: IsaSkillInstallOptions = {}): Pro
       sourceVersion: sourceFrontmatter.version,
       runtimeVersion: runtimeFrontmatter.version,
       baselines,
-      baseline,
+      baseline: baselineForDest,
       userAdditions,
+      skillKey,
     });
   }
 
-  const drift = await detectDrift(runtimeDir, baseline, sourceFiles, baselinesRead.corrupt);
+  const drift = await detectDrift(runtimeDir, baselineForDest, sourceFiles, baselinesRead.corrupt);
   if (drift.hasLocalEdits) {
     return writeUpgradeMarker({
       somaHome,
@@ -306,6 +323,7 @@ export async function installIsaSkill(options: IsaSkillInstallOptions = {}): Pro
     markerPath,
     userAdditions,
     actionOverride: "upgraded",
+    skillKey,
   });
 }
 
@@ -321,6 +339,7 @@ interface ReconcileSameVersionContext {
   baselines: SomaSkillBaselines;
   baseline: SomaSkillBaseline | undefined;
   userAdditions: string[];
+  skillKey: string;
 }
 
 async function reconcileSameVersion(ctx: ReconcileSameVersionContext): Promise<IsaSkillInstallResult> {
@@ -355,7 +374,7 @@ async function reconcileSameVersion(ctx: ReconcileSameVersionContext): Promise<I
     files: restoredFiles,
     installedAt: ctx.baseline?.installedAt ?? new Date().toISOString(),
   };
-  const nextBaselines = { ...ctx.baselines, [SKILL_NAME]: restoredBaseline };
+  const nextBaselines = { ...ctx.baselines, [ctx.skillKey]: restoredBaseline };
   await writeBaselines(ctx.somaHome, nextBaselines);
   return {
     somaHome: ctx.somaHome,
@@ -415,6 +434,7 @@ interface FreshInstallContext {
   markerPath: string;
   userAdditions: string[];
   actionOverride?: "fresh" | "upgraded";
+  skillKey: string;
 }
 
 async function freshInstall(ctx: FreshInstallContext): Promise<IsaSkillInstallResult> {
@@ -426,7 +446,7 @@ async function freshInstall(ctx: FreshInstallContext): Promise<IsaSkillInstallRe
   }
 
   const baselines = { ...ctx.baselines };
-  baselines[SKILL_NAME] = {
+  baselines[ctx.skillKey] = {
     version: ctx.sourceVersion,
     files: ctx.sourceHashes,
     installedAt: new Date().toISOString(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -314,6 +314,15 @@ export interface IsaSkillInstallOptions {
   somaHome?: string;
   somaRepoPath?: string;
   force?: boolean;
+  /**
+   * Absolute destination directory for the installed skill (#37). When
+   * omitted the installer writes to `<somaHome>/skills/ISA` (preserves
+   * pre-#37 behavior). When set — used by substrate adapters that want
+   * to install the same versioned skill under their own root, e.g.
+   * `~/.codex/skills/ISA`. The baseline + drift detection logic is
+   * shared regardless of destination.
+   */
+  skillDestinationDir?: string;
 }
 
 export type IsaSkillInstallAction = "fresh" | "upgraded" | "unchanged" | "preserved-local-edits" | "no-source";

--- a/test/adapter-active-isa.test.ts
+++ b/test/adapter-active-isa.test.ts
@@ -1,0 +1,180 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import {
+  activeIsaProjectionPath,
+  bootstrapSomaHome,
+  buildClaudeCodeContext,
+  buildClaudeCodeHomeContext,
+  buildCodexHomeContext,
+  buildPiDevHomeContext,
+  installClaudeCodeHomeProjection,
+  installCodexHomeProjection,
+  installPiDevHomeProjection,
+  installSomaForClaudeCode,
+  installSomaForCodex,
+  installSomaForPiDev,
+  loadActiveIsaForBundle,
+  renderActiveIsaFile,
+  scaffoldIsa,
+  setActiveIsa,
+} from "../src/index";
+import { portableContextInput } from "./fixtures";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-37-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+test("activeIsaProjectionPath: per-substrate paths match the #37 spec", () => {
+  expect(activeIsaProjectionPath("codex")).toBe("memories/soma/active-isa.md");
+  expect(activeIsaProjectionPath("pi-dev")).toBe("agent/soma/active-isa.md");
+  expect(activeIsaProjectionPath("claude-code")).toBe("PAI/ACTIVE_ISA.md");
+  expect(() => activeIsaProjectionPath("custom")).toThrow();
+  expect(() => activeIsaProjectionPath("cortex")).toThrow();
+});
+
+test("AC-1: codex/pi-dev/claude home builders all include active-isa when set", () => {
+  const codex = buildCodexHomeContext(portableContextInput, "/tmp/soma");
+  const piDev = buildPiDevHomeContext(portableContextInput, "/tmp/soma");
+  const claude = buildClaudeCodeHomeContext(portableContextInput);
+  const codexPaths = codex.files.map((f) => f.path);
+  const piPaths = piDev.files.map((f) => f.path);
+  const claudePaths = claude.files.map((f) => f.path);
+  expect(codexPaths).toContain("memories/soma/active-isa.md");
+  expect(piPaths).toContain("agent/soma/active-isa.md");
+  expect(claudePaths).toContain("PAI/ACTIVE_ISA.md");
+});
+
+test("AC-1: project bundle for claude-code includes active-isa when set", () => {
+  const bundle = buildClaudeCodeContext(portableContextInput);
+  const paths = bundle.files.map((f) => f.path);
+  expect(paths).toContain(".claude/soma/active-isa.md");
+});
+
+test("AC-2: omits active-isa when no active ISA — no empty file, no stale content", () => {
+  const inputWithoutIsa = { ...portableContextInput, activeIsa: undefined };
+  const codex = buildCodexHomeContext(inputWithoutIsa, "/tmp/soma");
+  const piDev = buildPiDevHomeContext(inputWithoutIsa, "/tmp/soma");
+  const claude = buildClaudeCodeHomeContext(inputWithoutIsa);
+  const claudeProject = buildClaudeCodeContext(inputWithoutIsa);
+  expect(codex.files.map((f) => f.path)).not.toContain("memories/soma/active-isa.md");
+  expect(piDev.files.map((f) => f.path)).not.toContain("agent/soma/active-isa.md");
+  expect(claude.files.map((f) => f.path)).not.toContain("PAI/ACTIVE_ISA.md");
+  expect(claude.files).toHaveLength(0);
+  expect(claudeProject.files.map((f) => f.path)).not.toContain(".claude/soma/active-isa.md");
+});
+
+test("AC-3: installSomaForCodex projects ISA skill source into ~/.codex/skills/ISA/", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const skillMd = await readFile(join(homeDir, ".codex/skills/ISA/SKILL.md"), "utf8");
+    expect(skillMd).toContain("name: ISA");
+    expect(skillMd).toMatch(/version:\s+\d+\.\d+\.\d+/);
+  });
+});
+
+test("AC-3: installSomaForPiDev projects ISA skill source into ~/.pi/agent/skills/ISA/", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForPiDev({ homeDir });
+    const skillMd = await readFile(join(homeDir, ".pi/agent/skills/ISA/SKILL.md"), "utf8");
+    expect(skillMd).toContain("name: ISA");
+  });
+});
+
+test("AC-3: installSomaForClaudeCode projects ISA skill source into ~/.claude/skills/ISA/", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir });
+    const skillMd = await readFile(join(homeDir, ".claude/skills/ISA/SKILL.md"), "utf8");
+    expect(skillMd).toContain("name: ISA");
+  });
+});
+
+test("AC-4: byte-portable active-ISA across all three substrate installs", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    await scaffoldIsa({
+      homeDir,
+      slug: "portability",
+      goal: "Adapters render the same bytes across substrates.",
+      effort: "E3",
+      initialCriteria: [
+        { id: "C1", text: "Codex projection equals pi-dev projection equals claude projection.", status: "open" },
+      ],
+    });
+    await setActiveIsa("portability", { homeDir });
+    const ctx = await loadActiveIsaForBundle({ homeDir });
+    expect(ctx).not.toBeNull();
+    // Run all three substrate installers against the same soma home.
+    await installSomaForCodex({ homeDir });
+    await installSomaForPiDev({ homeDir });
+    await installSomaForClaudeCode({ homeDir });
+
+    const codexFile = await readFile(join(homeDir, ".codex/memories/soma/active-isa.md"), "utf8");
+    const piFile = await readFile(join(homeDir, ".pi/agent/soma/active-isa.md"), "utf8");
+    const claudeFile = await readFile(join(homeDir, ".claude/PAI/ACTIVE_ISA.md"), "utf8");
+
+    // BYTE equality — the renderer-of-record is serializeIsa.
+    expect(codexFile).toBe(piFile);
+    expect(piFile).toBe(claudeFile);
+    expect(codexFile).toBe(renderActiveIsaFile(ctx!));
+  });
+});
+
+test("AC-4: portability holds when the active ISA is updated", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    await scaffoldIsa({ homeDir, slug: "demo", goal: "G", effort: "E1" });
+    await setActiveIsa("demo", { homeDir });
+    await installSomaForCodex({ homeDir });
+    await installSomaForPiDev({ homeDir });
+    await installSomaForClaudeCode({ homeDir });
+    const a = await readFile(join(homeDir, ".codex/memories/soma/active-isa.md"), "utf8");
+    const b = await readFile(join(homeDir, ".pi/agent/soma/active-isa.md"), "utf8");
+    const c = await readFile(join(homeDir, ".claude/PAI/ACTIVE_ISA.md"), "utf8");
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+});
+
+test("AC-5: skill installer baselines track each substrate independently", async () => {
+  await withTempHome(async (homeDir) => {
+    // Two installs into different substrates should both succeed with the
+    // skill present at their respective dest, without one's drift detection
+    // interfering with the other.
+    await installSomaForCodex({ homeDir });
+    await installSomaForPiDev({ homeDir });
+    const baselines = JSON.parse(
+      await readFile(join(homeDir, ".soma/memory/STATE/skill-baselines.json"), "utf8"),
+    ) as Record<string, unknown>;
+    // The default key remains, plus per-substrate keys exist.
+    expect(baselines.ISA).toBeDefined();
+    const substrateKeys = Object.keys(baselines).filter((k) => k.startsWith("ISA@"));
+    expect(substrateKeys.length).toBe(2);
+  });
+});
+
+test("home installers omit empty bundle gracefully (claude-code, no active ISA)", async () => {
+  await withTempHome(async (homeDir) => {
+    // No active ISA → claude home bundle is empty → install is a no-op.
+    const result = await installClaudeCodeHomeProjection(
+      { ...portableContextInput, activeIsa: undefined },
+      { homeDir },
+    );
+    expect(result.files).toHaveLength(0);
+  });
+});
+
+test("codex/pi-dev installs without active ISA still succeed (active-isa omitted)", async () => {
+  await withTempHome(async (homeDir) => {
+    const codex = await installCodexHomeProjection({ ...portableContextInput, activeIsa: undefined }, { homeDir });
+    const piDev = await installPiDevHomeProjection({ ...portableContextInput, activeIsa: undefined }, { homeDir });
+    expect(codex.files.some((p) => p.endsWith("active-isa.md"))).toBe(false);
+    expect(piDev.files.some((p) => p.endsWith("active-isa.md"))).toBe(false);
+  });
+});

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -38,8 +38,16 @@ test("resolves pi.dev home projection paths from a home directory", () => {
   expect(paths.substrateHome).toBe("/tmp/soma-test-home/.pi");
 });
 
+test("resolves claude-code home projection paths (#37)", () => {
+  const paths = resolveHomeProjectionPaths("claude-code", { homeDir: "/tmp/soma-test-home" });
+  expect(paths.substrate).toBe("claude-code");
+  expect(paths.somaHome).toBe("/tmp/soma-test-home/.soma");
+  expect(paths.substrateHome).toBe("/tmp/soma-test-home/.claude");
+});
+
 test("rejects unimplemented home projection substrates", () => {
-  expect(() => resolveHomeProjectionPaths("claude-code", { homeDir: "/tmp/soma-test-home" })).toThrow("not implemented");
+  expect(() => resolveHomeProjectionPaths("cortex", { homeDir: "/tmp/soma-test-home" })).toThrow("not implemented");
+  expect(() => resolveHomeProjectionPaths("custom", { homeDir: "/tmp/soma-test-home" })).toThrow("not implemented");
 });
 
 test("builds codex home projection bundle for default availability", () => {
@@ -63,6 +71,7 @@ test("builds codex home projection bundle for default availability", () => {
     "memories/soma/skills.md",
     "memories/soma/policy.md",
     "skills/the-algorithm/SKILL.md",
+    "memories/soma/active-isa.md",
   ]);
   expect(projection.bundle.instructions).toContain("Soma default availability");
   expect(projection.bundle.instructions).toContain("/tmp/soma-test-home/.soma");
@@ -108,6 +117,7 @@ test("builds pi.dev home projection bundle for default availability", () => {
     "agent/soma/policy.md",
     "agent/extensions/soma-path-guard.ts",
     "agent/skills/soma/SKILL.md",
+    "agent/soma/active-isa.md",
   ]);
   expect(projection.bundle.files.find((file) => file.path === "agent/extensions/soma.ts")?.content).toContain("before_agent_start");
   expect(projection.bundle.files.find((file) => file.path === "agent/extensions/soma.ts")?.content).toContain("session_start");
@@ -129,7 +139,7 @@ test("installs codex home projection into a substrate home", async () => {
 
     expect(result.substrate).toBe("codex");
     expect(result.rootDir).toBe(join(homeDir, ".codex"));
-    expect(result.files).toHaveLength(15);
+    expect(result.files).toHaveLength(16);
 
     const rules = await readFile(join(homeDir, ".codex/rules/soma.rules"), "utf8");
     const hooks = await readFile(join(homeDir, ".codex/hooks.json"), "utf8");
@@ -220,7 +230,7 @@ test("installs pi.dev home projection into a substrate home", async () => {
 
     expect(result.substrate).toBe("pi-dev");
     expect(result.rootDir).toBe(join(homeDir, ".pi"));
-    expect(result.files).toHaveLength(10);
+    expect(result.files).toHaveLength(11);
 
     const extension = await readFile(join(homeDir, ".pi/agent/extensions/soma.ts"), "utf8");
     const profile = await readFile(join(homeDir, ".pi/agent/soma/profile.md"), "utf8");


### PR DESCRIPTION
Closes #37. Sprint 3 Layer 6.

Active ISA projection across all three substrates, byte-identical, with per-substrate skill installer baselines.

## New module \`src/adapter-active-isa.ts\`

Single source of truth:

- \`loadActiveIsaForBundle(options)\` — resolves the active slug + reads ISA via Layer 3.
- \`renderActiveIsaFile(isa)\` — uses \`serializeIsa\` so every substrate ends up with byte-identical bytes (AC-4 contract).
- \`activeIsaProjectionPath(substrate)\` — per-spec table.

## Adapter wiring

\`buildCodexHomeContext\`, \`buildPiDevHomeContext\`, \`buildClaudeCodeContext\`, and new \`buildClaudeCodeHomeContext\` conditionally append \`active-isa.md\` when \`input.activeIsa\` is set. OMITTED otherwise — AC-2.

## Substrate skill installer (AC-3/AC-5)

\`installIsaSkill\` accepts \`skillDestinationDir\` so the same versioned/baseline/drift-protected installer can write to \`~/.codex/skills/ISA\`, \`~/.pi/agent/skills/ISA\`, \`~/.claude/skills/ISA\`. Per-destination baseline keys (\`ISA@<dir>\`) keep drift detection independent across substrates.

## Public install API

- \`installSomaForClaudeCode\` (new) — minimal Claude Code substrate installer.
- \`installSomaForCodex\` / \`installSomaForPiDev\` — now load the active ISA and install the ISA skill into the substrate dir.

Full Claude Code home install (full PAI projection, hooks, etc.) lands in #29 with the \`.claude/rules/\` pivot (issue #64).

## ACs

| AC | Test |
|----|------|
| AC-1 home builders include active-isa when set | ✓ |
| AC-2 cleanly omitted when unset | ✓ |
| AC-3 installers project ISA skill into substrate skills dir | ✓ |
| AC-4 portability — bytes identical across all three substrates | ✓ |
| AC-5 skill versioning baselines tracked per substrate | ✓ |

## Tests

368 pass (+12 new). Typecheck clean. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)