### PR TITLE
feat(cli): soma migrate pai orchestrator command (#67)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,11 @@ import {
   importAlgorithm,
   importPaiIdentity,
   importPaiPack,
+  migratePai,
+  planPaiMigration,
+  type PaiMigrationOptions,
+  type PaiMigrationPlan,
+  type PaiMigrationResult,
   installSomaForCodex,
   installSomaForPiDev,
   listAlgorithmRunSummaries,
@@ -99,6 +104,13 @@ interface ParsedImportArgs {
   options: PaiImportOptions | AlgorithmImportOptions | PaiPackImportOptions;
 }
 
+interface ParsedMigrateArgs {
+  command: "migrate";
+  source: "pai";
+  mode: "plan" | "apply" | "status";
+  options: PaiMigrationOptions;
+}
+
 interface ParsedAlgorithmArgs {
   command: "algorithm";
   action:
@@ -185,6 +197,7 @@ type ParsedArgs =
   | ParsedHelpArgs
   | ParsedInstallArgs
   | ParsedImportArgs
+  | ParsedMigrateArgs
   | ParsedAlgorithmArgs
   | ParsedLifecycleArgs
   | ParsedMemoryArgs
@@ -192,7 +205,7 @@ type ParsedArgs =
   | ParsedPolicyArgs
   | ParsedIsaArgs;
 
-const TOP_LEVEL_COMMANDS = ["algorithm", "feedback", "import", "install", "isa", "lifecycle", "memory", "policy"] as const;
+const TOP_LEVEL_COMMANDS = ["algorithm", "feedback", "import", "install", "isa", "lifecycle", "memory", "migrate", "policy"] as const;
 const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string, string> }> = {
   algorithm: {
     usage: "Usage: soma algorithm <new|classify|list|show|capabilities|plan|decision|change|step|verify|learn|batch|advance> ...",
@@ -248,6 +261,12 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
       pai: "Usage: soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>]",
       algorithm: "Usage: soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
       "pai-pack": "Usage: soma import pai-pack [--dry-run] [--apply] [--home-dir <dir>] [--source <dir>] [--soma-home <dir>]",
+    },
+  },
+  migrate: {
+    usage: "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-pack-dir <dir>]",
+    subcommands: {
+      pai: "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-pack-dir <dir>]",
     },
   },
   isa: {
@@ -1117,7 +1136,57 @@ function parseArgs(args: string[]): ParsedArgs {
     return parseImportArgs(args);
   }
 
+  if (args[0] === "migrate") {
+    return parseMigrateArgs(args);
+  }
+
   throw new Error(renderUnknownCommand(args[0]));
+}
+
+function parseMigrateArgs(args: string[]): ParsedMigrateArgs {
+  const [command, source, ...rest] = args;
+  if (command !== "migrate" || source !== "pai") {
+    throw new Error(commandUsage("migrate", source));
+  }
+  const options: PaiMigrationOptions = {};
+  let mode: "plan" | "apply" | "status" = "plan";
+  const packPaths: string[] = [];
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    switch (arg) {
+      case "--dry-run":
+        mode = "plan";
+        break;
+      case "--apply":
+        mode = "apply";
+        break;
+      case "--status":
+        mode = "status";
+        break;
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--claude-home":
+        options.claudeHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--pai-pack-dir":
+        packPaths.push(readOption(rest, index, arg));
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (packPaths.length > 0) options.paiPackPaths = packPaths;
+  return { command: "migrate", source: "pai", mode, options };
 }
 
 function helpTopic(args: string[]): string[] {
@@ -1256,6 +1325,63 @@ function formatInstallResult(result: SomaInstallResult): string {
     "Substrate files:",
     ...result.substrateHome.files.map((path) => `- ${path}`),
   ].join("\n");
+}
+
+function formatPaiMigrationPlan(plan: PaiMigrationPlan): string {
+  const algorithmLine = plan.algorithm
+    ? `  - algorithm: ${plan.algorithm.sourceFiles.length} source file(s)`
+    : "  - algorithm: not present";
+  return [
+    "soma migrate pai — plan (dry-run; pass --apply to execute)",
+    "",
+    `Source:   ${plan.claudeHome}`,
+    `Target:   ${plan.somaHome}`,
+    `Manifest: ${plan.manifestPath}`,
+    "",
+    "Categories:",
+    `  - identity: ${plan.identity.sourceFiles.length} source file(s)`,
+    algorithmLine,
+    `  - packs:    ${plan.packs.length} discovered`,
+    "",
+  ].join("\n");
+}
+
+function formatPaiMigrationResult(result: PaiMigrationResult): string {
+  return [
+    "soma migrate pai — applied",
+    "",
+    `Source:   ${result.claudeHome}`,
+    `Target:   ${result.somaHome}`,
+    `Manifest: ${result.manifestPath}`,
+    "",
+    "Written:",
+    `  - identity: ${result.identity.files.length} file(s)`,
+    result.algorithm ? `  - algorithm: ${result.algorithm.files.length} file(s)` : "  - algorithm: skipped (not present)",
+    `  - packs:    ${result.packs.length} pack(s), ${result.packs.reduce((sum, p) => sum + p.files.length, 0)} file(s)`,
+    "",
+    `Total files written: ${result.filesWritten.length}`,
+    "",
+  ].join("\n");
+}
+
+async function readPaiMigrationManifest(options: PaiMigrationOptions): Promise<string | null> {
+  const { readFile } = await import("node:fs/promises");
+  const plan = await planPaiMigration(options);
+  try {
+    return await readFile(plan.manifestPath, "utf8");
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function formatPaiMigrationStatus(manifest: string | null): string {
+  if (manifest === null) {
+    return "soma migrate pai — no migration manifest found. Run `soma migrate pai --apply` first.\n";
+  }
+  return `${manifest}\n`;
 }
 
 function formatPaiImportPlan(plan: PaiImportPlan): string {
@@ -1781,6 +1907,16 @@ export async function runSomaCli(args: string[]): Promise<string> {
     }
 
     return formatPaiImportResult(await importPaiIdentity(options));
+  }
+
+  if (parsed.command === "migrate") {
+    if (parsed.mode === "status") {
+      return formatPaiMigrationStatus(await readPaiMigrationManifest(parsed.options));
+    }
+    if (parsed.mode === "plan") {
+      return formatPaiMigrationPlan(await planPaiMigration(parsed.options));
+    }
+    return formatPaiMigrationResult(await migratePai(parsed.options));
   }
 
   if (!parsed.apply) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -206,6 +206,9 @@ type ParsedArgs =
   | ParsedIsaArgs;
 
 const TOP_LEVEL_COMMANDS = ["algorithm", "feedback", "import", "install", "isa", "lifecycle", "memory", "migrate", "policy"] as const;
+
+const MIGRATE_PAI_USAGE =
+  "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-pack-dir <dir>]";
 const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string, string> }> = {
   algorithm: {
     usage: "Usage: soma algorithm <new|classify|list|show|capabilities|plan|decision|change|step|verify|learn|batch|advance> ...",
@@ -264,10 +267,8 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
     },
   },
   migrate: {
-    usage: "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-pack-dir <dir>]",
-    subcommands: {
-      pai: "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-pack-dir <dir>]",
-    },
+    usage: MIGRATE_PAI_USAGE,
+    subcommands: { pai: MIGRATE_PAI_USAGE },
   },
   isa: {
     // Single source of truth lives in `./cli-isa.ts` (Sage round-1 dedup).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1365,10 +1365,18 @@ function formatPaiMigrationResult(result: PaiMigrationResult): string {
 }
 
 async function readPaiMigrationManifest(options: PaiMigrationOptions): Promise<string | null> {
+  // Sage r1: derive manifest path directly without invoking the
+  // migration planner. Status only needs to read the existing
+  // manifest; source-discovery + pack-listing work is irrelevant
+  // here and would make `--status` fail on, e.g., missing source
+  // dirs even when the manifest exists.
   const { readFile } = await import("node:fs/promises");
-  const plan = await planPaiMigration(options);
+  const { homedir } = await import("node:os");
+  const { join, resolve } = await import("node:path");
+  const somaHome = resolve(options.somaHome ?? join(options.homeDir ?? homedir(), ".soma"));
+  const manifestPath = join(somaHome, "profile/imports/claude/MIGRATION.md");
   try {
-    return await readFile(plan.manifestPath, "utf8");
+    return await readFile(manifestPath, "utf8");
   } catch (error) {
     if (typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT") {
       return null;

--- a/test/cli-migrate.test.ts
+++ b/test/cli-migrate.test.ts
@@ -1,0 +1,113 @@
+/**
+ * #67 — `soma migrate pai` CLI orchestrator command tests.
+ *
+ * Validates dry-run, --apply, --status, and unknown-flag behavior
+ * against a synthetic PAI fixture.
+ */
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { runSomaCli } from "../src/cli";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-cli-67-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function writePaiFixture(homeDir: string, opts: { withAlgorithm?: boolean } = {}): Promise<void> {
+  const userRoot = join(homeDir, ".claude/PAI/USER");
+  await mkdir(join(userRoot, "TELOS"), { recursive: true });
+  await writeFile(
+    join(userRoot, "PRINCIPAL_IDENTITY.md"),
+    "# Principal\n\n- **Name:** Test User\n- **Pronunciation:** Test\n- **Location:** Nowhere\n- **Timezone:** UTC\n- **Role:** Tester\n- **Focus:** Testing\n",
+    "utf8",
+  );
+  await writeFile(
+    join(userRoot, "DA_IDENTITY.md"),
+    "# DA Identity\n\n- **Full Name:** Bot\n- **Name:** Bot\n- **Display Name:** Bot\n- **Color:** #000\n- **Voice ID:** v\n- **Role:** assistant\n- **Operating Environment:** test\n",
+    "utf8",
+  );
+  for (const file of ["MISSION.md", "GOALS.md", "STRATEGIES.md", "BELIEFS.md"]) {
+    await writeFile(join(userRoot, "TELOS", file), `# ${file}\n\nFixture\n`, "utf8");
+  }
+  if (opts.withAlgorithm) {
+    const algoDir = join(homeDir, ".claude/PAI/Algorithm");
+    await mkdir(algoDir, { recursive: true });
+    await writeFile(join(algoDir, "v6.3.0.md"), "# Algorithm v6.3.0\n", "utf8");
+  }
+}
+
+test("soma migrate pai (no flags) → dry-run plan", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir, { withAlgorithm: true });
+    const output = await runSomaCli(["migrate", "pai", "--home-dir", homeDir]);
+    expect(output).toContain("dry-run");
+    expect(output).toContain("identity:");
+    expect(output).toContain("algorithm:");
+    expect(output).toContain(homeDir);
+    // No write happened.
+    await expect(stat(join(homeDir, ".soma/profile/imports/claude/MIGRATION.md"))).rejects.toThrow();
+  });
+});
+
+test("soma migrate pai --apply writes manifest + identity files", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir, { withAlgorithm: true });
+    const output = await runSomaCli(["migrate", "pai", "--apply", "--home-dir", homeDir]);
+    expect(output).toContain("applied");
+    expect(output).toContain("Total files written:");
+    await stat(join(homeDir, ".soma/profile/imports/claude/MIGRATION.md"));
+    await stat(join(homeDir, ".soma/profile/principal.md"));
+  });
+});
+
+test("soma migrate pai --status (no prior run) reports absence", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    const output = await runSomaCli(["migrate", "pai", "--status", "--home-dir", homeDir]);
+    expect(output).toContain("no migration manifest");
+  });
+});
+
+test("soma migrate pai --status (after apply) prints manifest", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir, { withAlgorithm: true });
+    await runSomaCli(["migrate", "pai", "--apply", "--home-dir", homeDir]);
+    const status = await runSomaCli(["migrate", "pai", "--status", "--home-dir", homeDir]);
+    expect(status).toContain("# PAI Migration");
+    expect(status).toContain("identity:");
+  });
+});
+
+test("soma migrate pai --help surfaces usage", async () => {
+  const output = await runSomaCli(["migrate", "pai", "--help"]);
+  expect(output).toContain("Usage: soma migrate pai");
+});
+
+test("soma migrate (no subcommand) errors with usage", async () => {
+  await expect(runSomaCli(["migrate"])).rejects.toThrow();
+});
+
+test("soma migrate pai --unknown-flag errors", async () => {
+  await withTempHome(async (homeDir) => {
+    await expect(
+      runSomaCli(["migrate", "pai", "--bogus", "--home-dir", homeDir]),
+    ).rejects.toThrow("Unknown option");
+  });
+});
+
+test("soma migrate pai --apply is idempotent (rerun produces no manifest content change)", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir, { withAlgorithm: true });
+    await runSomaCli(["migrate", "pai", "--apply", "--home-dir", homeDir]);
+    const before = await readFile(join(homeDir, ".soma/profile/imports/claude/MIGRATION.md"), "utf8");
+    await runSomaCli(["migrate", "pai", "--apply", "--home-dir", homeDir]);
+    const after = await readFile(join(homeDir, ".soma/profile/imports/claude/MIGRATION.md"), "utf8");
+    expect(after).toBe(before);
+  });
+});


### PR DESCRIPTION
Wires \`migratePai\` (from #28) into the CLI surface. Replaces part of #30 per the autonomous sprint plan.

## Surface

\`\`\`
soma migrate pai                # dry-run plan (default)
soma migrate pai --apply        # execute migration
soma migrate pai --status       # show last manifest
soma migrate pai --help         # usage

Options:
  --home-dir <dir>      override HOME
  --claude-home <dir>   override ~/.claude source root
  --soma-home <dir>     override ~/.soma target root
  --pai-pack-dir <dir>  explicit pack path (repeatable)
\`\`\`

## What ships

- New \`migrate\` top-level command + \`parseMigrateArgs\` modeled on the existing import parser.
- \`formatPaiMigrationPlan\` / \`formatPaiMigrationResult\` / \`formatPaiMigrationStatus\` human-readable output.
- \`--status\` reads \`~/.soma/profile/imports/claude/MIGRATION.md\` with the ENOENT-only swallow pattern from #28.

## Tests

8 new CLI tests. 411 pass total. Typecheck + lint clean.

Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)