### PR TITLE
fix(importer): generalize claude-path rewriter + strip PAI Customization block (#86)

### DIFF
--- a/docs/pai-pack-importer.md
+++ b/docs/pai-pack-importer.md
@@ -81,6 +81,64 @@ When substrate-specific files are explicitly included, Soma stores them outside
 the skill payload under `~/.soma/imports/pai-packs/<skill>/source/`. They are
 kept as migration source material, not projected skill content.
 
+## Normalization Actions
+
+`normalizeSkillContent` applies a fixed pipeline of deterministic
+transformations to every skill-rendered file (the entry `SKILL.md` and every
+`Workflows/*.md`, `Tools/*.md`). Each transformation either records an
+**action** in the audit trail (the change actually fired) or a **warning**
+(the change is advisory and needs human review). The pipeline runs in a
+fixed order — strips first so path rewrites do not chase content that is
+about to be deleted, deterministic rewrites before the catch-all so they
+keep their named-target detail, catch-all last so it only fires on residue.
+
+### Strip actions
+
+| Action kind | Trigger (in original content) | Replacement |
+| --- | --- | --- |
+| `stripped-mandatory-runtime-block` | A `## MANDATORY` heading whose section body contains `localhost:31337/notify`, `voice notification`, or `notify endpoint`. | Entire section removed. Unrelated `MANDATORY` headings (e.g. `## MANDATORY: Input Requirements`) survive. |
+| `removed-substrate-notification-hook` | A bare `curl ... localhost:31337/notify ...` line that was not already inside a stripped MANDATORY block. | Curl invocation line removed. |
+| `stripped-pai-customization-block` | A `## Customization` heading whose section body contains `SKILLCUSTOMIZATIONS`. | Entire section removed. The PAI runtime hook has no Soma equivalent (see "Out of scope" in issue #86). Unrelated `## Customization` headings (e.g. theme docs) survive. |
+
+### Deterministic path rewrites
+
+| Action kind | Pattern | Replacement |
+| --- | --- | --- |
+| `rewrote-claude-home-path` | `~/.claude/skills/<rest>` | `~/.soma/skills/<rest>` |
+| `rewrote-claude-home-path` | `~/.claude/PAI/MEMORY/<rest>` | `~/.soma/memory/<rest>` |
+
+### Catch-all rewrite (unmapped Claude paths)
+
+| Action kind | Pattern | Replacement |
+| --- | --- | --- |
+| `rewrote-unmapped-claude-path` | Any remaining `~/.claude/<segment>/<rest>` after deterministic rewrites and runtime-block strips. | `~/.soma/UNMAPPED/<segment>/<rest>` with a `unmapped-claude-home-path` warning per distinct first segment, per file. The placeholder makes runtime breakage loud (path does not exist) while the audit-trail warning makes import-time review loud. |
+| `rewrote-unmapped-claude-path` | Bare `~/.claude` or `~/.claude/` prose mentions (no path continuation). | `~/.soma` with an `unmapped-claude-home-path` warning. Used by sentence-form references like *"never leave `~/.claude`"*. |
+
+After the pipeline runs, a bare `grep "~/.claude" SKILL.md Workflows/*.md`
+returns zero — that is the integration-level invariant tested in
+`test/pai-pack-importer-issue-86.test.ts` against a real fixture pack.
+
+### Compaction
+
+| Action kind | Trigger | Replacement |
+| --- | --- | --- |
+| `compacted-skill-description` | Skill description longer than the 1024-character Soma portable metadata limit. | Sentence-boundary-aware truncation; falls back to hard truncation on a non-sentence input. |
+
+### Advisory warnings (no rewrite)
+
+| Warning kind | Trigger |
+| --- | --- |
+| `customization-overlay-reference` | `~/.claude/(context|user|customization)/...` — substrate-overlay model is undefined in Soma. |
+| `execution-logging-path` | `~/.claude/memory/...` or `~/.claude/(history|backup|logs)/...` — route through Soma memory events instead. |
+| `ambiguous-substrate-path` | `~/.claude/(docs|documentation)/...` — no deterministic Soma mapping. |
+| `substrate-mutation-command` | Embedded shell command that mutates Claude home (e.g. `rm -rf ~/.claude/skills/Foo`). |
+| `release-safety-path` | `grep`/`scan`/`check` for secrets, credentials, tokens, or keys against `~/.claude/...`. |
+| `unmapped-claude-home-path` | Catch-all signal that some part of the body referenced a Claude-only path with no Soma equivalent; emitted alongside the `rewrote-unmapped-claude-path` action. |
+
+The named warnings above can fire in addition to `unmapped-claude-home-path`
+— they communicate *why* a path is ambiguous, which the bare catch-all
+warning does not capture.
+
 ## Boundaries
 
 The importer does not:
@@ -102,3 +160,11 @@ expecting the skill to appear in that substrate's skill directory. For Codex:
 ```bash
 bun run soma install codex --apply --soma-home <soma-home>
 ```
+
+## Source archive preservation
+
+Every PAI-pack source file routed as `skill` or `skill-body` is also copied
+verbatim to `~/.soma/imports/pai-packs/<skill>/source/<original-path>`. The
+archive is never normalized — it is the auditable original. The normalized
+projection lives under `~/.soma/skills/<skill>/`; the archive lets a future
+reviewer diff what the normalizer changed.

--- a/src/pai-pack-normalizer.ts
+++ b/src/pai-pack-normalizer.ts
@@ -41,10 +41,52 @@ export const SOMA_SKILL_DESCRIPTION_MAX_LENGTH = 1024;
 const NOTIFICATION_HEADING = /^##+\s*(?:🚨\s*)?MANDATORY[^\n]*$/m;
 const NOTIFICATION_CURL = /^\s*curl\s+[^\n]*localhost:31337\/notify[^\n]*\n?/m;
 
+// PAI `## Customization` runtime block. Issue #86 / AC-2.
+//
+// PAI's Customization block instructs the assistant to look in
+// `~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/<SkillName>/` for user overlays.
+// Soma deliberately does not grow a SKILLCUSTOMIZATIONS equivalent in this
+// PR (see issue body "Out of scope"). The block is stripped as a PAI runtime
+// hook, the same way the MANDATORY notification block is stripped — not
+// rewritten, because there is no Soma side to point at.
+//
+// Anchored on the SKILLCUSTOMIZATIONS marker inside the section body so an
+// unrelated "## Customization" heading (e.g. theme docs) survives intact.
+const CUSTOMIZATION_HEADING = /^##+\s*Customization\s*$/m;
+const CUSTOMIZATION_BODY_MARKER = "SKILLCUSTOMIZATIONS";
+
 const CLAUDE_HOME_DETERMINISTIC: readonly { from: RegExp; to: string; kind: PaiPackNormalizationAction["kind"] }[] = [
-  // Skill payload root — has a clean Soma equivalent
+  // Skill payload root — clean Soma equivalent.
   { from: /~\/\.claude\/skills\//, to: "~/.soma/skills/", kind: "rewrote-claude-home-path" },
+  // Issue #86 / AC-1: PAI memory root → Soma memory root. Both substrates
+  // share the "memory" concept; mapping is one-to-one. The deeper subtree
+  // shape (SKILLS/execution.jsonl etc.) is preserved.
+  { from: /~\/\.claude\/PAI\/MEMORY\//, to: "~/.soma/memory/", kind: "rewrote-claude-home-path" },
 ];
+
+// Issue #86 / AC-1: catch-all for every other `~/.claude/<segment>/...`
+// path. Runs AFTER the deterministic rewrites and AFTER the Customization
+// block strip, so it only fires on paths that have no Soma equivalent and
+// have not been removed. Rewrites to a visible `~/.soma/UNMAPPED/<rest>`
+// placeholder so runtime breakage is loud (the path does not exist) and
+// emits a `unmapped-claude-home-path` warning so import-time review is loud.
+// Together these satisfy AC-3 (zero `~/.claude/` residue in the body) and
+// AC-1 (no silent passthrough — every unmapped reference shows up in the
+// audit trail).
+const CLAUDE_HOME_CATCHALL = /~\/\.claude\/([^\s`'")\]]+)/;
+const CLAUDE_HOME_UNMAPPED_PREFIX = "~/.soma/UNMAPPED/";
+
+// AC-3 strict-grep guard: a naked `~/.claude` or `~/.claude/` (no further
+// path content) in prose ("they never leave ~/.claude") would survive the
+// CLAUDE_HOME_CATCHALL above because it requires at least one character
+// after the slash. Rewrite the bare form to `~/.soma` so the issue's
+// reproduction `grep -n "~/.claude" SKILL.md Workflows/*.md` returns zero.
+// The lookahead anchors on what definitively continues a path segment —
+// alphanumeric, underscore, or dot-followed-by-alnum (for `.ts`, `.md`,
+// etc.). Period-followed-by-space-or-EOL is sentence punctuation, not a
+// path continuation. Anything that the substantive CLAUDE_HOME_CATCHALL
+// already matched is gone by the time this regex runs.
+const CLAUDE_HOME_BARE = /~\/\.claude\/?(?![A-Za-z0-9_-]|\.[A-Za-z0-9])/;
 
 const CLAUDE_HOME_AMBIGUOUS: readonly { pattern: RegExp; kind: PaiPackNormalizationWarning["kind"]; detail: string }[] = [
   {
@@ -95,7 +137,16 @@ export function normalizeSkillContent(relPath: string, content: string): Normali
   collectReleaseSafetyWarnings(relPath, content, warnings);
 
   let working = stripMandatoryNotificationBlock(relPath, content, actions);
+  // Strip the PAI Customization block BEFORE any path rewriting so the
+  // ~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/... path inside the block is
+  // removed wholesale rather than rewritten — there is no Soma equivalent
+  // mechanism to point at (issue #86 / AC-2, "Out of scope" note).
+  working = stripPaiCustomizationBlock(relPath, working, actions);
   working = applyDeterministicPathRewrites(relPath, working, actions);
+  // Catch-all runs LAST so deterministic rewrites and runtime-block strips
+  // get first crack. Anything still containing `~/.claude/...` after this
+  // point is unmapped — rewritten to `~/.soma/UNMAPPED/...` with a warning.
+  working = applyUnmappedClaudePathCatchall(relPath, working, actions, warnings);
 
   return { content: working, actions, warnings };
 }
@@ -149,6 +200,43 @@ function stripMandatoryNotificationBlock(
   return stripped.replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
 }
 
+function stripPaiCustomizationBlock(
+  relPath: string,
+  content: string,
+  actions: PaiPackNormalizationAction[],
+): string {
+  if (!CUSTOMIZATION_HEADING.test(content)) {
+    return content;
+  }
+
+  const headingMatch = CUSTOMIZATION_HEADING.exec(content);
+  if (!headingMatch) {
+    return content;
+  }
+
+  const start = headingMatch.index;
+  const rest = content.slice(start + headingMatch[0].length);
+  const nextHeading = /^##+\s+/m.exec(rest);
+  const end = nextHeading ? start + headingMatch[0].length + nextHeading.index : content.length;
+  const sectionBody = content.slice(start, end);
+
+  // Only strip when the section's body proves it is the PAI runtime
+  // customization block (SKILLCUSTOMIZATIONS marker). An unrelated
+  // "## Customization" heading (e.g. user-facing theme docs) survives —
+  // same conservative gating as the MANDATORY notification block strip.
+  if (!sectionBody.includes(CUSTOMIZATION_BODY_MARKER)) {
+    return content;
+  }
+
+  const stripped = `${content.slice(0, start).replace(/\n+$/, "\n")}${content.slice(end)}`;
+  actions.push({
+    file: relPath,
+    kind: "stripped-pai-customization-block",
+    detail: "Removed PAI Customization runtime block referencing ~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/.",
+  });
+  return stripped.replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
+}
+
 function applyDeterministicPathRewrites(
   relPath: string,
   content: string,
@@ -165,6 +253,61 @@ function applyDeterministicPathRewrites(
       });
     }
   }
+  return working;
+}
+
+function applyUnmappedClaudePathCatchall(
+  relPath: string,
+  content: string,
+  actions: PaiPackNormalizationAction[],
+  warnings: PaiPackNormalizationWarning[],
+): string {
+  let working = content;
+  const seenRests = new Set<string>();
+
+  if (CLAUDE_HOME_CATCHALL.test(working)) {
+    working = working.replace(globalize(CLAUDE_HOME_CATCHALL), (_match, rest: string) => {
+      // The first segment after `~/.claude/` is the routing root; record it
+      // for a single representative warning per file (avoids exploding the
+      // audit trail when the same root appears 20 times in one workflow).
+      const firstSegment = rest.split("/")[0] ?? "";
+      if (firstSegment && !seenRests.has(firstSegment)) {
+        seenRests.add(firstSegment);
+        warnings.push({
+          file: relPath,
+          kind: "unmapped-claude-home-path",
+          detail: `~/.claude/${firstSegment}/ has no Soma equivalent; rewrote to ${CLAUDE_HOME_UNMAPPED_PREFIX}${firstSegment}/ so runtime breakage is visible.`,
+        });
+      }
+      return `${CLAUDE_HOME_UNMAPPED_PREFIX}${rest}`;
+    });
+  }
+
+  // After the substantive catch-all, scrub bare `~/.claude` / `~/.claude/`
+  // mentions (prose like "never leave ~/.claude") so a bare grep on the
+  // projected body returns zero. These get a separate warning class so the
+  // distinction between "broken path reference" and "stale prose mention"
+  // stays visible in the audit trail.
+  if (CLAUDE_HOME_BARE.test(working)) {
+    working = working.replace(globalize(CLAUDE_HOME_BARE), "~/.soma");
+    if (!seenRests.has("__bare__")) {
+      seenRests.add("__bare__");
+      warnings.push({
+        file: relPath,
+        kind: "unmapped-claude-home-path",
+        detail: "Bare ~/.claude prose mention rewrote to ~/.soma to satisfy AC-3 zero-residue grep.",
+      });
+    }
+  }
+
+  if (working !== content) {
+    actions.push({
+      file: relPath,
+      kind: "rewrote-unmapped-claude-path",
+      detail: `Rewrote ${seenRests.size} unmapped ~/.claude/ reference(s) to ${CLAUDE_HOME_UNMAPPED_PREFIX} placeholder (or ~/.soma for bare mentions).`,
+    });
+  }
+
   return working;
 }
 

--- a/src/pai-pack-normalizer.ts
+++ b/src/pai-pack-normalizer.ts
@@ -157,16 +157,38 @@ export function normalizeSkillContent(relPath: string, content: string): Normali
 // round-2 blocker.
 const NOTIFICATION_BODY_MARKERS = /localhost:31337\/notify|voice notification|notify endpoint/i;
 
-// Sage R1 (PR #87) Maintainability + CodeQuality: shared section-strip
-// helper. Iterates every match of `headingRegex` (a heading line anchored
-// with /m), measures the section span to the next `^##+ ` heading or EOF,
-// and strips every section whose body satisfies `markerMatches`. Returns
-// the stripped content and the count of sections actually removed.
+// Returns the ATX heading level (count of leading `#`s) for a matched
+// heading string like `"## Customization"`. The matched string is
+// guaranteed to start with `#`s by the heading regex it came from.
+function headingHashCount(headingText: string): number {
+  const hashes = /^(#+)/.exec(headingText);
+  return hashes ? hashes[1].length : 0;
+}
+
+// Returns a fresh regex that matches the next ATX heading at the given
+// level or higher (fewer `#`s = higher level). Used to compute where a
+// stripped section ends — a deeper heading is part of the section's
+// hierarchy, but a same-or-higher heading starts the next section.
+function sameOrHigherHeadingBoundary(level: number): RegExp {
+  if (level <= 0) {
+    return /^#+\s+/m;
+  }
+  return new RegExp(`^#{1,${level}}\\s+`, "m");
+}
+
+// Sage R1 + R2 (PR #87) Maintainability + CodeQuality: shared section-
+// strip helper. Iterates every match of `headingRegex` (a heading line
+// anchored with /m), measures the section span to the next same-or-higher
+// ATX heading or EOF, and strips every section whose body satisfies
+// `markerMatches`. Returns the stripped content and the count of sections
+// actually removed.
 //
-// "Iterate every match" is the fix for the round-1 CodeQuality finding:
-// the original stripper only inspected the first match, so an unrelated
-// `## Customization` ahead of the real PAI runtime block would prevent
-// the strip from firing on the later block.
+// "Iterate every match" was the R1 fix: the original stripper only
+// inspected the first match, so an unrelated `## Customization` ahead of
+// the real PAI runtime block would prevent the strip from firing on the
+// later block. "Same-or-higher boundary" was the R2 fix: the original
+// boundary regex `/^##+\s+/m` would swallow an H1 between the stripped
+// `##` block and the next `##`.
 function stripMarkedHeadingSections(
   content: string,
   headingRegex: RegExp,
@@ -176,11 +198,11 @@ function stripMarkedHeadingSections(
   // mid-iteration. The heading regex is multiline-anchored; using
   // globalize() guarantees we never share lastIndex with caller-side
   // `.test()` / `.exec()` calls on the same RegExp instance.
-  const matchPositions: { start: number; headingLength: number }[] = [];
+  const matchPositions: { start: number; headingText: string }[] = [];
   const scanner = globalize(headingRegex);
   let scan: RegExpExecArray | null;
   while ((scan = scanner.exec(content)) !== null) {
-    matchPositions.push({ start: scan.index, headingLength: scan[0].length });
+    matchPositions.push({ start: scan.index, headingText: scan[0] });
     // Defend against zero-width matches looping forever.
     if (scan.index === scanner.lastIndex) scanner.lastIndex += 1;
   }
@@ -190,12 +212,23 @@ function stripMarkedHeadingSections(
   }
 
   // Resolve each match to its section span [start, end) over the ORIGINAL
-  // content. End is either the next `^##+ ` heading after the section
-  // header, or EOF. Filter to the ones whose body matches the marker.
+  // content. End is either the next same-or-higher ATX heading after the
+  // section header, or EOF. Filter to the ones whose body matches the
+  // marker.
+  //
+  // Sage R2 (PR #87) CodeQuality fix: the original boundary regex
+  // `/^##+\s+/m` only matched `##+`, so an H1 between the stripped block
+  // and the next `##` was swallowed. Boundary is now computed from the
+  // matched heading's own level — for a `##` strip, any `#` or `##` ends
+  // the section; deeper headings (`###`+) are treated as in-section
+  // subsections and stripped along with the parent block.
   const stripSpans: { start: number; end: number }[] = [];
-  for (const { start, headingLength } of matchPositions) {
+  for (const { start, headingText } of matchPositions) {
+    const headingLength = headingText.length;
+    const level = headingHashCount(headingText);
+    const boundary = sameOrHigherHeadingBoundary(level);
     const rest = content.slice(start + headingLength);
-    const nextHeading = /^##+\s+/m.exec(rest);
+    const nextHeading = boundary.exec(rest);
     const end = nextHeading ? start + headingLength + nextHeading.index : content.length;
     const sectionBody = content.slice(start, end);
     if (markerMatches(sectionBody)) {

--- a/src/pai-pack-normalizer.ts
+++ b/src/pai-pack-normalizer.ts
@@ -169,9 +169,15 @@ function headingHashCount(headingText: string): number {
 // level or higher (fewer `#`s = higher level). Used to compute where a
 // stripped section ends — a deeper heading is part of the section's
 // hierarchy, but a same-or-higher heading starts the next section.
+//
+// Precondition: `level >= 1`. Sage R3 (PR #87) Maintainability nit: the
+// only call site (`stripMarkedHeadingSections`) gets `level` from
+// `headingHashCount(headingText)` where `headingText` is captured by a
+// regex anchored on `^#+`, so `level >= 1` is always true. Asserting here
+// keeps the contract explicit instead of carrying a dead defensive branch.
 function sameOrHigherHeadingBoundary(level: number): RegExp {
-  if (level <= 0) {
-    return /^#+\s+/m;
+  if (level < 1) {
+    throw new Error(`sameOrHigherHeadingBoundary: level must be >= 1, got ${level}`);
   }
   return new RegExp(`^#{1,${level}}\\s+`, "m");
 }

--- a/src/pai-pack-normalizer.ts
+++ b/src/pai-pack-normalizer.ts
@@ -157,6 +157,66 @@ export function normalizeSkillContent(relPath: string, content: string): Normali
 // round-2 blocker.
 const NOTIFICATION_BODY_MARKERS = /localhost:31337\/notify|voice notification|notify endpoint/i;
 
+// Sage R1 (PR #87) Maintainability + CodeQuality: shared section-strip
+// helper. Iterates every match of `headingRegex` (a heading line anchored
+// with /m), measures the section span to the next `^##+ ` heading or EOF,
+// and strips every section whose body satisfies `markerMatches`. Returns
+// the stripped content and the count of sections actually removed.
+//
+// "Iterate every match" is the fix for the round-1 CodeQuality finding:
+// the original stripper only inspected the first match, so an unrelated
+// `## Customization` ahead of the real PAI runtime block would prevent
+// the strip from firing on the later block.
+function stripMarkedHeadingSections(
+  content: string,
+  headingRegex: RegExp,
+  markerMatches: (sectionBody: string) => boolean,
+): { content: string; stripped: number } {
+  // Collect ALL match positions first so position math does not shift
+  // mid-iteration. The heading regex is multiline-anchored; using
+  // globalize() guarantees we never share lastIndex with caller-side
+  // `.test()` / `.exec()` calls on the same RegExp instance.
+  const matchPositions: { start: number; headingLength: number }[] = [];
+  const scanner = globalize(headingRegex);
+  let scan: RegExpExecArray | null;
+  while ((scan = scanner.exec(content)) !== null) {
+    matchPositions.push({ start: scan.index, headingLength: scan[0].length });
+    // Defend against zero-width matches looping forever.
+    if (scan.index === scanner.lastIndex) scanner.lastIndex += 1;
+  }
+
+  if (matchPositions.length === 0) {
+    return { content, stripped: 0 };
+  }
+
+  // Resolve each match to its section span [start, end) over the ORIGINAL
+  // content. End is either the next `^##+ ` heading after the section
+  // header, or EOF. Filter to the ones whose body matches the marker.
+  const stripSpans: { start: number; end: number }[] = [];
+  for (const { start, headingLength } of matchPositions) {
+    const rest = content.slice(start + headingLength);
+    const nextHeading = /^##+\s+/m.exec(rest);
+    const end = nextHeading ? start + headingLength + nextHeading.index : content.length;
+    const sectionBody = content.slice(start, end);
+    if (markerMatches(sectionBody)) {
+      stripSpans.push({ start, end });
+    }
+  }
+
+  if (stripSpans.length === 0) {
+    return { content, stripped: 0 };
+  }
+
+  // Splice spans out from the tail so earlier indices remain valid.
+  let working = content;
+  for (let i = stripSpans.length - 1; i >= 0; i--) {
+    const { start, end } = stripSpans[i];
+    working = `${working.slice(0, start).replace(/\n+$/, "\n")}${working.slice(end)}`;
+  }
+
+  return { content: working, stripped: stripSpans.length };
+}
+
 function stripMandatoryNotificationBlock(
   relPath: string,
   content: string,
@@ -166,25 +226,23 @@ function stripMandatoryNotificationBlock(
     return content;
   }
 
-  let stripped = content;
-  const headingMatch = NOTIFICATION_HEADING.exec(content);
-  if (headingMatch) {
-    const start = headingMatch.index;
-    const rest = stripped.slice(start + headingMatch[0].length);
-    const nextHeading = /^##+\s+/m.exec(rest);
-    const end = nextHeading ? start + headingMatch[0].length + nextHeading.index : stripped.length;
-    const sectionBody = stripped.slice(start, end);
-    // Only strip when the section's body proves it is the notification
-    // runtime block (curl invocation or notification keyword). A heading
-    // like "## MANDATORY: Input Requirements" survives.
-    if (NOTIFICATION_BODY_MARKERS.test(sectionBody)) {
-      stripped = `${stripped.slice(0, start).replace(/\n+$/, "\n")}${stripped.slice(end)}`;
-      actions.push({
-        file: relPath,
-        kind: "stripped-mandatory-runtime-block",
-        detail: "Removed mandatory notification runtime block.",
-      });
-    }
+  // Sage R1 fix: use the shared helper. Strips every MANDATORY section
+  // whose body is the notification runtime block. Conservative gating
+  // (NOTIFICATION_BODY_MARKERS) preserves `## MANDATORY: Input Requirements`.
+  const { content: afterHeadingStrip, stripped: headingStrips } = stripMarkedHeadingSections(
+    content,
+    NOTIFICATION_HEADING,
+    (sectionBody) => NOTIFICATION_BODY_MARKERS.test(sectionBody),
+  );
+  let stripped = afterHeadingStrip;
+  if (headingStrips > 0) {
+    actions.push({
+      file: relPath,
+      kind: "stripped-mandatory-runtime-block",
+      detail: headingStrips === 1
+        ? "Removed mandatory notification runtime block."
+        : `Removed ${headingStrips} mandatory notification runtime blocks.`,
+    });
   }
 
   // Strip any stragglers — bare curl notification commands outside a heading.
@@ -209,30 +267,27 @@ function stripPaiCustomizationBlock(
     return content;
   }
 
-  const headingMatch = CUSTOMIZATION_HEADING.exec(content);
-  if (!headingMatch) {
+  // Sage R1 (PR #87) CodeQuality fix: strip ALL `## Customization`
+  // sections whose body contains the SKILLCUSTOMIZATIONS marker — not
+  // just the first match. An unrelated `## Customization` heading
+  // earlier in the document (e.g. theme docs) must not shield a later
+  // PAI runtime block from removal.
+  const { content: stripped, stripped: count } = stripMarkedHeadingSections(
+    content,
+    CUSTOMIZATION_HEADING,
+    (sectionBody) => sectionBody.includes(CUSTOMIZATION_BODY_MARKER),
+  );
+
+  if (count === 0) {
     return content;
   }
 
-  const start = headingMatch.index;
-  const rest = content.slice(start + headingMatch[0].length);
-  const nextHeading = /^##+\s+/m.exec(rest);
-  const end = nextHeading ? start + headingMatch[0].length + nextHeading.index : content.length;
-  const sectionBody = content.slice(start, end);
-
-  // Only strip when the section's body proves it is the PAI runtime
-  // customization block (SKILLCUSTOMIZATIONS marker). An unrelated
-  // "## Customization" heading (e.g. user-facing theme docs) survives —
-  // same conservative gating as the MANDATORY notification block strip.
-  if (!sectionBody.includes(CUSTOMIZATION_BODY_MARKER)) {
-    return content;
-  }
-
-  const stripped = `${content.slice(0, start).replace(/\n+$/, "\n")}${content.slice(end)}`;
   actions.push({
     file: relPath,
     kind: "stripped-pai-customization-block",
-    detail: "Removed PAI Customization runtime block referencing ~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/.",
+    detail: count === 1
+      ? "Removed PAI Customization runtime block referencing ~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/."
+      : `Removed ${count} PAI Customization runtime blocks referencing ~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/.`,
   });
   return stripped.replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -442,7 +442,9 @@ export interface PaiPackNormalizationAction {
   kind:
     | "removed-substrate-notification-hook"
     | "rewrote-claude-home-path"
+    | "rewrote-unmapped-claude-path"
     | "stripped-mandatory-runtime-block"
+    | "stripped-pai-customization-block"
     | "compacted-skill-description";
   detail: string;
 }
@@ -454,7 +456,8 @@ export interface PaiPackNormalizationWarning {
     | "substrate-mutation-command"
     | "execution-logging-path"
     | "customization-overlay-reference"
-    | "release-safety-path";
+    | "release-safety-path"
+    | "unmapped-claude-home-path";
   detail: string;
 }
 

--- a/test/fixtures/pai-packs/issue-86/INSTALL.md
+++ b/test/fixtures/pai-packs/issue-86/INSTALL.md
@@ -1,0 +1,3 @@
+# Install
+
+Fixture pack — not installable.

--- a/test/fixtures/pai-packs/issue-86/README.md
+++ b/test/fixtures/pai-packs/issue-86/README.md
@@ -1,0 +1,22 @@
+---
+name: Issue86Fixture
+description: USE WHEN reproducing issue 86 — surfaces every claude-path rewrite class plus PAI Customization block.
+---
+
+# Issue86Fixture
+
+Fixture pack that intentionally embeds every `~/.claude/<subpath>` shape called
+out in `the-metafactory/soma#86` plus the PAI `## Customization` runtime block.
+
+Used by the importer test suite to lock the post-fix normalizer against silent
+regressions on:
+
+- `~/.claude/skills/...` — deterministic Soma rewrite
+- `~/.claude/PAI/MEMORY/...` — deterministic Soma memory rewrite
+- `~/.claude/PAI/DOCUMENTATION/...` — unmapped catch-all
+- `~/.claude/PAI/SkillSystem.md` — unmapped catch-all (PAI runtime root)
+- `~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/...` — stripped via Customization block
+- `~/.claude/History/Backups/...` — unmapped catch-all
+- `## Customization` heading — stripped as PAI runtime block
+
+After normalization the body must contain zero `~/.claude/` strings.

--- a/test/fixtures/pai-packs/issue-86/VERIFY.md
+++ b/test/fixtures/pai-packs/issue-86/VERIFY.md
@@ -1,0 +1,3 @@
+# Verify
+
+Fixture pack — verification handled by the importer test suite.

--- a/test/fixtures/pai-packs/issue-86/src/SKILL.md
+++ b/test/fixtures/pai-packs/issue-86/src/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: Issue86Fixture
+description: USE WHEN reproducing issue 86 — surfaces every claude-path rewrite class plus PAI Customization block.
+---
+
+## Customization
+
+**Before executing, check for user customizations at:**
+`~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Issue86Fixture/`
+
+If this directory exists, load and apply any PREFERENCES.md, configurations, or
+resources found there. These override default behavior. If the directory does
+not exist, proceed with skill defaults.
+
+
+# Issue86Fixture
+
+## Authoritative Source
+
+**Before doing anything, READ:** `~/.claude/PAI/DOCUMENTATION/Skills/SkillSystem.md`
+
+**Canonical example:** any well-formed skill in `~/.claude/skills/` (e.g.
+`Research/SKILL.md`).
+
+## Runtime PAI references
+
+- Skill system root: `~/.claude/PAI/SkillSystem.md`
+- Execution log: `~/.claude/PAI/MEMORY/SKILLS/execution.jsonl`
+- Notification system: `~/.claude/PAI/DOCUMENTATION/Notifications/NotificationSystem.md`

--- a/test/fixtures/pai-packs/issue-86/src/Workflows/CanonicalizeSkill.md
+++ b/test/fixtures/pai-packs/issue-86/src/Workflows/CanonicalizeSkill.md
@@ -1,0 +1,18 @@
+# CanonicalizeSkill
+
+## Input
+
+```
+~/.claude/skills/[skill-name]/SKILL.md
+```
+
+## Steps
+
+1. Back up before modifying:
+   ```bash
+   cp -r ~/.claude/skills/[skill-name]/ ~/.claude/History/Backups/[skill-name]-backup-$(date +%Y%m%d)/
+   ```
+
+   **Note:** Backups go to `~/.claude/History/Backups/`, NEVER inside skill directories.
+
+2. Validate against the reference: `~/.claude/PAI/SkillSystem.md`

--- a/test/pai-pack-importer-issue-86.test.ts
+++ b/test/pai-pack-importer-issue-86.test.ts
@@ -69,6 +69,71 @@ test("AC-2: normalizeSkillContent strips the PAI Customization block", () => {
   expect(result.content).toContain("Real Content");
 });
 
+test("Sage R1 fix: shared helper strips ALL MANDATORY notification blocks (multi-match defense in depth)", () => {
+  // The MANDATORY stripper now uses the same shared helper as the
+  // Customization stripper. Multiple notification blocks in a single
+  // skill file (rare but observed in some PAI packs) all get stripped.
+  const content = [
+    "## MANDATORY: Voice Notification",
+    "",
+    "curl http://localhost:31337/notify",
+    "",
+    "## Body",
+    "",
+    "Section.",
+    "",
+    "## MANDATORY: Voice Notification (REQUIRED BEFORE ANY ACTION)",
+    "",
+    "Send voice notification via curl to localhost:31337/notify.",
+    "",
+    "## Footer",
+    "",
+    "End.",
+  ].join("\n");
+  const result = normalizeSkillContent("SKILL.md", content);
+  expect(result.content).not.toContain("MANDATORY");
+  expect(result.content).not.toContain("localhost:31337/notify");
+  expect(result.content).toContain("Footer");
+  expect(result.content).toContain("End.");
+  const mandatoryActions = result.actions.filter((a) => a.kind === "stripped-mandatory-runtime-block");
+  expect(mandatoryActions.length).toBeGreaterThan(0);
+});
+
+test("AC-2 Sage R1 fix: strips PAI Customization block even when an unrelated Customization heading appears earlier", () => {
+  // Sage R1 (PR #87) CodeQuality important finding: the original stripper
+  // matched only the first `## Customization` heading and bailed when its
+  // body lacked SKILLCUSTOMIZATIONS — leaving a later PAI runtime block
+  // intact. Scan all matches; strip the one(s) whose body carries the
+  // SKILLCUSTOMIZATIONS marker.
+  const content = [
+    "## Customization",
+    "",
+    "Configure colors in `theme.json` for your dashboard.",
+    "",
+    "## Body",
+    "",
+    "First real section.",
+    "",
+    "## Customization",
+    "",
+    "**Before executing, check for user customizations at:**",
+    "`~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Demo/`",
+    "",
+    "## Tail",
+    "",
+    "Trailing body.",
+  ].join("\n");
+  const result = normalizeSkillContent("SKILL.md", content);
+  // Theme-docs Customization heading survives
+  expect(result.content).toContain("theme.json");
+  // PAI runtime Customization block is gone
+  expect(result.content).not.toContain("SKILLCUSTOMIZATIONS");
+  expect(result.content).not.toContain("~/.claude/PAI/USER/");
+  expect(result.actions.some((a) => a.kind === "stripped-pai-customization-block")).toBe(true);
+  // Tail content preserved
+  expect(result.content).toContain("Trailing body.");
+});
+
 test("AC-2: leaves unrelated 'Customization' headings alone (requires SKILLCUSTOMIZATIONS marker)", () => {
   const content = [
     "## Customization",

--- a/test/pai-pack-importer-issue-86.test.ts
+++ b/test/pai-pack-importer-issue-86.test.ts
@@ -69,6 +69,52 @@ test("AC-2: normalizeSkillContent strips the PAI Customization block", () => {
   expect(result.content).toContain("Real Content");
 });
 
+test("Sage R2 fix: strip respects H1 boundary — `# Title` between `## Customization` and next `##` survives", () => {
+  // Sage R2 (PR #87) CodeQuality important finding: the section-end regex
+  // `/^##+\s+/m` only matched ##+ — an H1 (`# Foo`) after the stripped
+  // block but before the next `##` was treated as part of the stripped
+  // section and removed. Fix: use any-ATX-heading boundary `/^#+\s+/m`
+  // so the strip stops at the first heading of ANY level.
+  const content = [
+    "## Customization",
+    "",
+    "**Before executing, check for user customizations at:**",
+    "`~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Demo/`",
+    "",
+    "# MainTitle",
+    "",
+    "## Real Content",
+    "",
+    "Body here.",
+  ].join("\n");
+  const result = normalizeSkillContent("SKILL.md", content);
+  expect(result.content).not.toContain("SKILLCUSTOMIZATIONS");
+  // H1 between the stripped block and the next ## must survive.
+  expect(result.content).toContain("# MainTitle");
+  expect(result.content).toContain("## Real Content");
+  expect(result.content).toContain("Body here.");
+});
+
+test("Sage R2 fix: same boundary fix applies to MANDATORY notification strip", () => {
+  // The shared helper is used by both strippers — symmetry test.
+  const content = [
+    "## MANDATORY: Voice Notification",
+    "",
+    "curl http://localhost:31337/notify",
+    "",
+    "# MainTitle",
+    "",
+    "## Real Content",
+    "",
+    "Body.",
+  ].join("\n");
+  const result = normalizeSkillContent("SKILL.md", content);
+  expect(result.content).not.toContain("MANDATORY");
+  expect(result.content).not.toContain("localhost:31337/notify");
+  expect(result.content).toContain("# MainTitle");
+  expect(result.content).toContain("## Real Content");
+});
+
 test("Sage R1 fix: shared helper strips ALL MANDATORY notification blocks (multi-match defense in depth)", () => {
   // The MANDATORY stripper now uses the same shared helper as the
   // Customization stripper. Multiple notification blocks in a single

--- a/test/pai-pack-importer-issue-86.test.ts
+++ b/test/pai-pack-importer-issue-86.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Issue 86 — pai-pack-importer: claude-path rewriter too narrow,
+ * PAI Customization block copied verbatim.
+ *
+ * Tests live in their own file so the regression surface is grep-able by
+ * issue number and the fixture-driven invariants stay co-located.
+ *
+ * - AC-1: every `~/.claude/<subpath>` either rewrites, gets stripped, or
+ *         surfaces as a warning. No silent passthrough.
+ * - AC-2: PAI Customization block stripped via named action kind.
+ * - AC-3: importing the fixture produces ZERO `~/.claude/` residue in the
+ *         imported skill body (grep test on every projected .md).
+ * - AC-4: fixture-based coverage for every rewrite/strip/warn class.
+ */
+import { mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { normalizeSkillContent } from "../src/pai-pack-normalizer";
+import { importPaiPack } from "../src/index";
+
+const FIXTURE_PACK_DIR = join(import.meta.dir, "fixtures/pai-packs/issue-86");
+
+async function withTempHome<T>(fn: (homeDir: string, somaHome: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-issue-86-"));
+  try {
+    return await fn(homeDir, join(homeDir, ".soma"));
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function collectMarkdownFiles(root: string): Promise<string[]> {
+  const out: string[] = [];
+  async function visit(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await visit(full);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        out.push(full);
+      }
+    }
+  }
+  await visit(root);
+  return out.sort();
+}
+
+// ─── AC-2: PAI Customization block strip ────────────────────────────────
+
+test("AC-2: normalizeSkillContent strips the PAI Customization block", () => {
+  const content = [
+    "## Customization",
+    "",
+    "**Before executing, check for user customizations at:**",
+    "`~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/Demo/`",
+    "",
+    "If this directory exists, load and apply any PREFERENCES.md found there.",
+    "",
+    "## Real Content",
+    "",
+    "Body here.",
+  ].join("\n");
+  const result = normalizeSkillContent("SKILL.md", content);
+  expect(result.actions.some((a) => a.kind === "stripped-pai-customization-block")).toBe(true);
+  expect(result.content).not.toContain("Customization");
+  expect(result.content).not.toContain("SKILLCUSTOMIZATIONS");
+  expect(result.content).toContain("Real Content");
+});
+
+test("AC-2: leaves unrelated 'Customization' headings alone (requires SKILLCUSTOMIZATIONS marker)", () => {
+  const content = [
+    "## Customization",
+    "",
+    "Configure colors and fonts in `theme.json`.",
+    "",
+    "## Body",
+    "",
+    "Real content.",
+  ].join("\n");
+  const result = normalizeSkillContent("SKILL.md", content);
+  expect(result.actions.some((a) => a.kind === "stripped-pai-customization-block")).toBe(false);
+  expect(result.content).toContain("Customization");
+  expect(result.content).toContain("theme.json");
+});
+
+// ─── AC-1: catch-all for unmapped claude paths ─────────────────────────
+
+test("AC-1: PAI DOCUMENTATION path rewrites to UNMAPPED placeholder + warning", () => {
+  const content = "See `~/.claude/PAI/DOCUMENTATION/Skills/SkillSystem.md` for details.\n";
+  const result = normalizeSkillContent("body.md", content);
+  expect(result.content).not.toContain("~/.claude/");
+  expect(result.content).toContain("~/.soma/UNMAPPED/PAI/DOCUMENTATION/Skills/SkillSystem.md");
+  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(true);
+  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(true);
+});
+
+test("AC-1: PAI SkillSystem.md (no subdir) rewrites to UNMAPPED + warning", () => {
+  const content = "Reference: ~/.claude/PAI/SkillSystem.md\n";
+  const result = normalizeSkillContent("body.md", content);
+  expect(result.content).not.toContain("~/.claude/");
+  expect(result.content).toContain("~/.soma/UNMAPPED/PAI/SkillSystem.md");
+  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(true);
+});
+
+test("AC-1: History/Backups path rewrites to UNMAPPED + warning", () => {
+  const content = "cp -r ~/.claude/skills/Foo/ ~/.claude/History/Backups/Foo-backup/\n";
+  const result = normalizeSkillContent("body.md", content);
+  expect(result.content).not.toContain("~/.claude/");
+  // History/Backups → UNMAPPED catch-all
+  expect(result.content).toContain("~/.soma/UNMAPPED/History/Backups/");
+  // Skills path → deterministic rewrite (existing behavior preserved)
+  expect(result.content).toContain("~/.soma/skills/Foo/");
+});
+
+// ─── AC-1: new deterministic rewrite (PAI MEMORY → soma memory) ────────
+
+test("AC-1: PAI MEMORY path rewrites deterministically to ~/.soma/memory/", () => {
+  const content = "Log execution: ~/.claude/PAI/MEMORY/SKILLS/execution.jsonl\n";
+  const result = normalizeSkillContent("body.md", content);
+  expect(result.content).not.toContain("~/.claude/");
+  expect(result.content).toContain("~/.soma/memory/SKILLS/execution.jsonl");
+  // Deterministic mapping → no UNMAPPED warning; uses existing rewrote-claude-home-path action
+  expect(result.actions.some((a) => a.kind === "rewrote-claude-home-path")).toBe(true);
+  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
+});
+
+// ─── AC-1: skills root rewrite still works post-refactor ───────────────
+
+test("AC-1: deterministic ~/.claude/skills/ rewrite still works", () => {
+  const content = "ls ~/.claude/skills/Foo/Workflows/\n";
+  const result = normalizeSkillContent("body.md", content);
+  expect(result.content).toContain("~/.soma/skills/Foo/Workflows/");
+  expect(result.content).not.toContain("~/.claude/");
+  expect(result.actions.some((a) => a.kind === "rewrote-claude-home-path")).toBe(true);
+});
+
+// ─── AC-1: no claude residue — exhaustive catch-all ────────────────────
+
+test("AC-1: arbitrary unknown ~/.claude/X path still rewrites to UNMAPPED", () => {
+  const content = "Reference: ~/.claude/SomethingNew/file.md\n";
+  const result = normalizeSkillContent("body.md", content);
+  expect(result.content).not.toContain("~/.claude/");
+  expect(result.content).toContain("~/.soma/UNMAPPED/SomethingNew/file.md");
+  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(true);
+});
+
+test("AC-3: bare ~/.claude prose mentions rewrite to ~/.soma (zero-residue grep)", () => {
+  // Real strings from the stress-test CreateSkill SKILL.md:
+  //   "they never leave ~/.claude"        — no trailing slash
+  //   "someone else's ~/.claude/"         — trailing slash, no path
+  // A strict grep on the projected body must return zero — these
+  // prose mentions are the only thing standing in the way after the
+  // substantive catch-all runs.
+  const content = [
+    "Release tooling skips _* skills entirely — they never leave ~/.claude. Public",
+    "Anything that would be wrong in someone else's ~/.claude/ is _ALLCAPS.",
+  ].join("\n");
+  const result = normalizeSkillContent("SKILL.md", content);
+  expect(result.content).not.toContain("~/.claude");
+  expect(result.content).toContain("~/.soma");
+  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(true);
+  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(true);
+});
+
+// ─── AC-3 / AC-4: end-to-end fixture import — zero claude residue ──────
+
+test("AC-3 + AC-4: importing the issue-86 fixture leaves zero ~/.claude/ residue", async () => {
+  await withTempHome(async (homeDir, somaHome) => {
+    const result = await importPaiPack({ homeDir, somaHome, paiPackDir: FIXTURE_PACK_DIR });
+    const skillRoot = join(somaHome, "skills", result.skillName);
+    // Match the issue 86 reproduction scope: SKILL.md + Workflows/*.md only.
+    // The `references/` directory under the skill root preserves original
+    // PAI install/verify/readme docs verbatim — those are kept as
+    // historical artifacts (per docs/pai-pack-importer.md: "Source docs are
+    // preserved under references/ so Claude-specific installation guidance
+    // remains available"). Rewriting them would corrupt their meaning.
+    const projected = (await collectMarkdownFiles(skillRoot)).filter((path) => {
+      const rel = path.slice(skillRoot.length + 1);
+      return rel === "SKILL.md" || rel.startsWith("Workflows/");
+    });
+
+    expect(projected.length).toBeGreaterThan(0);
+    for (const file of projected) {
+      const body = await readFile(file, "utf8");
+      // AC-3 grep test: zero ~/.claude residue (path-form OR bare prose).
+      expect(body, `~/.claude residue in projected ${file}`).not.toContain("~/.claude");
+    }
+
+    // AC-2: the PAI runtime Customization block (heading + body referencing
+    // SKILLCUSTOMIZATIONS) is stripped from SKILL.md. Note: mentions of the
+    // word "SKILLCUSTOMIZATIONS" elsewhere in skill prose are conceptual
+    // documentation of the PAI mental model (e.g. "user-specific content
+    // lives in SKILLCUSTOMIZATIONS"); those are not runtime hooks and are
+    // left alone. The block-vs-mention distinction matches the existing
+    // MANDATORY-block strip pattern.
+    const skillMd = await readFile(join(skillRoot, "SKILL.md"), "utf8");
+    expect(skillMd).not.toMatch(/^##+\s*Customization\s*$/m);
+
+    // Each named action kind must be present in the audit trail at least once
+    const actionKinds = new Set(result.normalization.actions.map((a) => a.kind));
+    expect(actionKinds.has("stripped-pai-customization-block")).toBe(true);
+    expect(actionKinds.has("rewrote-claude-home-path")).toBe(true);
+    expect(actionKinds.has("rewrote-unmapped-claude-path")).toBe(true);
+
+    // Warning surface must include the catch-all kind so silent passthrough
+    // is impossible — AC-1.
+    const warningKinds = new Set(result.normalization.warnings.map((w) => w.kind));
+    expect(warningKinds.has("unmapped-claude-home-path")).toBe(true);
+
+    // Original PAI source must still be archived verbatim (AC-4 archive
+    // contract from the existing importer suite — re-asserted here so the
+    // archive doesn't regress when the projection rewrites change).
+    const archivedSkill = await readFile(
+      join(somaHome, "imports", "pai-packs", result.skillName, "source", "src", "SKILL.md"),
+      "utf8",
+    );
+    expect(archivedSkill).toContain("~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/");
+    expect(archivedSkill).toContain("## Customization");
+  });
+});
+
+// ─── AC-1: stress-test pack parity (real CreateSkill pack on disk) ─────
+
+test("AC-1 stress-test parity: every Claude path class from issue 86 produces an action or warning", () => {
+  // Synthesizes the 10 actual residues from the issue body. The promise is
+  // "no silent passthrough" — the assertions below check both halves of
+  // that promise: (1) zero `~/.claude/` residue in the rewritten body, and
+  // (2) every distinct unmapped routing root appears in the warning set
+  // exactly once (warnings are de-duped per file by root segment so the
+  // audit trail doesn't explode when a workflow mentions the same root 20
+  // times — but every root must be present at least once).
+  const residueLines = [
+    "Refer to ~/.claude/PAI/SkillSystem.md for the canonical contract.",
+    "Read ~/.claude/PAI/DOCUMENTATION/Skills/SkillSystem.md before creating any skill.",
+    "Notifications live in ~/.claude/PAI/DOCUMENTATION/Notifications/NotificationSystem.md.",
+    "Tool architecture: ~/.claude/PAI/DOCUMENTATION/Tools/CliFirstArchitecture.md.",
+    "User customizations at ~/.claude/PAI/USER/SKILLCUSTOMIZATIONS/CreateSkill/.",
+    "Backups go to ~/.claude/History/Backups/.",
+    "cp -r ~/.claude/skills/Foo/ ~/.claude/History/Backups/Foo/",
+    "echo run >> ~/.claude/PAI/MEMORY/SKILLS/execution.jsonl",
+    "ls ~/.claude/skills/Foo/Workflows/",
+    "cd ~/.claude/skills/Foo/",
+  ];
+  const content = residueLines.join("\n");
+  const result = normalizeSkillContent("Workflows/Stress.md", content);
+  // AC-3: no claude residue after normalization
+  expect(result.content).not.toContain("~/.claude/");
+  // AC-1: every unmapped routing root surfaced via the warning set
+  // (PAI and History both have no Soma equivalent — both must show up).
+  const unmappedDetails = result.warnings
+    .filter((w) => w.kind === "unmapped-claude-home-path")
+    .map((w) => w.detail);
+  expect(unmappedDetails.some((d) => d.includes("~/.claude/PAI/"))).toBe(true);
+  expect(unmappedDetails.some((d) => d.includes("~/.claude/History/"))).toBe(true);
+  // skills and PAI/MEMORY are deterministically mapped → action, not warning.
+  const actionKinds = new Set(result.actions.map((a) => a.kind));
+  expect(actionKinds.has("rewrote-claude-home-path")).toBe(true);
+  expect(actionKinds.has("rewrote-unmapped-claude-path")).toBe(true);
+});

--- a/test/pai-pack-normalizer.test.ts
+++ b/test/pai-pack-normalizer.test.ts
@@ -97,7 +97,14 @@ test("normalizeSkillContent rewrites deterministic Claude skills path", () => {
   expect(result.actions.some((a) => a.kind === "rewrote-claude-home-path")).toBe(true);
 });
 
-test("normalizeSkillContent warns on ambiguous Claude paths instead of rewriting", () => {
+test("normalizeSkillContent warns on ambiguous Claude paths AND rewrites them to the UNMAPPED placeholder", () => {
+  // Issue #86 / AC-1: every ~/.claude/<subpath> must be rewritten,
+  // stripped, or surface as a warning — silent passthrough is not
+  // acceptable. The named-class warnings (customization-overlay-reference,
+  // execution-logging-path, ambiguous-substrate-path) communicate *why* a
+  // path is ambiguous; the catch-all rewrites the literal path to
+  // ~/.soma/UNMAPPED/... so AC-3's "zero ~/.claude/ residue" promise is
+  // also satisfied.
   const content = [
     "Customization in ~/.claude/customization/x.md",
     "Memory at ~/.claude/memory/run.jsonl",
@@ -105,11 +112,18 @@ test("normalizeSkillContent warns on ambiguous Claude paths instead of rewriting
   ].join("\n");
   const result = normalizeSkillContent("body.md", content);
   const warningKinds = result.warnings.map((w) => w.kind);
+  // Named warnings still fire — they explain the substrate-meaning of
+  // each path class, which the bare unmapped-claude-home-path warning does
+  // not capture.
   expect(warningKinds).toContain("customization-overlay-reference");
   expect(warningKinds).toContain("execution-logging-path");
   expect(warningKinds).toContain("ambiguous-substrate-path");
-  // Ambiguous paths are NOT silently rewritten
-  expect(result.content).toContain("~/.claude/customization/x.md");
+  // Catch-all warning + action also fire (AC-1 baseline).
+  expect(warningKinds).toContain("unmapped-claude-home-path");
+  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(true);
+  // AC-3: zero ~/.claude/ residue
+  expect(result.content).not.toContain("~/.claude/");
+  expect(result.content).toContain("~/.soma/UNMAPPED/customization/x.md");
 });
 
 test("normalizeSkillContent warns on substrate mutation commands", () => {


### PR DESCRIPTION
Closes #86.

## Problem

The PAI pack importer previously only rewrote `~/.claude/skills/` paths, leaving every other `~/.claude/...` subpath (PAI/, History/, PAI/USER/SKILLCUSTOMIZATIONS/, PAI/DOCUMENTATION/, etc.) untouched in the projected skill body. The PAI Customization runtime hook was also copied verbatim into the imported SKILL.md, pointing the assistant at a SKILLCUSTOMIZATIONS path that does not exist in a Soma install.

Discovered via `/import` stress test on `~/work/PAI/Packs/CreateSkill` — 10 `~/.claude/...` residues survived normalization.

## Approach

Pipeline order: notification strip → customization strip → deterministic rewrites → unmapped catch-all. Strips run first so path rewrites do not chase content that is about to be deleted; catch-all runs last so it only fires on residue.

- **Deterministic rewrites** (action `rewrote-claude-home-path`):
  - `~/.claude/skills/` → `~/.soma/skills/` (existing)
  - `~/.claude/PAI/MEMORY/` → `~/.soma/memory/` (new — Soma has the same concept)
- **Strips**:
  - `## Customization` heading + body, gated on `SKILLCUSTOMIZATIONS` marker — new action `stripped-pai-customization-block`. Block is stripped, not translated, per issue's "Out of scope" note about not growing a Soma SKILLCUSTOMIZATIONS equivalent.
- **Catch-all** (new action `rewrote-unmapped-claude-path` + warning `unmapped-claude-home-path`):
  - Any remaining `~/.claude/<segment>/<rest>` → `~/.soma/UNMAPPED/<segment>/<rest>`. Placeholder makes runtime breakage loud; warning makes import-time review loud.
  - Bare `~/.claude` / `~/.claude/` prose mentions → `~/.soma`. Covers strings like *"they never leave `~/.claude`"* so a strict grep returns zero.

## AC checklist

- [x] **AC-1**: every `~/.claude/<subpath>` reference either rewrites to a documented Soma equivalent, gets stripped, or surfaces as a warning. No silent passthrough — verified via the unmapped catch-all (action + warning fire on every unmapped first segment per file).
- [x] **AC-2**: PAI Customization block is handled via the named `stripped-pai-customization-block` action kind, alongside the existing `stripped-mandatory-runtime-block`.
- [x] **AC-3**: re-importing `~/work/PAI/Packs/CreateSkill` produces zero remaining `~/.claude/...` strings in the imported skill body. Grep test on `SKILL.md` + `Workflows/*.md` (matching the issue's reproduction scope — `references/` keeps PAI source-docs verbatim as historical artifacts per `docs/pai-pack-importer.md`).
- [x] **AC-4**: fixture-based importer tests for every rewrite/strip/warn class (`test/pai-pack-importer-issue-86.test.ts`, 11 tests, fixture pack under `test/fixtures/pai-packs/issue-86/`).
- [x] **AC-5**: classification table in `docs/pai-pack-importer.md` lists every supported normalization action with trigger and replacement.

## Test evidence

```
$ bun run typecheck
$ tsc --noEmit
(clean)

$ bun test
 533 pass
 0 fail
 1645 expect() calls
Ran 533 tests across 36 files. [19.83s]
```

Baseline: 522 → 533 (+11). Pre-existing 4 lint errors in `cli.ts`/`install.ts`/`test/types.test.ts` unchanged (documented in `.claude/memory/decisions.md`).

## Stress-test against the issue's real pack

```
$ rm -rf /tmp/soma-test-86
$ bun src/cli.ts import pai-pack --pai-pack-dir ~/work/PAI/Packs/CreateSkill \
    --apply --soma-home /tmp/soma-test-86 --home-dir /tmp/soma-test-86-home
Normalization applied:
  actions: 22
  warnings: 10

$ grep -rn "~/.claude" /tmp/soma-test-86/skills/create-skill/SKILL.md \
    /tmp/soma-test-86/skills/create-skill/Workflows/*.md \
    || echo "ZERO RESIDUE — AC-3 satisfied"
ZERO RESIDUE — AC-3 satisfied
```

Action kinds recorded in `soma-pack.json`:
- `stripped-mandatory-runtime-block`
- `stripped-pai-customization-block` (1 occurrence)
- `rewrote-claude-home-path`
- `rewrote-unmapped-claude-path` (5 occurrences across SKILL.md + Workflows/)
- `removed-substrate-notification-hook`

Warning kinds:
- `unmapped-claude-home-path`
- `substrate-mutation-command`

## Out of scope (deferred)

- Whether Soma should grow a `SKILLCUSTOMIZATIONS` overlay equivalent — explicitly deferred per issue body. Strip-only behavior is shipped here; if a Soma overlay model is wanted, file a separate enhancement issue.
- Rewriting the PAI docs upstream to remove `~/.claude/` references at the source — importer defends against legacy packs regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)