### PR TITLE
fix(policy): allow Pi.dev writes to ~/.soma/ memory + ISA, guard destructive roots (#79)

### DIFF
--- a/docs/private-source-guard-v0.md
+++ b/docs/private-source-guard-v0.md
@@ -58,6 +58,43 @@ removing the Codex memory directory, removing the Soma home, or a patch
 write checks so memory can remain writable without allowing directory-removal
 accidents.
 
+## Protected Path Modify vs Delete
+
+The path guard distinguishes the `modify` and `delete` actions:
+
+- `delete` blocks any destructive operation against any descendant of a
+  protected root. `rm -rf ~/.soma`, `rm -rf ~/.soma/memory`, `rm -rf ~/.claude`
+  are all denied. There is no escape hatch for delete.
+- `modify` blocks overwrites of the protected root by default, but a
+  `SomaProtectedPath` may declare `allowedSubpaths` — relative subpaths under
+  the root where modify is permitted because the substrate is expected to
+  write there.
+
+The default protected paths declare these allowed modify subpaths:
+
+| Root         | Allowed modify subpaths                | Rationale                                            |
+| ------------ | -------------------------------------- | ---------------------------------------------------- |
+| `~/.soma`    | `isa/`, `memory/`                      | ISA edits and memory writes are the assistant's job  |
+| `~/.claude`  | `memory/`, `memories/`, `PAI/MEMORY/`  | Claude Code and PAI write working memory under these |
+| `~/.pi`      | `agent/memory/`                        | Pi.dev agent memory                                  |
+
+Writes to a protected root that fall outside its `allowedSubpaths` remain
+denied. `~/.soma/profile/identity.md` and `~/.soma/secret.md` are blocked for
+modify even though `~/.soma/isa/draft.md` is allowed. This keeps private roots
+(profile, identity, telos) safe while letting the assistant manage its own
+memory and ISA artifacts. See issue #79 (Pi.dev) and #48 (Codex) for the
+matching substrate-hook refinements.
+
+## Pi.dev Projection
+
+The Pi.dev home projection renders a `tool_call` extension
+(`agent/extensions/soma-path-guard.ts`) that reuses the portable
+`evaluatePathGuard` runtime with the explicit Soma home appended to
+`SOMA_DEFAULT_PROTECTED_PATHS`. The same `allowedSubpaths` apply to the
+explicit Soma home (`isa/`, `memory/`), so Pi.dev `write` and `edit` tool
+calls into `~/.soma/isa/*.md` and `~/.soma/memory/*/` pass while
+`rm -rf ~/.soma` and writes to `~/.soma/profile/` stay blocked (#79).
+
 ## Codex Projection
 
 The Codex home projection installs a `PreToolUse` hook for `Write`, `Edit`,

--- a/src/adapters/pi-dev/path-guard.ts
+++ b/src/adapters/pi-dev/path-guard.ts
@@ -2,15 +2,6 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 /**
- * Subpaths under the explicit Soma home where `modify` is permitted. Mirrors
- * `SOMA_HOME_ALLOWED_MODIFY_SUBPATHS` in `src/policy.ts` and the
- * `allowedSubpaths` on the `~/.soma` entry of
- * `SOMA_DEFAULT_PROTECTED_PATHS` (#79). Delete remains blocked everywhere
- * under the Soma home.
- */
-const SOMA_HOME_ALLOWED_MODIFY_SUBPATHS = ["isa", "memory"] as const;
-
-/**
  * Render a pi.dev extension that guards against destructive operations on
  * protected paths (Soma home, PAI home, Pi home, etc.).
  *
@@ -26,16 +17,18 @@ import {
   parseBashDestructivePaths,
   resolvePath,
   SOMA_DEFAULT_PROTECTED_PATHS,
+  SOMA_HOME_ALLOWED_MODIFY_SUBPATHS,
 } from ${JSON.stringify(runtimeModuleSpecifier)};
 
 const SOMA_HOME = ${JSON.stringify(somaHome)};
 // Allow legitimate Soma ISA + memory writes under the explicit SOMA_HOME
 // while still blocking overwrites of private roots (e.g. profile/) and any
-// destructive delete (allowedSubpaths is modify-only). See #79.
-const SOMA_HOME_ALLOWED_MODIFY_SUBPATHS = ${JSON.stringify([...SOMA_HOME_ALLOWED_MODIFY_SUBPATHS])};
+// destructive delete (allowedSubpaths is modify-only). The allowed subpaths
+// are sourced from policy-path-guard.ts so all enforcement layers agree on
+// one list. See #79.
 const PROTECTED_PATHS = [
   ...SOMA_DEFAULT_PROTECTED_PATHS,
-  { path: SOMA_HOME, description: "Soma private root", allowedSubpaths: SOMA_HOME_ALLOWED_MODIFY_SUBPATHS },
+  { path: SOMA_HOME, description: "Soma private root", allowedSubpaths: [...SOMA_HOME_ALLOWED_MODIFY_SUBPATHS] },
 ];
 
 function blockedTargets(targets: string[], cwd: string, action: "delete" | "modify"): string[] {

--- a/src/adapters/pi-dev/path-guard.ts
+++ b/src/adapters/pi-dev/path-guard.ts
@@ -2,6 +2,15 @@ import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 /**
+ * Subpaths under the explicit Soma home where `modify` is permitted. Mirrors
+ * `SOMA_HOME_ALLOWED_MODIFY_SUBPATHS` in `src/policy.ts` and the
+ * `allowedSubpaths` on the `~/.soma` entry of
+ * `SOMA_DEFAULT_PROTECTED_PATHS` (#79). Delete remains blocked everywhere
+ * under the Soma home.
+ */
+const SOMA_HOME_ALLOWED_MODIFY_SUBPATHS = ["isa", "memory"] as const;
+
+/**
  * Render a pi.dev extension that guards against destructive operations on
  * protected paths (Soma home, PAI home, Pi home, etc.).
  *
@@ -20,9 +29,13 @@ import {
 } from ${JSON.stringify(runtimeModuleSpecifier)};
 
 const SOMA_HOME = ${JSON.stringify(somaHome)};
+// Allow legitimate Soma ISA + memory writes under the explicit SOMA_HOME
+// while still blocking overwrites of private roots (e.g. profile/) and any
+// destructive delete (allowedSubpaths is modify-only). See #79.
+const SOMA_HOME_ALLOWED_MODIFY_SUBPATHS = ${JSON.stringify([...SOMA_HOME_ALLOWED_MODIFY_SUBPATHS])};
 const PROTECTED_PATHS = [
   ...SOMA_DEFAULT_PROTECTED_PATHS,
-  { path: SOMA_HOME, description: "Soma private root" },
+  { path: SOMA_HOME, description: "Soma private root", allowedSubpaths: SOMA_HOME_ALLOWED_MODIFY_SUBPATHS },
 ];
 
 function blockedTargets(targets: string[], cwd: string, action: "delete" | "modify"): string[] {

--- a/src/policy-path-guard.ts
+++ b/src/policy-path-guard.ts
@@ -9,17 +9,37 @@ import type { SomaProtectedPath } from "./types";
 // These are Soma's opinionated defaults; operators can override or extend via
 // `protectedPaths` in SomaPolicyCheckOptions.
 
+/**
+ * Subpaths under `~/.soma` where `modify` is permitted. Exported so the
+ * policy.ts root-protection wrapper and the Pi.dev path-guard extension
+ * renderer share a single source of truth. Delete remains blocked everywhere
+ * under the Soma home (allowedSubpaths is modify-only). See #79.
+ */
+export const SOMA_HOME_ALLOWED_MODIFY_SUBPATHS: readonly string[] = Object.freeze(["isa", "memory"]);
+
+/**
+ * Subpaths under `~/.claude` where `modify` is permitted (working memory and
+ * legacy PAI memory layouts). See #79.
+ */
+export const CLAUDE_HOME_ALLOWED_MODIFY_SUBPATHS: readonly string[] = Object.freeze(["memory", "memories", "PAI/MEMORY"]);
+
+/**
+ * Subpaths under `~/.pi` where `modify` is permitted (agent working memory).
+ * See #79.
+ */
+export const PI_HOME_ALLOWED_MODIFY_SUBPATHS: readonly string[] = Object.freeze(["agent/memory"]);
+
 export const SOMA_DEFAULT_PROTECTED_PATHS: readonly SomaProtectedPath[] = Object.freeze([
   // ~/.soma is the Soma portable home. Modify-guarded by default to keep the
   // profile and other private roots safe, but ISA + memory subtrees are the
   // assistant's working surface and must remain writable. Delete remains
   // blocked everywhere under ~/.soma.
-  { path: "~/.soma", description: "Soma portable assistant home", allowedSubpaths: ["isa", "memory"] },
+  { path: "~/.soma", description: "Soma portable assistant home", allowedSubpaths: [...SOMA_HOME_ALLOWED_MODIFY_SUBPATHS] },
   // Claude Code / PAI home — same shape: protect the root, allow legitimate
   // memory writes (memory/, memories/, PAI/MEMORY/).
-  { path: "~/.claude", description: "Claude Code / PAI home", allowedSubpaths: ["memory", "memories", "PAI/MEMORY"] },
+  { path: "~/.claude", description: "Claude Code / PAI home", allowedSubpaths: [...CLAUDE_HOME_ALLOWED_MODIFY_SUBPATHS] },
   // Pi.dev home — only the agent's memory subtree is a known write target.
-  { path: "~/.pi", description: "Pi.dev home", allowedSubpaths: ["agent/memory"] },
+  { path: "~/.pi", description: "Pi.dev home", allowedSubpaths: [...PI_HOME_ALLOWED_MODIFY_SUBPATHS] },
   { path: "~/.config/cortex", description: "Cortex operator config" },
   { path: "~/.config/metafactory", description: "Metafactory ecosystem config" },
   { path: "~/.config/k", description: "kai-launcher config" },

--- a/src/policy-path-guard.ts
+++ b/src/policy-path-guard.ts
@@ -10,9 +10,16 @@ import type { SomaProtectedPath } from "./types";
 // `protectedPaths` in SomaPolicyCheckOptions.
 
 export const SOMA_DEFAULT_PROTECTED_PATHS: readonly SomaProtectedPath[] = Object.freeze([
-  { path: "~/.soma", description: "Soma portable assistant home" },
-  { path: "~/.claude", description: "Claude Code / PAI home" },
-  { path: "~/.pi", description: "Pi.dev home" },
+  // ~/.soma is the Soma portable home. Modify-guarded by default to keep the
+  // profile and other private roots safe, but ISA + memory subtrees are the
+  // assistant's working surface and must remain writable. Delete remains
+  // blocked everywhere under ~/.soma.
+  { path: "~/.soma", description: "Soma portable assistant home", allowedSubpaths: ["isa", "memory"] },
+  // Claude Code / PAI home — same shape: protect the root, allow legitimate
+  // memory writes (memory/, memories/, PAI/MEMORY/).
+  { path: "~/.claude", description: "Claude Code / PAI home", allowedSubpaths: ["memory", "memories", "PAI/MEMORY"] },
+  // Pi.dev home — only the agent's memory subtree is a known write target.
+  { path: "~/.pi", description: "Pi.dev home", allowedSubpaths: ["agent/memory"] },
   { path: "~/.config/cortex", description: "Cortex operator config" },
   { path: "~/.config/metafactory", description: "Metafactory ecosystem config" },
   { path: "~/.config/k", description: "kai-launcher config" },
@@ -183,9 +190,20 @@ function findProtectedPath(resolvedPath: string, protectedPaths: readonly SomaPr
     if (action === "modify" && pp.guardModify === false) continue;
 
     const protectedRoot = realProtectedRoot(resolve(expandTilde(pp.path)), realScopeCache, protectedRootCache);
-    if (isInsidePath(realResolvedPath, protectedRoot)) {
-      return pp;
+    if (!isInsidePath(realResolvedPath, protectedRoot)) continue;
+
+    // allowedSubpaths only relaxes `modify` (writes/edits). Destructive
+    // operations against any descendant of a protected root remain blocked
+    // regardless of subpath — `rm -rf ~/.soma/memory` should still fail.
+    if (action === "modify" && pp.allowedSubpaths && pp.allowedSubpaths.length > 0) {
+      const insideAllowed = pp.allowedSubpaths.some((subpath) => {
+        const allowedRoot = realProtectedRoot(resolve(protectedRoot, subpath), realScopeCache, protectedRootCache);
+        return isInsidePath(realResolvedPath, allowedRoot);
+      });
+      if (insideAllowed) continue;
     }
+
+    return pp;
   }
 
   return undefined;

--- a/src/policy-path-guard.ts
+++ b/src/policy-path-guard.ts
@@ -1,6 +1,6 @@
 import { existsSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, normalize, resolve } from "node:path";
 import { isInsidePath } from "./path-utils";
 import type { SomaProtectedPath } from "./types";
 
@@ -215,9 +215,14 @@ function findProtectedPath(resolvedPath: string, protectedPaths: readonly SomaPr
     // allowedSubpaths only relaxes `modify` (writes/edits). Destructive
     // operations against any descendant of a protected root remain blocked
     // regardless of subpath — `rm -rf ~/.soma/memory` should still fail.
+    // Unsafe subpath values (absolute, tilde-prefixed, or `..`-traversing)
+    // are silently dropped to prevent escape from the protected root.
     if (action === "modify" && pp.allowedSubpaths && pp.allowedSubpaths.length > 0) {
-      const insideAllowed = pp.allowedSubpaths.some((subpath) => {
+      const insideAllowed = pp.allowedSubpaths.filter(isSafeAllowedSubpath).some((subpath) => {
         const allowedRoot = realProtectedRoot(resolve(protectedRoot, subpath), realScopeCache, protectedRootCache);
+        // Defense in depth: re-verify the resolved allowed root stays inside
+        // the protected root even after symlink resolution.
+        if (!isInsidePath(allowedRoot, protectedRoot)) return false;
         return isInsidePath(realResolvedPath, allowedRoot);
       });
       if (insideAllowed) continue;
@@ -227,6 +232,23 @@ function findProtectedPath(resolvedPath: string, protectedPaths: readonly SomaPr
   }
 
   return undefined;
+}
+
+/**
+ * Return true iff `subpath` is a safe relative descendant of a protected
+ * root: not absolute, no tilde expansion, no `..` traversal after
+ * normalization, and non-empty. Defends `allowedSubpaths` (a public option)
+ * against operators or callers passing values that would escape the
+ * protected root and silently allow all modifies inside it.
+ */
+function isSafeAllowedSubpath(subpath: string): boolean {
+  if (typeof subpath !== "string" || subpath.length === 0) return false;
+  if (isAbsolute(subpath)) return false;
+  if (subpath.startsWith("~")) return false;
+  const normalized = normalize(subpath).replace(/\/+$/, "");
+  if (normalized === "" || normalized === "." || normalized === "..") return false;
+  if (normalized.startsWith("..")) return false;
+  return true;
 }
 
 function realProtectedRoot(path: string, realScopeCache: Map<string, string>, protectedRootCache: Map<string, string>): string {

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,7 +1,7 @@
 import { access, realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
-import { evaluatePathGuard, SOMA_DEFAULT_PROTECTED_PATHS } from "./policy-path-guard";
+import { evaluatePathGuard, SOMA_DEFAULT_PROTECTED_PATHS, SOMA_HOME_ALLOWED_MODIFY_SUBPATHS } from "./policy-path-guard";
 import { hasSomaPolicyPrivateMarker } from "./policy-marker";
 import { isInsidePath } from "./path-utils";
 import type { SomaPolicyBatchCheckOptions, SomaPolicyBatchCheckResult, SomaPolicyBatchTarget, SomaPolicyCheckOptions, SomaPolicyCheckResult, SomaPolicyFinding, SomaProtectedPath } from "./types";
@@ -27,13 +27,6 @@ const SOMA_POLICY_PORTABLE_MARKERS = [
   "~/.pi/agent/skills/soma",
 ] as const;
 
-/**
- * Subpaths under `~/.soma` where `modify` is permitted. Mirrors the
- * `allowedSubpaths` declared on `SOMA_DEFAULT_PROTECTED_PATHS` for `~/.soma`
- * so that policy.ts and policy-path-guard.ts agree on the same allowed
- * memory/ISA destinations.
- */
-const SOMA_HOME_ALLOWED_MODIFY_SUBPATHS = ["isa", "memory"];
 
 interface SomaPolicyScope {
   destinationPath: string;
@@ -166,7 +159,7 @@ function evaluateResolvedSomaPathGuard(options: SomaPolicyCheckOptions & { actio
   const rootProtectedPaths: SomaProtectedPath[] = roots.map((root) => ({
     path: root,
     description: `Soma private root: ${markerFor(root, options.homeDir)}`,
-    ...(root === somaHome ? { allowedSubpaths: SOMA_HOME_ALLOWED_MODIFY_SUBPATHS } : {}),
+    ...(root === somaHome ? { allowedSubpaths: [...SOMA_HOME_ALLOWED_MODIFY_SUBPATHS] } : {}),
   }));
   const normalizeProtectedPaths = (protectedPaths: readonly SomaProtectedPath[]): SomaProtectedPath[] =>
     protectedPaths.map((protectedPath) => ({

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -27,6 +27,14 @@ const SOMA_POLICY_PORTABLE_MARKERS = [
   "~/.pi/agent/skills/soma",
 ] as const;
 
+/**
+ * Subpaths under `~/.soma` where `modify` is permitted. Mirrors the
+ * `allowedSubpaths` declared on `SOMA_DEFAULT_PROTECTED_PATHS` for `~/.soma`
+ * so that policy.ts and policy-path-guard.ts agree on the same allowed
+ * memory/ISA destinations.
+ */
+const SOMA_HOME_ALLOWED_MODIFY_SUBPATHS = ["isa", "memory"];
+
 interface SomaPolicyScope {
   destinationPath: string;
   destinationScopePath: string;
@@ -149,9 +157,16 @@ function evaluateResolvedSomaPathGuard(options: SomaPolicyCheckOptions & { actio
 
   // Convert all private roots to protected paths for delete/modify actions.
   // This ensures the somaHome itself is protected, not just user-specified paths.
+  //
+  // For the Soma home specifically, mirror the SOMA_DEFAULT_PROTECTED_PATHS
+  // policy: allow modify on isa/ and memory/ subtrees so legitimate ISA and
+  // memory writes pass `soma policy check --action modify` even when the
+  // operator passes an explicit --soma-home. Delete remains blocked for the
+  // whole tree (allowedSubpaths is modify-only).
   const rootProtectedPaths: SomaProtectedPath[] = roots.map((root) => ({
     path: root,
     description: `Soma private root: ${markerFor(root, options.homeDir)}`,
+    ...(root === somaHome ? { allowedSubpaths: SOMA_HOME_ALLOWED_MODIFY_SUBPATHS } : {}),
   }));
   const normalizeProtectedPaths = (protectedPaths: readonly SomaProtectedPath[]): SomaProtectedPath[] =>
     protectedPaths.map((protectedPath) => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -602,6 +602,17 @@ export interface SomaProtectedPath {
   description: string;
   guardDelete?: boolean;
   guardModify?: boolean;
+  /**
+   * Subpaths (relative to `path`) where `modify` is permitted even though the
+   * surrounding root is otherwise modify-guarded. Has no effect on `delete`;
+   * destructive operations against any descendant of `path` remain blocked.
+   *
+   * Used to declare known memory/ISA destinations under a private root so that
+   * legitimate Soma writes (e.g. `~/.soma/isa/*.md`, `~/.soma/memory/...`)
+   * pass while overwrites of the private root itself (`~/.soma/profile/...`)
+   * stay denied.
+   */
+  allowedSubpaths?: string[];
 }
 
 export interface SomaPolicyCheckOptions {

--- a/test/policy-path-guard.test.ts
+++ b/test/policy-path-guard.test.ts
@@ -915,12 +915,20 @@ test("generated pi.dev guard blocks destructive commands, redirections, mv sourc
   }
 });
 
-test("generated pi.dev guard allows writes to Soma ISA and memory subtrees", async () => {
-  const tmpDir = await mkdtemp(join(tmpdir(), "soma-guard-ext-allow-"));
+// Pi.dev rendered-extension harness shared by the #79 AC tests. Boots the
+// rendered guard against a temporary HOME, returns the tool_call handler,
+// and owns all cleanup (extension file, HOME restore, tmpDir removal).
+type RenderedPiHandler = (
+  event: { toolName: string; input?: { command?: string; file_path?: string; path?: string } },
+  ctx: { cwd?: string; ui?: { notify?: (message: string, level: string) => void } },
+) => unknown;
+
+async function withRenderedPiPathGuardHandler<T>(prefix: string, fn: (ctx: { tmpDir: string; handler: RenderedPiHandler }) => Promise<T>): Promise<T> {
+  const tmpDir = await mkdtemp(join(tmpdir(), prefix));
   const extension = renderPathGuardExtension(join(tmpDir, ".soma"));
   const extPath = join(tmpDir, "soma-path-guard.ts");
   const originalHome = process.env.HOME;
-  let handler: ((event: { toolName: string; input?: { command?: string; file_path?: string; path?: string } }, ctx: { cwd?: string; ui?: { notify?: (message: string, level: string) => void } }) => unknown) | undefined;
+  let handler: RenderedPiHandler | undefined;
 
   try {
     process.env.HOME = tmpDir;
@@ -935,92 +943,55 @@ test("generated pi.dev guard allows writes to Soma ISA and memory subtrees", asy
       },
     });
 
+    if (!handler) throw new Error("rendered Pi.dev extension did not register a tool_call handler");
+    return await fn({ tmpDir, handler });
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+test("generated pi.dev guard allows writes to Soma ISA and memory subtrees", async () => {
+  await withRenderedPiPathGuardHandler("soma-guard-ext-allow-", async ({ tmpDir, handler }) => {
     // ISA write should be allowed (#79 AC-1)
-    const isaWrite = await handler?.({ toolName: "write", input: { file_path: ".soma/isa/personal/draft.md" } }, { cwd: tmpDir });
+    const isaWrite = await handler({ toolName: "write", input: { file_path: ".soma/isa/personal/draft.md" } }, { cwd: tmpDir });
     // ISA edit should be allowed (#79 AC-1)
-    const isaEdit = await handler?.({ toolName: "edit", input: { file_path: ".soma/isa/personal/draft.md" } }, { cwd: tmpDir });
+    const isaEdit = await handler({ toolName: "edit", input: { file_path: ".soma/isa/personal/draft.md" } }, { cwd: tmpDir });
     // Memory write should be allowed (#79 AC-2)
-    const memoryWrite = await handler?.({ toolName: "write", input: { file_path: ".soma/memory/STATE/active.json" } }, { cwd: tmpDir });
+    const memoryWrite = await handler({ toolName: "write", input: { file_path: ".soma/memory/STATE/active.json" } }, { cwd: tmpDir });
     // Memory edit on nested file should be allowed
-    const memoryEdit = await handler?.({ toolName: "edit", input: { file_path: ".soma/memory/WORK/run-123/notes.md" } }, { cwd: tmpDir });
+    const memoryEdit = await handler({ toolName: "edit", input: { file_path: ".soma/memory/WORK/run-123/notes.md" } }, { cwd: tmpDir });
 
     expect(isaWrite).toBeUndefined();
     expect(isaEdit).toBeUndefined();
     expect(memoryWrite).toBeUndefined();
     expect(memoryEdit).toBeUndefined();
-  } finally {
-    if (originalHome === undefined) delete process.env.HOME;
-    else process.env.HOME = originalHome;
-    await rm(tmpDir, { recursive: true, force: true });
-  }
+  });
 });
 
 test("generated pi.dev guard still blocks destructive deletes of Soma home (#79 AC-3)", async () => {
-  const tmpDir = await mkdtemp(join(tmpdir(), "soma-guard-ext-delete-"));
-  const extension = renderPathGuardExtension(join(tmpDir, ".soma"));
-  const extPath = join(tmpDir, "soma-path-guard.ts");
-  const originalHome = process.env.HOME;
-  let handler: ((event: { toolName: string; input?: { command?: string; file_path?: string; path?: string } }, ctx: { cwd?: string; ui?: { notify?: (message: string, level: string) => void } }) => unknown) | undefined;
-
-  try {
-    process.env.HOME = tmpDir;
-    await mkdir(join(tmpDir, ".soma"), { recursive: true });
-    await writeFile(extPath, extension, "utf8");
-    const mod = (await import(pathToFileURL(extPath).href)) as {
-      default: (pi: { on: (event: "tool_call", cb: NonNullable<typeof handler>) => void }) => void;
-    };
-    mod.default({
-      on: (_event, cb) => {
-        handler = cb;
-      },
-    });
-
-    const rmHome = await handler?.({ toolName: "bash", input: { command: "rm -rf ~/.soma" } }, { cwd: tmpDir });
-    const rmIsa = await handler?.({ toolName: "bash", input: { command: "rm -rf ~/.soma/isa" } }, { cwd: tmpDir });
-    const rmMemory = await handler?.({ toolName: "bash", input: { command: "rm -rf ~/.soma/memory" } }, { cwd: tmpDir });
+  await withRenderedPiPathGuardHandler("soma-guard-ext-delete-", async ({ tmpDir, handler }) => {
+    const rmHome = await handler({ toolName: "bash", input: { command: "rm -rf ~/.soma" } }, { cwd: tmpDir });
+    const rmIsa = await handler({ toolName: "bash", input: { command: "rm -rf ~/.soma/isa" } }, { cwd: tmpDir });
+    const rmMemory = await handler({ toolName: "bash", input: { command: "rm -rf ~/.soma/memory" } }, { cwd: tmpDir });
 
     expect(rmHome).toMatchObject({ block: true });
     expect(rmIsa).toMatchObject({ block: true });
     expect(rmMemory).toMatchObject({ block: true });
-  } finally {
-    if (originalHome === undefined) delete process.env.HOME;
-    else process.env.HOME = originalHome;
-    await rm(tmpDir, { recursive: true, force: true });
-  }
+  });
 });
 
 test("generated pi.dev guard still blocks writes to ~/.soma/profile (#79 AC-4 private root)", async () => {
-  const tmpDir = await mkdtemp(join(tmpdir(), "soma-guard-ext-profile-"));
-  const extension = renderPathGuardExtension(join(tmpDir, ".soma"));
-  const extPath = join(tmpDir, "soma-path-guard.ts");
-  const originalHome = process.env.HOME;
-  let handler: ((event: { toolName: string; input?: { command?: string; file_path?: string; path?: string } }, ctx: { cwd?: string; ui?: { notify?: (message: string, level: string) => void } }) => unknown) | undefined;
-
-  try {
-    process.env.HOME = tmpDir;
-    await mkdir(join(tmpDir, ".soma"), { recursive: true });
-    await writeFile(extPath, extension, "utf8");
-    const mod = (await import(pathToFileURL(extPath).href)) as {
-      default: (pi: { on: (event: "tool_call", cb: NonNullable<typeof handler>) => void }) => void;
-    };
-    mod.default({
-      on: (_event, cb) => {
-        handler = cb;
-      },
-    });
-
-    const writeProfile = await handler?.({ toolName: "write", input: { file_path: ".soma/profile/identity.md" } }, { cwd: tmpDir });
-    const editProfile = await handler?.({ toolName: "edit", input: { file_path: ".soma/profile/identity.md" } }, { cwd: tmpDir });
-    const writeRoot = await handler?.({ toolName: "write", input: { file_path: ".soma/secret.md" } }, { cwd: tmpDir });
+  await withRenderedPiPathGuardHandler("soma-guard-ext-profile-", async ({ tmpDir, handler }) => {
+    const writeProfile = await handler({ toolName: "write", input: { file_path: ".soma/profile/identity.md" } }, { cwd: tmpDir });
+    const editProfile = await handler({ toolName: "edit", input: { file_path: ".soma/profile/identity.md" } }, { cwd: tmpDir });
+    const writeRoot = await handler({ toolName: "write", input: { file_path: ".soma/secret.md" } }, { cwd: tmpDir });
 
     expect(writeProfile).toMatchObject({ block: true });
     expect(editProfile).toMatchObject({ block: true });
     expect(writeRoot).toMatchObject({ block: true });
-  } finally {
-    if (originalHome === undefined) delete process.env.HOME;
-    else process.env.HOME = originalHome;
-    await rm(tmpDir, { recursive: true, force: true });
-  }
+  });
 });
 
 // ── Policy write action still works ──

--- a/test/policy-path-guard.test.ts
+++ b/test/policy-path-guard.test.ts
@@ -549,6 +549,84 @@ test("allowedSubpaths does not affect delete action", () => {
   expect(result.blocked).toBe(true);
 });
 
+// ── allowedSubpaths input hardening (#79 R2 important: prevent escape via
+// absolute paths, tilde-prefixes, or `..` traversal in operator-supplied
+// allowedSubpaths values) ──
+
+test("allowedSubpaths rejects absolute-path subpath values (cannot relax beyond root)", () => {
+  const customRoot = "/tmp/custom-root";
+  // An attacker / misconfigured operator passes an absolute path. The
+  // expected behavior: the unsafe value is dropped, the target is still
+  // blocked because it is inside the protected root and no safe allowed
+  // subpath matches.
+  const result = evaluatePathGuard({
+    targetPaths: [resolve(customRoot, "private/identity.md")],
+    cwd: "/tmp",
+    action: "modify",
+    protectedPaths: [{ path: customRoot, description: "custom", allowedSubpaths: ["/"] }],
+  });
+
+  expect(result.blocked).toBe(true);
+});
+
+test("allowedSubpaths rejects parent-traversal subpath values", () => {
+  const customRoot = "/tmp/custom-root";
+  // `..` would resolve to /tmp and let any modify inside /tmp/* pass.
+  const result = evaluatePathGuard({
+    targetPaths: [resolve(customRoot, "private/identity.md")],
+    cwd: "/tmp",
+    action: "modify",
+    protectedPaths: [{ path: customRoot, description: "custom", allowedSubpaths: [".."] }],
+  });
+
+  expect(result.blocked).toBe(true);
+});
+
+test("allowedSubpaths rejects tilde-prefixed subpath values", () => {
+  const customRoot = "/tmp/custom-root";
+  const result = evaluatePathGuard({
+    targetPaths: [resolve(customRoot, "private/identity.md")],
+    cwd: "/tmp",
+    action: "modify",
+    protectedPaths: [{ path: customRoot, description: "custom", allowedSubpaths: ["~/anywhere"] }],
+  });
+
+  expect(result.blocked).toBe(true);
+});
+
+test("allowedSubpaths rejects empty and dot-only subpath values", () => {
+  const customRoot = "/tmp/custom-root";
+  for (const unsafe of ["", ".", "./"]) {
+    const result = evaluatePathGuard({
+      targetPaths: [resolve(customRoot, "private/identity.md")],
+      cwd: "/tmp",
+      action: "modify",
+      protectedPaths: [{ path: customRoot, description: "custom", allowedSubpaths: [unsafe] }],
+    });
+    expect(result.blocked).toBe(true);
+  }
+});
+
+test("allowedSubpaths drops unsafe entries but still honors safe siblings", () => {
+  const customRoot = "/tmp/custom-root";
+  // The "../escape" is unsafe and dropped; "scratch" is safe and applied.
+  const escape = evaluatePathGuard({
+    targetPaths: [resolve(customRoot, "private/identity.md")],
+    cwd: "/tmp",
+    action: "modify",
+    protectedPaths: [{ path: customRoot, description: "custom", allowedSubpaths: ["../escape", "scratch"] }],
+  });
+  const safe = evaluatePathGuard({
+    targetPaths: [resolve(customRoot, "scratch/note.md")],
+    cwd: "/tmp",
+    action: "modify",
+    protectedPaths: [{ path: customRoot, description: "custom", allowedSubpaths: ["../escape", "scratch"] }],
+  });
+
+  expect(escape.blocked).toBe(true);
+  expect(safe.blocked).toBe(false);
+});
+
 // ── Policy Integration ──
 
 test("policy check denies delete on Soma home path", async () => {

--- a/test/policy-path-guard.test.ts
+++ b/test/policy-path-guard.test.ts
@@ -426,6 +426,129 @@ test("honors guardModify: false", () => {
   expect(result.blocked).toBe(false);
 });
 
+// ── Allowed Subpaths (legitimate memory/ISA writes) ──
+
+test("allows modify on ~/.soma/isa subtree by default", () => {
+  const somaHome = join(process.env.HOME ?? "/tmp", ".soma");
+  const result = evaluatePathGuard({
+    targetPaths: [join(somaHome, "isa", "personal", "draft.md")],
+    cwd: "/tmp",
+    action: "modify",
+  });
+
+  expect(result.blocked).toBe(false);
+  expect(result.matchedPaths).toEqual([]);
+});
+
+test("allows modify on ~/.soma/memory subtree by default", () => {
+  const somaHome = join(process.env.HOME ?? "/tmp", ".soma");
+  const result = evaluatePathGuard({
+    targetPaths: [join(somaHome, "memory", "STATE", "active.json")],
+    cwd: "/tmp",
+    action: "modify",
+  });
+
+  expect(result.blocked).toBe(false);
+});
+
+test("allows modify on ~/.claude memory subtrees by default", () => {
+  const claudeHome = join(process.env.HOME ?? "/tmp", ".claude");
+  for (const subpath of ["memory", "memories", join("PAI", "MEMORY")]) {
+    const result = evaluatePathGuard({
+      targetPaths: [join(claudeHome, subpath, "note.md")],
+      cwd: "/tmp",
+      action: "modify",
+    });
+    expect(result.blocked).toBe(false);
+  }
+});
+
+test("allows modify on ~/.pi agent memory subtree by default", () => {
+  const piHome = join(process.env.HOME ?? "/tmp", ".pi");
+  const result = evaluatePathGuard({
+    targetPaths: [join(piHome, "agent", "memory", "session.md")],
+    cwd: "/tmp",
+    action: "modify",
+  });
+
+  expect(result.blocked).toBe(false);
+});
+
+test("still blocks modify on ~/.soma/profile (private root)", () => {
+  const somaHome = join(process.env.HOME ?? "/tmp", ".soma");
+  const result = evaluatePathGuard({
+    targetPaths: [join(somaHome, "profile", "identity.md")],
+    cwd: "/tmp",
+    action: "modify",
+  });
+
+  expect(result.blocked).toBe(true);
+});
+
+test("still blocks modify on ~/.soma root files (not in allowed subpaths)", () => {
+  const somaHome = join(process.env.HOME ?? "/tmp", ".soma");
+  const result = evaluatePathGuard({
+    targetPaths: [join(somaHome, "secret.md")],
+    cwd: "/tmp",
+    action: "modify",
+  });
+
+  expect(result.blocked).toBe(true);
+});
+
+test("still blocks delete on ~/.soma/memory (allowed-subpath does not extend to delete)", () => {
+  const somaHome = join(process.env.HOME ?? "/tmp", ".soma");
+  const result = evaluatePathGuard({
+    targetPaths: [join(somaHome, "memory", "STATE", "active.json")],
+    cwd: "/tmp",
+    action: "delete",
+  });
+
+  expect(result.blocked).toBe(true);
+});
+
+test("still blocks delete on ~/.soma/isa (allowed-subpath does not extend to delete)", () => {
+  const somaHome = join(process.env.HOME ?? "/tmp", ".soma");
+  const result = evaluatePathGuard({
+    targetPaths: [join(somaHome, "isa", "personal", "draft.md")],
+    cwd: "/tmp",
+    action: "delete",
+  });
+
+  expect(result.blocked).toBe(true);
+});
+
+test("respects explicit allowedSubpaths on custom protected paths", () => {
+  const customRoot = "/tmp/custom-root";
+  const allowed = evaluatePathGuard({
+    targetPaths: [resolve(customRoot, "scratch/note.md")],
+    cwd: "/tmp",
+    action: "modify",
+    protectedPaths: [{ path: customRoot, description: "custom", allowedSubpaths: ["scratch"] }],
+  });
+  const blocked = evaluatePathGuard({
+    targetPaths: [resolve(customRoot, "vault/secret.md")],
+    cwd: "/tmp",
+    action: "modify",
+    protectedPaths: [{ path: customRoot, description: "custom", allowedSubpaths: ["scratch"] }],
+  });
+
+  expect(allowed.blocked).toBe(false);
+  expect(blocked.blocked).toBe(true);
+});
+
+test("allowedSubpaths does not affect delete action", () => {
+  const customRoot = "/tmp/custom-root";
+  const result = evaluatePathGuard({
+    targetPaths: [resolve(customRoot, "scratch/note.md")],
+    cwd: "/tmp",
+    action: "delete",
+    protectedPaths: [{ path: customRoot, description: "custom", allowedSubpaths: ["scratch"] }],
+  });
+
+  expect(result.blocked).toBe(true);
+});
+
 // ── Policy Integration ──
 
 test("policy check denies delete on Soma home path", async () => {
@@ -473,6 +596,66 @@ test("policy check denies delete on configured-home Claude path by default", asy
     expect(result.findings[0]).toMatchObject({
       kind: "protected-path",
     });
+  });
+});
+
+test("policy check allows modify on Soma ISA subtree (legitimate Soma write)", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const result = await checkSomaPolicy({
+      homeDir,
+      somaHome,
+      action: "modify",
+      destinationPath: join(somaHome, "isa", "personal", "active.md"),
+      record: "none",
+    });
+
+    expect(result.decision).toBe("allow");
+  });
+});
+
+test("policy check allows modify on Soma memory subtree (legitimate memory write)", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const result = await checkSomaPolicy({
+      homeDir,
+      somaHome,
+      action: "modify",
+      destinationPath: join(somaHome, "memory", "STATE", "active.json"),
+      record: "none",
+    });
+
+    expect(result.decision).toBe("allow");
+  });
+});
+
+test("policy check still denies modify on Soma profile (private root)", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const result = await checkSomaPolicy({
+      homeDir,
+      somaHome,
+      action: "modify",
+      destinationPath: join(somaHome, "profile", "identity.md"),
+      record: "none",
+    });
+
+    expect(result.decision).toBe("deny");
+  });
+});
+
+test("policy check still denies delete on Soma memory subtree", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const result = await checkSomaPolicy({
+      homeDir,
+      somaHome,
+      action: "delete",
+      destinationPath: join(somaHome, "memory", "STATE", "active.json"),
+      record: "none",
+    });
+
+    expect(result.decision).toBe("deny");
   });
 });
 
@@ -725,6 +908,114 @@ test("generated pi.dev guard blocks destructive commands, redirections, mv sourc
     expect(redirectResult).toMatchObject({ block: true });
     expect((redirectResult as { reason?: string } | undefined)?.reason).not.toContain("cat /dev/null");
     expect(writeResult).toMatchObject({ block: true });
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("generated pi.dev guard allows writes to Soma ISA and memory subtrees", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "soma-guard-ext-allow-"));
+  const extension = renderPathGuardExtension(join(tmpDir, ".soma"));
+  const extPath = join(tmpDir, "soma-path-guard.ts");
+  const originalHome = process.env.HOME;
+  let handler: ((event: { toolName: string; input?: { command?: string; file_path?: string; path?: string } }, ctx: { cwd?: string; ui?: { notify?: (message: string, level: string) => void } }) => unknown) | undefined;
+
+  try {
+    process.env.HOME = tmpDir;
+    await mkdir(join(tmpDir, ".soma"), { recursive: true });
+    await writeFile(extPath, extension, "utf8");
+    const mod = (await import(pathToFileURL(extPath).href)) as {
+      default: (pi: { on: (event: "tool_call", cb: NonNullable<typeof handler>) => void }) => void;
+    };
+    mod.default({
+      on: (_event, cb) => {
+        handler = cb;
+      },
+    });
+
+    // ISA write should be allowed (#79 AC-1)
+    const isaWrite = await handler?.({ toolName: "write", input: { file_path: ".soma/isa/personal/draft.md" } }, { cwd: tmpDir });
+    // ISA edit should be allowed (#79 AC-1)
+    const isaEdit = await handler?.({ toolName: "edit", input: { file_path: ".soma/isa/personal/draft.md" } }, { cwd: tmpDir });
+    // Memory write should be allowed (#79 AC-2)
+    const memoryWrite = await handler?.({ toolName: "write", input: { file_path: ".soma/memory/STATE/active.json" } }, { cwd: tmpDir });
+    // Memory edit on nested file should be allowed
+    const memoryEdit = await handler?.({ toolName: "edit", input: { file_path: ".soma/memory/WORK/run-123/notes.md" } }, { cwd: tmpDir });
+
+    expect(isaWrite).toBeUndefined();
+    expect(isaEdit).toBeUndefined();
+    expect(memoryWrite).toBeUndefined();
+    expect(memoryEdit).toBeUndefined();
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("generated pi.dev guard still blocks destructive deletes of Soma home (#79 AC-3)", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "soma-guard-ext-delete-"));
+  const extension = renderPathGuardExtension(join(tmpDir, ".soma"));
+  const extPath = join(tmpDir, "soma-path-guard.ts");
+  const originalHome = process.env.HOME;
+  let handler: ((event: { toolName: string; input?: { command?: string; file_path?: string; path?: string } }, ctx: { cwd?: string; ui?: { notify?: (message: string, level: string) => void } }) => unknown) | undefined;
+
+  try {
+    process.env.HOME = tmpDir;
+    await mkdir(join(tmpDir, ".soma"), { recursive: true });
+    await writeFile(extPath, extension, "utf8");
+    const mod = (await import(pathToFileURL(extPath).href)) as {
+      default: (pi: { on: (event: "tool_call", cb: NonNullable<typeof handler>) => void }) => void;
+    };
+    mod.default({
+      on: (_event, cb) => {
+        handler = cb;
+      },
+    });
+
+    const rmHome = await handler?.({ toolName: "bash", input: { command: "rm -rf ~/.soma" } }, { cwd: tmpDir });
+    const rmIsa = await handler?.({ toolName: "bash", input: { command: "rm -rf ~/.soma/isa" } }, { cwd: tmpDir });
+    const rmMemory = await handler?.({ toolName: "bash", input: { command: "rm -rf ~/.soma/memory" } }, { cwd: tmpDir });
+
+    expect(rmHome).toMatchObject({ block: true });
+    expect(rmIsa).toMatchObject({ block: true });
+    expect(rmMemory).toMatchObject({ block: true });
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("generated pi.dev guard still blocks writes to ~/.soma/profile (#79 AC-4 private root)", async () => {
+  const tmpDir = await mkdtemp(join(tmpdir(), "soma-guard-ext-profile-"));
+  const extension = renderPathGuardExtension(join(tmpDir, ".soma"));
+  const extPath = join(tmpDir, "soma-path-guard.ts");
+  const originalHome = process.env.HOME;
+  let handler: ((event: { toolName: string; input?: { command?: string; file_path?: string; path?: string } }, ctx: { cwd?: string; ui?: { notify?: (message: string, level: string) => void } }) => unknown) | undefined;
+
+  try {
+    process.env.HOME = tmpDir;
+    await mkdir(join(tmpDir, ".soma"), { recursive: true });
+    await writeFile(extPath, extension, "utf8");
+    const mod = (await import(pathToFileURL(extPath).href)) as {
+      default: (pi: { on: (event: "tool_call", cb: NonNullable<typeof handler>) => void }) => void;
+    };
+    mod.default({
+      on: (_event, cb) => {
+        handler = cb;
+      },
+    });
+
+    const writeProfile = await handler?.({ toolName: "write", input: { file_path: ".soma/profile/identity.md" } }, { cwd: tmpDir });
+    const editProfile = await handler?.({ toolName: "edit", input: { file_path: ".soma/profile/identity.md" } }, { cwd: tmpDir });
+    const writeRoot = await handler?.({ toolName: "write", input: { file_path: ".soma/secret.md" } }, { cwd: tmpDir });
+
+    expect(writeProfile).toMatchObject({ block: true });
+    expect(editProfile).toMatchObject({ block: true });
+    expect(writeRoot).toMatchObject({ block: true });
   } finally {
     if (originalHome === undefined) delete process.env.HOME;
     else process.env.HOME = originalHome;


### PR DESCRIPTION
## Summary

The Pi.dev path guard's `write`/`edit` enforcement was blocking every write to `~/.soma/`, including the ISA and memory paths Soma itself is designed to manage. This refines the modify policy while keeping destructive operations and private-root overwrites blocked.

Symmetric to the Codex fix in `4f32527` (#48) — same policy model, different substrate. The fix is layered:

1. **`SomaProtectedPath.allowedSubpaths?: string[]`** — new optional field. When the action is `modify`, target paths inside an allowed subpath of a protected root pass through. Delete still cascades to the whole root (the relaxation is modify-only).
2. **`SOMA_DEFAULT_PROTECTED_PATHS` updated** — `~/.soma` allows `isa/` + `memory/`; `~/.claude` allows `memory/`, `memories/`, `PAI/MEMORY/`; `~/.pi` allows `agent/memory/`. Other roots (`~/.config/cortex`, etc.) unchanged.
3. **`policy.ts`** — when somaHome is added as a protected root for delete/modify checks via `--soma-home`, it carries the same `["isa", "memory"]` allowed subpaths so the CLI behaves consistently with the path-guard runtime.
4. **`src/adapters/pi-dev/path-guard.ts`** — the rendered Pi.dev extension's explicit `SOMA_HOME` entry now also declares `allowedSubpaths`. A constant kept in lockstep with the policy.ts constant so the two layers don't drift.
5. **`docs/private-source-guard-v0.md`** — new "Protected Path Modify vs Delete" section documenting the table of allowed subpaths plus a "Pi.dev Projection" section symmetric to the existing Codex one.

## Acceptance criteria (from issue #79)

- [x] `edit` tool can write to `~/.soma/isa/*.md` and `~/.soma/memory/*/`
- [x] `write` tool can create files under `~/.soma/isa/` and `~/.soma/memory/`
- [x] Destructive ops (`rm -rf ~/.soma`) remain blocked
- [x] Private-to-public leakage (copying `~/.soma/profile/` into a public repo README) remains blocked
- [x] Tests cover allowed writes, denied destructive ops, and denied public leakage

## Test evidence

- Baseline before: 455/455 pass
- After fix: **472/472 pass** (+17 new tests in `test/policy-path-guard.test.ts`)
- `bun run typecheck` clean

New test groups:
- *Allowed Subpaths (legitimate memory/ISA writes)* — 9 tests on `evaluatePathGuard` covering `~/.soma/isa`, `~/.soma/memory`, `~/.claude/{memory,memories,PAI/MEMORY}`, `~/.pi/agent/memory` allowed for modify; `~/.soma/profile`, `~/.soma/secret.md` still blocked; delete on `~/.soma/memory` and `~/.soma/isa` still blocked; custom `allowedSubpaths` on user-supplied protected paths; `allowedSubpaths` ignored on delete.
- *Policy integration* — 4 tests on `checkSomaPolicy` covering the same allow/deny matrix at the `soma policy check` layer.
- *Generated Pi.dev extension* — 3 tests booting the rendered extension and exercising it through the `tool_call` handler with `write`, `edit`, and `bash` events for ISA writes (allow), memory writes (allow), `rm -rf` (block), profile writes (block), root-level secret writes (block).

The existing "write policy with explicit action still blocks private markers" test passes unchanged, confirming private-to-public leakage detection in `policy.ts` is unaffected — that lives in a different layer (content-marker scanning, not path-guard).

## Test plan

- [x] `bun run typecheck`
- [x] `bun test` (472/472)
- [x] Inspect rendered Pi.dev extension manually: contains `SOMA_HOME_ALLOWED_MODIFY_SUBPATHS = ["isa","memory"]` and the `PROTECTED_PATHS` entry carries it.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)