### PR TITLE
feat(cli): align surface with CONTEXT.md runtime modes + lifecycle verbs (#54)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -335,11 +335,11 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
     },
   },
   uninstall: {
-    usage: "Usage: soma uninstall <codex|pi-dev|claude-code> [--workspace] [--home-dir <dir>] [--substrate-home <dir>]",
+    usage: "Usage: soma uninstall <codex|pi-dev|claude-code> [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
     subcommands: {
-      codex: "Usage: soma uninstall codex [--workspace] [--home-dir <dir>] [--substrate-home <dir>]",
-      "pi-dev": "Usage: soma uninstall pi-dev [--workspace] [--home-dir <dir>] [--substrate-home <dir>]",
-      "claude-code": "Usage: soma uninstall claude-code [--workspace] [--home-dir <dir>] [--substrate-home <dir>]",
+      codex: "Usage: soma uninstall codex [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+      "pi-dev": "Usage: soma uninstall pi-dev [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+      "claude-code": "Usage: soma uninstall claude-code [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
     },
   },
   reproject: {
@@ -412,15 +412,16 @@ function resolveJoin(...parts: string[]): string {
   return parts.join("/").replace(/\/+/g, "/");
 }
 
-function parseInstallArgs(args: string[]): ParsedInstallArgs {
-  const [command, substrate, ...rest] = args;
-
-  if (command !== "install" || !isInstallSubstrate(substrate)) {
-    throw new Error(commandUsage("install"));
-  }
-
+// Shared option parser used by install/uninstall/reproject/upgrade.
+// All four verbs accept the same workspace + path triplet; this
+// keeps the workspace-default fallback in one place (Sage r1
+// maintainability finding on #54).
+function parseSubstrateLifecycleOptions(
+  substrate: InstallSubstrate,
+  rest: string[],
+  extra: (arg: string, index: number) => boolean,
+): { workspace: boolean; options: SomaInstallOptions } {
   const options: SomaInstallOptions = {};
-  let apply = false;
   let workspace = false;
   let substrateHomeExplicit = false;
 
@@ -428,44 +429,61 @@ function parseInstallArgs(args: string[]): ParsedInstallArgs {
     const arg = rest[index];
 
     switch (arg) {
-      case "--dry-run":
-        apply = false;
-        break;
-      case "--apply":
-        apply = true;
-        break;
       case "--workspace":
         workspace = true;
-        break;
+        continue;
       case "--home-dir":
         options.homeDir = readOption(rest, index, arg);
         index += 1;
-        break;
+        continue;
       case "--soma-home":
         options.somaHome = readOption(rest, index, arg);
         index += 1;
-        break;
+        continue;
       case "--substrate-home":
         options.substrateHome = readOption(rest, index, arg);
         substrateHomeExplicit = true;
         index += 1;
-        break;
-      default:
-        throw new Error(`Unknown option: ${arg}`);
+        continue;
     }
+
+    if (extra(arg, index)) continue;
+
+    throw new Error(`Unknown option: ${arg}`);
   }
 
   if (workspace && !substrateHomeExplicit) {
     options.substrateHome = workspaceSubstrateHome(substrate);
   }
 
-  return {
-    command,
-    substrate,
-    apply,
-    workspace,
-    options,
-  };
+  return { workspace, options };
+}
+
+function parseInstallArgs(args: string[]): ParsedInstallArgs {
+  const [command, substrate, ...rest] = args;
+
+  if (command !== "install" || !isInstallSubstrate(substrate)) {
+    throw new Error(commandUsage("install"));
+  }
+
+  let apply = false;
+  // The install verb layers --dry-run / --apply on top of the
+  // shared substrate-lifecycle option set. The `extra` callback
+  // hands those two flags to the shared parser so it can recognize
+  // them without claiming the other options.
+  const { workspace, options } = parseSubstrateLifecycleOptions(substrate, rest, (arg) => {
+    switch (arg) {
+      case "--dry-run":
+        apply = false;
+        return true;
+      case "--apply":
+        apply = true;
+        return true;
+    }
+    return false;
+  });
+
+  return { command, substrate, apply, workspace, options };
 }
 
 function parseLifecycleVerbArgs<T extends "uninstall" | "reproject" | "upgrade">(
@@ -478,39 +496,7 @@ function parseLifecycleVerbArgs<T extends "uninstall" | "reproject" | "upgrade">
     throw new Error(commandUsage(verb));
   }
 
-  const options: SomaInstallOptions = {};
-  let workspace = false;
-  let substrateHomeExplicit = false;
-
-  for (let index = 0; index < rest.length; index += 1) {
-    const arg = rest[index];
-
-    switch (arg) {
-      case "--workspace":
-        workspace = true;
-        break;
-      case "--home-dir":
-        options.homeDir = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--soma-home":
-        options.somaHome = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--substrate-home":
-        options.substrateHome = readOption(rest, index, arg);
-        substrateHomeExplicit = true;
-        index += 1;
-        break;
-      default:
-        throw new Error(`Unknown option: ${arg}`);
-    }
-  }
-
-  if (workspace && !substrateHomeExplicit) {
-    options.substrateHome = workspaceSubstrateHome(substrate);
-  }
-
+  const { workspace, options } = parseSubstrateLifecycleOptions(substrate, rest, () => false);
   return { substrate, workspace, options };
 }
 
@@ -2332,11 +2318,15 @@ async function runExport(parsed: ParsedExportArgs): Promise<{ files: { path: str
     return { files: projection };
   }
   const outRoot = resolveAbsolute(parsed.out);
-  const written: { path: string; content: string }[] = [];
-  for (const file of projection) {
-    const absolute = await writeProjectionExportFile(outRoot, file.path, file.content);
-    written.push({ path: absolute, content: file.content });
-  }
+  // Parallel writes — independent files, order preserved by mapping
+  // over the original projection array (sage r1 performance finding
+  // on #54).
+  const written = await Promise.all(
+    projection.map(async (file) => {
+      const absolute = await writeProjectionExportFile(outRoot, file.path, file.content);
+      return { path: absolute, content: file.content };
+    }),
+  );
   return { files: written, out: outRoot };
 }
 
@@ -2376,17 +2366,34 @@ function resolveAbsolute(path: string): string {
 }
 
 async function writeProjectionExportFile(outRoot: string, relativePath: string, content: string): Promise<string> {
-  const { mkdir, writeFile } = await import("node:fs/promises");
+  const { mkdir, realpath, writeFile } = await import("node:fs/promises");
   const path = await import("node:path");
-  // Guard against absolute paths or path-escape in the projection
-  // file list — projections are produced by trusted adapter code but
-  // the export verb is principal-facing so we belt-and-brace.
+  // Lexical guard: reject paths that try to escape --out via
+  // absolute paths or `..` segments before we touch the disk.
   const safeRelative = relativePath.replace(/^[/\\]+/, "");
   const absolute = path.resolve(outRoot, safeRelative);
-  if (!absolute.startsWith(path.resolve(outRoot) + path.sep) && absolute !== path.resolve(outRoot)) {
+  const resolvedOutRoot = path.resolve(outRoot);
+  if (absolute !== resolvedOutRoot && !absolute.startsWith(resolvedOutRoot + path.sep)) {
     throw new SomaCliError(`soma export refused to write outside --out (path: ${relativePath}).`, 2);
   }
-  await mkdir(path.dirname(absolute), { recursive: true });
+  // Symlink guard (sage r1 security finding on #54): after mkdir,
+  // resolve the real path of the parent directory and verify it is
+  // still under --out's real path. A symlink such as
+  // `<out>/rules -> ~/.ssh` would let writeFile land outside --out
+  // even though the lexical check passed. Resolving --out itself
+  // canonicalizes any symlinks the principal pointed --out at on
+  // purpose — those are allowed; only intermediate components are
+  // checked.
+  const parent = path.dirname(absolute);
+  await mkdir(parent, { recursive: true });
+  const realParent = await realpath(parent);
+  const realOutRoot = await realpath(resolvedOutRoot);
+  if (realParent !== realOutRoot && !realParent.startsWith(realOutRoot + path.sep)) {
+    throw new SomaCliError(
+      `soma export refused to follow a symlink that escapes --out (path: ${relativePath}).`,
+      2,
+    );
+  }
   await writeFile(absolute, content, "utf8");
   return absolute;
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,7 @@ import type {
   PaiPackImportOptions,
   PaiPackImportPlan,
   PaiPackImportResult,
+  ProjectionInput,
   SomaInstallOptions,
   SomaInstallPlan,
   SomaInstallResult,
@@ -2318,12 +2319,18 @@ async function runExport(parsed: ParsedExportArgs): Promise<{ files: { path: str
     return { files: projection };
   }
   const outRoot = resolveAbsolute(parsed.out);
+  // Compute realpath(--out) once per export run instead of per file
+  // (sage r2 performance finding on #54). The symlink guard inside
+  // `writeProjectionExportFile` reuses this cached value.
+  const { mkdir, realpath } = await import("node:fs/promises");
+  await mkdir(outRoot, { recursive: true });
+  const realOutRoot = await realpath(outRoot);
   // Parallel writes — independent files, order preserved by mapping
   // over the original projection array (sage r1 performance finding
   // on #54).
   const written = await Promise.all(
     projection.map(async (file) => {
-      const absolute = await writeProjectionExportFile(outRoot, file.path, file.content);
+      const absolute = await writeProjectionExportFile(outRoot, realOutRoot, file.path, file.content);
       return { path: absolute, content: file.content };
     }),
   );
@@ -2340,19 +2347,22 @@ async function buildExportProjection(
     somaHome: options.somaHome,
     substrateHome: options.substrateHome,
   };
+  const files = projectionFilesFor(substrate, projectionInput, projectionOptions);
+  return files.map((f) => ({ path: f.path, content: f.content }));
+}
+
+function projectionFilesFor(
+  substrate: InstallSubstrate,
+  input: ProjectionInput,
+  options: { homeDir?: string; somaHome?: string; substrateHome?: string },
+): readonly { path: string; content: string }[] {
   switch (substrate) {
-    case "codex": {
-      const result = buildCodexHomeProjection(projectionInput, projectionOptions);
-      return result.bundle.files.map((f) => ({ path: f.path, content: f.content }));
-    }
-    case "pi-dev": {
-      const result = buildPiDevHomeProjection(projectionInput, projectionOptions);
-      return result.bundle.files.map((f) => ({ path: f.path, content: f.content }));
-    }
-    case "claude-code": {
-      const result = buildClaudeCodeHomeProjection(projectionInput, projectionOptions);
-      return result.bundle.files.map((f) => ({ path: f.path, content: f.content }));
-    }
+    case "codex":
+      return buildCodexHomeProjection(input, options).bundle.files;
+    case "pi-dev":
+      return buildPiDevHomeProjection(input, options).bundle.files;
+    case "claude-code":
+      return buildClaudeCodeHomeProjection(input, options).bundle.files;
   }
 }
 
@@ -2365,7 +2375,12 @@ function resolveAbsolute(path: string): string {
   return path.startsWith("/") ? path : resolveJoin(process.cwd(), path);
 }
 
-async function writeProjectionExportFile(outRoot: string, relativePath: string, content: string): Promise<string> {
+async function writeProjectionExportFile(
+  outRoot: string,
+  realOutRoot: string,
+  relativePath: string,
+  content: string,
+): Promise<string> {
   const { mkdir, realpath, writeFile } = await import("node:fs/promises");
   const path = await import("node:path");
   // Lexical guard: reject paths that try to escape --out via
@@ -2380,14 +2395,11 @@ async function writeProjectionExportFile(outRoot: string, relativePath: string, 
   // resolve the real path of the parent directory and verify it is
   // still under --out's real path. A symlink such as
   // `<out>/rules -> ~/.ssh` would let writeFile land outside --out
-  // even though the lexical check passed. Resolving --out itself
-  // canonicalizes any symlinks the principal pointed --out at on
-  // purpose — those are allowed; only intermediate components are
-  // checked.
+  // even though the lexical check passed. `realOutRoot` is computed
+  // once by `runExport` (sage r2 performance finding).
   const parent = path.dirname(absolute);
   await mkdir(parent, { recursive: true });
   const realParent = await realpath(parent);
-  const realOutRoot = await realpath(resolvedOutRoot);
   if (realParent !== realOutRoot && !realParent.startsWith(realOutRoot + path.sep)) {
     throw new SomaCliError(
       `soma export refused to follow a symlink that escapes --out (path: ${relativePath}).`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,10 @@ import {
   uninstallSomaForClaudeCode,
   type UninstallClaudeCodeOptions,
   type UninstallClaudeCodeResult,
+  buildClaudeCodeHomeProjection,
+  buildCodexHomeProjection,
+  buildPiDevHomeProjection,
+  loadSomaHome,
   listAlgorithmRunSummaries,
   planAlgorithmImport,
   planPaiImport,
@@ -95,11 +99,46 @@ export class SomaCliError extends Error {
 import { getCriteria, getGoal } from "./isa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
 
+type InstallSubstrate = "codex" | "pi-dev" | "claude-code";
+
 interface ParsedInstallArgs {
   command: "install";
-  substrate: "codex" | "pi-dev";
+  substrate: InstallSubstrate;
   apply: boolean;
+  workspace: boolean;
   options: SomaInstallOptions;
+}
+
+interface ParsedUninstallArgs {
+  command: "uninstall";
+  substrate: InstallSubstrate;
+  workspace: boolean;
+  options: SomaInstallOptions & UninstallClaudeCodeOptions;
+}
+
+interface ParsedReprojectArgs {
+  command: "reproject";
+  substrate: InstallSubstrate;
+  workspace: boolean;
+  options: SomaInstallOptions;
+}
+
+interface ParsedUpgradeArgs {
+  command: "upgrade";
+  substrate: InstallSubstrate;
+  workspace: boolean;
+  options: SomaInstallOptions;
+}
+
+interface ParsedExportArgs {
+  command: "export";
+  substrate: InstallSubstrate;
+  out?: string;
+  options: SomaInstallOptions;
+}
+
+interface ParsedDaemonArgs {
+  command: "daemon";
 }
 
 interface ParsedImportArgs {
@@ -208,6 +247,11 @@ interface ParsedIsaArgs {
 type ParsedArgs =
   | ParsedHelpArgs
   | ParsedInstallArgs
+  | ParsedUninstallArgs
+  | ParsedReprojectArgs
+  | ParsedUpgradeArgs
+  | ParsedExportArgs
+  | ParsedDaemonArgs
   | ParsedImportArgs
   | ParsedMigrateArgs
   | ParsedAdoptArgs
@@ -218,7 +262,23 @@ type ParsedArgs =
   | ParsedPolicyArgs
   | ParsedIsaArgs;
 
-const TOP_LEVEL_COMMANDS = ["adopt", "algorithm", "feedback", "import", "install", "isa", "lifecycle", "memory", "migrate", "policy"] as const;
+const TOP_LEVEL_COMMANDS = [
+  "adopt",
+  "algorithm",
+  "daemon",
+  "export",
+  "feedback",
+  "import",
+  "install",
+  "isa",
+  "lifecycle",
+  "memory",
+  "migrate",
+  "policy",
+  "reproject",
+  "uninstall",
+  "upgrade",
+] as const;
 
 const MIGRATE_PAI_USAGE =
   "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-pack-dir <dir>]";
@@ -267,11 +327,32 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
     usage: "Usage: soma lifecycle <session-start|algorithm-updated|session-end> [--home-dir <dir>] [--soma-home <dir>] [--substrate <id>] [--session-id <id>]",
   },
   install: {
-    usage: "Usage: soma install <codex|pi-dev> [--dry-run] [--apply] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+    usage: "Usage: soma install <codex|pi-dev|claude-code> [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
     subcommands: {
-      codex: "Usage: soma install codex [--dry-run] [--apply] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      "pi-dev": "Usage: soma install pi-dev [--dry-run] [--apply] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+      codex: "Usage: soma install codex [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+      "pi-dev": "Usage: soma install pi-dev [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+      "claude-code": "Usage: soma install claude-code [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
     },
+  },
+  uninstall: {
+    usage: "Usage: soma uninstall <codex|pi-dev|claude-code> [--workspace] [--home-dir <dir>] [--substrate-home <dir>]",
+    subcommands: {
+      codex: "Usage: soma uninstall codex [--workspace] [--home-dir <dir>] [--substrate-home <dir>]",
+      "pi-dev": "Usage: soma uninstall pi-dev [--workspace] [--home-dir <dir>] [--substrate-home <dir>]",
+      "claude-code": "Usage: soma uninstall claude-code [--workspace] [--home-dir <dir>] [--substrate-home <dir>]",
+    },
+  },
+  reproject: {
+    usage: "Usage: soma reproject <codex|pi-dev|claude-code> [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+  },
+  upgrade: {
+    usage: "Usage: soma upgrade <codex|pi-dev|claude-code> [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+  },
+  export: {
+    usage: "Usage: soma export <codex|pi-dev|claude-code> [--out <dir>] [--home-dir <dir>] [--soma-home <dir>]",
+  },
+  daemon: {
+    usage: "Usage: soma daemon  (not yet implemented — placeholder reserves the runtime mode)",
   },
   import: {
     usage: "Usage: soma import <pai|algorithm|pai-pack> ...",
@@ -311,15 +392,37 @@ function commandUsage(command: string, action?: string): string {
   return (action ? commandHelp?.subcommands?.[action] : undefined) ?? commandHelp?.usage ?? `Usage: soma ${command} ...`;
 }
 
+const INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code"] as const satisfies readonly InstallSubstrate[];
+
+function isInstallSubstrate(value: string | undefined): value is InstallSubstrate {
+  return value !== undefined && (INSTALL_SUBSTRATES as readonly string[]).includes(value);
+}
+
+function workspaceSubstrateHome(substrate: InstallSubstrate): string {
+  // CONTEXT.md Runtime modes: workspace projection lives at
+  // `./.{codex,pi,claude}/soma` — a soma-scoped subdir so it doesn't
+  // collide with substrate-native workspace files the principal may
+  // already have for that repo.
+  const folder = substrate === "pi-dev" ? ".pi" : substrate === "claude-code" ? ".claude" : ".codex";
+  return resolveJoin(process.cwd(), folder, "soma");
+}
+
+function resolveJoin(...parts: string[]): string {
+  // Local helper to keep the cli surface free of an extra import.
+  return parts.join("/").replace(/\/+/g, "/");
+}
+
 function parseInstallArgs(args: string[]): ParsedInstallArgs {
   const [command, substrate, ...rest] = args;
 
-  if (command !== "install" || (substrate !== "codex" && substrate !== "pi-dev")) {
+  if (command !== "install" || !isInstallSubstrate(substrate)) {
     throw new Error(commandUsage("install"));
   }
 
   const options: SomaInstallOptions = {};
   let apply = false;
+  let workspace = false;
+  let substrateHomeExplicit = false;
 
   for (let index = 0; index < rest.length; index += 1) {
     const arg = rest[index];
@@ -331,6 +434,9 @@ function parseInstallArgs(args: string[]): ParsedInstallArgs {
       case "--apply":
         apply = true;
         break;
+      case "--workspace":
+        workspace = true;
+        break;
       case "--home-dir":
         options.homeDir = readOption(rest, index, arg);
         index += 1;
@@ -341,6 +447,7 @@ function parseInstallArgs(args: string[]): ParsedInstallArgs {
         break;
       case "--substrate-home":
         options.substrateHome = readOption(rest, index, arg);
+        substrateHomeExplicit = true;
         index += 1;
         break;
       default:
@@ -348,12 +455,119 @@ function parseInstallArgs(args: string[]): ParsedInstallArgs {
     }
   }
 
+  if (workspace && !substrateHomeExplicit) {
+    options.substrateHome = workspaceSubstrateHome(substrate);
+  }
+
   return {
     command,
     substrate,
     apply,
+    workspace,
     options,
   };
+}
+
+function parseLifecycleVerbArgs<T extends "uninstall" | "reproject" | "upgrade">(
+  verb: T,
+  args: string[],
+): { substrate: InstallSubstrate; workspace: boolean; options: SomaInstallOptions } {
+  const [command, substrate, ...rest] = args;
+
+  if (command !== verb || !isInstallSubstrate(substrate)) {
+    throw new Error(commandUsage(verb));
+  }
+
+  const options: SomaInstallOptions = {};
+  let workspace = false;
+  let substrateHomeExplicit = false;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+
+    switch (arg) {
+      case "--workspace":
+        workspace = true;
+        break;
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--substrate-home":
+        options.substrateHome = readOption(rest, index, arg);
+        substrateHomeExplicit = true;
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (workspace && !substrateHomeExplicit) {
+    options.substrateHome = workspaceSubstrateHome(substrate);
+  }
+
+  return { substrate, workspace, options };
+}
+
+function parseUninstallArgs(args: string[]): ParsedUninstallArgs {
+  const { substrate, workspace, options } = parseLifecycleVerbArgs("uninstall", args);
+  return { command: "uninstall", substrate, workspace, options };
+}
+
+function parseReprojectArgs(args: string[]): ParsedReprojectArgs {
+  const { substrate, workspace, options } = parseLifecycleVerbArgs("reproject", args);
+  return { command: "reproject", substrate, workspace, options };
+}
+
+function parseUpgradeArgs(args: string[]): ParsedUpgradeArgs {
+  const { substrate, workspace, options } = parseLifecycleVerbArgs("upgrade", args);
+  return { command: "upgrade", substrate, workspace, options };
+}
+
+function parseExportArgs(args: string[]): ParsedExportArgs {
+  const [command, substrate, ...rest] = args;
+
+  if (command !== "export" || !isInstallSubstrate(substrate)) {
+    throw new Error(commandUsage("export"));
+  }
+
+  const options: SomaInstallOptions = {};
+  let out: string | undefined;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+
+    switch (arg) {
+      case "--out":
+        out = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return { command: "export", substrate, out, options };
+}
+
+function parseDaemonArgs(args: string[]): ParsedDaemonArgs {
+  if (args[0] !== "daemon" || args.length > 1) {
+    throw new Error(commandUsage("daemon"));
+  }
+  return { command: "daemon" };
 }
 
 function parseImportArgs(args: string[]): ParsedImportArgs {
@@ -1150,6 +1364,26 @@ function parseArgs(args: string[]): ParsedArgs {
 
   if (args[0] === "install") {
     return parseInstallArgs(args);
+  }
+
+  if (args[0] === "uninstall") {
+    return parseUninstallArgs(args);
+  }
+
+  if (args[0] === "reproject") {
+    return parseReprojectArgs(args);
+  }
+
+  if (args[0] === "upgrade") {
+    return parseUpgradeArgs(args);
+  }
+
+  if (args[0] === "export") {
+    return parseExportArgs(args);
+  }
+
+  if (args[0] === "daemon") {
+    return parseDaemonArgs(args);
   }
 
   if (args[0] === "import") {
@@ -2025,15 +2259,150 @@ export async function runSomaCli(args: string[]): Promise<string> {
     return formatInstallResult(await installSomaForClaudeCode(parsed.options));
   }
 
-  if (!parsed.apply) {
-    return formatPlan(
-      parsed.substrate === "codex" ? planSomaForCodexInstall(parsed.options) : planSomaForPiDevInstall(parsed.options),
-    );
+  if (parsed.command === "daemon") {
+    // Reserved CLI surface — `daemon` mode (long-lived Myelin
+    // subscriber) is not yet implemented. The verb exists so that
+    // CONTEXT.md's "Runtime modes" table maps onto the CLI surface
+    // one-to-one (#54 AC). Implementation lands in a follow-up
+    // issue.
+    throw new SomaCliError("soma daemon is not yet implemented (placeholder reserves the runtime mode).", 1);
   }
 
-  return formatInstallResult(
-    parsed.substrate === "codex" ? await installSomaForCodex(parsed.options) : await installSomaForPiDev(parsed.options),
+  if (parsed.command === "export") {
+    return formatExportResult(await runExport(parsed));
+  }
+
+  if (parsed.command === "uninstall") {
+    return runUninstall(parsed);
+  }
+
+  if (parsed.command === "reproject" || parsed.command === "upgrade") {
+    // Both verbs reuse the install code path: reproject re-emits the
+    // projection; upgrade is reproject + future migration work
+    // (#54: migration content is a follow-up). They always apply —
+    // unlike `install`, the principal opted into the verb explicitly.
+    return formatInstallResult(await runInstall(parsed.substrate, parsed.options));
+  }
+
+  if (!parsed.apply) {
+    return formatPlan(planInstall(parsed.substrate, parsed.options));
+  }
+
+  return formatInstallResult(await runInstall(parsed.substrate, parsed.options));
+}
+
+function planInstall(substrate: InstallSubstrate, options: SomaInstallOptions): SomaInstallPlan {
+  switch (substrate) {
+    case "codex":
+      return planSomaForCodexInstall(options);
+    case "pi-dev":
+      return planSomaForPiDevInstall(options);
+    case "claude-code":
+      return planSomaForClaudeCodeInstall(options);
+  }
+}
+
+async function runInstall(substrate: InstallSubstrate, options: SomaInstallOptions): Promise<SomaInstallResult> {
+  switch (substrate) {
+    case "codex":
+      return installSomaForCodex(options);
+    case "pi-dev":
+      return installSomaForPiDev(options);
+    case "claude-code":
+      return installSomaForClaudeCode(options);
+  }
+}
+
+async function runUninstall(parsed: ParsedUninstallArgs): Promise<string> {
+  if (parsed.substrate === "claude-code") {
+    return formatClaudeUninstallResult(await uninstallSomaForClaudeCode(parsed.options));
+  }
+  // Codex and Pi.dev uninstallers are not yet implemented. The CLI
+  // surface is reserved so CONTEXT.md's "Lifecycle verbs" table maps
+  // one-to-one (#54 AC); functional removal lands in a follow-up.
+  throw new SomaCliError(
+    `soma uninstall ${parsed.substrate} is not yet implemented (claude-code is currently the only functional uninstaller; codex and pi-dev removal land in a follow-up).`,
+    1,
   );
+}
+
+async function runExport(parsed: ParsedExportArgs): Promise<{ files: { path: string; content: string }[]; out?: string }> {
+  const projection = await buildExportProjection(parsed.substrate, parsed.options);
+  if (!parsed.out) {
+    return { files: projection };
+  }
+  const outRoot = resolveAbsolute(parsed.out);
+  const written: { path: string; content: string }[] = [];
+  for (const file of projection) {
+    const absolute = await writeProjectionExportFile(outRoot, file.path, file.content);
+    written.push({ path: absolute, content: file.content });
+  }
+  return { files: written, out: outRoot };
+}
+
+async function buildExportProjection(
+  substrate: InstallSubstrate,
+  options: SomaInstallOptions,
+): Promise<{ path: string; content: string }[]> {
+  const projectionInput = await loadSomaHome(options.somaHome ?? defaultSomaHomePath(options.homeDir));
+  const projectionOptions = {
+    homeDir: options.homeDir,
+    somaHome: options.somaHome,
+    substrateHome: options.substrateHome,
+  };
+  switch (substrate) {
+    case "codex": {
+      const result = buildCodexHomeProjection(projectionInput, projectionOptions);
+      return result.bundle.files.map((f) => ({ path: f.path, content: f.content }));
+    }
+    case "pi-dev": {
+      const result = buildPiDevHomeProjection(projectionInput, projectionOptions);
+      return result.bundle.files.map((f) => ({ path: f.path, content: f.content }));
+    }
+    case "claude-code": {
+      const result = buildClaudeCodeHomeProjection(projectionInput, projectionOptions);
+      return result.bundle.files.map((f) => ({ path: f.path, content: f.content }));
+    }
+  }
+}
+
+function defaultSomaHomePath(homeDir?: string): string {
+  const base = homeDir ?? process.env.HOME ?? process.cwd();
+  return resolveJoin(base, ".soma");
+}
+
+function resolveAbsolute(path: string): string {
+  return path.startsWith("/") ? path : resolveJoin(process.cwd(), path);
+}
+
+async function writeProjectionExportFile(outRoot: string, relativePath: string, content: string): Promise<string> {
+  const { mkdir, writeFile } = await import("node:fs/promises");
+  const path = await import("node:path");
+  // Guard against absolute paths or path-escape in the projection
+  // file list — projections are produced by trusted adapter code but
+  // the export verb is principal-facing so we belt-and-brace.
+  const safeRelative = relativePath.replace(/^[/\\]+/, "");
+  const absolute = path.resolve(outRoot, safeRelative);
+  if (!absolute.startsWith(path.resolve(outRoot) + path.sep) && absolute !== path.resolve(outRoot)) {
+    throw new SomaCliError(`soma export refused to write outside --out (path: ${relativePath}).`, 2);
+  }
+  await mkdir(path.dirname(absolute), { recursive: true });
+  await writeFile(absolute, content, "utf8");
+  return absolute;
+}
+
+function formatExportResult(result: { files: { path: string; content: string }[]; out?: string }): string {
+  if (result.out) {
+    return [
+      "Soma export applied",
+      `out: ${result.out}`,
+      "",
+      "Files:",
+      ...result.files.map((f) => `- ${f.path}`),
+    ].join("\n");
+  }
+  // No --out → emit JSON to stdout for downstream tools / diffing.
+  return JSON.stringify(result.files, null, 2);
 }
 
 if (import.meta.main) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -31,7 +31,12 @@ test("cli shows no-argument usage as normal help", async () => {
   const output = await runSomaCli([]);
 
   expect(output).toContain("Usage:");
-  expect(output).toContain("soma install <codex|pi-dev>");
+  expect(output).toContain("soma install <codex|pi-dev|claude-code>");
+  expect(output).toContain("soma uninstall <codex|pi-dev|claude-code>");
+  expect(output).toContain("soma reproject <codex|pi-dev|claude-code>");
+  expect(output).toContain("soma upgrade <codex|pi-dev|claude-code>");
+  expect(output).toContain("soma export <codex|pi-dev|claude-code>");
+  expect(output).toContain("soma daemon");
 
   const result = spawnSync(process.execPath, ["run", "soma"], {
     cwd: join(import.meta.dir, ".."),
@@ -47,7 +52,7 @@ test("cli supports explicit main help as normal help", async () => {
   const output = await runSomaCli(["--help"]);
 
   expect(output).toContain("Usage:");
-  expect(output).toContain("soma install <codex|pi-dev>");
+  expect(output).toContain("soma install <codex|pi-dev|claude-code>");
 
   const result = spawnSync(process.execPath, ["run", "soma", "--help"], {
     cwd: join(import.meta.dir, ".."),
@@ -624,6 +629,113 @@ test("cli dry-runs and applies pi.dev install", async () => {
   });
 });
 
-test("cli rejects unsupported commands", async () => {
-  await expect(runSomaCli(["install", "claude-code"])).rejects.toThrow("Usage:");
+test("cli rejects unsupported install substrate", async () => {
+  await expect(runSomaCli(["install", "bogus-substrate"])).rejects.toThrow("Usage:");
+});
+
+test("cli install supports claude-code substrate (dry-run)", async () => {
+  await withTempHome(async (homeDir) => {
+    const output = await runSomaCli(["install", "claude-code", "--home-dir", homeDir]);
+
+    expect(output).toContain("mode: dry-run");
+    expect(output).toContain(`substrate: claude-code`);
+    expect(output).toContain(join(homeDir, ".claude"));
+    await expect(stat(join(homeDir, ".claude"))).rejects.toThrow();
+  });
+});
+
+test("cli install --workspace defaults substrate-home to ./.<sub>/soma", async () => {
+  await withTempHome(async (homeDir) => {
+    const output = await runSomaCli(["install", "codex", "--workspace", "--home-dir", homeDir]);
+
+    expect(output).toContain("mode: dry-run");
+    // workspace path is rooted in process.cwd(), not homeDir
+    expect(output).toContain(`/.codex/soma`);
+    expect(output).not.toContain(`${homeDir}/.codex/`);
+  });
+});
+
+test("cli install --workspace respects explicit --substrate-home", async () => {
+  await withTempHome(async (homeDir) => {
+    const explicit = join(homeDir, "explicit-target");
+    const output = await runSomaCli([
+      "install",
+      "codex",
+      "--workspace",
+      "--substrate-home",
+      explicit,
+      "--home-dir",
+      homeDir,
+    ]);
+
+    expect(output).toContain(`substrateHome: ${explicit}`);
+    expect(output).not.toContain(`/.codex/soma`);
+  });
+});
+
+test("cli uninstall claude-code reports no-op when not installed", async () => {
+  await withTempHome(async (homeDir) => {
+    const output = await runSomaCli(["uninstall", "claude-code", "--home-dir", homeDir]);
+
+    expect(output).toContain("uninstall");
+    expect(output).toContain("Nothing to remove");
+  });
+});
+
+test("cli uninstall codex/pi-dev is a reserved stub", async () => {
+  await expect(runSomaCli(["uninstall", "codex"])).rejects.toThrow("not yet implemented");
+  await expect(runSomaCli(["uninstall", "pi-dev"])).rejects.toThrow("not yet implemented");
+});
+
+test("cli reproject codex routes through the install applier", async () => {
+  await withTempHome(async (homeDir) => {
+    const output = await runSomaCli(["reproject", "codex", "--home-dir", homeDir]);
+
+    expect(output).toContain("Soma install applied");
+    expect(output).toContain(`substrate: codex`);
+    await expect(stat(join(homeDir, ".codex/rules/soma.rules"))).resolves.toBeDefined();
+  });
+});
+
+test("cli upgrade codex routes through the install applier", async () => {
+  await withTempHome(async (homeDir) => {
+    const output = await runSomaCli(["upgrade", "codex", "--home-dir", homeDir]);
+
+    expect(output).toContain("Soma install applied");
+    expect(output).toContain(`substrate: codex`);
+  });
+});
+
+test("cli daemon is a reserved placeholder", async () => {
+  await expect(runSomaCli(["daemon"])).rejects.toThrow("not yet implemented");
+});
+
+test("cli export emits projection JSON without touching home", async () => {
+  await withTempHome(async (homeDir) => {
+    // Seed a minimal soma home so loadSomaHome succeeds.
+    await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);
+    // Delete the codex home to prove export doesn't recreate it.
+    await rm(join(homeDir, ".codex"), { recursive: true, force: true });
+
+    const output = await runSomaCli(["export", "codex", "--home-dir", homeDir]);
+    const parsed = JSON.parse(output) as { path: string; content: string }[];
+
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBeGreaterThan(0);
+    expect(parsed.some((f) => f.path.endsWith("rules/soma.rules"))).toBe(true);
+    await expect(stat(join(homeDir, ".codex"))).rejects.toThrow();
+  });
+});
+
+test("cli export --out writes projection files into the out dir", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);
+    const outDir = join(homeDir, "exported");
+
+    const output = await runSomaCli(["export", "codex", "--out", outDir, "--home-dir", homeDir]);
+
+    expect(output).toContain("Soma export applied");
+    expect(output).toContain(`out: ${outDir}`);
+    await expect(stat(join(outDir, "rules/soma.rules"))).resolves.toBeDefined();
+  });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -739,3 +739,27 @@ test("cli export --out writes projection files into the out dir", async () => {
     await expect(stat(join(outDir, "rules/soma.rules"))).resolves.toBeDefined();
   });
 });
+
+test("cli export --out rejects symlink escape from within out dir", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);
+    const outDir = join(homeDir, "exported-symlinked");
+    const escapeTarget = join(homeDir, "escape-target");
+    await mkdir(outDir, { recursive: true });
+    await mkdir(escapeTarget, { recursive: true });
+    // Symlink the projection's `rules` subdir to a directory outside
+    // --out. With only the lexical guard, soma export would happily
+    // resolve writes through the symlink. The realpath check now
+    // catches this.
+    const { symlink } = await import("node:fs/promises");
+    await symlink(escapeTarget, join(outDir, "rules"));
+
+    await expect(
+      runSomaCli(["export", "codex", "--out", outDir, "--home-dir", homeDir]),
+    ).rejects.toThrow(/symlink that escapes --out/);
+
+    // The legit target outside --out must not have received the
+    // projection content via the symlink.
+    await expect(stat(join(escapeTarget, "soma.rules"))).rejects.toThrow();
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -682,6 +682,18 @@ test("cli uninstall claude-code reports no-op when not installed", async () => {
   });
 });
 
+test("cli uninstall claude-code removes the rules/soma projection (always-apply)", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli(["install", "claude-code", "--apply", "--home-dir", homeDir]);
+    await expect(stat(join(homeDir, ".claude/rules/soma"))).resolves.toBeDefined();
+
+    const output = await runSomaCli(["uninstall", "claude-code", "--home-dir", homeDir]);
+
+    expect(output).toContain("Removed");
+    await expect(stat(join(homeDir, ".claude/rules/soma"))).rejects.toThrow();
+  });
+});
+
 test("cli uninstall codex/pi-dev is a reserved stub", async () => {
   await expect(runSomaCli(["uninstall", "codex"])).rejects.toThrow("not yet implemented");
   await expect(runSomaCli(["uninstall", "pi-dev"])).rejects.toThrow("not yet implemented");


### PR DESCRIPTION
## Summary

CONTEXT.md Q10 (lifecycle verbs) and Q12 (runtime modes) lock the canonical CLI vocabulary. This PR brings `soma --help` and the parsed command surface in line with those tables.

| CONTEXT.md group | Glossary entries | CLI surface |
|---|---|---|
| Lifecycle verbs | install, reproject, upgrade, load, uninstall | `install`, `reproject`, `upgrade`, `uninstall` (load is substrate-internal) |
| Runtime modes | home, workspace, library, daemon, export | `install` (home default), `install --workspace`, `daemon`, `export` (library is internal) |

## Install

- Accept `claude-code` as a substrate alongside `codex` and `pi-dev`. Routes through the existing `installSomaForClaudeCode` shipped in #29 / PR #66. **No new adapter — just exposing the existing installer via the unified verb.** `soma adopt claude` continues to work as a legacy alias; this PR does not retire it.
- Add `--workspace` flag. When set without an explicit `--substrate-home`, defaults `substrateHome` to `./.{codex,pi,claude}/soma` per CONTEXT.md Runtime modes. Explicit `--substrate-home` always wins.

## Uninstall

- `soma uninstall claude-code` reuses `uninstallSomaForClaudeCode`.
- `soma uninstall codex|pi-dev` is a reserved CLI surface that exits non-zero with a clear "not yet implemented" message. The verb exists so CONTEXT.md maps onto the CLI one-to-one (#54 AC); functional codex/pi-dev removal lands in a follow-up.

## Reproject / Upgrade

Both route through the install applier. Reproject re-emits the projection; upgrade is reproject + future migration work. Migration content is a deliberate follow-up; the verbs ship now so prose and scripts can use them.

## Export

- `soma export <substrate>` builds the home projection in memory via `build{Codex,PiDev,ClaudeCode}HomeProjection` and emits the file list as JSON to stdout. No homes are touched.
- `--out <dir>` writes the projection into `<dir>`, with a path-escape guard so adapter-provided relative paths cannot break out of `--out`.

## Daemon

Reserved placeholder that exits non-zero with a clear "not yet implemented" message. The verb claims the runtime mode slot from CONTEXT.md so future Myelin subscription work has a stable home.

## Acceptance criteria

- [x] `soma --help` lists install/uninstall/reproject/upgrade/export/daemon consistently
- [x] `soma install <codex|pi-dev|claude-code>` works for all three
- [x] `--workspace` flag projects to the workspace; default remains home
- [x] `soma export` produces deterministic projection bytes without touching disk under any home (other than `--out`)
- [x] CONTEXT.md "Runtime modes" and "Lifecycle verbs" sections map 1:1 onto the surfaced commands

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun test` — 453/453 pass (was 443; +10 new tests covering each new verb)
- [x] Old usage-banner tests updated for the three-substrate install line
- [x] CONTEXT.md sections re-read to confirm 1:1 verb/mode mapping

## Follow-ups (not blocking this PR)

- Functional `soma uninstall codex|pi-dev` removal
- `soma daemon` Myelin subscription implementation
- `soma upgrade` migration content (currently a clean reproject alias)
- Decide whether to retire `soma adopt claude` once `soma install claude-code` has settled

Closes #54