### PR TITLE
feat(cli): soma adopt claude orchestrator command (#68)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,8 +16,13 @@ import {
   type PaiMigrationOptions,
   type PaiMigrationPlan,
   type PaiMigrationResult,
+  installSomaForClaudeCode,
   installSomaForCodex,
   installSomaForPiDev,
+  planSomaForClaudeCodeInstall,
+  uninstallSomaForClaudeCode,
+  type UninstallClaudeCodeOptions,
+  type UninstallClaudeCodeResult,
   listAlgorithmRunSummaries,
   planAlgorithmImport,
   planPaiImport,
@@ -111,6 +116,13 @@ interface ParsedMigrateArgs {
   options: PaiMigrationOptions;
 }
 
+interface ParsedAdoptArgs {
+  command: "adopt";
+  substrate: "claude";
+  mode: "plan" | "apply" | "uninstall";
+  options: SomaInstallOptions & UninstallClaudeCodeOptions;
+}
+
 interface ParsedAlgorithmArgs {
   command: "algorithm";
   action:
@@ -198,6 +210,7 @@ type ParsedArgs =
   | ParsedInstallArgs
   | ParsedImportArgs
   | ParsedMigrateArgs
+  | ParsedAdoptArgs
   | ParsedAlgorithmArgs
   | ParsedLifecycleArgs
   | ParsedMemoryArgs
@@ -205,10 +218,12 @@ type ParsedArgs =
   | ParsedPolicyArgs
   | ParsedIsaArgs;
 
-const TOP_LEVEL_COMMANDS = ["algorithm", "feedback", "import", "install", "isa", "lifecycle", "memory", "migrate", "policy"] as const;
+const TOP_LEVEL_COMMANDS = ["adopt", "algorithm", "feedback", "import", "install", "isa", "lifecycle", "memory", "migrate", "policy"] as const;
 
 const MIGRATE_PAI_USAGE =
   "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-pack-dir <dir>]";
+const ADOPT_CLAUDE_USAGE =
+  "Usage: soma adopt claude [--dry-run] [--apply] [--uninstall] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string, string> }> = {
   algorithm: {
     usage: "Usage: soma algorithm <new|classify|list|show|capabilities|plan|decision|change|step|verify|learn|batch|advance> ...",
@@ -269,6 +284,10 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
   migrate: {
     usage: MIGRATE_PAI_USAGE,
     subcommands: { pai: MIGRATE_PAI_USAGE },
+  },
+  adopt: {
+    usage: ADOPT_CLAUDE_USAGE,
+    subcommands: { claude: ADOPT_CLAUDE_USAGE },
   },
   isa: {
     // Single source of truth lives in `./cli-isa.ts` (Sage round-1 dedup).
@@ -1141,7 +1160,49 @@ function parseArgs(args: string[]): ParsedArgs {
     return parseMigrateArgs(args);
   }
 
+  if (args[0] === "adopt") {
+    return parseAdoptArgs(args);
+  }
+
   throw new Error(renderUnknownCommand(args[0]));
+}
+
+function parseAdoptArgs(args: string[]): ParsedAdoptArgs {
+  const [command, substrate, ...rest] = args;
+  if (command !== "adopt" || substrate !== "claude") {
+    throw new Error(commandUsage("adopt", substrate));
+  }
+  const options: SomaInstallOptions & UninstallClaudeCodeOptions = {};
+  let mode: "plan" | "apply" | "uninstall" = "plan";
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    switch (arg) {
+      case "--dry-run":
+        mode = "plan";
+        break;
+      case "--apply":
+        mode = "apply";
+        break;
+      case "--uninstall":
+        mode = "uninstall";
+        break;
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--substrate-home":
+        options.substrateHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return { command: "adopt", substrate: "claude", mode, options };
 }
 
 function parseMigrateArgs(args: string[]): ParsedMigrateArgs {
@@ -1325,6 +1386,27 @@ function formatInstallResult(result: SomaInstallResult): string {
     "",
     "Substrate files:",
     ...result.substrateHome.files.map((path) => `- ${path}`),
+  ].join("\n");
+}
+
+function formatClaudeUninstallResult(result: UninstallClaudeCodeResult): string {
+  if (result.removed.length === 0) {
+    return [
+      "soma adopt claude — uninstall",
+      "",
+      `Substrate home: ${result.substrateHome}`,
+      "Nothing to remove — Soma was not installed at this substrate home.",
+      "",
+    ].join("\n");
+  }
+  return [
+    "soma adopt claude — uninstall",
+    "",
+    `Substrate home: ${result.substrateHome}`,
+    "",
+    "Removed:",
+    ...result.removed.map((p) => `  - ${p}`),
+    "",
   ].join("\n");
 }
 
@@ -1926,6 +2008,16 @@ export async function runSomaCli(args: string[]): Promise<string> {
       return formatPaiMigrationPlan(await planPaiMigration(parsed.options));
     }
     return formatPaiMigrationResult(await migratePai(parsed.options));
+  }
+
+  if (parsed.command === "adopt") {
+    if (parsed.mode === "uninstall") {
+      return formatClaudeUninstallResult(await uninstallSomaForClaudeCode(parsed.options));
+    }
+    if (parsed.mode === "plan") {
+      return formatPlan(planSomaForClaudeCodeInstall(parsed.options));
+    }
+    return formatInstallResult(await installSomaForClaudeCode(parsed.options));
   }
 
   if (!parsed.apply) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1198,6 +1198,11 @@ function parseAdoptArgs(args: string[]): ParsedAdoptArgs {
         options.substrateHome = readOption(rest, index, arg);
         index += 1;
         break;
+      case "--help":
+        // Defensive: parseArgs intercepts --help at the top, but keep
+        // this branch so the parser surfaces usage if called directly
+        // (sage r1 on #72 — blocker bar).
+        throw new Error(ADOPT_CLAUDE_USAGE);
       default:
         throw new Error(`Unknown option: ${arg}`);
     }

--- a/test/cli-adopt.test.ts
+++ b/test/cli-adopt.test.ts
@@ -1,0 +1,82 @@
+/**
+ * #68 — `soma adopt claude` CLI orchestrator command tests.
+ *
+ * Validates dry-run, --apply, --uninstall, --help, and unknown-flag
+ * behavior against a temp home.
+ */
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { runSomaCli } from "../src/cli";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-cli-68-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+test("soma adopt claude (no flags) → dry-run plan", async () => {
+  await withTempHome(async (homeDir) => {
+    const output = await runSomaCli(["adopt", "claude", "--home-dir", homeDir]);
+    expect(output).toContain("Soma install plan");
+    expect(output).toContain("substrate: claude-code");
+    expect(output).toContain("rules/soma/");
+    // No writes happened.
+    await expect(stat(join(homeDir, ".claude/rules/soma"))).rejects.toThrow();
+  });
+});
+
+test("soma adopt claude --apply writes rules/soma/ skeleton + ISA skill", async () => {
+  await withTempHome(async (homeDir) => {
+    const output = await runSomaCli(["adopt", "claude", "--apply", "--home-dir", homeDir]);
+    expect(output).toContain("Soma install applied");
+    expect(output).toContain("substrate: claude-code");
+    await stat(join(homeDir, ".claude/rules/soma/README.md"));
+    await stat(join(homeDir, ".claude/rules/soma/CONTEXT.md"));
+    await stat(join(homeDir, ".claude/skills/ISA/SKILL.md"));
+  });
+});
+
+test("soma adopt claude --apply is idempotent (rerun byte-stable)", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli(["adopt", "claude", "--apply", "--home-dir", homeDir]);
+    const before = await readFile(join(homeDir, ".claude/rules/soma/CONTEXT.md"), "utf8");
+    await runSomaCli(["adopt", "claude", "--apply", "--home-dir", homeDir]);
+    const after = await readFile(join(homeDir, ".claude/rules/soma/CONTEXT.md"), "utf8");
+    expect(after).toBe(before);
+  });
+});
+
+test("soma adopt claude --uninstall removes rules/soma + skills/ISA", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli(["adopt", "claude", "--apply", "--home-dir", homeDir]);
+    const output = await runSomaCli(["adopt", "claude", "--uninstall", "--home-dir", homeDir]);
+    expect(output).toContain("Removed:");
+    await expect(stat(join(homeDir, ".claude/rules/soma"))).rejects.toThrow();
+    await expect(stat(join(homeDir, ".claude/skills/ISA"))).rejects.toThrow();
+  });
+});
+
+test("soma adopt claude --uninstall (no install) reports nothing-to-remove", async () => {
+  await withTempHome(async (homeDir) => {
+    const output = await runSomaCli(["adopt", "claude", "--uninstall", "--home-dir", homeDir]);
+    expect(output).toContain("Nothing to remove");
+  });
+});
+
+test("soma adopt claude --help surfaces usage", async () => {
+  const output = await runSomaCli(["adopt", "claude", "--help"]);
+  expect(output).toContain("Usage: soma adopt claude");
+});
+
+test("soma adopt (no substrate) errors with usage", async () => {
+  await expect(runSomaCli(["adopt"])).rejects.toThrow();
+});
+
+test("soma adopt claude --bogus errors", async () => {
+  await expect(runSomaCli(["adopt", "claude", "--bogus"])).rejects.toThrow("Unknown option");
+});


### PR DESCRIPTION
Re-opens after #67 merged (original PR #71 auto-closed when #67's branch was deleted). Wires \`installSomaForClaudeCode\` + \`uninstallSomaForClaudeCode\` + \`planSomaForClaudeCodeInstall\` (from #29) into the CLI surface. Replaces part of #30 per the autonomous sprint plan.

## Surface

\`\`\`
soma adopt claude               # dry-run plan (default)
soma adopt claude --apply       # install rules/soma/ + ISA skill
soma adopt claude --uninstall   # remove rules/soma/ + skills/ISA
soma adopt claude --help        # usage
\`\`\`

## What ships

- New \`adopt\` top-level command + \`parseAdoptArgs\` modeled on the install parser.
- \`formatClaudeUninstallResult\` for human-readable uninstall (handles nothing-to-remove cleanly).
- Re-uses \`formatPlan\` + \`formatInstallResult\` from the existing install surface.
- Extracted \`ADOPT_CLAUDE_USAGE\` constant to mirror #67's r2 finding.

## Tests

8 new CLI tests. 419 pass total. Typecheck + lint clean.

Closes #68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)