### PR TITLE
Fix Pi skill name projection

### DIFF
--- a/src/adapters/pi-dev/adapter.ts
+++ b/src/adapters/pi-dev/adapter.ts
@@ -1,6 +1,7 @@
 import type { SomaAdapter, SomaContextBundle, SomaContextInput, SomaTask } from "../../types";
 import { renderFeedbackHookHelper } from "../shared/feedback-helper";
 import { renderPathGuardExtension } from "./path-guard";
+import { buildPiDevPortableSkillFiles } from "./skill-projection";
 import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
 import { activeIsaBundleFile } from "../../adapter-active-isa";
 import { SOMA_VERSION } from "../../version";
@@ -466,12 +467,7 @@ export function buildPiDevContext(input: SomaContextInput): SomaContextBundle {
 
 export function buildPiDevHomeContext(input: SomaContextInput, somaHome: string): SomaContextBundle {
   const instructions = renderInstructions(input);
-  const portableSkillFiles = input.profile.skills.flatMap((skill) =>
-    (skill.files ?? []).map((file) => ({
-      path: `agent/skills/${skill.name}/${file.path}`,
-      content: file.content,
-    })),
-  );
+  const portableSkillFiles = buildPiDevPortableSkillFiles(input.profile.skills);
 
   return {
     substrate: "pi-dev",

--- a/src/adapters/pi-dev/skill-projection.ts
+++ b/src/adapters/pi-dev/skill-projection.ts
@@ -1,0 +1,64 @@
+import { readdir, rm } from "node:fs/promises";
+import { resolve } from "node:path";
+import { rewriteSkillNameFrontmatter } from "../../skill-frontmatter";
+import type { SomaContextBundle, SomaSkill } from "../../types";
+
+export const PI_DEV_ISA_SKILL_ID = "isa";
+
+export function piDevSkillId(name: string): string {
+  const id = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return id || "skill";
+}
+
+export function renderPiDevSkillFileContent(skillName: string, filePath: string, content: string): string {
+  return rewriteSkillNameFrontmatter(filePath, content, piDevSkillId(skillName));
+}
+
+export function buildPiDevPortableSkillFiles(skills: SomaSkill[]): SomaContextBundle["files"] {
+  const ids = new Map<string, string>();
+  const files: SomaContextBundle["files"] = [];
+
+  for (const skill of skills) {
+    const id = piDevSkillId(skill.name);
+    const existingName = ids.get(id);
+    if (existingName && existingName !== skill.name) {
+      throw new Error(`Pi.dev skill id collision: ${JSON.stringify(existingName)} and ${JSON.stringify(skill.name)} both normalize to ${JSON.stringify(id)}.`);
+    }
+    ids.set(id, skill.name);
+
+    for (const file of skill.files ?? []) {
+      files.push({
+        path: `agent/skills/${id}/${file.path}`,
+        content: renderPiDevSkillFileContent(skill.name, file.path, file.content),
+      });
+    }
+  }
+
+  return files;
+}
+
+export function piDevIsaSkillDestinationDir(substrateHome: string): string {
+  return resolve(substrateHome, "agent/skills", PI_DEV_ISA_SKILL_ID);
+}
+
+function legacyPiDevIsaSkillDestinationDir(substrateHome: string): string {
+  return resolve(substrateHome, "agent/skills/ISA");
+}
+
+export async function removeLegacyPiDevIsaSkillProjection(substrateHome: string): Promise<void> {
+  const skillsDir = resolve(substrateHome, "agent/skills");
+  let entries;
+  try {
+    entries = await readdir(skillsDir, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  if (entries.some((entry) => entry.isDirectory() && entry.name === "ISA")) {
+    await rm(legacyPiDevIsaSkillDestinationDir(substrateHome), { recursive: true, force: true });
+  }
+}

--- a/src/install.ts
+++ b/src/install.ts
@@ -2,11 +2,16 @@ import { homedir } from "node:os";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { configureCodexInstall } from "./adapters/codex";
+import {
+  PI_DEV_ISA_SKILL_ID,
+  piDevIsaSkillDestinationDir,
+  removeLegacyPiDevIsaSkillProjection,
+} from "./adapters/pi-dev/skill-projection";
 import { installClaudeCodeHomeProjection, installCodexHomeProjection, installPiDevHomeProjection } from "./home-projection";
 import { buildSomaStartupContext, runSomaLifecycleAlgorithmUpdated } from "./lifecycle";
 import { defaultSomaRepoPath } from "./repo-path";
 import { bootstrapSomaHome } from "./soma-home";
-import { installIsaSkill } from "./isa-skill-installer";
+import { installIsaSkill, installIsaSkillProjection } from "./isa-skill-installer";
 import { DEFAULT_SUBSTRATE_HOMES, loadActiveIsaForBundle } from "./adapter-active-isa";
 import type { SomaContextInput, SomaInstallOptions, SomaInstallPlan, SomaInstallResult } from "./types";
 
@@ -76,9 +81,8 @@ const PI_DEV_HOME_FILES = [
 import { CLAUDE_CODE_RULES_FILES } from "./adapters/claude-code";
 const CLAUDE_CODE_HOME_FILES = CLAUDE_CODE_RULES_FILES;
 
-const SKILL_SUBPATHS: Record<InstallSubstrate, string> = {
+const SKILL_SUBPATHS: Record<Exclude<InstallSubstrate, "pi-dev">, string> = {
   codex: "skills/ISA",
-  "pi-dev": "agent/skills/ISA",
   "claude-code": "skills/ISA",
 };
 
@@ -97,7 +101,19 @@ function resolveInstallHomes(substrate: InstallSubstrate, options: SomaInstallOp
 }
 
 function resolveSubstrateSkillDir(substrate: InstallSubstrate, substrateHome: string): string {
+  if (substrate === "pi-dev") return piDevIsaSkillDestinationDir(substrateHome);
   return resolve(substrateHome, SKILL_SUBPATHS[substrate]);
+}
+
+function substrateSkillNameOverride(substrate: InstallSubstrate): string | undefined {
+  if (substrate === "pi-dev") return PI_DEV_ISA_SKILL_ID;
+  return undefined;
+}
+
+async function prepareSubstrateSkillDestination(substrate: InstallSubstrate, substrateHome: string): Promise<void> {
+  if (substrate === "pi-dev") {
+    await removeLegacyPiDevIsaSkillProjection(substrateHome);
+  }
 }
 
 // soma#73 pre-flight is shared with the codex adapter — see
@@ -149,7 +165,7 @@ async function installSomaForSubstrate(
   const somaRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();
   // Install ISA skill into Soma home (canonical baseline) so other
   // tooling reading <somaHome>/skills/ISA continues to work.
-  await installIsaSkill({
+  await installIsaSkillProjection({
     homeDir: options.homeDir,
     somaHome: somaHome.somaHome,
     somaRepoPath,
@@ -166,11 +182,13 @@ async function installSomaForSubstrate(
   // inherits installIsaSkill's local-edits-preserved contract.
   const resolvedHomeDir = resolve(options.homeDir ?? homedir());
   const substrateRoot = resolve(options.substrateHome ?? join(resolvedHomeDir, DEFAULT_SUBSTRATE_HOMES[substrate]));
-  await installIsaSkill({
+  await prepareSubstrateSkillDestination(substrate, substrateRoot);
+  await installIsaSkillProjection({
     homeDir: options.homeDir,
     somaHome: somaHome.somaHome,
     somaRepoPath,
     skillDestinationDir: resolveSubstrateSkillDir(substrate, substrateRoot),
+    skillNameOverride: substrateSkillNameOverride(substrate),
   });
   // Populate the projection input with the active ISA so each
   // substrate writes its `active-isa.md` file (#37 AC-1/AC-2).

--- a/src/isa-skill-installer.ts
+++ b/src/isa-skill-installer.ts
@@ -3,6 +3,7 @@ import { mkdir, readdir, readFile, stat, unlink, writeFile } from "node:fs/promi
 import { homedir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { defaultSomaRepoPath } from "./repo-path";
+import { SKILL_MD, rewriteSkillNameFrontmatter } from "./skill-frontmatter";
 import type {
   IsaSkillInstallOptions,
   IsaSkillInstallResult,
@@ -10,12 +11,15 @@ import type {
   SomaSkillBaselines,
 } from "./types";
 
+interface InternalIsaSkillInstallOptions extends IsaSkillInstallOptions {
+  skillNameOverride?: string;
+}
+
 const SKILL_NAME = "ISA";
 const SOURCE_SUBPATH = `src/skills/${SKILL_NAME}`;
 const RUNTIME_SUBPATH = `skills/${SKILL_NAME}`;
 const BASELINES_SUBPATH = "memory/STATE/skill-baselines.json";
 const UPGRADE_MARKER_NAME = ".upgrade-available";
-const SKILL_MD = "SKILL.md";
 
 /**
  * Baselines are keyed by destination so multi-substrate installs (#37)
@@ -80,10 +84,14 @@ async function listSkillFiles(root: string): Promise<string[]> {
   return out.sort();
 }
 
-async function hashSkillFiles(root: string, relativePaths: string[]): Promise<Record<string, string>> {
+async function hashSkillFiles(
+  root: string,
+  relativePaths: string[],
+  skillNameOverride?: string,
+): Promise<Record<string, string>> {
   const out: Record<string, string> = {};
   for (const rel of relativePaths) {
-    out[rel] = sha256(await readFile(join(root, rel), "utf8"));
+    out[rel] = sha256(transformSkillFileContent(rel, await readFile(join(root, rel), "utf8"), skillNameOverride));
   }
   return out;
 }
@@ -166,9 +174,14 @@ async function readSkillFrontmatter(skillMdPath: string): Promise<SkillFrontmatt
   return parseSkillFrontmatter(await readFile(skillMdPath, "utf8"));
 }
 
-async function copyFile(source: string, destination: string): Promise<void> {
+async function copySkillFile(source: string, destination: string, relPath: string, skillNameOverride?: string): Promise<void> {
   await mkdir(dirname(destination), { recursive: true });
-  await writeFile(destination, await readFile(source, "utf8"), "utf8");
+  const content = transformSkillFileContent(relPath, await readFile(source, "utf8"), skillNameOverride);
+  await writeFile(destination, content, "utf8");
+}
+
+function transformSkillFileContent(relPath: string, content: string, skillNameOverride?: string): string {
+  return rewriteSkillNameFrontmatter(relPath, content, skillNameOverride);
 }
 
 interface DetectedDrift {
@@ -220,7 +233,15 @@ async function detectDrift(
  *     marker, no overwrite. User decides via `soma isa skill upgrade` (#36).
  *   - `force: true` → behave as fresh install regardless of state.
  */
-export async function installIsaSkill(options: IsaSkillInstallOptions = {}): Promise<IsaSkillInstallResult> {
+export function installIsaSkill(options: IsaSkillInstallOptions = {}): Promise<IsaSkillInstallResult> {
+  return installIsaSkillInternal(options);
+}
+
+export function installIsaSkillProjection(options: InternalIsaSkillInstallOptions = {}): Promise<IsaSkillInstallResult> {
+  return installIsaSkillInternal(options);
+}
+
+async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions = {}): Promise<IsaSkillInstallResult> {
   const somaHome = resolveSomaHome(options);
   const somaRepoPath = resolveSomaRepoPath(options);
   const sourceDir = isaSkillSourceDir(somaRepoPath);
@@ -253,7 +274,7 @@ export async function installIsaSkill(options: IsaSkillInstallOptions = {}): Pro
     throw new Error(`ISA skill source ${SKILL_MD} missing version or pack-id frontmatter.`);
   }
   const sourceFiles = await listSkillFiles(sourceDir);
-  const sourceHashes = await hashSkillFiles(sourceDir, sourceFiles);
+  const sourceHashes = await hashSkillFiles(sourceDir, sourceFiles, options.skillNameOverride);
 
   const runtimeFrontmatter = await readSkillFrontmatter(join(runtimeDir, SKILL_MD));
   const baselinesRead = await readBaselines(somaHome);
@@ -277,6 +298,7 @@ export async function installIsaSkill(options: IsaSkillInstallOptions = {}): Pro
       markerPath,
       userAdditions,
       skillKey,
+      skillNameOverride: options.skillNameOverride,
     });
   }
 
@@ -295,6 +317,7 @@ export async function installIsaSkill(options: IsaSkillInstallOptions = {}): Pro
       baseline: baselineForDest,
       userAdditions,
       skillKey,
+      skillNameOverride: options.skillNameOverride,
     });
   }
 
@@ -324,6 +347,7 @@ export async function installIsaSkill(options: IsaSkillInstallOptions = {}): Pro
     userAdditions,
     actionOverride: "upgraded",
     skillKey,
+    skillNameOverride: options.skillNameOverride,
   });
 }
 
@@ -340,6 +364,7 @@ interface ReconcileSameVersionContext {
   baseline: SomaSkillBaseline | undefined;
   userAdditions: string[];
   skillKey: string;
+  skillNameOverride?: string;
 }
 
 async function reconcileSameVersion(ctx: ReconcileSameVersionContext): Promise<IsaSkillInstallResult> {
@@ -358,7 +383,7 @@ async function reconcileSameVersion(ctx: ReconcileSameVersionContext): Promise<I
   const written: string[] = [];
   for (const rel of missingFiles) {
     const dest = join(ctx.runtimeDir, rel);
-    await copyFile(join(ctx.sourceDir, rel), dest);
+    await copySkillFile(join(ctx.sourceDir, rel), dest, rel, ctx.skillNameOverride);
     written.push(dest);
   }
   // Handle the pre-baselines runtime case: existing runtime installed before
@@ -435,13 +460,14 @@ interface FreshInstallContext {
   userAdditions: string[];
   actionOverride?: "fresh" | "upgraded";
   skillKey: string;
+  skillNameOverride?: string;
 }
 
 async function freshInstall(ctx: FreshInstallContext): Promise<IsaSkillInstallResult> {
   const written: string[] = [];
   for (const rel of ctx.sourceFiles) {
     const dest = join(ctx.runtimeDir, rel);
-    await copyFile(join(ctx.sourceDir, rel), dest);
+    await copySkillFile(join(ctx.sourceDir, rel), dest, rel, ctx.skillNameOverride);
     written.push(dest);
   }
 

--- a/src/skill-frontmatter.ts
+++ b/src/skill-frontmatter.ts
@@ -1,0 +1,12 @@
+export const SKILL_MD = "SKILL.md";
+
+const NAME_KEY = /^name:\s*(.+?)\s*$/m;
+const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---(?=\r?\n|$)/;
+
+export function rewriteSkillNameFrontmatter(relPath: string, content: string, skillName?: string): string {
+  if (!skillName || relPath !== SKILL_MD) return content;
+  const frontmatter = FRONTMATTER.exec(content);
+  if (!frontmatter) return content;
+  const rewritten = frontmatter[0].replace(NAME_KEY, `name: ${skillName}`);
+  return `${rewritten}${content.slice(frontmatter[0].length)}`;
+}

--- a/test/adapter-active-isa.test.ts
+++ b/test/adapter-active-isa.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
@@ -82,11 +82,28 @@ test("AC-3: installSomaForCodex projects ISA skill source into ~/.codex/skills/I
   });
 });
 
-test("AC-3: installSomaForPiDev projects ISA skill source into ~/.pi/agent/skills/ISA/", async () => {
+test("AC-3: installSomaForPiDev projects ISA skill source into Pi-safe ~/.pi/agent/skills/isa/", async () => {
   await withTempHome(async (homeDir) => {
     await installSomaForPiDev({ homeDir });
-    const skillMd = await readFile(join(homeDir, ".pi/agent/skills/ISA/SKILL.md"), "utf8");
-    expect(skillMd).toContain("name: ISA");
+    const skillMd = await readFile(join(homeDir, ".pi/agent/skills/isa/SKILL.md"), "utf8");
+    const skillDirs = await readdir(join(homeDir, ".pi/agent/skills"));
+    expect(skillMd).toContain("name: isa");
+    expect(skillDirs).toContain("isa");
+    expect(skillDirs).not.toContain("ISA");
+  });
+});
+
+test("AC-3: installSomaForPiDev removes legacy uppercase ISA projection", async () => {
+  await withTempHome(async (homeDir) => {
+    await mkdir(join(homeDir, ".pi/agent/skills/ISA"), { recursive: true });
+    await writeFile(join(homeDir, ".pi/agent/skills/ISA/SKILL.md"), "---\nname: ISA\n---\n", "utf8");
+
+    await installSomaForPiDev({ homeDir });
+
+    const skillDirs = await readdir(join(homeDir, ".pi/agent/skills"));
+    expect(skillDirs).not.toContain("ISA");
+    expect(skillDirs).toContain("isa");
+    await expect(readFile(join(homeDir, ".pi/agent/skills/isa/SKILL.md"), "utf8")).resolves.toContain("name: isa");
   });
 });
 

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -168,6 +168,98 @@ test("builds pi.dev home projection bundle for default availability", () => {
   expect(projection.bundle.files.find((file) => file.path === "agent/skills/soma/SKILL.md")?.content).toContain("name: soma");
 });
 
+test("pi.dev home projection normalizes portable skill paths and frontmatter names", () => {
+  const projection = buildPiDevHomeProjection(
+    {
+      ...portableContextInput,
+      profile: {
+        ...portableContextInput.profile,
+        skills: [
+          {
+            name: "ISA",
+            path: "skills/ISA",
+            description: "Ideal State Artifact.",
+            triggers: ["isa"],
+            files: [
+              {
+                path: "SKILL.md",
+                content: "---\nname: ISA\n---\n\n# ISA\n",
+              },
+            ],
+          },
+          {
+            name: "Ledger Update",
+            path: "skills/ledger-update",
+            description: "Update a project ledger.",
+            triggers: ["ledger"],
+            files: [
+              {
+                path: "SKILL.md",
+                content: "---\nname: Ledger Update\n---\n\n# Ledger Update\n",
+              },
+            ],
+          },
+          {
+            name: "Body Example",
+            path: "skills/body-example",
+            description: "Contains a body example that looks like YAML.",
+            triggers: ["body"],
+            files: [
+              {
+                path: "SKILL.md",
+                content: "# Body Example\n\n```yaml\nname: Body Example\n```\n",
+              },
+            ],
+          },
+        ],
+      },
+    },
+    { homeDir: "/tmp/soma-test-home" },
+  );
+
+  const isa = projection.bundle.files.find((file) => file.path === "agent/skills/isa/SKILL.md");
+  const ledger = projection.bundle.files.find((file) => file.path === "agent/skills/ledger-update/SKILL.md");
+  const bodyExample = projection.bundle.files.find((file) => file.path === "agent/skills/body-example/SKILL.md");
+
+  expect(isa?.content).toContain("name: isa");
+  expect(isa?.content).not.toContain("name: ISA");
+  expect(ledger?.content).toContain("name: ledger-update");
+  expect(bodyExample?.content).toContain("name: Body Example");
+  expect(bodyExample?.content).not.toContain("name: body-example");
+  expect(projection.bundle.files.map((file) => file.path)).not.toContain("agent/skills/ISA/SKILL.md");
+});
+
+test("pi.dev home projection rejects normalized portable skill id collisions", () => {
+  expect(() =>
+    buildPiDevHomeProjection(
+      {
+        ...portableContextInput,
+        profile: {
+          ...portableContextInput.profile,
+          skills: [
+            {
+              name: "Ledger Update",
+              path: "skills/ledger-update",
+              description: "Update a project ledger.",
+              triggers: ["ledger"],
+              files: [{ path: "SKILL.md", content: "---\nname: Ledger Update\n---\n" }],
+            },
+            {
+              name: "Ledger-Update",
+              path: "skills/ledger-update-alt",
+              description: "Collision.",
+              triggers: ["ledger"],
+              files: [{ path: "SKILL.md", content: "---\nname: Ledger-Update\n---\n" }],
+            },
+          ],
+        },
+      },
+      { homeDir: "/tmp/soma-test-home" },
+    ),
+  ).toThrow("Pi.dev skill id collision");
+});
+
+
 test("installs codex home projection into a substrate home", async () => {
   await withTempHome(async (homeDir) => {
     const result = await installCodexHomeProjection(portableContextInput, { homeDir });


### PR DESCRIPTION
## Summary

Fixes #76.

- Normalize Pi-projected portable skill directory names and `SKILL.md` frontmatter names to lowercase `a-z`, `0-9`, and hyphen IDs.
- Install the bundled ISA skill for Pi as `agent/skills/isa/SKILL.md` with `name: isa`, while leaving the source skill metadata unchanged.
- Remove an actual legacy uppercase `agent/skills/ISA` directory entry before reinstalling so existing broken Pi projections do not keep producing startup conflicts.

## Verification

- `bun test test/home-projection.test.ts`
- `bun test test/adapter-active-isa.test.ts`
- `bun test` (442 pass)
- `bun run typecheck`
- `git diff --check`
