### PR TITLE
feat(isa): deterministic reconcile (#35)

### DIFF
--- a/docs/isa-reconcile.md
+++ b/docs/isa-reconcile.md
@@ -1,0 +1,144 @@
+# ISA Reconcile
+
+`reconcileIsa` merges a derived or ephemeral feature ISA back into the master
+ISA for the same work. The merge is deterministic and keyed by stable ISC IDs.
+It is not a three-way merge and it does not try to infer author intent from
+free-form prose.
+
+The source of truth remains the master ISA under
+`<soma-home>/isa/<slug>.md`. Feature ISAs are derived views. They may
+contribute criterion status, criterion evidence, Decisions, Changelog,
+Verification entries, and new non-conflicting sections. They do not replace the
+master document wholesale.
+
+## Interface
+
+The file-backed function lives in `src/isa-reconcile.ts`:
+
+```ts
+reconcileIsa(slug, feature, options)
+```
+
+- `slug` identifies the master ISA in `<soma-home>/isa/<slug>.md`.
+- `feature` is either a parsed `IdealStateArtifact` or a path to a feature ISA.
+- `options.onConflict` can force a policy for tests or explicit callers.
+- without an override, the default policy is read from
+  `<soma-home>/isa/config.json`:
+
+```json
+{
+  "defaultConflictPolicy": "error"
+}
+```
+
+Valid policies are `error`, `prefer-master`, and `prefer-feature`.
+
+Every file-backed reconcile appends an `isa.reconcile` event to
+`memory/STATE/events.jsonl` with a full conflict report.
+
+## Merge Rules
+
+### Sections
+
+Known ISA sections are matched by canonical section name. Header whitespace is
+normalized by the parser, so `## Goal`, `##  Goal`, and `## Goal ` all identify
+the same section.
+
+Unknown sections are allowed only when they are absent from master. They append
+after the canonical sections. If an unknown section exists in both inputs with
+different content, it is a conflict.
+
+Section rename detection is intentionally conservative. Soma currently has no
+stable section IDs; section identity is the canonical name string. If a feature
+references a section absent from master while master has a likely renamed
+section with similar content, reconcile records a conflict instead of creating
+two competing sections.
+
+### Criteria
+
+Criteria merge by stable ISC ID. The master order is preserved. Feature-only
+criteria append to the Criteria section.
+
+Status merge is monotonic by default:
+
+```text
+open < failed < passed
+open < dropped
+```
+
+`passed` and `dropped` are terminal relative to feature regressions. A feature
+with `[ ] ISC-3` never reopens a master `[x] ISC-3`. Tombstoned or dropped
+criteria are preserved and never resurrected by feature content.
+
+If both sides change the same criterion text or evidence differently, the
+selected conflict policy applies.
+
+### Logs
+
+Decisions, Changelog, and Verification are append-only logs. Entries are keyed
+by `(timestamp, phase, text)`.
+
+Duplicate entries are de-duplicated. Same timestamp and phase with different
+text is a conflict because ordering alone is not enough to prove author intent.
+With `prefer-master`, only master entries are kept for that key. With
+`prefer-feature`, the feature entry is appended after existing master entries.
+
+### Whitespace
+
+Reconcile uses Soma's existing parser and serializer. If no structural mutation
+occurs, byte identity is preserved by the parser cache. When merge changes are
+written, output is canonical Markdown with trailing whitespace removed and a
+single trailing newline.
+
+## Adversarial Inputs
+
+1. **Section added in feature branch absent from master**
+   - Canonical or unknown section absent from master is appended.
+   - If the section appears to be a rename of an existing master section,
+     reject under `error` and record `section-rename`.
+
+2. **Same ISC ID in two sections of master**
+   - Error. Criteria identity must be unique inside the master document.
+   - Reconcile refuses to choose the first copy.
+
+3. **User manually edited master between feature branch creation and reconcile**
+   - V0 has no three-way merge baseline hash. The current master on disk wins
+     unless a concrete field conflict is detected. Conflicts follow policy.
+
+4. **Whitespace normalization**
+   - Parse semantically, render canonically after mutation. Do not preserve
+     arbitrary feature whitespace.
+
+5. **Header formatting drift**
+   - Treat whitespace-only drift as the same section. Semantic section renames
+     are conflicts.
+
+6. **ISC status regression**
+   - Do not regress. Terminal master statuses stay terminal unless
+     `prefer-feature` is explicitly forced and the master is not tombstoned.
+
+7. **Conflicting Decisions entries with same timestamp**
+   - `error`: conflict.
+   - `prefer-master`: keep master entry.
+   - `prefer-feature`: append feature entry after master entries.
+
+8. **Tombstoned ISCs**
+   - Dropped criteria are tombstones. Reconcile preserves them and does not
+     resurrect them from feature content.
+
+9. **Feature references a section renamed in master**
+   - Because sections have no stable IDs, V0 detects likely rename drift and
+     conflicts rather than duplicating both names.
+
+## Acceptance Invariants
+
+- `reconcile(master, master) === master`
+- `reconcile(reconcile(master, feature), feature) === reconcile(master, feature)`
+- non-conflicting feature ISC IDs appear in the output
+- master content untouched by the feature stays present
+- conflict reports are written to the append-only memory event log
+
+## Sign-Off
+
+This design requires review by someone other than the Layer 3 CRUD author
+before release. The PR review is the sign-off surface for this issue.

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,6 +251,17 @@ export {
   type SetActiveIsaResult,
   type WriteIsaResult,
 } from "./isa";
+export {
+  canonicalIsaSectionsForReconcile,
+  defaultIsaReconcileConfigPath,
+  reconcileIsa,
+  reconcileIsaArtifacts,
+  type IsaConflictPolicy,
+  type IsaReconcileConflict,
+  type IsaReconcileReport,
+  type IsaReconcileResult,
+  type ReconcileIsaOptions,
+} from "./isa-reconcile";
 export { type CompletenessGap, type CompletenessReport } from "./isa-schema";
 
 export const SOMA_VERSION = "0.1.3";

--- a/src/index.ts
+++ b/src/index.ts
@@ -252,8 +252,6 @@ export {
   type WriteIsaResult,
 } from "./isa";
 export {
-  canonicalIsaSectionsForReconcile,
-  defaultIsaReconcileConfigPath,
   reconcileIsa,
   reconcileIsaArtifacts,
   type IsaConflictPolicy,

--- a/src/isa-parse.ts
+++ b/src/isa-parse.ts
@@ -296,7 +296,7 @@ function parseSections(body: string): readonly IsaSection[] {
   let currentContent: string[] = [];
 
   for (const line of lines) {
-    const match = /^## (.+)$/.exec(line);
+    const match = /^##\s+(.+?)\s*$/.exec(line);
     if (match) {
       if (currentName !== null) {
         sections.push({ name: currentName, content: stripBlock(currentContent) });

--- a/src/isa-reconcile.ts
+++ b/src/isa-reconcile.ts
@@ -105,7 +105,7 @@ export function reconcileIsaArtifacts(
   let next: IdealStateArtifact = {
     ...master,
     sections: master.sections.map((section) => ({ ...section })),
-    frontmatter: { ...master.frontmatter, updated: options.timestamp ?? master.frontmatter.updated },
+    frontmatter: { ...master.frontmatter },
   };
 
   next = mergeCriteria(next, feature, policy, report);
@@ -114,6 +114,9 @@ export function reconcileIsaArtifacts(
   next = mergeLogSection(next, feature, { sectionName: SECTION_NAME_MAP.verification, readEntries: getVerification, policy, report });
   next = mergeOtherSections(next, feature, policy, report);
   report.changed = hasStructuralChange(master, next);
+  if (report.changed && options.timestamp) {
+    next = { ...next, frontmatter: { ...next.frontmatter, updated: options.timestamp } };
+  }
 
   return { isa: next, report };
 }

--- a/src/isa-reconcile.ts
+++ b/src/isa-reconcile.ts
@@ -68,9 +68,9 @@ export async function reconcileIsa(
   options: ReconcileIsaOptions = {},
 ): Promise<IsaReconcileResult> {
   const somaHome = resolveSomaHome(options);
-  const policy = options.onConflict ?? (await readDefaultConflictPolicy(somaHome));
-  const master = await readIsa(slug, options);
-  const featureIsa = await loadFeatureIsa(feature);
+  const policyPromise = options.onConflict ? Promise.resolve(options.onConflict) : readDefaultConflictPolicy(somaHome);
+  const [policy, master, featureIsa] = await Promise.all([policyPromise, readIsa(slug, options), loadFeatureIsa(feature)]);
+  assertValidPolicy(policy);
   const result = reconcileIsaArtifacts(master, featureIsa, { onConflict: policy, timestamp: options.timestamp });
 
   if (result.report.conflicts.some((conflict) => conflict.resolution === "error")) {
@@ -109,9 +109,9 @@ export function reconcileIsaArtifacts(
   };
 
   next = mergeCriteria(next, feature, policy, report);
-  next = mergeLogSection(next, feature, SECTION_NAME_MAP.decisions, getDecisions, policy, report);
-  next = mergeLogSection(next, feature, SECTION_NAME_MAP.changelog, getChangelog, policy, report);
-  next = mergeLogSection(next, feature, SECTION_NAME_MAP.verification, getVerification, policy, report);
+  next = mergeLogSection(next, feature, { sectionName: SECTION_NAME_MAP.decisions, readEntries: getDecisions, policy, report });
+  next = mergeLogSection(next, feature, { sectionName: SECTION_NAME_MAP.changelog, readEntries: getChangelog, policy, report });
+  next = mergeLogSection(next, feature, { sectionName: SECTION_NAME_MAP.verification, readEntries: getVerification, policy, report });
   next = mergeOtherSections(next, feature, policy, report);
   report.changed = hasStructuralChange(master, next);
 
@@ -291,14 +291,15 @@ function statusRank(status: IdealStateCriterion["status"]): number {
   }
 }
 
-function mergeLogSection(
-  master: IdealStateArtifact,
-  feature: IdealStateArtifact,
-  sectionName: string,
-  readEntries: (isa: IdealStateArtifact) => AlgorithmLogEntry[],
-  policy: IsaConflictPolicy,
-  report: IsaReconcileReport,
-): IdealStateArtifact {
+interface LogMergeSpec {
+  sectionName: string;
+  readEntries: (isa: IdealStateArtifact) => AlgorithmLogEntry[];
+  policy: IsaConflictPolicy;
+  report: IsaReconcileReport;
+}
+
+function mergeLogSection(master: IdealStateArtifact, feature: IdealStateArtifact, spec: LogMergeSpec): IdealStateArtifact {
+  const { sectionName, readEntries, policy, report } = spec;
   const masterEntries = readEntries(master);
   const featureEntries = readEntries(feature);
   if (featureEntries.length === 0) return master;
@@ -399,7 +400,7 @@ function addConflict(
     nonErrorResolution?: "master" | "feature" | "merged";
   },
 ): IsaReconcileConflict["resolution"] {
-  const resolution = input.forcedResolution ?? (policy === "error" ? "error" : input.nonErrorResolution ?? (policy === "prefer-feature" ? "feature" : "master"));
+  const resolution = resolveConflict(policy, input);
   report.conflicts.push({
     kind: input.kind,
     target: input.target,
@@ -408,6 +409,19 @@ function addConflict(
     detail: input.detail,
   });
   return resolution;
+}
+
+function resolveConflict(
+  policy: IsaConflictPolicy,
+  input: {
+    forcedResolution?: "error" | "master" | "feature" | "merged";
+    nonErrorResolution?: "master" | "feature" | "merged";
+  },
+): IsaReconcileConflict["resolution"] {
+  if (input.forcedResolution) return input.forcedResolution;
+  if (policy === "error") return "error";
+  if (input.nonErrorResolution) return input.nonErrorResolution;
+  return policy === "prefer-feature" ? "feature" : "master";
 }
 
 function formatConflictError(report: IsaReconcileReport): string {

--- a/src/isa-reconcile.ts
+++ b/src/isa-reconcile.ts
@@ -1,0 +1,452 @@
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import {
+  SECTION_NAME_MAP,
+  TWELVE_SECTIONS,
+  getChangelog,
+  getCriteria,
+  getDecisions,
+  getVerification,
+  renderCriteriaMarkdown,
+  renderLogEntries,
+  setSection,
+} from "./isa-accessors";
+import { readIsa, resolveSomaHome, writeIsa, type IsaLibraryOptions } from "./isa";
+import { appendSomaMemoryEvent } from "./memory";
+import { parseIsa } from "./isa-parse";
+import type { AlgorithmLogEntry, IdealStateArtifact, IdealStateCriterion, IsaSection, SubstrateId } from "./types";
+
+export type IsaConflictPolicy = "error" | "prefer-master" | "prefer-feature";
+
+export type IsaReconcileConflictKind =
+  | "criterion-duplicate"
+  | "criterion-text"
+  | "criterion-evidence"
+  | "criterion-status-regression"
+  | "criterion-tombstone"
+  | "section-content"
+  | "section-rename"
+  | "log-entry";
+
+export interface IsaReconcileConflict {
+  kind: IsaReconcileConflictKind;
+  target: string;
+  policy: IsaConflictPolicy;
+  resolution: "error" | "master" | "feature" | "merged";
+  detail: string;
+}
+
+export interface IsaReconcileReport {
+  policy: IsaConflictPolicy;
+  changed: boolean;
+  conflicts: IsaReconcileConflict[];
+  mergedCriteria: string[];
+  mergedSections: string[];
+  mergedLogs: string[];
+}
+
+export interface IsaReconcileResult {
+  isa: IdealStateArtifact;
+  report: IsaReconcileReport;
+  path?: string;
+}
+
+export interface ReconcileIsaOptions extends IsaLibraryOptions {
+  onConflict?: IsaConflictPolicy;
+  timestamp?: string;
+  substrate?: SubstrateId;
+}
+
+type FeatureIsaInput = IdealStateArtifact | string;
+
+const VALID_POLICIES: readonly IsaConflictPolicy[] = ["error", "prefer-master", "prefer-feature"];
+const LOG_SECTIONS = new Set<string>([SECTION_NAME_MAP.decisions, SECTION_NAME_MAP.changelog, SECTION_NAME_MAP.verification]);
+
+export async function reconcileIsa(
+  slug: string,
+  feature: FeatureIsaInput,
+  options: ReconcileIsaOptions = {},
+): Promise<IsaReconcileResult> {
+  const somaHome = resolveSomaHome(options);
+  const policy = options.onConflict ?? (await readDefaultConflictPolicy(somaHome));
+  const master = await readIsa(slug, options);
+  const featureIsa = await loadFeatureIsa(feature);
+  const result = reconcileIsaArtifacts(master, featureIsa, { onConflict: policy, timestamp: options.timestamp });
+
+  if (result.report.conflicts.some((conflict) => conflict.resolution === "error")) {
+    await emitReconcileEvent(somaHome, options, slug, result.report, undefined);
+    throw new Error(formatConflictError(result.report));
+  }
+
+  const write = await writeIsa(slug, result.isa, options);
+  result.report.changed = write.changed;
+  await emitReconcileEvent(somaHome, options, slug, result.report, write.path);
+  return { ...result, path: write.path };
+}
+
+export function reconcileIsaArtifacts(
+  master: IdealStateArtifact,
+  feature: IdealStateArtifact,
+  options: Pick<ReconcileIsaOptions, "onConflict" | "timestamp"> = {},
+): IsaReconcileResult {
+  const policy = options.onConflict ?? "error";
+  assertValidPolicy(policy);
+  const report: IsaReconcileReport = {
+    policy,
+    changed: false,
+    conflicts: [],
+    mergedCriteria: [],
+    mergedSections: [],
+    mergedLogs: [],
+  };
+  assertUniqueCriterionLines(master, policy, report);
+  assertUniqueCriterionLines(feature, policy, report);
+
+  let next: IdealStateArtifact = {
+    ...master,
+    sections: master.sections.map((section) => ({ ...section })),
+    frontmatter: { ...master.frontmatter, updated: options.timestamp ?? master.frontmatter.updated },
+  };
+
+  next = mergeCriteria(next, feature, policy, report);
+  next = mergeLogSection(next, feature, SECTION_NAME_MAP.decisions, getDecisions, policy, report);
+  next = mergeLogSection(next, feature, SECTION_NAME_MAP.changelog, getChangelog, policy, report);
+  next = mergeLogSection(next, feature, SECTION_NAME_MAP.verification, getVerification, policy, report);
+  next = mergeOtherSections(next, feature, policy, report);
+  report.changed = hasStructuralChange(master, next);
+
+  return { isa: next, report };
+}
+
+async function loadFeatureIsa(feature: FeatureIsaInput): Promise<IdealStateArtifact> {
+  if (typeof feature !== "string") return feature;
+  return parseIsa(await readFile(feature, "utf8"), feature);
+}
+
+async function readDefaultConflictPolicy(somaHome: string): Promise<IsaConflictPolicy> {
+  const configPath = join(somaHome, "isa", "config.json");
+  const raw = await readFile(configPath, "utf8").catch(() => "");
+  if (raw.length === 0) return "error";
+  try {
+    const parsed = JSON.parse(raw) as { defaultConflictPolicy?: unknown };
+    const value = parsed.defaultConflictPolicy;
+    return typeof value === "string" && isValidPolicy(value) ? value : "error";
+  } catch {
+    return "error";
+  }
+}
+
+function assertValidPolicy(policy: string): void {
+  if (!isValidPolicy(policy)) {
+    throw new Error(`Invalid ISA reconcile conflict policy: ${policy}`);
+  }
+}
+
+function isValidPolicy(value: string): value is IsaConflictPolicy {
+  return (VALID_POLICIES as readonly string[]).includes(value);
+}
+
+function assertUniqueCriterionLines(isa: IdealStateArtifact, policy: IsaConflictPolicy, report: IsaReconcileReport): void {
+  const seen = new Set<string>();
+  for (const section of isa.sections) {
+    for (const criterion of parseCriterionLines(section)) {
+      if (seen.has(criterion.id)) {
+        addConflict(report, policy, {
+          kind: "criterion-duplicate",
+          target: criterion.id,
+          detail: `Criterion ${criterion.id} appears more than once in ${isa.slug}.`,
+          forcedResolution: "error",
+        });
+      }
+      seen.add(criterion.id);
+    }
+  }
+}
+
+function parseCriterionLines(section: IsaSection): IdealStateCriterion[] {
+  const synthetic: IdealStateArtifact = {
+    slug: "section",
+    frontmatter: {
+      task: "section",
+      effort: "E1",
+      phase: "observe",
+      progress: "0/0",
+      verified: false,
+      updated: "1970-01-01T00:00:00.000Z",
+    },
+    sections: [{ name: SECTION_NAME_MAP.criteria, content: section.content }],
+  };
+  return getCriteria(synthetic);
+}
+
+function mergeCriteria(
+  master: IdealStateArtifact,
+  feature: IdealStateArtifact,
+  policy: IsaConflictPolicy,
+  report: IsaReconcileReport,
+): IdealStateArtifact {
+  const masterCriteria = getCriteria(master);
+  const featureCriteria = getCriteria(feature);
+  if (featureCriteria.length === 0) return master;
+
+  const byId = new Map(masterCriteria.map((criterion) => [criterion.id, { ...criterion }]));
+  const order = masterCriteria.map((criterion) => criterion.id);
+
+  for (const featureCriterion of featureCriteria) {
+    const current = byId.get(featureCriterion.id);
+    if (!current) {
+      byId.set(featureCriterion.id, { ...featureCriterion });
+      order.push(featureCriterion.id);
+      report.mergedCriteria.push(featureCriterion.id);
+      continue;
+    }
+    const merged = mergeCriterion(current, featureCriterion, policy, report);
+    byId.set(featureCriterion.id, merged);
+    if (JSON.stringify(merged) !== JSON.stringify(current)) report.mergedCriteria.push(featureCriterion.id);
+  }
+
+  return setSection(master, SECTION_NAME_MAP.criteria, renderCriteriaMarkdown(order.map((id) => byId.get(id)).filter((criterion): criterion is IdealStateCriterion => !!criterion)));
+}
+
+function mergeCriterion(
+  master: IdealStateCriterion,
+  feature: IdealStateCriterion,
+  policy: IsaConflictPolicy,
+  report: IsaReconcileReport,
+): IdealStateCriterion {
+  if (master.status === "dropped" && feature.status !== "dropped") {
+    addConflict(report, policy, {
+      kind: "criterion-tombstone",
+      target: master.id,
+      detail: `Feature attempted to resurrect dropped criterion ${master.id}.`,
+      forcedResolution: "master",
+    });
+    return master;
+  }
+
+  let next = { ...master, status: mergeStatus(master, feature, policy, report) };
+
+  if (feature.text !== master.text) {
+    const resolution = addConflict(report, policy, {
+      kind: "criterion-text",
+      target: master.id,
+      detail: `Criterion ${master.id} text differs between master and feature.`,
+    });
+    if (resolution === "feature") next = { ...next, text: feature.text };
+  }
+
+  if (!master.verification && feature.verification) {
+    next = { ...next, verification: feature.verification };
+  } else if ((feature.verification ?? "") !== (master.verification ?? "") && feature.verification) {
+    const resolution = addConflict(report, policy, {
+      kind: "criterion-evidence",
+      target: master.id,
+      detail: `Criterion ${master.id} evidence differs between master and feature.`,
+    });
+    if (resolution === "feature") next = { ...next, verification: feature.verification };
+    if (resolution === "merged" && feature.verification) next = { ...next, verification: feature.verification };
+  }
+
+  return next;
+}
+
+function mergeStatus(
+  master: IdealStateCriterion,
+  feature: IdealStateCriterion,
+  policy: IsaConflictPolicy,
+  report: IsaReconcileReport,
+): IdealStateCriterion["status"] {
+  if (master.status === feature.status) return master.status;
+  if (master.status === "dropped") return "dropped";
+  if (feature.status === "dropped") return "dropped";
+  if (statusRank(feature.status) < statusRank(master.status)) {
+    const resolution = addConflict(report, policy, {
+      kind: "criterion-status-regression",
+      target: master.id,
+      detail: `Feature status ${feature.status} would regress master status ${master.status}.`,
+      nonErrorResolution: policy === "prefer-feature" ? "feature" : "master",
+    });
+    return resolution === "feature" ? feature.status : master.status;
+  }
+  return feature.status;
+}
+
+function statusRank(status: IdealStateCriterion["status"]): number {
+  switch (status) {
+    case "open":
+      return 0;
+    case "failed":
+      return 1;
+    case "passed":
+      return 2;
+    case "dropped":
+      return 3;
+  }
+}
+
+function mergeLogSection(
+  master: IdealStateArtifact,
+  feature: IdealStateArtifact,
+  sectionName: string,
+  readEntries: (isa: IdealStateArtifact) => AlgorithmLogEntry[],
+  policy: IsaConflictPolicy,
+  report: IsaReconcileReport,
+): IdealStateArtifact {
+  const masterEntries = readEntries(master);
+  const featureEntries = readEntries(feature);
+  if (featureEntries.length === 0) return master;
+  const existing = new Set(masterEntries.map(logIdentity));
+  const timestampPhase = new Map(masterEntries.map((entry) => [logTimestampPhase(entry), entry.text]));
+  const next = [...masterEntries];
+
+  for (const entry of featureEntries) {
+    if (existing.has(logIdentity(entry))) continue;
+    const key = logTimestampPhase(entry);
+    const existingText = timestampPhase.get(key);
+    if (existingText !== undefined && existingText !== entry.text) {
+      const resolution = addConflict(report, policy, {
+        kind: "log-entry",
+        target: `${sectionName}:${key}`,
+        detail: `Conflicting ${sectionName} entries share timestamp and phase.`,
+      });
+      if (resolution !== "feature") continue;
+    }
+    next.push(entry);
+    existing.add(logIdentity(entry));
+    timestampPhase.set(key, entry.text);
+    report.mergedLogs.push(`${sectionName}:${entry.timestamp}`);
+  }
+  return setSection(master, sectionName, renderLogEntries(next));
+}
+
+function logIdentity(entry: AlgorithmLogEntry): string {
+  return `${entry.timestamp}\u0000${entry.phase}\u0000${entry.text}`;
+}
+
+function logTimestampPhase(entry: AlgorithmLogEntry): string {
+  return `${entry.timestamp}\u0000${entry.phase}`;
+}
+
+function mergeOtherSections(
+  master: IdealStateArtifact,
+  feature: IdealStateArtifact,
+  policy: IsaConflictPolicy,
+  report: IsaReconcileReport,
+): IdealStateArtifact {
+  let next = master;
+  const masterNames = new Set(master.sections.map((section) => section.name));
+  for (const featureSection of feature.sections) {
+    if (featureSection.name === SECTION_NAME_MAP.criteria || LOG_SECTIONS.has(featureSection.name)) continue;
+    const masterSection = next.sections.find((section) => section.name === featureSection.name);
+    if (!masterSection) {
+      const renamed = findLikelyRenamedSection(next.sections, featureSection);
+      if (renamed) {
+        const resolution = addConflict(report, policy, {
+          kind: "section-rename",
+          target: featureSection.name,
+          detail: `Feature section ${featureSection.name} looks like renamed master section ${renamed.name}.`,
+        });
+        if (resolution !== "feature") continue;
+      }
+      next = setSection(next, featureSection.name, featureSection.content);
+      report.mergedSections.push(featureSection.name);
+      continue;
+    }
+    if (normalizeBlock(masterSection.content) === normalizeBlock(featureSection.content)) continue;
+    if (!masterNames.has(featureSection.name)) continue;
+    const resolution = addConflict(report, policy, {
+      kind: "section-content",
+      target: featureSection.name,
+      detail: `Section ${featureSection.name} differs between master and feature.`,
+    });
+    if (resolution === "feature") {
+      next = setSection(next, featureSection.name, featureSection.content);
+      report.mergedSections.push(featureSection.name);
+    }
+  }
+  return next;
+}
+
+function findLikelyRenamedSection(masterSections: readonly IsaSection[], featureSection: IsaSection): IsaSection | undefined {
+  const featureContent = normalizeBlock(featureSection.content);
+  if (featureContent.length < 4) return undefined;
+  return masterSections.find((section) => section.name !== featureSection.name && normalizeBlock(section.content) === featureContent);
+}
+
+function normalizeBlock(value: string): string {
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join("\n");
+}
+
+function addConflict(
+  report: IsaReconcileReport,
+  policy: IsaConflictPolicy,
+  input: {
+    kind: IsaReconcileConflictKind;
+    target: string;
+    detail: string;
+    forcedResolution?: "error" | "master" | "feature" | "merged";
+    nonErrorResolution?: "master" | "feature" | "merged";
+  },
+): IsaReconcileConflict["resolution"] {
+  const resolution = input.forcedResolution ?? (policy === "error" ? "error" : input.nonErrorResolution ?? (policy === "prefer-feature" ? "feature" : "master"));
+  report.conflicts.push({
+    kind: input.kind,
+    target: input.target,
+    policy,
+    resolution,
+    detail: input.detail,
+  });
+  return resolution;
+}
+
+function formatConflictError(report: IsaReconcileReport): string {
+  const conflicts = report.conflicts.filter((conflict) => conflict.resolution === "error");
+  return `ISA reconcile failed with ${conflicts.length} conflict(s): ${conflicts.map((conflict) => `${conflict.kind}:${conflict.target}`).join(", ")}`;
+}
+
+function hasStructuralChange(left: IdealStateArtifact, right: IdealStateArtifact): boolean {
+  return JSON.stringify({
+    frontmatter: left.frontmatter,
+    sections: left.sections,
+  }) !== JSON.stringify({
+    frontmatter: right.frontmatter,
+    sections: right.sections,
+  });
+}
+
+async function emitReconcileEvent(
+  somaHome: string,
+  options: ReconcileIsaOptions,
+  slug: string,
+  report: IsaReconcileReport,
+  path: string | undefined,
+): Promise<void> {
+  await appendSomaMemoryEvent(somaHome, {
+    substrate: options.substrate ?? "custom",
+    kind: "isa.reconcile",
+    summary: `Reconciled ISA ${slug}`,
+    artifactPaths: path ? [resolve(path)] : undefined,
+    metadata: {
+      slug,
+      policy: report.policy,
+      changed: report.changed,
+      conflictCount: report.conflicts.length,
+      conflicts: report.conflicts,
+      mergedCriteria: report.mergedCriteria,
+      mergedSections: report.mergedSections,
+      mergedLogs: report.mergedLogs,
+    },
+  });
+}
+
+export function defaultIsaReconcileConfigPath(somaHome: string): string {
+  return join(somaHome, "isa", "config.json");
+}
+
+export function canonicalIsaSectionsForReconcile(): readonly string[] {
+  return TWELVE_SECTIONS;
+}

--- a/src/isa-reconcile.ts
+++ b/src/isa-reconcile.ts
@@ -244,7 +244,6 @@ function mergeCriterion(
       detail: `Criterion ${master.id} evidence differs between master and feature.`,
     });
     if (resolution === "feature") next = { ...next, verification: feature.verification };
-    if (resolution === "merged" && feature.verification) next = { ...next, verification: feature.verification };
   }
 
   return next;
@@ -258,7 +257,15 @@ function mergeStatus(
 ): IdealStateCriterion["status"] {
   if (master.status === feature.status) return master.status;
   if (master.status === "dropped") return "dropped";
-  if (feature.status === "dropped") return "dropped";
+  if (feature.status === "dropped") {
+    const resolution = addConflict(report, policy, {
+      kind: "criterion-status-regression",
+      target: master.id,
+      detail: `Feature status dropped would tombstone master status ${master.status}.`,
+      nonErrorResolution: policy === "prefer-feature" ? "feature" : "master",
+    });
+    return resolution === "feature" ? "dropped" : master.status;
+  }
   if (statusRank(feature.status) < statusRank(master.status)) {
     const resolution = addConflict(report, policy, {
       kind: "criterion-status-regression",

--- a/src/isa-reconcile.ts
+++ b/src/isa-reconcile.ts
@@ -113,6 +113,13 @@ export function reconcileIsaArtifacts(
   next = mergeLogSection(next, feature, { sectionName: SECTION_NAME_MAP.changelog, readEntries: getChangelog, policy, report });
   next = mergeLogSection(next, feature, { sectionName: SECTION_NAME_MAP.verification, readEntries: getVerification, policy, report });
   next = mergeOtherSections(next, feature, policy, report);
+  if (hasErrorConflict(report)) {
+    report.changed = false;
+    report.mergedCriteria = [];
+    report.mergedSections = [];
+    report.mergedLogs = [];
+    return { isa: master, report };
+  }
   report.changed = hasStructuralChange(master, next);
   if (report.changed && options.timestamp) {
     next = { ...next, frontmatter: { ...next.frontmatter, updated: options.timestamp } };
@@ -412,6 +419,10 @@ function addConflict(
     detail: input.detail,
   });
   return resolution;
+}
+
+function hasErrorConflict(report: IsaReconcileReport): boolean {
+  return report.conflicts.some((conflict) => conflict.resolution === "error");
 }
 
 function resolveConflict(

--- a/src/isa-reconcile.ts
+++ b/src/isa-reconcile.ts
@@ -134,7 +134,7 @@ async function loadFeatureIsa(feature: FeatureIsaInput): Promise<IdealStateArtif
 }
 
 async function readDefaultConflictPolicy(somaHome: string): Promise<IsaConflictPolicy> {
-  const configPath = join(somaHome, "isa", "config.json");
+  const configPath = defaultIsaReconcileConfigPath(somaHome);
   const raw = await readFile(configPath, "utf8").catch(() => "");
   if (raw.length === 0) return "error";
   try {

--- a/src/isa-reconcile.ts
+++ b/src/isa-reconcile.ts
@@ -2,7 +2,6 @@ import { readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import {
   SECTION_NAME_MAP,
-  TWELVE_SECTIONS,
   getChangelog,
   getCriteria,
   getDecisions,
@@ -316,6 +315,7 @@ function mergeLogSection(master: IdealStateArtifact, feature: IdealStateArtifact
   const existing = new Set(masterEntries.map(logIdentity));
   const timestampPhase = new Map(masterEntries.map((entry) => [logTimestampPhase(entry), entry.text]));
   const next = [...masterEntries];
+  let appended = false;
 
   for (const entry of featureEntries) {
     if (existing.has(logIdentity(entry))) continue;
@@ -333,7 +333,9 @@ function mergeLogSection(master: IdealStateArtifact, feature: IdealStateArtifact
     existing.add(logIdentity(entry));
     timestampPhase.set(key, entry.text);
     report.mergedLogs.push(`${sectionName}:${entry.timestamp}`);
+    appended = true;
   }
+  if (!appended) return master;
   return setSection(master, sectionName, renderLogEntries(next));
 }
 
@@ -478,10 +480,6 @@ async function emitReconcileEvent(
   });
 }
 
-export function defaultIsaReconcileConfigPath(somaHome: string): string {
+function defaultIsaReconcileConfigPath(somaHome: string): string {
   return join(somaHome, "isa", "config.json");
-}
-
-export function canonicalIsaSectionsForReconcile(): readonly string[] {
-  return TWELVE_SECTIONS;
 }

--- a/src/isa-reconcile.ts
+++ b/src/isa-reconcile.ts
@@ -313,14 +313,15 @@ function mergeLogSection(master: IdealStateArtifact, feature: IdealStateArtifact
   const featureEntries = readEntries(feature);
   if (featureEntries.length === 0) return master;
   const existing = new Set(masterEntries.map(logIdentity));
-  const timestampPhase = new Map(masterEntries.map((entry) => [logTimestampPhase(entry), entry.text]));
+  const masterTimestampPhase = new Map(masterEntries.map((entry) => [logTimestampPhase(entry), entry.text]));
+  const acceptedFeatureTimestampPhase = new Map<string, string>();
   const next = [...masterEntries];
   let appended = false;
 
   for (const entry of featureEntries) {
     if (existing.has(logIdentity(entry))) continue;
     const key = logTimestampPhase(entry);
-    const existingText = timestampPhase.get(key);
+    const existingText = masterTimestampPhase.get(key);
     if (existingText !== undefined && existingText !== entry.text) {
       const resolution = addConflict(report, policy, {
         kind: "log-entry",
@@ -329,9 +330,19 @@ function mergeLogSection(master: IdealStateArtifact, feature: IdealStateArtifact
       });
       if (resolution !== "feature") continue;
     }
+    const acceptedText = acceptedFeatureTimestampPhase.get(key);
+    if (acceptedText !== undefined && acceptedText !== entry.text) {
+      addConflict(report, policy, {
+        kind: "log-entry",
+        target: `${sectionName}:${key}`,
+        detail: `Conflicting feature ${sectionName} entries share timestamp and phase.`,
+        nonErrorResolution: "merged",
+      });
+      continue;
+    }
     next.push(entry);
     existing.add(logIdentity(entry));
-    timestampPhase.set(key, entry.text);
+    acceptedFeatureTimestampPhase.set(key, entry.text);
     report.mergedLogs.push(`${sectionName}:${entry.timestamp}`);
     appended = true;
   }

--- a/test/isa-reconcile.test.ts
+++ b/test/isa-reconcile.test.ts
@@ -85,6 +85,12 @@ test("AC-6 correctness: stable ISC IDs from feature land in master criteria", ()
   expect(criteria.find((c) => c.id === "ISC-1")?.verification).toBe("evidence");
 });
 
+test("invalid conflict policy rejects before merge resolution", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "passed", "Done", "evidence")]);
+  const feature = buildIsa("demo", [criterion("ISC-1", "open", "Done")]);
+  expect(() => reconcileIsaArtifacts(master, feature, { onConflict: "prefer-mistake" as never })).toThrow("Invalid ISA reconcile conflict policy");
+});
+
 test("adversarial 1: section added in feature appends when absent from master", () => {
   const master = buildIsa("demo", [criterion("ISC-1", "open")], { [SECTION_NAME_MAP.constraints]: "Master constraint" });
   const feature = buildIsa("demo", [criterion("ISC-1", "open")], { Research: "Feature evidence" });

--- a/test/isa-reconcile.test.ts
+++ b/test/isa-reconcile.test.ts
@@ -65,6 +65,13 @@ test("AC-4 property: reconcile(master, master) is identity", () => {
   expect(result.report.changed).toBe(false);
 });
 
+test("AC-4 property: no-op reconcile ignores timestamp-only changes", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "open")], { Notes: "Keep me" });
+  const result = reconcileIsaArtifacts(master, master, { timestamp: "2026-05-17T11:00:00.000Z" });
+  expect(serializeIsa(result.isa)).toBe(serializeIsa(master));
+  expect(result.report.changed).toBe(false);
+});
+
 test("AC-5 property: reconcile is idempotent for the same feature", () => {
   const master = buildIsa("demo", [criterion("ISC-1", "open")]);
   const feature = buildIsa("demo", [criterion("ISC-1", "passed", "ISC-1 works", "bun test passed"), criterion("ISC-2", "open")], {

--- a/test/isa-reconcile.test.ts
+++ b/test/isa-reconcile.test.ts
@@ -72,6 +72,16 @@ test("AC-4 property: no-op reconcile ignores timestamp-only changes", () => {
   expect(result.report.changed).toBe(false);
 });
 
+test("AC-4 property: no-op reconcile preserves existing log sections", () => {
+  const entry = { timestamp: "2026-05-17T00:00:00.000Z", phase: "plan", text: "Keep exact log" } as const;
+  const master = buildIsa("demo", [criterion("ISC-1", "open")], {
+    [SECTION_NAME_MAP.decisions]: decisions(entry),
+  });
+  const result = reconcileIsaArtifacts(master, master);
+  expect(serializeIsa(result.isa)).toBe(serializeIsa(master));
+  expect(result.report.changed).toBe(false);
+});
+
 test("AC-5 property: reconcile is idempotent for the same feature", () => {
   const master = buildIsa("demo", [criterion("ISC-1", "open")]);
   const feature = buildIsa("demo", [criterion("ISC-1", "passed", "ISC-1 works", "bun test passed"), criterion("ISC-2", "open")], {

--- a/test/isa-reconcile.test.ts
+++ b/test/isa-reconcile.test.ts
@@ -1,0 +1,198 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import {
+  bootstrapSomaHome,
+  getCriteria,
+  parseIsa,
+  reconcileIsa,
+  reconcileIsaArtifacts,
+  scaffoldIsa,
+  serializeIsa,
+  somaMemoryEventsPath,
+  writeIsa,
+} from "../src/index";
+import { SECTION_NAME_MAP, getDecisions, getGoal, renderCriteriaMarkdown, renderLogEntries, setSection } from "../src/isa-accessors";
+import type { AlgorithmLogEntry, IdealStateArtifact, IdealStateCriterion } from "../src/types";
+
+async function withSomaHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-isa-reconcile-"));
+  try {
+    await bootstrapSomaHome({ homeDir });
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+function buildIsa(slug: string, criteria: IdealStateCriterion[], sections: Record<string, string> = {}): IdealStateArtifact {
+  const timestamp = "2026-05-17T00:00:00.000Z";
+  const isa = parseIsa(
+    [
+      "---",
+      `task: ${slug}`,
+      "effort: E3",
+      "phase: observe",
+      `updated: ${timestamp}`,
+      "---",
+      "",
+      "## Goal",
+      "",
+      `${slug} goal`,
+      "",
+      "## Criteria",
+      "",
+      renderCriteriaMarkdown(criteria),
+      "",
+    ].join("\n"),
+  );
+  return Object.entries(sections).reduce((current, [name, content]) => setSection(current, name, content), { ...isa, slug });
+}
+
+function decisions(...entries: AlgorithmLogEntry[]): string {
+  return renderLogEntries(entries);
+}
+
+function criterion(id: string, status: IdealStateCriterion["status"], text = `${id} works`, verification?: string): IdealStateCriterion {
+  return { id, text, status, verification };
+}
+
+test("AC-4 property: reconcile(master, master) is identity", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "open")], { Notes: "Keep me" });
+  const result = reconcileIsaArtifacts(master, master);
+  expect(serializeIsa(result.isa)).toBe(serializeIsa(master));
+  expect(result.report.changed).toBe(false);
+});
+
+test("AC-5 property: reconcile is idempotent for the same feature", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "open")]);
+  const feature = buildIsa("demo", [criterion("ISC-1", "passed", "ISC-1 works", "bun test passed"), criterion("ISC-2", "open")], {
+    Notes: "Feature notes",
+  });
+  const once = reconcileIsaArtifacts(master, feature, { onConflict: "prefer-feature" }).isa;
+  const twice = reconcileIsaArtifacts(once, feature, { onConflict: "prefer-feature" }).isa;
+  expect(serializeIsa(twice)).toBe(serializeIsa(once));
+});
+
+test("AC-6 correctness: stable ISC IDs from feature land in master criteria", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "open")]);
+  const feature = buildIsa("demo", [criterion("ISC-1", "passed", "ISC-1 works", "evidence"), criterion("ISC-2", "open")]);
+  const result = reconcileIsaArtifacts(master, feature, { onConflict: "prefer-feature" });
+  const criteria = getCriteria(result.isa);
+  expect(criteria.map((c) => c.id)).toEqual(["ISC-1", "ISC-2"]);
+  expect(criteria.find((c) => c.id === "ISC-1")?.status).toBe("passed");
+  expect(criteria.find((c) => c.id === "ISC-1")?.verification).toBe("evidence");
+});
+
+test("adversarial 1: section added in feature appends when absent from master", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "open")], { [SECTION_NAME_MAP.constraints]: "Master constraint" });
+  const feature = buildIsa("demo", [criterion("ISC-1", "open")], { Research: "Feature evidence" });
+  const result = reconcileIsaArtifacts(master, feature);
+  expect(result.isa.sections.find((s) => s.name === "Research")?.content).toBe("Feature evidence");
+  expect(result.report.mergedLogs).toHaveLength(0);
+});
+
+test("adversarial 2: duplicate ISC IDs in master reject file-backed reconcile", async () => {
+  await withSomaHome(async (homeDir) => {
+    await scaffoldIsa({ homeDir, slug: "dup", goal: "G", effort: "E1", initialCriteria: [criterion("ISC-1", "open")] });
+    const master = buildIsa("dup", [criterion("ISC-1", "open")], { Extra: "- [ ] ISC-1: Duplicate" });
+    await writeIsa("dup", master, { homeDir });
+    const feature = buildIsa("dup", [criterion("ISC-2", "open")]);
+    await expect(reconcileIsa("dup", feature, { homeDir })).rejects.toThrow("criterion-duplicate");
+  });
+});
+
+test("adversarial 3: manual master edits are preserved under prefer-master", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "open")], { [SECTION_NAME_MAP.goal]: "Manual master goal" });
+  const feature = buildIsa("demo", [criterion("ISC-2", "open")], { [SECTION_NAME_MAP.goal]: "Old feature goal" });
+  const result = reconcileIsaArtifacts(master, feature, { onConflict: "prefer-master" });
+  expect(getGoal(result.isa)).toBe("Manual master goal");
+  expect(getCriteria(result.isa).map((c) => c.id)).toContain("ISC-2");
+});
+
+test("adversarial 4 and 5: whitespace normalization and header drift parse as same section", () => {
+  const markdown = [
+    "---",
+    "task: drift",
+    "effort: E1",
+    "phase: observe",
+    "---",
+    "",
+    "##  Goal   ",
+    "",
+    "Drift goal  ",
+    "",
+    "##   Criteria",
+    "",
+    "- [ ] ISC-1: Works   ",
+    "",
+  ].join("\n");
+  const isa = parseIsa(markdown);
+  expect(getGoal(isa)).toBe("Drift goal");
+  expect(getCriteria(isa)[0]?.id).toBe("ISC-1");
+});
+
+test("adversarial 6: feature cannot regress passed master status by default", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "passed", "Done", "evidence")]);
+  const feature = buildIsa("demo", [criterion("ISC-1", "open", "Done")]);
+  const result = reconcileIsaArtifacts(master, feature, { onConflict: "prefer-master" });
+  expect(getCriteria(result.isa)[0]?.status).toBe("passed");
+  expect(result.report.conflicts.some((c) => c.kind === "criterion-status-regression")).toBe(true);
+});
+
+test("adversarial 7: conflicting Decisions timestamp errors unless policy resolves", () => {
+  const entryA = { timestamp: "2026-05-17T00:00:00.000Z", phase: "plan", text: "Master decision" } as const;
+  const entryB = { timestamp: "2026-05-17T00:00:00.000Z", phase: "plan", text: "Feature decision" } as const;
+  const master = buildIsa("demo", [criterion("ISC-1", "open")], { [SECTION_NAME_MAP.decisions]: decisions(entryA) });
+  const feature = buildIsa("demo", [criterion("ISC-1", "open")], { [SECTION_NAME_MAP.decisions]: decisions(entryB) });
+  const errored = reconcileIsaArtifacts(master, feature);
+  expect(errored.report.conflicts.some((c) => c.resolution === "error" && c.kind === "log-entry")).toBe(true);
+  const resolved = reconcileIsaArtifacts(master, feature, { onConflict: "prefer-feature" });
+  expect(getDecisions(resolved.isa).map((entry) => entry.text)).toEqual(["Master decision", "Feature decision"]);
+});
+
+test("adversarial 8: tombstoned criteria are preserved and never resurrected", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "dropped", "[DROPPED - see Decisions]")]);
+  const feature = buildIsa("demo", [criterion("ISC-1", "passed", "Resurrected", "evidence")]);
+  const result = reconcileIsaArtifacts(master, feature, { onConflict: "prefer-feature" });
+  const merged = getCriteria(result.isa)[0];
+  expect(merged?.status).toBe("dropped");
+  expect(merged?.text).toContain("DROPPED");
+});
+
+test("adversarial 9: likely section rename conflicts instead of duplicating", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "open")], { "Acceptance Criteria": "Same body" });
+  const feature = buildIsa("demo", [criterion("ISC-1", "open")], { "Verification Criteria": "Same body" });
+  const result = reconcileIsaArtifacts(master, feature);
+  expect(result.report.conflicts.some((c) => c.kind === "section-rename" && c.resolution === "error")).toBe(true);
+  expect(result.isa.sections.some((s) => s.name === "Verification Criteria")).toBe(false);
+});
+
+test("file-backed reconcile reads conflict policy from config and appends event report", async () => {
+  await withSomaHome(async (homeDir) => {
+    await scaffoldIsa({ homeDir, slug: "cfg", goal: "G", effort: "E1", initialCriteria: [criterion("ISC-1", "open")] });
+    const somaHome = join(homeDir, ".soma");
+    await mkdir(join(somaHome, "isa"), { recursive: true });
+    await writeFile(join(somaHome, "isa", "config.json"), '{"defaultConflictPolicy":"prefer-feature"}\n', "utf8");
+    const featurePath = join(homeDir, "feature.md");
+    await writeFile(featurePath, serializeIsa(buildIsa("cfg", [criterion("ISC-1", "passed", "ISC-1 works", "ok")])), "utf8");
+    const result = await reconcileIsa("cfg", featurePath, { homeDir, timestamp: "2026-05-17T10:00:00.000Z" });
+    expect(result.report.policy).toBe("prefer-feature");
+    expect(getCriteria(result.isa)[0]?.status).toBe("passed");
+    const events = (await readFile(somaMemoryEventsPath(somaHome), "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { kind: string; metadata?: { policy?: string; conflictCount?: number } });
+    const event = [...events].reverse().find((candidate) => candidate.kind === "isa.reconcile");
+    expect(event?.metadata?.policy).toBe("prefer-feature");
+    expect(event?.metadata?.conflictCount).toBeGreaterThanOrEqual(0);
+  });
+});
+
+test("correctness: master content untouched by feature stays present", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "open")], { [SECTION_NAME_MAP.constraints]: "Do not lose this" });
+  const feature = buildIsa("demo", [criterion("ISC-2", "open")]);
+  const result = reconcileIsaArtifacts(master, feature);
+  expect(result.isa.sections.find((s) => s.name === SECTION_NAME_MAP.constraints)?.content).toBe("Do not lose this");
+});

--- a/test/isa-reconcile.test.ts
+++ b/test/isa-reconcile.test.ts
@@ -175,6 +175,16 @@ test("adversarial 7: conflicting Decisions timestamp errors unless policy resolv
   expect(getDecisions(resolved.isa).map((entry) => entry.text)).toEqual(["Master decision", "Feature decision"]);
 });
 
+test("adversarial 7: duplicate feature log keys merge at most one entry", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "open")]);
+  const entryA = { timestamp: "2026-05-17T00:00:00.000Z", phase: "plan", text: "Feature decision A" } as const;
+  const entryB = { timestamp: "2026-05-17T00:00:00.000Z", phase: "plan", text: "Feature decision B" } as const;
+  const feature = buildIsa("demo", [criterion("ISC-1", "open")], { [SECTION_NAME_MAP.decisions]: decisions(entryA, entryB) });
+  const resolved = reconcileIsaArtifacts(master, feature, { onConflict: "prefer-feature" });
+  expect(getDecisions(resolved.isa).map((entry) => entry.text)).toEqual(["Feature decision A"]);
+  expect(resolved.report.conflicts.some((conflict) => conflict.kind === "log-entry")).toBe(true);
+});
+
 test("adversarial 8: tombstoned criteria are preserved and never resurrected", () => {
   const master = buildIsa("demo", [criterion("ISC-1", "dropped", "[DROPPED - see Decisions]")]);
   const feature = buildIsa("demo", [criterion("ISC-1", "passed", "Resurrected", "evidence")]);

--- a/test/isa-reconcile.test.ts
+++ b/test/isa-reconcile.test.ts
@@ -161,6 +161,17 @@ test("adversarial 8: tombstoned criteria are preserved and never resurrected", (
   expect(merged?.text).toContain("DROPPED");
 });
 
+test("feature-side dropped status obeys conflict policy", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "passed", "Done", "evidence")]);
+  const feature = buildIsa("demo", [criterion("ISC-1", "dropped", "Drop it")]);
+  const preferMaster = reconcileIsaArtifacts(master, feature, { onConflict: "prefer-master" });
+  expect(getCriteria(preferMaster.isa)[0]?.status).toBe("passed");
+  expect(preferMaster.report.conflicts.some((conflict) => conflict.kind === "criterion-status-regression")).toBe(true);
+
+  const preferFeature = reconcileIsaArtifacts(master, feature, { onConflict: "prefer-feature" });
+  expect(getCriteria(preferFeature.isa)[0]?.status).toBe("dropped");
+});
+
 test("adversarial 9: likely section rename conflicts instead of duplicating", () => {
   const master = buildIsa("demo", [criterion("ISC-1", "open")], { "Acceptance Criteria": "Same body" });
   const feature = buildIsa("demo", [criterion("ISC-1", "open")], { "Verification Criteria": "Same body" });

--- a/test/isa-reconcile.test.ts
+++ b/test/isa-reconcile.test.ts
@@ -193,6 +193,16 @@ test("adversarial 9: likely section rename conflicts instead of duplicating", ()
   expect(result.isa.sections.some((s) => s.name === "Verification Criteria")).toBe(false);
 });
 
+test("error-policy conflicts return the original master artifact", () => {
+  const master = buildIsa("demo", [criterion("ISC-1", "passed", "Done", "evidence")], { Keep: "Master" });
+  const feature = buildIsa("demo", [criterion("ISC-1", "open", "Done"), criterion("ISC-2", "open")], { Added: "Feature" });
+  const result = reconcileIsaArtifacts(master, feature);
+  expect(result.report.conflicts.some((conflict) => conflict.resolution === "error")).toBe(true);
+  expect(result.report.changed).toBe(false);
+  expect(result.report.mergedCriteria).toEqual([]);
+  expect(serializeIsa(result.isa)).toBe(serializeIsa(master));
+});
+
 test("file-backed reconcile reads conflict policy from config and appends event report", async () => {
   await withSomaHome(async (homeDir) => {
     await scaffoldIsa({ homeDir, slug: "cfg", goal: "G", effort: "E1", initialCriteria: [criterion("ISC-1", "open")] });


### PR DESCRIPTION
## Summary
- add docs/isa-reconcile.md with the adversarial merge decisions for #35
- add src/isa-reconcile.ts with file-backed reconcileIsa plus pure reconcileIsaArtifacts
- merge stable ISC IDs, append log entries, preserve tombstones, support conflict policy, and emit isa.reconcile events
- accept whitespace-only header drift in ISA parsing

## Verification
- bun test
- bun run typecheck
- bun run lint

Closes #35