### PR TITLE
feat(migration): PAI → Soma orchestrator (#28 minimal)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -202,6 +202,14 @@ export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from ".
 export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
 export { importPaiPack, planPaiPackImport } from "./pai-pack-importer";
+// PAI → Soma migration orchestrator (#28 minimal scope).
+export {
+  migratePai,
+  planPaiMigration,
+  type PaiMigrationOptions,
+  type PaiMigrationPlan,
+  type PaiMigrationResult,
+} from "./pai-migration";
 export { checkSomaPolicy, checkSomaPolicyBatch } from "./policy-audit";
 export { evaluateSomaPolicy } from "./policy";
 export { bootstrapSomaHome, loadSomaHome } from "./soma-home";

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -119,6 +119,30 @@ function manifestPathFor(somaHome: string): string {
 }
 
 /**
+ * Run async work with a bounded concurrency window (sage r4: prevent
+ * unlimited pack-import fan-out on large installs).
+ */
+async function runBoundedConcurrent<T, R>(
+  items: readonly T[],
+  fn: (item: T) => Promise<R>,
+  limit: number,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const results: R[] = new Array<R>(items.length);
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index]);
+    }
+  }
+  const workerCount = Math.min(limit, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
+/**
  * Shared discovery between dry-run and apply paths (sage r1 finding):
  * resolves algorithm presence and pack paths once so the two surfaces
  * cannot drift as new categories are added.
@@ -216,11 +240,14 @@ export async function migratePai(options: PaiMigrationOptions = {}): Promise<Pai
     : await importAlgorithm({ homeDir: options.homeDir, paiAlgorithmDir: algorithmDir, somaHome });
   if (algorithm) filesWritten.push(...algorithm.files);
 
-  // Sage r1: parallelize independent pack imports — each pack imports
-  // into its own subtree under <somaHome>/skills/, so there is no
-  // cross-pack ordering constraint.
-  const packs: PaiPackImportResult[] = await Promise.all(
-    packPaths.map((paiPackDir) => importPaiPack({ homeDir: options.homeDir, paiPackDir, somaHome })),
+  // Sage r1: parallelize independent pack imports. Sage r4: bound the
+  // fan-out so large installs don't burst FD limits or thrash the FS.
+  // Per-pack work is mostly I/O; 4 workers is enough to hide latency
+  // without unbounded parallelism.
+  const packs = await runBoundedConcurrent(
+    packPaths,
+    (paiPackDir) => importPaiPack({ homeDir: options.homeDir, paiPackDir, somaHome }),
+    4,
   );
   for (const r of packs) filesWritten.push(...r.files);
 

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -80,8 +80,16 @@ async function exists(path: string): Promise<boolean> {
   try {
     await stat(path);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    // Sage r3: only ENOENT/ENOTDIR (path absent / parent is a file)
+    // mean "not present" — those are normal control-flow signals.
+    // EACCES or other I/O errors must surface so a silent miss can't
+    // produce a "successful" migration that quietly drops a category.
+    if (isEnoent(error)) return false;
+    if (typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOTDIR") {
+      return false;
+    }
+    throw error;
   }
 }
 

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -131,7 +131,7 @@ async function runBoundedConcurrent<T, R>(
   const results: R[] = new Array<R>(items.length);
   let cursor = 0;
   async function worker(): Promise<void> {
-    while (true) {
+    for (;;) {
       const index = cursor++;
       if (index >= items.length) return;
       results[index] = await fn(items[index]);

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -97,20 +97,33 @@ function manifestPathFor(somaHome: string): string {
 }
 
 /**
+ * Shared discovery between dry-run and apply paths (sage r1 finding):
+ * resolves algorithm presence and pack paths once so the two surfaces
+ * cannot drift as new categories are added.
+ */
+async function discoverMigrationSources(
+  claudeHome: string,
+  options: PaiMigrationOptions,
+): Promise<{ algorithmDir: string | null; packPaths: string[] }> {
+  const algorithmDirCandidate = join(claudeHome, "PAI/Algorithm");
+  const algorithmDir = (await exists(algorithmDirCandidate)) ? algorithmDirCandidate : null;
+  const packPaths = options.paiPackPaths ?? (await autoDiscoverPackPaths(claudeHome));
+  return { algorithmDir, packPaths };
+}
+
+/**
  * Plan what migratePai would do. Same-shape sub-plans as the
  * underlying importers + the manifest target. `apply: false` is
  * always false for plans — to execute call migratePai.
  */
 export async function planPaiMigration(options: PaiMigrationOptions = {}): Promise<PaiMigrationPlan> {
   const { claudeHome, somaHome } = resolvePaths(options);
+  const { algorithmDir, packPaths } = await discoverMigrationSources(claudeHome, options);
+
   const identity = planPaiImport({ homeDir: options.homeDir, claudeHome, somaHome });
-
-  const algorithmDir = join(claudeHome, "PAI/Algorithm");
-  const algorithm = (await exists(algorithmDir))
-    ? planAlgorithmImport({ homeDir: options.homeDir, paiAlgorithmDir: algorithmDir, somaHome })
-    : null;
-
-  const packPaths = options.paiPackPaths ?? (await autoDiscoverPackPaths(claudeHome));
+  const algorithm = algorithmDir === null
+    ? null
+    : planAlgorithmImport({ homeDir: options.homeDir, paiAlgorithmDir: algorithmDir, somaHome });
   const packs = await Promise.all(
     packPaths.map((paiPackDir) => planPaiPackImport({ homeDir: options.homeDir, paiPackDir, somaHome })),
   );
@@ -127,7 +140,10 @@ export async function planPaiMigration(options: PaiMigrationOptions = {}): Promi
 }
 
 function renderManifest(result: Omit<PaiMigrationResult, "manifestPath" | "filesWritten">): string {
-  const now = new Date().toISOString();
+  // Sage r1: the manifest used to embed a fresh timestamp on every
+  // rerun, breaking the documented idempotency. Now the manifest is a
+  // pure function of the import results — second rerun with identical
+  // imports produces byte-identical bytes.
   const packLines = result.packs.length === 0
     ? "- (none discovered)"
     : result.packs.map((p, idx) => `- pack ${idx + 1}: ${p.files.length} files`).join("\n");
@@ -135,7 +151,6 @@ function renderManifest(result: Omit<PaiMigrationResult, "manifestPath" | "files
     "# PAI Migration",
     "",
     `Source: ${result.claudeHome}`,
-    `Migrated: ${now}`,
     "",
     "## Categories",
     `- identity: ${result.identity.files.length} files`,
@@ -168,24 +183,24 @@ function renderManifest(result: Omit<PaiMigrationResult, "manifestPath" | "files
  */
 export async function migratePai(options: PaiMigrationOptions = {}): Promise<PaiMigrationResult> {
   const { claudeHome, somaHome } = resolvePaths(options);
+  const { algorithmDir, packPaths } = await discoverMigrationSources(claudeHome, options);
   const filesWritten: string[] = [];
 
   const identity = await importPaiIdentity({ homeDir: options.homeDir, claudeHome, somaHome });
   filesWritten.push(...identity.files);
 
-  const algorithmDir = join(claudeHome, "PAI/Algorithm");
-  const algorithm = (await exists(algorithmDir))
-    ? await importAlgorithm({ homeDir: options.homeDir, paiAlgorithmDir: algorithmDir, somaHome })
-    : null;
+  const algorithm = algorithmDir === null
+    ? null
+    : await importAlgorithm({ homeDir: options.homeDir, paiAlgorithmDir: algorithmDir, somaHome });
   if (algorithm) filesWritten.push(...algorithm.files);
 
-  const packPaths = options.paiPackPaths ?? (await autoDiscoverPackPaths(claudeHome));
-  const packs: PaiPackImportResult[] = [];
-  for (const paiPackDir of packPaths) {
-    const r = await importPaiPack({ homeDir: options.homeDir, paiPackDir, somaHome });
-    packs.push(r);
-    filesWritten.push(...r.files);
-  }
+  // Sage r1: parallelize independent pack imports — each pack imports
+  // into its own subtree under <somaHome>/skills/, so there is no
+  // cross-pack ordering constraint.
+  const packs: PaiPackImportResult[] = await Promise.all(
+    packPaths.map((paiPackDir) => importPaiPack({ homeDir: options.homeDir, paiPackDir, somaHome })),
+  );
+  for (const r of packs) filesWritten.push(...r.files);
 
   const manifestPath = manifestPathFor(somaHome);
   await mkdir(dirname(manifestPath), { recursive: true });

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -85,10 +85,24 @@ async function exists(path: string): Promise<boolean> {
   }
 }
 
+function isEnoent(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT";
+}
+
 async function autoDiscoverPackPaths(claudeHome: string): Promise<string[]> {
   const packsRoot = join(claudeHome, "PAI/Packs");
   if (!(await exists(packsRoot))) return [];
-  const entries = await readdir(packsRoot, { withFileTypes: true }).catch(() => []);
+  // Sage r2: only treat ENOENT (raced delete) as "no packs". Other
+  // errors (EACCES on the packs dir, transient I/O failure) must
+  // surface — a silent miss would produce a "successful" migration
+  // that quietly omits the pack category.
+  let entries;
+  try {
+    entries = await readdir(packsRoot, { withFileTypes: true });
+  } catch (error) {
+    if (isEnoent(error)) return [];
+    throw error;
+  }
   return entries.filter((e) => e.isDirectory()).map((e) => join(packsRoot, e.name));
 }
 

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -1,0 +1,197 @@
+/**
+ * PAI → Soma migration orchestrator (#28 minimal scope).
+ *
+ * Wraps the three existing importers (`importPaiIdentity`,
+ * `importAlgorithm`, `importPaiPack`) behind a single `migratePai`
+ * call + writes a human-readable MIGRATION.md manifest at
+ * `~/.soma/profile/imports/claude/MIGRATION.md`.
+ *
+ * Out of scope for this minimal cut (filed as follow-ups on #28):
+ *   - per-category importers for skills/agents/commands/hooks
+ *   - auto-memory copy
+ *   - idempotency conflict detection beyond what the underlying
+ *     importers already provide
+ *   - TTY auto-detect prompt
+ *   - CLI integration (lands in soma#67 `soma migrate pai`)
+ *
+ * The thin orchestrator is enough to:
+ *   - Land the canonical `soma migrate pai` integration point.
+ *   - Give a single manifest the user can read to confirm what was
+ *     imported in one place.
+ *   - Unblock #29's full Claude Code install path.
+ */
+import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { importAlgorithm, planAlgorithmImport } from "./algorithm-importer";
+import { importPaiIdentity, planPaiImport } from "./pai-importer";
+import { importPaiPack, planPaiPackImport } from "./pai-pack-importer";
+import type {
+  AlgorithmImportPlan,
+  AlgorithmImportResult,
+  PaiImportPlan,
+  PaiImportResult,
+  PaiPackImportPlan,
+  PaiPackImportResult,
+} from "./types";
+
+export interface PaiMigrationOptions {
+  homeDir?: string;
+  claudeHome?: string;
+  somaHome?: string;
+  /**
+   * When provided, each pack at this list of paths is imported via the
+   * existing pack-importer. When omitted, packs are auto-discovered
+   * under `<claudeHome>/PAI/Packs/` (no-op when the directory does not
+   * exist).
+   */
+  paiPackPaths?: string[];
+}
+
+export interface PaiMigrationPlan {
+  apply: false;
+  claudeHome: string;
+  somaHome: string;
+  identity: PaiImportPlan;
+  algorithm: AlgorithmImportPlan | null;
+  packs: PaiPackImportPlan[];
+  manifestPath: string;
+}
+
+export interface PaiMigrationResult {
+  claudeHome: string;
+  somaHome: string;
+  identity: PaiImportResult;
+  algorithm: AlgorithmImportResult | null;
+  packs: PaiPackImportResult[];
+  manifestPath: string;
+  filesWritten: string[];
+}
+
+function resolvePaths(options: PaiMigrationOptions): { claudeHome: string; somaHome: string } {
+  const home = resolve(options.homeDir ?? homedir());
+  return {
+    claudeHome: resolve(options.claudeHome ?? join(home, ".claude")),
+    somaHome: resolve(options.somaHome ?? join(home, ".soma")),
+  };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function autoDiscoverPackPaths(claudeHome: string): Promise<string[]> {
+  const packsRoot = join(claudeHome, "PAI/Packs");
+  if (!(await exists(packsRoot))) return [];
+  const entries = await readdir(packsRoot, { withFileTypes: true }).catch(() => []);
+  return entries.filter((e) => e.isDirectory()).map((e) => join(packsRoot, e.name));
+}
+
+function manifestPathFor(somaHome: string): string {
+  return join(somaHome, "profile/imports/claude/MIGRATION.md");
+}
+
+/**
+ * Plan what migratePai would do. Same-shape sub-plans as the
+ * underlying importers + the manifest target. `apply: false` is
+ * always false for plans — to execute call migratePai.
+ */
+export async function planPaiMigration(options: PaiMigrationOptions = {}): Promise<PaiMigrationPlan> {
+  const { claudeHome, somaHome } = resolvePaths(options);
+  const identity = planPaiImport({ homeDir: options.homeDir, claudeHome, somaHome });
+
+  const algorithmDir = join(claudeHome, "PAI/Algorithm");
+  const algorithm = (await exists(algorithmDir))
+    ? planAlgorithmImport({ homeDir: options.homeDir, paiAlgorithmDir: algorithmDir, somaHome })
+    : null;
+
+  const packPaths = options.paiPackPaths ?? (await autoDiscoverPackPaths(claudeHome));
+  const packs = await Promise.all(
+    packPaths.map((paiPackDir) => planPaiPackImport({ homeDir: options.homeDir, paiPackDir, somaHome })),
+  );
+
+  return {
+    apply: false,
+    claudeHome,
+    somaHome,
+    identity,
+    algorithm,
+    packs,
+    manifestPath: manifestPathFor(somaHome),
+  };
+}
+
+function renderManifest(result: Omit<PaiMigrationResult, "manifestPath" | "filesWritten">): string {
+  const now = new Date().toISOString();
+  const packLines = result.packs.length === 0
+    ? "- (none discovered)"
+    : result.packs.map((p, idx) => `- pack ${idx + 1}: ${p.files.length} files`).join("\n");
+  return [
+    "# PAI Migration",
+    "",
+    `Source: ${result.claudeHome}`,
+    `Migrated: ${now}`,
+    "",
+    "## Categories",
+    `- identity: ${result.identity.files.length} files`,
+    `- algorithm: ${result.algorithm ? `${result.algorithm.files.length} files` : "not present"}`,
+    `- packs:`,
+    packLines.split("\n").map((l) => `  ${l}`).join("\n"),
+    "",
+    "## What was skipped",
+    "- Skills / agents / commands / hooks / auto-memory: not yet covered by the",
+    "  minimal orchestrator. Per-category importers will follow in incremental PRs",
+    "  layered on top of #28.",
+    "",
+    "## How to re-run",
+    "- `soma migrate pai` is idempotent at the importer level — each underlying",
+    "  importer compares source vs. target and writes only changed files.",
+    "- To roll back the Claude Code projection (not the Soma home itself) run",
+    "  `soma adopt claude --uninstall` (soma#68).",
+    "",
+  ].join("\n");
+}
+
+/**
+ * Execute the migration plan. Runs identity → algorithm → packs in
+ * order, then writes the MIGRATION.md manifest. Idempotency comes
+ * from the underlying importers; this wrapper does not re-implement
+ * it.
+ *
+ * Throws only if an underlying importer throws — there is no
+ * partial-success swallow. The caller decides whether to retry.
+ */
+export async function migratePai(options: PaiMigrationOptions = {}): Promise<PaiMigrationResult> {
+  const { claudeHome, somaHome } = resolvePaths(options);
+  const filesWritten: string[] = [];
+
+  const identity = await importPaiIdentity({ homeDir: options.homeDir, claudeHome, somaHome });
+  filesWritten.push(...identity.files);
+
+  const algorithmDir = join(claudeHome, "PAI/Algorithm");
+  const algorithm = (await exists(algorithmDir))
+    ? await importAlgorithm({ homeDir: options.homeDir, paiAlgorithmDir: algorithmDir, somaHome })
+    : null;
+  if (algorithm) filesWritten.push(...algorithm.files);
+
+  const packPaths = options.paiPackPaths ?? (await autoDiscoverPackPaths(claudeHome));
+  const packs: PaiPackImportResult[] = [];
+  for (const paiPackDir of packPaths) {
+    const r = await importPaiPack({ homeDir: options.homeDir, paiPackDir, somaHome });
+    packs.push(r);
+    filesWritten.push(...r.files);
+  }
+
+  const manifestPath = manifestPathFor(somaHome);
+  await mkdir(dirname(manifestPath), { recursive: true });
+  const manifest = renderManifest({ claudeHome, somaHome, identity, algorithm, packs });
+  await writeFile(manifestPath, manifest, "utf8");
+  filesWritten.push(manifestPath);
+
+  return { claudeHome, somaHome, identity, algorithm, packs, manifestPath, filesWritten };
+}

--- a/test/pai-migration.test.ts
+++ b/test/pai-migration.test.ts
@@ -114,6 +114,24 @@ test("migratePai omits algorithm when PAI install has no Algorithm dir", async (
   });
 });
 
+test("migratePai surfaces EACCES on Algorithm dir instead of silently dropping (sage r3)", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir, { withAlgorithm: true });
+    const algoDir = join(homeDir, ".claude/PAI/Algorithm");
+    const { chmod } = await import("node:fs/promises");
+    // Make Algorithm's parent unreadable so stat on Algorithm
+    // itself fails with EACCES, not ENOENT.
+    const paiDir = join(homeDir, ".claude/PAI");
+    await chmod(paiDir, 0o000);
+    try {
+      await expect(migratePai({ homeDir })).rejects.toThrow();
+    } finally {
+      await chmod(paiDir, 0o700);
+      await chmod(algoDir, 0o700).catch(() => undefined);
+    }
+  });
+});
+
 test("migratePai surfaces EACCES on packs dir instead of silently skipping (sage r2)", async () => {
   await withTempHome(async (homeDir) => {
     await writePaiFixture(homeDir);

--- a/test/pai-migration.test.ts
+++ b/test/pai-migration.test.ts
@@ -114,6 +114,22 @@ test("migratePai omits algorithm when PAI install has no Algorithm dir", async (
   });
 });
 
+test("migratePai surfaces EACCES on packs dir instead of silently skipping (sage r2)", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    // Create an unreadable packs dir.
+    const packsRoot = join(homeDir, ".claude/PAI/Packs");
+    await mkdir(packsRoot, { recursive: true });
+    const { chmod } = await import("node:fs/promises");
+    await chmod(packsRoot, 0o000);
+    try {
+      await expect(migratePai({ homeDir })).rejects.toThrow();
+    } finally {
+      await chmod(packsRoot, 0o700);
+    }
+  });
+});
+
 test("migratePai writes manifest with claude/MIGRATION.md path", async () => {
   await withTempHome(async (homeDir) => {
     await writePaiFixture(homeDir);

--- a/test/pai-migration.test.ts
+++ b/test/pai-migration.test.ts
@@ -92,11 +92,15 @@ test("migratePai executes identity + algorithm + writes MIGRATION.md", async () 
 test("migratePai is idempotent at the file level (rerun = no file content change)", async () => {
   await withTempHome(async (homeDir) => {
     await writePaiFixture(homeDir, { withAlgorithm: true });
+    const first = await migratePai({ homeDir });
+    const beforePrincipal = await readFile(join(homeDir, ".soma/profile/principal.md"), "utf8");
+    const beforeManifest = await readFile(first.manifestPath, "utf8");
     await migratePai({ homeDir });
-    const before = await readFile(join(homeDir, ".soma/profile/principal.md"), "utf8");
-    await migratePai({ homeDir });
-    const after = await readFile(join(homeDir, ".soma/profile/principal.md"), "utf8");
-    expect(after).toBe(before);
+    const afterPrincipal = await readFile(join(homeDir, ".soma/profile/principal.md"), "utf8");
+    const afterManifest = await readFile(first.manifestPath, "utf8");
+    expect(afterPrincipal).toBe(beforePrincipal);
+    // Sage r1: manifest must also be stable across reruns.
+    expect(afterManifest).toBe(beforeManifest);
   });
 });
 

--- a/test/pai-migration.test.ts
+++ b/test/pai-migration.test.ts
@@ -1,0 +1,121 @@
+/**
+ * #28 minimal-scope orchestrator tests.
+ *
+ * Validates `planPaiMigration` + `migratePai` end-to-end against a
+ * synthetic PAI fixture covering identity + algorithm + zero-pack.
+ * Per-category importer tests (skills/agents/commands/auto-memory)
+ * land with their respective importers in incremental PRs.
+ */
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { expect, test } from "bun:test";
+import { migratePai, planPaiMigration } from "../src/index";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-28-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function writePaiFixture(homeDir: string, opts: { withAlgorithm?: boolean } = {}): Promise<void> {
+  const userRoot = join(homeDir, ".claude/PAI/USER");
+  await mkdir(join(userRoot, "TELOS"), { recursive: true });
+  await writeFile(
+    join(userRoot, "PRINCIPAL_IDENTITY.md"),
+    "# Principal\n\n- **Name:** Test User\n- **Pronunciation:** Test\n- **Location:** Nowhere\n- **Timezone:** UTC\n- **Role:** Tester\n- **Focus:** Testing\n",
+    "utf8",
+  );
+  await writeFile(
+    join(userRoot, "DA_IDENTITY.md"),
+    "# DA Identity\n\n- **Full Name:** Bot\n- **Name:** Bot\n- **Display Name:** Bot\n- **Color:** #000\n- **Voice ID:** v\n- **Role:** assistant\n- **Operating Environment:** test\n",
+    "utf8",
+  );
+  for (const file of ["MISSION.md", "GOALS.md", "STRATEGIES.md", "BELIEFS.md"]) {
+    await writeFile(join(userRoot, "TELOS", file), `# ${file}\n\nFixture\n`, "utf8");
+  }
+  if (opts.withAlgorithm) {
+    const algoDir = join(homeDir, ".claude/PAI/Algorithm");
+    await mkdir(algoDir, { recursive: true });
+    await writeFile(
+      join(algoDir, "v6.3.0.md"),
+      "# Algorithm v6.3.0\n\nThe doctrine.\n",
+      "utf8",
+    );
+  }
+}
+
+test("planPaiMigration returns subplans + manifest path without writing", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir, { withAlgorithm: true });
+    const plan = await planPaiMigration({ homeDir });
+    expect(plan.apply).toBe(false);
+    expect(plan.claudeHome).toBe(join(homeDir, ".claude"));
+    expect(plan.somaHome).toBe(join(homeDir, ".soma"));
+    expect(plan.identity.sourceFiles.length).toBeGreaterThan(0);
+    expect(plan.algorithm).not.toBeNull();
+    expect(plan.algorithm!.sourceFiles.length).toBeGreaterThan(0);
+    expect(plan.packs).toEqual([]);
+    expect(plan.manifestPath).toBe(join(homeDir, ".soma/profile/imports/claude/MIGRATION.md"));
+    // Plan must not write — manifest path doesn't exist yet.
+    await expect(stat(plan.manifestPath)).rejects.toThrow();
+  });
+});
+
+test("planPaiMigration handles missing algorithm dir gracefully", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir, { withAlgorithm: false });
+    const plan = await planPaiMigration({ homeDir });
+    expect(plan.algorithm).toBeNull();
+  });
+});
+
+test("migratePai executes identity + algorithm + writes MIGRATION.md", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir, { withAlgorithm: true });
+    const result = await migratePai({ homeDir });
+    expect(result.identity.files.length).toBeGreaterThan(0);
+    expect(result.algorithm).not.toBeNull();
+    expect(result.algorithm!.files.length).toBeGreaterThan(0);
+    expect(result.packs).toEqual([]);
+    const manifest = await readFile(result.manifestPath, "utf8");
+    expect(manifest).toContain("# PAI Migration");
+    expect(manifest).toContain("identity:");
+    expect(manifest).toContain("algorithm:");
+    expect(manifest).toContain(homeDir);
+  });
+});
+
+test("migratePai is idempotent at the file level (rerun = no file content change)", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir, { withAlgorithm: true });
+    await migratePai({ homeDir });
+    const before = await readFile(join(homeDir, ".soma/profile/principal.md"), "utf8");
+    await migratePai({ homeDir });
+    const after = await readFile(join(homeDir, ".soma/profile/principal.md"), "utf8");
+    expect(after).toBe(before);
+  });
+});
+
+test("migratePai omits algorithm when PAI install has no Algorithm dir", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir, { withAlgorithm: false });
+    const result = await migratePai({ homeDir });
+    expect(result.algorithm).toBeNull();
+    const manifest = await readFile(result.manifestPath, "utf8");
+    expect(manifest).toContain("algorithm: not present");
+  });
+});
+
+test("migratePai writes manifest with claude/MIGRATION.md path", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    const result = await migratePai({ homeDir });
+    expect(result.manifestPath).toBe(join(homeDir, ".soma/profile/imports/claude/MIGRATION.md"));
+    await stat(result.manifestPath); // throws if missing
+    expect(result.filesWritten).toContain(result.manifestPath);
+  });
+});


### PR DESCRIPTION
Sprint 4 #28 minimal scope. Single orchestrator on top of the existing three importers.

## What ships

\`src/pai-migration.ts\`:
- \`planPaiMigration(options)\` — composes identity + algorithm + packs sub-plans + manifest path.
- \`migratePai(options)\` — executes in order, auto-discovers packs under \`<claudeHome>/PAI/Packs/\`, writes \`MIGRATION.md\` at \`~/.soma/profile/imports/claude/MIGRATION.md\`.
- Auto-skips algorithm when \`<claudeHome>/PAI/Algorithm/\` absent.
- Idempotency inherited from underlying importers.

## ACs

| AC | Status |
|----|--------|
| AC-1 dry-run plan | ✅ planPaiMigration |
| AC-2 apply against fixture | ✅ migratePai |
| AC-3 second apply unchanged | ✅ idempotency test |
| AC-4 per-file change detection | DEFERRED |
| AC-5 mtime conflict refusal | DEFERRED |
| AC-6 categories present (identity + algorithm + packs) | ✅ |
| AC-6 extended (skills/agents/commands/auto-memory) | DEFERRED (per-category PRs follow) |
| AC-7 substrate-specific handling | DEFERRED |
| AC-8 MIGRATION.md human-readable | ✅ |
| AC-9 TTY auto-detect | DEFERRED (lands with CLI in #67) |
| AC-10 full fixture | partial (minimal synthetic fixture only) |

## Tests

6 new tests. 401 pass total. Typecheck + lint clean.

Closes #28 (minimal-correct scope; deferred ACs become per-category follow-ups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)