### PR TITLE
refactor: context→projection vocabulary (#52)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ src/adapters/codex.ts
 ```
 
 That adapter should implement the `SomaAdapter` interface from `src/types.ts`
-and produce a `SomaContextBundle` that Codex can use as a local instruction
+and produce a `Projection` that Codex can use as a local instruction
 package.
 
 ## Design Boundaries
@@ -71,6 +71,6 @@ adapter:
 
 1. Add `src/adapters/codex.ts`.
 2. Export it from `src/index.ts`.
-3. Add tests proving it builds a context bundle from a minimal `SomaProfile`.
+3. Add tests proving it builds a projection from a minimal `SomaProfile`.
 4. Document the adapter behavior in `docs/substrate-adapters.md`.
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ soma adopt claude --apply
 Then start a session and watch Soma surface its context.
 
 Claude Code uses its native rules directory as the home projection so Claude
-can auto-discover Soma context without depending on fragile home-directory
-imports. `soma adopt claude --uninstall` removes only the generated Soma
-projection.
+can auto-discover the Soma projection without depending on fragile
+home-directory imports. `soma adopt claude --uninstall` removes only the
+generated Soma projection.
 
 <!--
   Demo recording brief (replace this whole block with the rendered asset).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,9 +109,6 @@ interface SomaAdapter {
 }
 ```
 
-> Note: existing code still uses `buildContext` / `SomaContextInput` /
-> `SomaContextBundle`. Rename tracked in #52.
-
 Examples:
 
 - Codex adapter projects Soma into Codex-readable instruction files.

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -18,9 +18,9 @@ Codex is a coding-agent substrate. The Codex projection should carry:
 Open question: whether Codex plugins should carry the adapter or whether Soma
 should project a workspace-local instruction set consumed by Codex.
 
-Initial answer: start with a workspace projection. `projectCodex` (currently
-named `buildCodexContext`, rename tracked in #52) returns deterministic files
-under `.codex/soma/` plus an instruction string. Codex execution and plugins
+Initial answer: start with a workspace projection. `projectCodex` returns
+deterministic files under `.codex/soma/` plus an instruction string. Codex
+execution and plugins
 come later, after the same input can be projected into at least one second
 substrate.
 
@@ -46,14 +46,14 @@ The first useful Pi adapter can be a `soma-core` extension with:
 - `capture_learning`
 - `policy_check`
 
-Initial implementation: `projectPiDev` (currently `buildPiDevContext`) generates
-a workspace-shaped `soma-core` extension projection under
+Initial implementation: `projectPiDev` generates a workspace-shaped
+`soma-core` extension projection under
 `.pi/extensions/soma-core/`. It includes an extension manifest, portable
 content, tool contract, memory layout, skills, and policy projection. The tools
 are named as the adapter contract; execution is not wired yet.
 
-Home implementation: `projectPiDevHome` (currently `buildPiDevHomeContext`)
-projects into `~/.pi/agent/`: `agent/extensions/soma.ts` registers the
+Home implementation: `projectPiDevHome` projects into `~/.pi/agent/`:
+`agent/extensions/soma.ts` registers the
 `soma_context` tool, while `agent/soma/` holds the generated projection
 snapshot and `agent/skills/soma/SKILL.md` advertises the Soma skill as a Pi.dev
 skill. The extension appends Soma identity to the LLM context on
@@ -76,8 +76,8 @@ The Claude Code adapter can be the highest-fidelity implementation, but the
 core must not depend on Claude-only primitives. Hooks should improve behavior;
 they should not be required for the storage contract to function.
 
-Initial implementation: `projectClaudeCode` (currently `buildClaudeCodeContext`)
-generates a Claude-shaped projection with `CLAUDE.md` plus `.claude/soma/`
+Initial implementation: `projectClaudeCode` generates a Claude-shaped
+projection with `CLAUDE.md` plus `.claude/soma/`
 projection files. Hooks are documented as optional enhancements, not
 requirements for the portable core.
 

--- a/src/adapter-active-isa.ts
+++ b/src/adapter-active-isa.ts
@@ -25,7 +25,7 @@ export interface LoadActiveIsaOptions {
 /**
  * Resolve the active ISA from the Soma home, or null when no slug is
  * set. Used by per-substrate installers to populate `input.activeIsa`
- * before invoking the adapter's `build*HomeContext`.
+ * before invoking the adapter's `project*Home`.
  */
 export async function loadActiveIsaForBundle(
   options: LoadActiveIsaOptions = {},
@@ -78,7 +78,7 @@ export function activeIsaProjectionPath(substrate: SubstrateId): string {
 }
 
 /**
- * Convenience for adapter `build*HomeContext` functions (#37 sage r1):
+ * Convenience for adapter `project*Home` functions (#37 sage r1):
  * returns the single-entry bundle file array when `activeIsa` is set,
  * empty array otherwise. Lets adapters spread `...activeIsaBundleFile(...)`
  * instead of re-implementing the conditional and path lookup.

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -1,8 +1,8 @@
-import type { SomaAdapter, SomaContextBundle, SomaContextInput, SomaTask } from "../types";
+import type { SomaAdapter, Projection, ProjectionInput, SomaTask } from "../types";
 import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "./shared";
 import { activeIsaBundleFile } from "../adapter-active-isa";
 
-function renderInstructions(input: SomaContextInput): string {
+function renderInstructions(input: ProjectionInput): string {
   return [
     "# Soma Claude Code Context",
     "",
@@ -19,7 +19,7 @@ function renderInstructions(input: SomaContextInput): string {
   ].join("\n");
 }
 
-function renderClaudeMd(input: SomaContextInput): string {
+function renderClaudeMd(input: ProjectionInput): string {
   return [
     "# Claude Code Soma Projection",
     "",
@@ -45,7 +45,7 @@ function renderHooksPlan(): string {
   ].join("\n");
 }
 
-export function buildClaudeCodeContext(input: SomaContextInput): SomaContextBundle {
+export function projectClaudeCode(input: ProjectionInput): Projection {
   const instructions = renderInstructions(input);
 
   return {
@@ -82,7 +82,7 @@ export function buildClaudeCodeContext(input: SomaContextInput): SomaContextBund
       // Active-ISA projection (#37). OMITTED when no active ISA — AC-2.
       // Note: project bundle uses `.claude/soma/active-isa.md` (workspace
       // overlay path), not `PAI/ACTIVE_ISA.md` (the home path used by
-      // buildClaudeCodeHomeContext + activeIsaProjectionPath).
+      // projectClaudeCodeHome + activeIsaProjectionPath).
       ...(input.activeIsa
         ? [{ path: ".claude/soma/active-isa.md", content: activeIsaBundleFile("claude-code", input.activeIsa)[0].content }]
         : []),
@@ -120,7 +120,7 @@ function renderClaudeRulesReadme(): string {
   ].join("\n");
 }
 
-function renderClaudeRulesContext(input: SomaContextInput): string {
+function renderClaudeRulesContext(input: ProjectionInput): string {
   return [
     "# Soma Context (Claude Code)",
     "",
@@ -128,11 +128,11 @@ function renderClaudeRulesContext(input: SomaContextInput): string {
   ].join("\n");
 }
 
-function renderClaudeProfile(input: SomaContextInput): string {
+function renderClaudeProfile(input: ProjectionInput): string {
   return ["# Soma Profile Projection", "", renderAssistantCore(input)].join("\n");
 }
 
-function renderClaudeTelos(input: SomaContextInput): string {
+function renderClaudeTelos(input: ProjectionInput): string {
   const t = input.profile.telos;
   return [
     "# Soma Telos Projection",
@@ -184,7 +184,7 @@ export const CLAUDE_CODE_RULES_FILES = [
 
 const CLAUDE_RULES_CONTENT_BUILDERS: Record<
   Exclude<(typeof CLAUDE_CODE_RULES_FILES)[number], "rules/soma/ACTIVE_ISA.md">,
-  (input: SomaContextInput) => string
+  (input: ProjectionInput) => string
 > = {
   "rules/soma/README.md": () => renderClaudeRulesReadme(),
   "rules/soma/CONTEXT.md": (input) => renderClaudeRulesContext(input),
@@ -212,7 +212,7 @@ const CLAUDE_RULES_CONTENT_BUILDERS: Record<
  *     the CLI surface refactor in #30 split.
  *   - Active CLAUDE.md modification: dropped by the #64 pivot.
  */
-export function buildClaudeCodeHomeContext(input: SomaContextInput): SomaContextBundle {
+export function projectClaudeCodeHome(input: ProjectionInput): Projection {
   const skeleton = (Object.keys(CLAUDE_RULES_CONTENT_BUILDERS) as (keyof typeof CLAUDE_RULES_CONTENT_BUILDERS)[]).map((path) => ({
     path,
     content: CLAUDE_RULES_CONTENT_BUILDERS[path](input),
@@ -233,15 +233,15 @@ export const claudeCodeAdapter: SomaAdapter = {
   detect() {
     return Promise.resolve(Boolean(process.env.CLAUDE_CODE ?? process.env.CLAUDECODE));
   },
-  buildContext(input) {
-    return Promise.resolve(buildClaudeCodeContext(input));
+  project(input) {
+    return Promise.resolve(projectClaudeCode(input));
   },
   run(task: SomaTask) {
     return Promise.resolve({
       taskId: task.id,
       substrate: "claude-code",
       status: "failed",
-      summary: "Claude Code execution is not implemented yet; use buildContext() to generate the context projection.",
+      summary: "Claude Code execution is not implemented yet; use project() to generate the context projection.",
     });
   },
 };

--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -1,6 +1,6 @@
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import type { SomaAdapter, SomaContextBundle, SomaContextInput, SomaTask } from "../../types";
+import type { SomaAdapter, Projection, ProjectionInput, SomaTask } from "../../types";
 import { defaultSomaRepoPath } from "../../repo-path";
 import { resolveBunExecutable } from "../../bun-probe";
 import { readCodexHookAsset } from "./hooks/assets";
@@ -51,7 +51,7 @@ function renderCodexPolicy(): string {
   ]);
 }
 
-function renderInstructions(input: SomaContextInput): string {
+function renderInstructions(input: ProjectionInput): string {
   return [
     "# Soma Codex Context",
     "",
@@ -69,7 +69,7 @@ function renderInstructions(input: SomaContextInput): string {
   ].join("\n");
 }
 
-function renderHomeRules(input: SomaContextInput, somaHome: string): string {
+function renderHomeRules(input: ProjectionInput, somaHome: string): string {
   const contextLines = [
     "# Soma default availability",
     "",
@@ -97,7 +97,7 @@ function renderHomeRules(input: SomaContextInput, somaHome: string): string {
   ].join("\n");
 }
 
-function renderHomeSkill(input: SomaContextInput, somaHome: string): string {
+function renderHomeSkill(input: ProjectionInput, somaHome: string): string {
   return [
     "---",
     "name: soma",
@@ -405,7 +405,7 @@ function renderCodexHookEntry(): string {
   ]);
 }
 
-export function buildCodexContext(input: SomaContextInput): SomaContextBundle {
+export function projectCodex(input: ProjectionInput): Projection {
   const instructions = renderInstructions(input);
 
   return {
@@ -432,7 +432,7 @@ export function buildCodexContext(input: SomaContextInput): SomaContextBundle {
   };
 }
 
-export function buildCodexHomeContext(input: SomaContextInput, somaHome: string, homeDir?: string, somaRepoPath = defaultSomaRepoPath()): SomaContextBundle {
+export function projectCodexHome(input: ProjectionInput, somaHome: string, homeDir?: string, somaRepoPath = defaultSomaRepoPath()): Projection {
   const instructions = renderHomeRules(input, somaHome);
   const portableSkillFiles = input.profile.skills.flatMap((skill) =>
     (skill.files ?? []).map((file) => ({
@@ -526,15 +526,15 @@ export const codexAdapter: SomaAdapter = {
   detect() {
     return Promise.resolve(Boolean(process.env.CODEX_SANDBOX ?? process.env.CODEX_HOME));
   },
-  buildContext(input) {
-    return Promise.resolve(buildCodexContext(input));
+  project(input) {
+    return Promise.resolve(projectCodex(input));
   },
   run(task: SomaTask) {
     return Promise.resolve({
       taskId: task.id,
       substrate: "codex",
       status: "failed",
-      summary: "Codex execution is not implemented yet; use buildContext() to generate the substrate bundle.",
+      summary: "Codex execution is not implemented yet; use project() to generate the substrate bundle.",
     });
   },
 };

--- a/src/adapters/codex/hooks/soma-lifecycle.mjs
+++ b/src/adapters/codex/hooks/soma-lifecycle.mjs
@@ -6,7 +6,7 @@
 //   - shebang `bun` — every soma substrate hook runs under Bun
 //   - colocated `soma-lifecycle.config.json` holds the install-time
 //     config (somaHome, trustedSomaRepo, privateRoots, policyMarkers)
-//   - this file is shipped verbatim by `buildCodexHomeContext`; no
+//   - this file is shipped verbatim by `projectCodexHome`; no
 //     install-time string templating
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -1,2 +1,2 @@
-export { buildCodexContext, buildCodexHomeContext, codexAdapter } from "./adapter";
+export { projectCodex, projectCodexHome, codexAdapter } from "./adapter";
 export { configureCodexInstall } from "./config";

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,3 +1,3 @@
-export { buildClaudeCodeContext, buildClaudeCodeHomeContext, claudeCodeAdapter } from "./claude-code";
-export { buildCodexContext, buildCodexHomeContext, codexAdapter } from "./codex";
-export { buildPiDevContext, buildPiDevHomeContext, piDevAdapter } from "./pi-dev";
+export { projectClaudeCode, projectClaudeCodeHome, claudeCodeAdapter } from "./claude-code";
+export { projectCodex, projectCodexHome, codexAdapter } from "./codex";
+export { projectPiDev, projectPiDevHome, piDevAdapter } from "./pi-dev";

--- a/src/adapters/pi-dev/adapter.ts
+++ b/src/adapters/pi-dev/adapter.ts
@@ -1,4 +1,4 @@
-import type { SomaAdapter, SomaContextBundle, SomaContextInput, SomaTask } from "../../types";
+import type { SomaAdapter, Projection, ProjectionInput, SomaTask } from "../../types";
 import { renderFeedbackHookHelper } from "../shared/feedback-helper";
 import { renderPathGuardExtension } from "./path-guard";
 import { buildPiDevPortableSkillFiles } from "./skill-projection";
@@ -6,7 +6,7 @@ import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, render
 import { activeIsaBundleFile } from "../../adapter-active-isa";
 import { SOMA_VERSION } from "../../version";
 
-function renderInstructions(input: SomaContextInput): string {
+function renderInstructions(input: ProjectionInput): string {
   return [
     "# Soma Pi.dev Context",
     "",
@@ -382,7 +382,7 @@ function renderHomeExtension(somaHome: string): string {
   ].join("\n");
 }
 
-function renderHomeSkill(input: SomaContextInput, somaHome: string): string {
+function renderHomeSkill(input: ProjectionInput, somaHome: string): string {
   return [
     "---",
     "name: soma",
@@ -421,7 +421,7 @@ function resolvePiDevSomaHome(): string {
   return `${process.env.HOME}/.soma`;
 }
 
-export function buildPiDevContext(input: SomaContextInput): SomaContextBundle {
+export function projectPiDev(input: ProjectionInput): Projection {
   const instructions = renderInstructions(input);
   const somaHome = resolvePiDevSomaHome();
 
@@ -465,7 +465,7 @@ export function buildPiDevContext(input: SomaContextInput): SomaContextBundle {
   };
 }
 
-export function buildPiDevHomeContext(input: SomaContextInput, somaHome: string): SomaContextBundle {
+export function projectPiDevHome(input: ProjectionInput, somaHome: string): Projection {
   const instructions = renderInstructions(input);
   const portableSkillFiles = buildPiDevPortableSkillFiles(input.profile.skills);
 
@@ -529,15 +529,15 @@ export const piDevAdapter: SomaAdapter = {
   detect() {
     return Promise.resolve(Boolean(process.env.PI_DEV_HOME ?? process.env.PIDEV_HOME));
   },
-  buildContext(input) {
-    return Promise.resolve(buildPiDevContext(input));
+  project(input) {
+    return Promise.resolve(projectPiDev(input));
   },
   run(task: SomaTask) {
     return Promise.resolve({
       taskId: task.id,
       substrate: "pi-dev",
       status: "failed",
-      summary: "Pi.dev execution is not implemented yet; use buildContext() to generate the extension bundle.",
+      summary: "Pi.dev execution is not implemented yet; use project() to generate the extension bundle.",
     });
   },
 };

--- a/src/adapters/pi-dev/index.ts
+++ b/src/adapters/pi-dev/index.ts
@@ -1,1 +1,1 @@
-export { buildPiDevContext, buildPiDevHomeContext, piDevAdapter } from "./adapter";
+export { projectPiDev, projectPiDevHome, piDevAdapter } from "./adapter";

--- a/src/adapters/pi-dev/skill-projection.ts
+++ b/src/adapters/pi-dev/skill-projection.ts
@@ -1,7 +1,7 @@
 import { readdir, rm } from "node:fs/promises";
 import { resolve } from "node:path";
 import { rewriteSkillNameFrontmatter } from "../../skill-frontmatter";
-import type { SomaContextBundle, SomaSkill } from "../../types";
+import type { Projection, SomaSkill } from "../../types";
 
 export const PI_DEV_ISA_SKILL_ID = "isa";
 
@@ -18,9 +18,9 @@ export function renderPiDevSkillFileContent(skillName: string, filePath: string,
   return rewriteSkillNameFrontmatter(filePath, content, piDevSkillId(skillName));
 }
 
-export function buildPiDevPortableSkillFiles(skills: SomaSkill[]): SomaContextBundle["files"] {
+export function buildPiDevPortableSkillFiles(skills: SomaSkill[]): Projection["files"] {
   const ids = new Map<string, string>();
-  const files: SomaContextBundle["files"] = [];
+  const files: Projection["files"] = [];
 
   for (const skill of skills) {
     const id = piDevSkillId(skill.name);

--- a/src/adapters/shared/index.ts
+++ b/src/adapters/shared/index.ts
@@ -1,4 +1,4 @@
-import type { SomaContextInput } from "../../types";
+import type { ProjectionInput } from "../../types";
 import { getCriteria, getGoal } from "../../isa-accessors";
 
 export function formatList(items: string[]): string {
@@ -15,7 +15,7 @@ export function formatRecord(record: Record<string, unknown> | undefined): strin
     .join("\n");
 }
 
-export function renderActiveIsa(input: SomaContextInput): string {
+export function renderActiveIsa(input: ProjectionInput): string {
   if (!input.activeIsa) {
     return "No active ISA was provided.";
   }
@@ -37,7 +37,7 @@ export function renderActiveIsa(input: SomaContextInput): string {
   ].join("\n");
 }
 
-export function renderAssistantCore(input: SomaContextInput): string {
+export function renderAssistantCore(input: ProjectionInput): string {
   const { profile } = input;
 
   return [
@@ -74,7 +74,7 @@ export function renderAssistantCore(input: SomaContextInput): string {
     .join("\n");
 }
 
-export function renderMemoryLayout(input: SomaContextInput): string {
+export function renderMemoryLayout(input: ProjectionInput): string {
   const { memory } = input.profile;
 
   return [
@@ -89,7 +89,7 @@ export function renderMemoryLayout(input: SomaContextInput): string {
   ].join("\n");
 }
 
-export function renderSkills(input: SomaContextInput): string {
+export function renderSkills(input: ProjectionInput): string {
   const skills = input.profile.skills.map((skill) =>
     [`## ${skill.name}`, "", skill.description, "", `Path: ${skill.path}`, "", "Triggers:", formatList(skill.triggers)].join("\n"),
   );

--- a/src/home-projection.ts
+++ b/src/home-projection.ts
@@ -1,10 +1,10 @@
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { buildClaudeCodeHomeContext, buildCodexHomeContext, buildPiDevHomeContext } from "./adapters";
-import { writeContextBundle } from "./context-bundle";
+import { projectClaudeCodeHome, projectCodexHome, projectPiDevHome } from "./adapters";
+import { writeProjection } from "./projection";
 import { defaultSomaRepoPath } from "./repo-path";
 import { DEFAULT_SUBSTRATE_HOMES } from "./adapter-active-isa";
-import type { SomaContextInput, SomaHomeProjection, SomaHomeProjectionOptions, SubstrateId, WrittenContextBundle } from "./types";
+import type { ProjectionInput, SomaHomeProjection, SomaHomeProjectionOptions, SubstrateId, WrittenProjection } from "./types";
 
 export function resolveHomeProjectionPaths(
   substrate: SubstrateId,
@@ -24,40 +24,40 @@ export function resolveHomeProjectionPaths(
   };
 }
 
-export function buildCodexHomeProjection(input: SomaContextInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
+export function buildCodexHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
   const paths = resolveHomeProjectionPaths("codex", options);
   const homeDir = resolve(options.homeDir ?? homedir());
   const somaRepoPath = resolve(options.somaRepoPath ?? defaultSomaRepoPath());
 
   return {
     ...paths,
-    bundle: buildCodexHomeContext(input, paths.somaHome, homeDir, somaRepoPath),
+    bundle: projectCodexHome(input, paths.somaHome, homeDir, somaRepoPath),
   };
 }
 
 export async function installCodexHomeProjection(
-  input: SomaContextInput,
+  input: ProjectionInput,
   options: SomaHomeProjectionOptions = {},
-): Promise<WrittenContextBundle> {
+): Promise<WrittenProjection> {
   const projection = buildCodexHomeProjection(input, options);
-  return writeContextBundle(projection.bundle, projection.substrateHome);
+  return writeProjection(projection.bundle, projection.substrateHome);
 }
 
-export function buildPiDevHomeProjection(input: SomaContextInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
+export function buildPiDevHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
   const paths = resolveHomeProjectionPaths("pi-dev", options);
 
   return {
     ...paths,
-    bundle: buildPiDevHomeContext(input, paths.somaHome),
+    bundle: projectPiDevHome(input, paths.somaHome),
   };
 }
 
 export async function installPiDevHomeProjection(
-  input: SomaContextInput,
+  input: ProjectionInput,
   options: SomaHomeProjectionOptions = {},
-): Promise<WrittenContextBundle> {
+): Promise<WrittenProjection> {
   const projection = buildPiDevHomeProjection(input, options);
-  return writeContextBundle(projection.bundle, projection.substrateHome);
+  return writeProjection(projection.bundle, projection.substrateHome);
 }
 
 /**
@@ -66,21 +66,21 @@ export async function installPiDevHomeProjection(
  * install lands in #29 with the `.claude/rules/` pivot.
  */
 export function buildClaudeCodeHomeProjection(
-  input: SomaContextInput,
+  input: ProjectionInput,
   options: SomaHomeProjectionOptions = {},
 ): SomaHomeProjection {
   const paths = resolveHomeProjectionPaths("claude-code", options);
 
   return {
     ...paths,
-    bundle: buildClaudeCodeHomeContext(input),
+    bundle: projectClaudeCodeHome(input),
   };
 }
 
 export async function installClaudeCodeHomeProjection(
-  input: SomaContextInput,
+  input: ProjectionInput,
   options: SomaHomeProjectionOptions = {},
-): Promise<WrittenContextBundle> {
+): Promise<WrittenProjection> {
   const projection = buildClaudeCodeHomeProjection(input, options);
-  return writeContextBundle(projection.bundle, projection.substrateHome);
+  return writeProjection(projection.bundle, projection.substrateHome);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,8 @@ export type {
   SomaSkillBaseline,
   SomaSkillBaselines,
   SomaAdapter,
-  SomaContextBundle,
-  SomaContextInput,
+  Projection,
+  ProjectionInput,
   SomaMemoryLayout,
   SomaProfile,
   SomaRunResult,
@@ -84,7 +84,7 @@ export type {
   PaiPackNormalizationReport,
   PaiPackNormalizationWarning,
   SomaSkillManifest,
-  WrittenContextBundle,
+  WrittenProjection,
 } from "./types";
 
 export {
@@ -144,17 +144,17 @@ export {
   type WrittenAlgorithmRun,
 } from "./algorithm-store";
 export {
-  buildClaudeCodeContext,
-  buildClaudeCodeHomeContext,
-  buildCodexContext,
-  buildCodexHomeContext,
-  buildPiDevContext,
-  buildPiDevHomeContext,
+  projectClaudeCode,
+  projectClaudeCodeHome,
+  projectCodex,
+  projectCodexHome,
+  projectPiDev,
+  projectPiDevHome,
   claudeCodeAdapter,
   codexAdapter,
   piDevAdapter,
 } from "./adapters";
-export { writeContextBundle } from "./context-bundle";
+export { writeProjection } from "./projection";
 export {
   buildClaudeCodeHomeProjection,
   buildCodexHomeProjection,

--- a/src/install.ts
+++ b/src/install.ts
@@ -13,7 +13,7 @@ import { defaultSomaRepoPath } from "./repo-path";
 import { bootstrapSomaHome } from "./soma-home";
 import { installIsaSkill, installIsaSkillProjection } from "./isa-skill-installer";
 import { DEFAULT_SUBSTRATE_HOMES, loadActiveIsaForBundle } from "./adapter-active-isa";
-import type { SomaContextInput, SomaInstallOptions, SomaInstallPlan, SomaInstallResult } from "./types";
+import type { ProjectionInput, SomaInstallOptions, SomaInstallPlan, SomaInstallResult } from "./types";
 
 const SOMA_BOOTSTRAP_FILES = [
   "profile/assistant.md",
@@ -192,7 +192,7 @@ async function installSomaForSubstrate(
   });
   // Populate the projection input with the active ISA so each
   // substrate writes its `active-isa.md` file (#37 AC-1/AC-2).
-  const contextWithActiveIsa: SomaContextInput = {
+  const contextWithActiveIsa: ProjectionInput = {
     ...somaHome.context,
     activeIsa: (await loadActiveIsaForBundle({ somaHome: somaHome.somaHome })) ?? undefined,
   };
@@ -221,7 +221,7 @@ async function installSomaForSubstrate(
 
 async function installHomeProjectionFor(
   substrate: InstallSubstrate,
-  context: SomaContextInput,
+  context: ProjectionInput,
   options: { homeDir?: string; somaHome?: string; substrateHome?: string; somaRepoPath: string },
 ) {
   switch (substrate) {

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -1,6 +1,6 @@
 import { chmod, mkdir, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, resolve, sep } from "node:path";
-import type { SomaContextBundle, WrittenContextBundle } from "./types";
+import type { Projection, WrittenProjection } from "./types";
 
 function assertSafeBundlePath(rootDir: string, bundlePath: string): string {
   if (bundlePath.length === 0) {
@@ -22,7 +22,7 @@ function assertSafeBundlePath(rootDir: string, bundlePath: string): string {
   return target;
 }
 
-export async function writeContextBundle(bundle: SomaContextBundle, rootDir: string): Promise<WrittenContextBundle> {
+export async function writeProjection(bundle: Projection, rootDir: string): Promise<WrittenProjection> {
   const writtenFiles: string[] = [];
 
   for (const file of bundle.files) {

--- a/src/soma-home.ts
+++ b/src/soma-home.ts
@@ -1,7 +1,7 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, relative, resolve, sep } from "node:path";
-import type { SomaContextInput, SomaHomeBootstrapOptions, SomaHomeBootstrapResult, SomaSkill } from "./types";
+import type { ProjectionInput, SomaHomeBootstrapOptions, SomaHomeBootstrapResult, SomaSkill } from "./types";
 
 const MEMORY_DIRS = ["WORK", "KNOWLEDGE", "LEARNING", "RELATIONSHIP", "STATE"] as const;
 
@@ -173,7 +173,7 @@ async function loadSomaSkills(somaHome: string): Promise<SomaSkill[]> {
   return skills.sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export async function loadSomaHome(somaHome: string): Promise<SomaContextInput> {
+export async function loadSomaHome(somaHome: string): Promise<ProjectionInput> {
   const assistant = await readFile(join(somaHome, "profile/assistant.md"), "utf8");
   const principal = await readFile(join(somaHome, "profile/principal.md"), "utf8");
   const telos = await readFile(join(somaHome, "profile/telos.md"), "utf8");

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,13 +214,13 @@ export interface SomaProfile {
   skills: SomaSkill[];
 }
 
-export interface SomaContextInput {
+export interface ProjectionInput {
   profile: SomaProfile;
   activeIsa?: IdealStateArtifact;
   prompt?: string;
 }
 
-export interface SomaContextBundle {
+export interface Projection {
   substrate: SubstrateId;
   instructions: string;
   files: {
@@ -236,7 +236,7 @@ export interface SomaContextBundle {
   }[];
 }
 
-export interface WrittenContextBundle {
+export interface WrittenProjection {
   substrate: SubstrateId;
   rootDir: string;
   files: string[];
@@ -253,7 +253,7 @@ export interface SomaHomeProjection {
   substrate: SubstrateId;
   somaHome: string;
   substrateHome: string;
-  bundle: SomaContextBundle;
+  bundle: Projection;
 }
 
 export interface SomaHomeBootstrapOptions {
@@ -263,7 +263,7 @@ export interface SomaHomeBootstrapOptions {
 
 export interface SomaHomeBootstrapResult {
   somaHome: string;
-  context: SomaContextInput;
+  context: ProjectionInput;
   files: string[];
 }
 
@@ -277,7 +277,7 @@ export interface SomaInstallOptions {
 export interface SomaInstallResult {
   substrate: SubstrateId;
   somaHome: SomaHomeBootstrapResult;
-  substrateHome: WrittenContextBundle;
+  substrateHome: WrittenProjection;
 }
 
 export interface SomaInstallPlan {
@@ -719,6 +719,6 @@ export interface SomaRunResult {
 export interface SomaAdapter {
   name: SubstrateId;
   detect(): Promise<boolean>;
-  buildContext(input: SomaContextInput): Promise<SomaContextBundle>;
+  project(input: ProjectionInput): Promise<Projection>;
   run(task: SomaTask): Promise<SomaRunResult>;
 }

--- a/test/adapter-active-isa.test.ts
+++ b/test/adapter-active-isa.test.ts
@@ -5,10 +5,10 @@ import { expect, test } from "bun:test";
 import {
   activeIsaProjectionPath,
   bootstrapSomaHome,
-  buildClaudeCodeContext,
-  buildClaudeCodeHomeContext,
-  buildCodexHomeContext,
-  buildPiDevHomeContext,
+  projectClaudeCode,
+  projectClaudeCodeHome,
+  projectCodexHome,
+  projectPiDevHome,
   installClaudeCodeHomeProjection,
   installCodexHomeProjection,
   installPiDevHomeProjection,
@@ -20,7 +20,7 @@ import {
   scaffoldIsa,
   setActiveIsa,
 } from "../src/index";
-import { portableContextInput } from "./fixtures";
+import { portableProjectionInput } from "./fixtures";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-37-"));
@@ -40,9 +40,9 @@ test("activeIsaProjectionPath: per-substrate paths match the #37 spec", () => {
 });
 
 test("AC-1: codex/pi-dev/claude home builders all include active-isa when set", () => {
-  const codex = buildCodexHomeContext(portableContextInput, "/tmp/soma");
-  const piDev = buildPiDevHomeContext(portableContextInput, "/tmp/soma");
-  const claude = buildClaudeCodeHomeContext(portableContextInput);
+  const codex = projectCodexHome(portableProjectionInput, "/tmp/soma");
+  const piDev = projectPiDevHome(portableProjectionInput, "/tmp/soma");
+  const claude = projectClaudeCodeHome(portableProjectionInput);
   const codexPaths = codex.files.map((f) => f.path);
   const piPaths = piDev.files.map((f) => f.path);
   const claudePaths = claude.files.map((f) => f.path);
@@ -52,17 +52,17 @@ test("AC-1: codex/pi-dev/claude home builders all include active-isa when set", 
 });
 
 test("AC-1: project bundle for claude-code includes active-isa when set", () => {
-  const bundle = buildClaudeCodeContext(portableContextInput);
+  const bundle = projectClaudeCode(portableProjectionInput);
   const paths = bundle.files.map((f) => f.path);
   expect(paths).toContain(".claude/soma/active-isa.md");
 });
 
 test("AC-2: omits active-isa when no active ISA — no empty file, no stale content", () => {
-  const inputWithoutIsa = { ...portableContextInput, activeIsa: undefined };
-  const codex = buildCodexHomeContext(inputWithoutIsa, "/tmp/soma");
-  const piDev = buildPiDevHomeContext(inputWithoutIsa, "/tmp/soma");
-  const claude = buildClaudeCodeHomeContext(inputWithoutIsa);
-  const claudeProject = buildClaudeCodeContext(inputWithoutIsa);
+  const inputWithoutIsa = { ...portableProjectionInput, activeIsa: undefined };
+  const codex = projectCodexHome(inputWithoutIsa, "/tmp/soma");
+  const piDev = projectPiDevHome(inputWithoutIsa, "/tmp/soma");
+  const claude = projectClaudeCodeHome(inputWithoutIsa);
+  const claudeProject = projectClaudeCode(inputWithoutIsa);
   expect(codex.files.map((f) => f.path)).not.toContain("memories/soma/active-isa.md");
   expect(piDev.files.map((f) => f.path)).not.toContain("agent/soma/active-isa.md");
   // Per #29 the claude home bundle now always contains the rules/soma/*
@@ -182,7 +182,7 @@ test("AC-5: skill installer baselines track each substrate independently", async
 test("claude-code home install writes rules/soma skeleton even without active ISA (#29)", async () => {
   await withTempHome(async (homeDir) => {
     const result = await installClaudeCodeHomeProjection(
-      { ...portableContextInput, activeIsa: undefined },
+      { ...portableProjectionInput, activeIsa: undefined },
       { homeDir },
     );
     // Skeleton files are always written; ACTIVE_ISA only when set.
@@ -194,8 +194,8 @@ test("claude-code home install writes rules/soma skeleton even without active IS
 
 test("codex/pi-dev installs without active ISA still succeed (active-isa omitted)", async () => {
   await withTempHome(async (homeDir) => {
-    const codex = await installCodexHomeProjection({ ...portableContextInput, activeIsa: undefined }, { homeDir });
-    const piDev = await installPiDevHomeProjection({ ...portableContextInput, activeIsa: undefined }, { homeDir });
+    const codex = await installCodexHomeProjection({ ...portableProjectionInput, activeIsa: undefined }, { homeDir });
+    const piDev = await installPiDevHomeProjection({ ...portableProjectionInput, activeIsa: undefined }, { homeDir });
     expect(codex.files.some((p) => p.endsWith("active-isa.md"))).toBe(false);
     expect(piDev.files.some((p) => p.endsWith("active-isa.md"))).toBe(false);
   });

--- a/test/claude-code-install.test.ts
+++ b/test/claude-code-install.test.ts
@@ -10,14 +10,14 @@ import { join } from "node:path";
 import { expect, test } from "bun:test";
 import {
   bootstrapSomaHome,
-  buildClaudeCodeHomeContext,
+  projectClaudeCodeHome,
   installSomaForClaudeCode,
   planSomaForClaudeCodeInstall,
   scaffoldIsa,
   setActiveIsa,
   uninstallSomaForClaudeCode,
 } from "../src/index";
-import { portableContextInput } from "./fixtures";
+import { portableProjectionInput } from "./fixtures";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-29-"));
@@ -28,8 +28,8 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
   }
 }
 
-test("AC-1: buildClaudeCodeHomeContext writes everything under rules/soma/", () => {
-  const bundle = buildClaudeCodeHomeContext(portableContextInput);
+test("AC-1: projectClaudeCodeHome writes everything under rules/soma/", () => {
+  const bundle = projectClaudeCodeHome(portableProjectionInput);
   for (const f of bundle.files) {
     expect(f.path.startsWith("rules/soma/")).toBe(true);
   }
@@ -162,7 +162,7 @@ test("active-ISA file is omitted from skeleton when no active ISA set", async ()
 });
 
 test("README documents the directory contract for humans", () => {
-  const bundle = buildClaudeCodeHomeContext(portableContextInput);
+  const bundle = projectClaudeCodeHome(portableProjectionInput);
   const readme = bundle.files.find((f) => f.path === "rules/soma/README.md");
   expect(readme).toBeDefined();
   expect(readme!.content).toContain("Soma");

--- a/test/codex-adapter.test.ts
+++ b/test/codex-adapter.test.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "bun:test";
-import { buildCodexContext, codexAdapter } from "../src/index";
-import { portableContextInput } from "./fixtures";
+import { projectCodex, codexAdapter } from "../src/index";
+import { portableProjectionInput } from "./fixtures";
 
 test("codex adapter builds a portable context bundle", () => {
-  const bundle = buildCodexContext(portableContextInput);
+  const bundle = projectCodex(portableProjectionInput);
 
   expect(bundle.substrate).toBe("codex");
   expect(bundle.instructions).toContain("Soma Codex Context");
@@ -18,7 +18,7 @@ test("codex adapter builds a portable context bundle", () => {
 });
 
 test("codex adapter exposes context build before execution", async () => {
-  await expect(codexAdapter.buildContext(portableContextInput)).resolves.toMatchObject({
+  await expect(codexAdapter.project(portableProjectionInput)).resolves.toMatchObject({
     substrate: "codex",
   });
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,7 +1,7 @@
-import type { SomaContextInput } from "../src/index";
+import type { ProjectionInput } from "../src/index";
 import { SECTION_NAME_MAP, renderCriteriaMarkdown } from "../src/isa-accessors";
 
-export const portableContextInput: SomaContextInput = {
+export const portableProjectionInput: ProjectionInput = {
   profile: {
     assistant: {
       name: "soma",

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -9,7 +9,7 @@ import {
   installPiDevHomeProjection,
   resolveHomeProjectionPaths,
 } from "../src/index";
-import { portableContextInput } from "./fixtures";
+import { portableProjectionInput } from "./fixtures";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-home-"));
@@ -50,7 +50,7 @@ test("rejects unimplemented home projection substrates", () => {
 });
 
 test("builds codex home projection bundle for default availability", () => {
-  const projection = buildCodexHomeProjection(portableContextInput, { homeDir: "/tmp/soma-test-home" });
+  const projection = buildCodexHomeProjection(portableProjectionInput, { homeDir: "/tmp/soma-test-home" });
 
   expect(projection.substrateHome).toBe("/tmp/soma-test-home/.codex");
   expect(projection.somaHome).toBe("/tmp/soma-test-home/.soma");
@@ -104,7 +104,7 @@ test("builds codex home projection bundle for default availability", () => {
 
 test("soma#73 sage r2: installed lifecycle hook is executable (0o755)", async () => {
   await withTempHome(async (homeDir) => {
-    await installCodexHomeProjection(portableContextInput, { homeDir });
+    await installCodexHomeProjection(portableProjectionInput, { homeDir });
     const { stat } = await import("node:fs/promises");
     const info = await stat(join(homeDir, ".codex/hooks/soma-lifecycle.mjs"));
     // Owner-execute bit (0o100) must be set so Codex can run the
@@ -117,7 +117,7 @@ test("soma#73 sage r2: installed lifecycle hook is executable (0o755)", async ()
 });
 
 test("soma#73: codex lifecycle hook ships verbatim with bun shebang + colocated config", () => {
-  const projection = buildCodexHomeProjection(portableContextInput, { homeDir: "/tmp/soma-test-home" });
+  const projection = buildCodexHomeProjection(portableProjectionInput, { homeDir: "/tmp/soma-test-home" });
   const hook = projection.bundle.files.find((f) => f.path === "hooks/soma-lifecycle.mjs");
   const config = projection.bundle.files.find((f) => f.path === "hooks/soma-lifecycle.config.json");
   expect(hook).toBeDefined();
@@ -137,7 +137,7 @@ test("soma#73: codex lifecycle hook ships verbatim with bun shebang + colocated 
 });
 
 test("builds pi.dev home projection bundle for default availability", () => {
-  const projection = buildPiDevHomeProjection(portableContextInput, { homeDir: "/tmp/soma-test-home" });
+  const projection = buildPiDevHomeProjection(portableProjectionInput, { homeDir: "/tmp/soma-test-home" });
 
   expect(projection.substrateHome).toBe("/tmp/soma-test-home/.pi");
   expect(projection.somaHome).toBe("/tmp/soma-test-home/.soma");
@@ -171,9 +171,9 @@ test("builds pi.dev home projection bundle for default availability", () => {
 test("pi.dev home projection normalizes portable skill paths and frontmatter names", () => {
   const projection = buildPiDevHomeProjection(
     {
-      ...portableContextInput,
+      ...portableProjectionInput,
       profile: {
-        ...portableContextInput.profile,
+        ...portableProjectionInput.profile,
         skills: [
           {
             name: "ISA",
@@ -233,9 +233,9 @@ test("pi.dev home projection rejects normalized portable skill id collisions", (
   expect(() =>
     buildPiDevHomeProjection(
       {
-        ...portableContextInput,
+        ...portableProjectionInput,
         profile: {
-          ...portableContextInput.profile,
+          ...portableProjectionInput.profile,
           skills: [
             {
               name: "Ledger Update",
@@ -262,7 +262,7 @@ test("pi.dev home projection rejects normalized portable skill id collisions", (
 
 test("installs codex home projection into a substrate home", async () => {
   await withTempHome(async (homeDir) => {
-    const result = await installCodexHomeProjection(portableContextInput, { homeDir });
+    const result = await installCodexHomeProjection(portableProjectionInput, { homeDir });
 
     expect(result.substrate).toBe("codex");
     expect(result.rootDir).toBe(join(homeDir, ".codex"));
@@ -321,11 +321,11 @@ test("codex algorithm contract wins over imported portable skill body", async ()
   await withTempHome(async (homeDir) => {
     await installCodexHomeProjection(
       {
-        ...portableContextInput,
+        ...portableProjectionInput,
         profile: {
-          ...portableContextInput.profile,
+          ...portableProjectionInput.profile,
           skills: [
-            ...portableContextInput.profile.skills,
+            ...portableProjectionInput.profile.skills,
             {
               name: "the-algorithm",
               path: "skills/the-algorithm",
@@ -362,7 +362,7 @@ test("codex algorithm contract wins over imported portable skill body", async ()
 
 test("installs pi.dev home projection into a substrate home", async () => {
   await withTempHome(async (homeDir) => {
-    const result = await installPiDevHomeProjection(portableContextInput, { homeDir });
+    const result = await installPiDevHomeProjection(portableProjectionInput, { homeDir });
 
     expect(result.substrate).toBe("pi-dev");
     expect(result.rootDir).toBe(join(homeDir, ".pi"));

--- a/test/projection.test.ts
+++ b/test/projection.test.ts
@@ -3,13 +3,13 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import {
-  buildClaudeCodeContext,
-  buildCodexContext,
-  buildPiDevContext,
-  type SomaContextBundle,
-  writeContextBundle,
+  projectClaudeCode,
+  projectCodex,
+  projectPiDev,
+  type Projection,
+  writeProjection,
 } from "../src/index";
-import { portableContextInput } from "./fixtures";
+import { portableProjectionInput } from "./fixtures";
 
 async function withTempDir<T>(fn: (rootDir: string) => Promise<T>): Promise<T> {
   const rootDir = await mkdtemp(join(tmpdir(), "soma-context-"));
@@ -23,8 +23,8 @@ async function withTempDir<T>(fn: (rootDir: string) => Promise<T>): Promise<T> {
 
 test("writes a codex context bundle to disk", async () => {
   await withTempDir(async (rootDir) => {
-    const bundle = buildCodexContext(portableContextInput);
-    const result = await writeContextBundle(bundle, rootDir);
+    const bundle = projectCodex(portableProjectionInput);
+    const result = await writeProjection(bundle, rootDir);
 
     expect(result.substrate).toBe("codex");
     expect(result.rootDir).toBe(rootDir);
@@ -38,8 +38,8 @@ test("writes a codex context bundle to disk", async () => {
 
 test("writes pi.dev and claude code bundles to substrate-shaped paths", async () => {
   await withTempDir(async (rootDir) => {
-    const piResult = await writeContextBundle(buildPiDevContext(portableContextInput), rootDir);
-    const claudeResult = await writeContextBundle(buildClaudeCodeContext(portableContextInput), rootDir);
+    const piResult = await writeProjection(projectPiDev(portableProjectionInput), rootDir);
+    const claudeResult = await writeProjection(projectClaudeCode(portableProjectionInput), rootDir);
 
     expect(piResult.files.some((file) => file.endsWith(".pi/extensions/soma-core/extension.json"))).toBe(true);
     expect(claudeResult.files.some((file) => file.endsWith("CLAUDE.md"))).toBe(true);
@@ -54,7 +54,7 @@ test("writes pi.dev and claude code bundles to substrate-shaped paths", async ()
 
 test("rejects context bundle paths that escape the root", async () => {
   await withTempDir(async (rootDir) => {
-    const bundle: SomaContextBundle = {
+    const bundle: Projection = {
       substrate: "custom",
       instructions: "",
       files: [
@@ -65,13 +65,13 @@ test("rejects context bundle paths that escape the root", async () => {
       ],
     };
 
-    await expect(writeContextBundle(bundle, rootDir)).rejects.toThrow("escapes root");
+    await expect(writeProjection(bundle, rootDir)).rejects.toThrow("escapes root");
   });
 });
 
 test("rejects absolute context bundle paths", async () => {
   await withTempDir(async (rootDir) => {
-    const bundle: SomaContextBundle = {
+    const bundle: Projection = {
       substrate: "custom",
       instructions: "",
       files: [
@@ -82,6 +82,6 @@ test("rejects absolute context bundle paths", async () => {
       ],
     };
 
-    await expect(writeContextBundle(bundle, rootDir)).rejects.toThrow("must be relative");
+    await expect(writeProjection(bundle, rootDir)).rejects.toThrow("must be relative");
   });
 });

--- a/test/soma-home.test.ts
+++ b/test/soma-home.test.ts
@@ -120,7 +120,7 @@ test("AC-3: SomaActiveIsaState type exported with correct shape", () => {
   expect(sample.updatedAt).toContain("2026");
 });
 
-test("AC-5: SomaContextInput.activeIsa unchanged shape after bootstrap", async () => {
+test("AC-5: ProjectionInput.activeIsa unchanged shape after bootstrap", async () => {
   await withTempHome(async (homeDir) => {
     const { context } = await bootstrapSomaHome({ homeDir });
     // No activeIsa expected on fresh bootstrap — bootstrap doesn't seed one

--- a/test/substrate-adapters.test.ts
+++ b/test/substrate-adapters.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from "bun:test";
 import {
-  buildClaudeCodeContext,
-  buildCodexContext,
-  buildPiDevContext,
+  projectClaudeCode,
+  projectCodex,
+  projectPiDev,
   claudeCodeAdapter,
   piDevAdapter,
-  type SomaContextBundle,
+  type Projection,
 } from "../src/index";
-import { portableContextInput } from "./fixtures";
+import { portableProjectionInput } from "./fixtures";
 
-function expectPortableSemantics(bundle: SomaContextBundle) {
+function expectPortableSemantics(bundle: Projection) {
   expect(bundle.instructions).toContain("Soma");
   expect(bundle.instructions).toContain("Keep personal assistant context portable across substrates.");
   expect(bundle.instructions).toContain("Substrate adapters translate; they do not own core concepts");
@@ -20,7 +20,7 @@ function expectPortableSemantics(bundle: SomaContextBundle) {
 }
 
 test("pi.dev adapter builds an extension-shaped context bundle", () => {
-  const bundle = buildPiDevContext(portableContextInput);
+  const bundle = projectPiDev(portableProjectionInput);
 
   expect(bundle.substrate).toBe("pi-dev");
   expect(bundle.files.map((file) => file.path)).toContain(".pi/extensions/soma-core/extension.json");
@@ -36,7 +36,7 @@ test("pi.dev adapter requires HOME when SOMA_HOME is unset", () => {
   try {
     delete process.env.HOME;
     delete process.env.SOMA_HOME;
-    expect(() => buildPiDevContext(portableContextInput)).toThrow("HOME must be set");
+    expect(() => projectPiDev(portableProjectionInput)).toThrow("HOME must be set");
   } finally {
     if (originalHome === undefined) delete process.env.HOME;
     else process.env.HOME = originalHome;
@@ -46,7 +46,7 @@ test("pi.dev adapter requires HOME when SOMA_HOME is unset", () => {
 });
 
 test("claude code adapter builds a claude-shaped context bundle", () => {
-  const bundle = buildClaudeCodeContext(portableContextInput);
+  const bundle = projectClaudeCode(portableProjectionInput);
 
   expect(bundle.substrate).toBe("claude-code");
   expect(bundle.files.map((file) => file.path)).toContain("CLAUDE.md");
@@ -57,9 +57,9 @@ test("claude code adapter builds a claude-shaped context bundle", () => {
 
 test("codex, pi.dev, and claude code preserve portable semantics from one input", () => {
   const bundles = [
-    buildCodexContext(portableContextInput),
-    buildPiDevContext(portableContextInput),
-    buildClaudeCodeContext(portableContextInput),
+    projectCodex(portableProjectionInput),
+    projectPiDev(portableProjectionInput),
+    projectClaudeCode(portableProjectionInput),
   ];
 
   for (const bundle of bundles) {
@@ -68,11 +68,11 @@ test("codex, pi.dev, and claude code preserve portable semantics from one input"
 });
 
 test("pi.dev and claude code adapters expose context build before execution", async () => {
-  await expect(piDevAdapter.buildContext(portableContextInput)).resolves.toMatchObject({
+  await expect(piDevAdapter.project(portableProjectionInput)).resolves.toMatchObject({
     substrate: "pi-dev",
   });
 
-  await expect(claudeCodeAdapter.buildContext(portableContextInput)).resolves.toMatchObject({
+  await expect(claudeCodeAdapter.project(portableProjectionInput)).resolves.toMatchObject({
     substrate: "claude-code",
   });
 

--- a/test/types.test.ts
+++ b/test/types.test.ts
@@ -24,7 +24,7 @@ test("adapter contract is structurally usable", async () => {
     async detect() {
       return true;
     },
-    async buildContext() {
+    async project() {
       return { substrate: "custom", instructions: "", files: [] };
     },
     async run(task) {


### PR DESCRIPTION
## Summary

CONTEXT.md Q8 reserves `context` for the LLM context window only. The on-disk artifact an adapter writes into a substrate is a `Projection`, produced by `project()`. This PR applies the rename across types, functions, file names, and prose.

## Rename map

| Old | New |
|---|---|
| `SomaContextBundle` | `Projection` |
| `SomaContextInput` | `ProjectionInput` |
| `WrittenContextBundle` | `WrittenProjection` |
| `buildContext` (SomaAdapter method) | `project` |
| `buildCodexContext` / `buildCodexHomeContext` | `projectCodex` / `projectCodexHome` |
| `buildClaudeCodeContext` / `buildClaudeCodeHomeContext` | `projectClaudeCode` / `projectClaudeCodeHome` |
| `buildPiDevContext` / `buildPiDevHomeContext` | `projectPiDev` / `projectPiDevHome` |
| `writeContextBundle` | `writeProjection` |
| `src/context-bundle.ts` | `src/projection.ts` |
| `test/context-bundle.test.ts` | `test/projection.test.ts` |
| `portableContextInput` (test fixture) | `portableProjectionInput` |

## Kept as-is

- `SomaStartupContext` / `buildSomaStartupContext`: this IS the LLM context window passed at session start. Glossary-legal.
- `SomaHomeProjection.bundle` field name and local `bundle` variables: not banned by the glossary; cleanup left for a follow-up if the inconsistency proves painful in practice.
- No public CLI surface exposed `build-context`, so the alias acceptance criterion is trivially satisfied.

## Docs

- Dropped the "rename tracked in #52" notes from `docs/architecture.md` and `docs/substrate-adapters.md`.
- `AGENTS.md`: `SomaContextBundle` → `Projection`; "context bundle" → "projection".
- `README.md`: "auto-discover Soma context" → "auto-discover the Soma projection" (referred to the on-disk artifact).

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun test` — 443/443 pass across 31 files
- [x] grep audit: no `SomaContextBundle` / `SomaContextInput` / `WrittenContextBundle` / `buildContext` / `build*Context` / `writeContextBundle` / `portableContextInput` remain anywhere
- [x] grep audit: no "context bundle" / "Soma context" prose remaining outside legit LLM-context-window references

Closes #52