### PR TITLE
docs: PAI canonical migration plan + DDs + CONTEXT.md migrate-verb

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -232,11 +232,32 @@ The lifecycle reads:
 
 **Not synonyms — killed from glossary:**
 - `sync`, `rebuild`, `refresh`, `regenerate` → `reproject`
-- `migrate`, `republish`, `bump` → `upgrade`
+- `republish`, `bump` → `upgrade`
 - `rehydrate`, `wake`, `rebind`, `activate` → `load`
 - `remove`, `detach`, `purge` → `uninstall`
 
 **Why:** Without these verbs, the glossary was silent on the lifecycle and prose was inconsistent. `reproject` composes naturally with [[project]]. `upgrade` is user-familiar. `load` is passive because the substrate does it, not Soma — preserves the agency direction. `uninstall` is symmetric to `install`.
+
+---
+
+## migrate (system-to-system orchestration)
+
+Distinct from [[upgrade]] (same system, new version). **`migrate`** is the orchestration verb for moving ownership of an existing personal-AI installation from one system-of-record into Soma. The canonical case today is `soma migrate pai` — wrapping `importPaiIdentity` + `importAlgorithm` + per-pack `importPaiPack` + (forthcoming) memory import + doc import into one principal-facing command.
+
+| Term | Direction | Scope |
+| --- | --- | --- |
+| **[[import]]** (verb, existing) | external source → Soma | one artifact (one pack, one identity file, one algorithm) |
+| **migrate** | external system → Soma | full orchestration: multiple imports + structural alignment + manifest |
+| **[[upgrade]]** | Soma → Soma (or adapter → adapter) | new version of same thing |
+
+**Why both `import` and `migrate`:** import is the unit; migrate is the orchestration. A user running `soma import pai-pack ...` brings one skill in. A user running `soma migrate pai` brings their whole PAI installation in. Conflating them loses the principal-facing simplicity of "I want to move from PAI to Soma" as one verb.
+
+**Why `migrate` is no longer killed:** an earlier glossary lock killed `migrate` as a synonym for `upgrade`, on the principle that "one canonical term per concept". After Soma adopted the [[Soma|new-canonical-home]] stance — Soma is the canonical home of personal AI state, PAI is the source system being moved out of — the verb describes a real, distinct operation that `upgrade` cannot. Reinstated with the sharper meaning above.
+
+**Not synonyms — still killed:**
+- `transfer`, `move`, `port`, `convert` → `migrate`
+
+**Naming for future migrations:** `soma migrate <source-system>` where the source-system is the system being moved out of (e.g., `migrate pai`, future: `migrate cortex`, `migrate <other-personal-ai>`).
 
 ---
 

--- a/Plans/2026-05-17-pai-canonical-migration.md
+++ b/Plans/2026-05-17-pai-canonical-migration.md
@@ -25,7 +25,7 @@ If you are picking this up in a fresh session, you need:
 These were resolved in a `/grill-with-docs` session on 2026-05-17 and recorded as DDs:
 
 - **DD-1: Soma is the new canonical home of personal AI state.** PAI's `~/.claude/` becomes a *projection* that Soma writes via `soma install claude-code`. Migration from PAI is a **translation** (PAI memory taxonomy → Soma taxonomy, PAI skill format → Soma skill format), not a copy.
-- **DD-2: Adopt PAI v5.0.0 memory taxonomy wholesale, mark PAI-specific categories.** 17-category bootstrap (`WORK`, `STATE`, `LEARNING`, `RELATIONSHIP`, `KNOWLEDGE`, `OBSERVABILITY`, `SECURITY`, `SCRATCHPAD`, `BOOKMARKS`, `RESEARCH`, `PROJECT`, `WISDOM`, `VERIFICATION`, `DATA`, `RAW`, `REFERENCE`, `SKILLS`, plus PAI-bound `PAISYSTEMUPDATES`, `AUTO`). PAI-bound READMEs explicitly call out provenance. No backcompat migration needed (pre-release).
+- **DD-2: Adopt PAI v5.0.0 memory taxonomy wholesale, mark PAI-specific categories.** 19-category bootstrap = 17 substrate-neutral (`WORK`, `STATE`, `LEARNING`, `RELATIONSHIP`, `KNOWLEDGE`, `OBSERVABILITY`, `SECURITY`, `SCRATCHPAD`, `BOOKMARKS`, `RESEARCH`, `PROJECT`, `WISDOM`, `VERIFICATION`, `DATA`, `RAW`, `REFERENCE`, `SKILLS`) + 2 PAI-bound (`PAISYSTEMUPDATES`, `AUTO`). PAI-bound READMEs explicitly call out provenance. No backcompat migration needed (pre-release).
 - **DD-3: `migrate` reinstated for system-to-system orchestration.** Distinct from `upgrade` (same system, new version). `soma migrate <source-system>` is the principal-facing orchestration verb. CONTEXT.md updated; the prior glossary lock that killed `migrate` as a synonym for `upgrade` is superseded.
 
 Read each DD in full before starting:
@@ -62,7 +62,7 @@ If you find yourself questioning a DD during implementation, stop and surface to
 
 **Suggested execution order (one issue at a time, single implementer):**
 
-1. **#88** — `Align Soma memory bootstrap to PAI v5.0.0 canonical taxonomy (17 categories)`. Pure bootstrap change. Independent of everything. Ship first.
+1. **#88** — `Align Soma memory bootstrap to PAI v5.0.0 canonical taxonomy (17 categories)`. (Issue title kept as filed; canonical count is 19 = 17 substrate-neutral + 2 PAI-bound — see DD-2.) Pure bootstrap change. Independent of everything. Ship first.
 2. **#89** — `New CLI: soma import pai-docs`. Independent of #88 but small and self-contained. Can also be done first; pick whichever has the fresher state in your head.
 3. **#90** — `Extend soma migrate pai`. Depends on #88 + #89 being merged. This is the largest of the four; budget ~2 days. Memory translation is the most subtle piece (per-file SHA recording in manifest, idempotency contract).
 4. **#91** — `Importer: replace UNMAPPED catch-all with deterministic rewrites`. Depends on #89 (need `~/.soma/PAI/` to exist) and #88 (need `~/.soma/memory/` taxonomy). Smallest of the four; mechanical follow-on.
@@ -183,11 +183,11 @@ Return to Step 1 with the next issue from the queue. New worktree, never reuse.
 
 **Smallest issue. Ship first.**
 
-- Touches `src/install.ts` (`SOMA_BOOTSTRAP_DIRECTORIES` constant). Add the 12 new categories.
+- Touches `src/install.ts` (`SOMA_BOOTSTRAP_DIRECTORIES` constant). Add the 14 new categories (12 substrate-neutral + 2 PAI-bound). Existing 5 stay. Final count: 19.
 - Each new category needs a `README.md`. Use the existing `~/work/PAI/Releases/v5.0.0/.claude/PAI/MEMORY/<CAT>/README.md` as the textual basis where one exists; mark `PAISYSTEMUPDATES/` and `AUTO/` as PAI-substrate-bound in their READMEs.
 - The bootstrap creates the dirs + README files. Match the existing pattern for the 5 dirs already there.
 - Update `docs/private-source-guard-v0.md` and `docs/writeback-and-policy.md` if they enumerate memory paths.
-- Tests: extend `test/install.test.ts` bootstrap assertion to cover all 17 dirs.
+- Tests: extend `test/install.test.ts` bootstrap assertion to cover all 19 dirs.
 
 **No backcompat shims.** Pre-release. Existing `~/.soma/memory/` installs that lack the new dirs just need a `soma install <substrate> --apply` to backfill (idempotent).
 

--- a/Plans/2026-05-17-pai-canonical-migration.md
+++ b/Plans/2026-05-17-pai-canonical-migration.md
@@ -1,0 +1,273 @@
+# PAI → Soma Canonical Migration — Sprint Plan
+
+**Period:** 2026-05-17 → ~2026-05-24 (1 week, fresh session can start cold)
+**Scope:** Ship the four GitHub issues (#88 → #89 → #90 → #91) that turn Soma into the new canonical home of personal AI state, with PAI v5.0.0 as the canonical source system. Includes memory taxonomy alignment, PAI docs import, full `soma migrate pai` orchestration, and importer normalization cleanup.
+**Mode:** Autonomous execution (`pilot-review-loop` pattern, Sage via NATS as reviewer). User may be away; no clarifications mid-flight. Surface design questions only if they cannot be answered from this plan + linked DDs + the issue body.
+**Budget:** ~1 day for #88 + #89 in parallel, ~2 days for #90, ~half day for #91 once #89 lands.
+
+---
+
+## Cold-start onboarding (read this first)
+
+If you are picking this up in a fresh session, you need:
+
+1. **This plan** — `Plans/2026-05-17-pai-canonical-migration.md` (you are here).
+2. **The cycle doctrine** — `Plans/2026-05-isa-rollout.md`. The canonical issue-to-merge loop (worktree → branch → PR → Sage → merge → cleanup). Cycle invariants live there.
+3. **Design decisions** — `design/design-decisions.md` (DD-1, DD-2, DD-3). These are the *why* behind the four issues. They are durable rule-records; don't relitigate them mid-implementation.
+4. **Glossary** — `CONTEXT.md`. Locked vocabulary for all four issues; in particular `## migrate (system-to-system orchestration)`, `## Lifecycle verbs`, `## Runtime modes`.
+5. **The four issues** — `gh issue view {88,89,90,91} --repo the-metafactory/soma`. Each has its own ACs, scope, dependencies.
+6. **Repo state at plan time** — main at `3775081` (last commit: `fix(importer): generalize claude-path rewriter + strip PAI Customization block (#86) (#87)`). All prior sprint work (#52, #54, #78, #79, #43, #86) shipped. Pi.dev queue (#52/#54/#78) drained. Repo-only open issues at plan time: #85 (deferred renderer ACs from #43 — out of scope here), and #88-#91 (this plan).
+
+---
+
+## Decisions in force (do not relitigate)
+
+These were resolved in a `/grill-with-docs` session on 2026-05-17 and recorded as DDs:
+
+- **DD-1: Soma is the new canonical home of personal AI state.** PAI's `~/.claude/` becomes a *projection* that Soma writes via `soma install claude-code`. Migration from PAI is a **translation** (PAI memory taxonomy → Soma taxonomy, PAI skill format → Soma skill format), not a copy.
+- **DD-2: Adopt PAI v5.0.0 memory taxonomy wholesale, mark PAI-specific categories.** 17-category bootstrap (`WORK`, `STATE`, `LEARNING`, `RELATIONSHIP`, `KNOWLEDGE`, `OBSERVABILITY`, `SECURITY`, `SCRATCHPAD`, `BOOKMARKS`, `RESEARCH`, `PROJECT`, `WISDOM`, `VERIFICATION`, `DATA`, `RAW`, `REFERENCE`, `SKILLS`, plus PAI-bound `PAISYSTEMUPDATES`, `AUTO`). PAI-bound READMEs explicitly call out provenance. No backcompat migration needed (pre-release).
+- **DD-3: `migrate` reinstated for system-to-system orchestration.** Distinct from `upgrade` (same system, new version). `soma migrate <source-system>` is the principal-facing orchestration verb. CONTEXT.md updated; the prior glossary lock that killed `migrate` as a synonym for `upgrade` is superseded.
+
+Read each DD in full before starting:
+
+```bash
+sed -n '/^### DD-1/,/^### DD-2/p' design/design-decisions.md
+sed -n '/^### DD-2/,/^### DD-3/p' design/design-decisions.md
+sed -n '/^### DD-3/,/^---$/p'    design/design-decisions.md
+```
+
+If you find yourself questioning a DD during implementation, stop and surface to the principal — don't silently diverge.
+
+---
+
+## Queue — strict dependency order
+
+```
+        ┌──────────────────────────────────────────────────────────────┐
+        │                                                              │
+        │   #88  Memory taxonomy alignment       (independent)         │
+        │   ─────────────────────────────────                          │
+        │       ▼                                                      │
+        │   #91  Importer deterministic rewrites                       │
+        │       (depends on #88 for memory rewrite + #89 for doc       │
+        │        rewrite)                                              │
+        │       ▲                                                      │
+        │   ─────────────────────────────────                          │
+        │   #89  soma import pai-docs            (independent)         │
+        │       ▼                                                      │
+        │   #90  Extend soma migrate pai         (depends #88 + #89)   │
+        │                                                              │
+        └──────────────────────────────────────────────────────────────┘
+```
+
+**Suggested execution order (one issue at a time, single implementer):**
+
+1. **#88** — `Align Soma memory bootstrap to PAI v5.0.0 canonical taxonomy (17 categories)`. Pure bootstrap change. Independent of everything. Ship first.
+2. **#89** — `New CLI: soma import pai-docs`. Independent of #88 but small and self-contained. Can also be done first; pick whichever has the fresher state in your head.
+3. **#90** — `Extend soma migrate pai`. Depends on #88 + #89 being merged. This is the largest of the four; budget ~2 days. Memory translation is the most subtle piece (per-file SHA recording in manifest, idempotency contract).
+4. **#91** — `Importer: replace UNMAPPED catch-all with deterministic rewrites`. Depends on #89 (need `~/.soma/PAI/` to exist) and #88 (need `~/.soma/memory/` taxonomy). Smallest of the four; mechanical follow-on.
+
+**Alternative parallel execution:** spawn two background agents at start — agent A on #88, agent B on #89. They are file-disjoint (#88 touches `src/install.ts` + `src/install/bootstrap.ts` + new `memory/*/README.md` files; #89 adds a new file `src/pai-docs-importer.ts` + `src/cli.ts` parser hooks). Once both merge, run #90 + #91 sequentially.
+
+---
+
+## Development cycle (per issue)
+
+This is the canonical loop from `Plans/2026-05-isa-rollout.md` adapted to the `pilot-review-loop` pattern with Sage as reviewer (NATS dispatch, no Luna/pilot CLI). All actions happen autonomously; the human is informed by GitHub state.
+
+### Step 1 — Claim and worktree
+
+```bash
+cd /Users/fischer/work/mf/soma
+git fetch && git pull --ff-only origin main
+git worktree add -b feat/issue-<N>-<short-slug> ../soma-issue-<N> main
+cd ../soma-issue-<N>
+bun install
+```
+
+Slug convention: `feat/issue-88-memory-taxonomy`, `feat/issue-89-import-pai-docs`, `feat/issue-90-migrate-pai-full`, `feat/issue-91-importer-deterministic-rewrites`.
+
+### Step 2 — Implement (TDD where it fits)
+
+- Read the GitHub issue: `gh issue view <N> --repo the-metafactory/soma`. ACs are the contract.
+- Add fixture-based tests for any pure-logic surface first; make them pass.
+- Cross-reference DDs when implementation forces a design choice. If the DDs don't cover it, file a question as a PR comment and continue with the smallest reasonable interpretation; flag the assumption explicitly in the commit body.
+- Run verification continuously:
+  ```bash
+  bun run typecheck    # must be clean
+  bun test             # all-green; baseline 537 (after #87); grows as you add tests
+  ```
+
+### Step 3 — Commit
+
+Conventional commit format per repo history (`feat(...)`, `fix(...)`, `chore(...)`). Title must end with `(#<N>)`. Body must include AC checklist with each box checked + test evidence.
+
+Use HEREDOC for multi-line commit messages:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(<area>): <short summary> (#<N>)
+
+<body — what shipped, why, AC checklist, test evidence>
+
+Closes #<N>
+EOF
+)"
+```
+
+### Step 4 — Push and open PR
+
+```bash
+git push -u origin feat/issue-<N>-<slug>
+gh pr create --title "<conventional title> (#<N>)" --body "$(cat <<'EOF'
+<PR body — summary, AC checklist with all boxes checked, test plan,
+follow-ups if any, Closes #<N>>
+EOF
+)"
+```
+
+### Step 5 — Sage review loop (NATS dispatch, autonomous)
+
+```bash
+~/bin/sage dispatch the-metafactory/soma#<PR> --post --wait 600
+```
+
+Notes:
+- `--post` posts Sage's verdict back to the PR as a review comment.
+- `--wait 600` blocks until verdict for up to 10 minutes. The dispatch is synchronous from your perspective; you don't need `ScheduleWakeup`.
+- The dispatch requires NATS connectivity (`nats://localhost:4222` default). Check with `nats server check connection` if it stalls. Sage daemon may run remotely; the dispatch enqueues regardless.
+
+**Per round:**
+- **Important findings**: apply. Push fix commits to the same branch. Re-dispatch.
+- **Suggestions**: apply unless principled pushback. If pushing back, post a PR comment with reasoning before re-dispatching ("Pushed back on R<n> finding X because Y").
+- **Cap: 5 rounds per PR.** Doctrine says "don't grind". After 5 rounds OR when state goes `commented` (no blockers), merge with the final fix. The #43 / PR #84 9-round outlier is *not* the pattern — only stretch the cap if every round is producing a strictly smaller surface, and document the reason in the merge commit body.
+- **Pushback rights**: Sage is the gate but can be wrong. Surface disagreement in the PR thread, not via bypass. See #54 / PR #81 R2 (Sage misread of uninstall-as-dry-run) for the canonical pushback example.
+
+### Step 6 — Merge
+
+```bash
+gh pr merge <PR> --repo the-metafactory/soma --squash --delete-branch
+```
+
+Confirm:
+
+```bash
+gh pr view <PR> --repo the-metafactory/soma --json state,mergeCommit
+# expect: state=MERGED
+```
+
+### Step 7 — Sync and cleanup
+
+```bash
+cd /Users/fischer/work/mf/soma
+git fetch && git pull --ff-only origin main
+git worktree remove ../soma-issue-<N>
+git worktree list   # confirm gone
+```
+
+### Step 8 — Memory update
+
+Append entries to `.claude/memory/session-log.md` and `.claude/memory/decisions.md` in the same style as existing 2026-05-17 entries (look at #80, #81, #82, #83, #84, #87). Each entry records: PR number, merge SHA, files changed, tests added, Sage rounds, pushbacks, what shipped, what's deferred.
+
+The `.claude/memory/` directory is gitignored (per-user). The entries are for the next session's cold-start orientation.
+
+### Step 9 — Repeat for next issue
+
+Return to Step 1 with the next issue from the queue. New worktree, never reuse.
+
+---
+
+## Issue-specific notes
+
+### #88 — Memory taxonomy alignment
+
+**Smallest issue. Ship first.**
+
+- Touches `src/install.ts` (`SOMA_BOOTSTRAP_DIRECTORIES` constant). Add the 12 new categories.
+- Each new category needs a `README.md`. Use the existing `~/work/PAI/Releases/v5.0.0/.claude/PAI/MEMORY/<CAT>/README.md` as the textual basis where one exists; mark `PAISYSTEMUPDATES/` and `AUTO/` as PAI-substrate-bound in their READMEs.
+- The bootstrap creates the dirs + README files. Match the existing pattern for the 5 dirs already there.
+- Update `docs/private-source-guard-v0.md` and `docs/writeback-and-policy.md` if they enumerate memory paths.
+- Tests: extend `test/install.test.ts` bootstrap assertion to cover all 17 dirs.
+
+**No backcompat shims.** Pre-release. Existing `~/.soma/memory/` installs that lack the new dirs just need a `soma install <substrate> --apply` to backfill (idempotent).
+
+### #89 — `soma import pai-docs`
+
+**New verb. Self-contained.**
+
+- New file: `src/pai-docs-importer.ts`. Exports `planPaiDocsImport(options)` and `importPaiDocs(options)`. Mirrors the shape of `src/pai-pack-importer.ts`.
+- New CLI parser in `src/cli.ts`: `parsePaiDocsImportArgs` + dispatch. Follow the shape of the existing `import pai-pack` parser. Update `import` subcommand `COMMAND_HELP`.
+- Writes to `~/.soma/PAI/{DOCUMENTATION,TEMPLATES,ALGORITHM}/` from `<pai-source-dir>/<same>/`. Lexical + symlink-realpath escape guards — copy from `soma export --out` (lands `src/cli.ts` around line 2375 after #54).
+- `~/.soma/PAI/.import-manifest.json` records source path, release version (parse from `<pai-source-dir>/VERSION` if present or infer from path like `Releases/v5.0.0`), timestamp, per-file SHA. Used to detect drift on re-import.
+- Refuse sources without a `DOCUMENTATION/` subdir — loud error.
+- Tests: fixture-based. Use `~/work/PAI/Releases/v5.0.0/.claude/PAI/` if available in the test environment, or ship a minimal fixture tree under `test/fixtures/pai-source/v5.0.0/`.
+
+### #90 — Extend `soma migrate pai`
+
+**Largest issue. Budget 2 days.**
+
+- Touches `src/pai-migration.ts` (orchestrator), `src/cli.ts` (flag parsing + dispatch), and adds `src/pai-memory-migrator.ts` (new — translates `~/.claude/PAI/MEMORY/*` → `~/.soma/memory/*`).
+- New flags: `--pai-install <path>` (defaults to `~/.claude`), `--pai-source-dir <release>` (optional; triggers docs import via #89 verb), `--pai-packs-dir <path>` (defaults to `<pai-source-dir>/Packs/` or `~/work/PAI/Packs`), `--skip-memory`, `--skip-skills`, `--skip-docs`, `--overwrite-reserved`.
+- Memory translation: 1:1 dir map per DD-2 mapping table. Content-preserving. Records per-file SHA in `~/.soma/imports/pai-migration/.manifest.json`. Idempotent (compare SHAs on re-run).
+- Bulk skill import: iterate `<pai-packs-dir>/*` and call `importPaiPack` per pack. Reserved skill names (`ISA`, `the-algorithm`, `knowledge`, `telos`) refused unless `--overwrite-reserved`. Audit recorded as today.
+- `--status` reports last successful migration: source paths, timestamp, file counts per phase. Read from the manifest.
+- Sage is likely to flag idempotency edge cases and reserved-skill collision handling — preempt by having strong fixture tests for both before opening the PR.
+
+### #91 — Importer deterministic rewrites
+
+**Smallest follow-on. Half-day.**
+
+- Touches `src/pai-pack-normalizer.ts`. Add the 4 deterministic rewrite rules (DOCUMENTATION, TEMPLATES, ALGORITHM, MEMORY) ordered *before* the existing UNMAPPED catch-all.
+- Each rule gets a named action kind in the audit trail.
+- Re-import `~/work/PAI/Packs/CreateSkill` and verify the audit shows zero `rewrote-unmapped-claude-path` actions for paths now covered. Add this as an explicit test in `test/pai-pack-importer-issue-86.test.ts` (or a sibling file).
+- Update `docs/pai-pack-importer.md` classification table.
+
+---
+
+## Failure modes & escalation
+
+| Failure | Response |
+|---|---|
+| Sage flags blocker | Fix in the same PR. No new issue. Re-dispatch. |
+| Sage flags out-of-scope concern | File a new issue, link from the PR, ignore in the current cycle. |
+| Sage and implementer disagree on a finding | Post PR comment with reasoning. Re-dispatch. If Sage holds firm and the implementer still disagrees → surface to principal. |
+| Two Sage rounds with no progress | Pause issue. Re-scope or close. Don't grind. |
+| CI fails after Sage approval | Fix in the same PR. Re-dispatch for the delta only. |
+| Dependency PR not yet merged | Wait. Do not start a dependent issue against a not-yet-merged base. |
+| Memory migration test fails on edge case | Surface the edge case via PR comment; the migration is content-preserving by contract — if it has to alter content to make a test pass, you're solving the wrong problem. |
+| `--pai-source-dir` points at a directory that doesn't look like PAI | Refuse loud. Do not attempt heuristic guessing. |
+
+---
+
+## Session-end contract
+
+When all 4 issues are merged OR you run out of budget:
+
+1. **Update this plan** — append a final section enumerating which issues shipped (with PR numbers + merge SHAs) and which remain.
+2. **Update `.claude/memory/session-log.md` and `.claude/memory/decisions.md`** with the per-issue entries.
+3. **Verify repo state** — `gh issue list --repo the-metafactory/soma --state open` should show #85 (deferred renderer ACs from #43) and whatever this plan left unfinished. Nothing else.
+4. **If time remains**: re-run the original stress test that triggered this whole arc:
+   ```bash
+   rm -rf /tmp/soma-test-final && bun src/cli.ts import pai-pack \
+     --pai-pack-dir ~/work/PAI/Packs/CreateSkill --apply --soma-home /tmp/soma-test-final
+   grep -rn "UNMAPPED" /tmp/soma-test-final/skills/create-skill/ || echo "ZERO UNMAPPED — success"
+   ```
+   Zero UNMAPPED warnings = the full chain (DD-1 + DD-2 + #88 + #89 + #90 + #91) actually closes the loop. Document the result in the final plan update.
+
+---
+
+## Quick reference
+
+```
+Issues:    https://github.com/the-metafactory/soma/issues/{88,89,90,91}
+Doctrine:  Plans/2026-05-isa-rollout.md
+Decisions: design/design-decisions.md
+Glossary:  CONTEXT.md
+Sage:      ~/bin/sage dispatch the-metafactory/soma#<PR> --post --wait 600
+Tests:     bun test (537 baseline after #87)
+Typecheck: bun run typecheck
+PAI v5:    ~/work/PAI/Releases/v5.0.0/.claude/PAI/
+PAI packs: ~/work/PAI/Packs/
+User PAI:  ~/.claude/ (the install being migrated from)
+Soma home: ~/.soma/ (the canonical home being migrated to)
+```

--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -1,0 +1,113 @@
+# soma — Design Decisions
+
+**Date:** 2026-05-17
+**Authors:** Jens-Christian Fischer
+**Status:** Living document — updated as decisions are made
+**Format:** metafactory DD (lightweight ADR)
+
+---
+
+## How This Document Works
+
+Each decision is numbered, dated, and linked to the discussion or research that informed it. Decisions are grouped by domain. Status values: **decided**, **superseded**, **open**.
+
+`ISA.md` is the live source of truth for current scope and verification. DDs are the durable rule-record — the *why* behind decisions that future readers would otherwise have to reconstruct.
+
+---
+
+## 1. Boundary & Canonical Home
+
+### DD-1: Soma is the new canonical home of personal AI state
+
+**Status:** Decided (2026-05-17)
+
+**Context:** Soma's mission is "substrate-portable Personal AI Assistant core" (per `ISA.md`, `CONTEXT.md`). A live migration path from PAI to Soma forced a foundational question: where does personal state *live*?
+
+Three candidates surfaced:
+- **(a) Soma is the new canonical home.** PAI's `~/.claude/` becomes a *projection* that Soma writes (via `soma install claude-code`). PAI conventions are translated to Soma's shape during import.
+- **(b) Soma is a portable wrapper around PAI.** Soma mirrors PAI's structure. PAI conventions win where they conflict. Soma's existing memory/identity taxonomies adjust to match PAI's.
+- **(c) Dual-write contract.** Soma and PAI both write to a shared "personal data" location via a write-through layer.
+
+**Decision:** **(a)** — Soma is the canonical home. The `*core*` lives in Soma; substrates (Codex, Pi.dev, Claude Code) are projections of it. PAI becomes one substrate among several, projected into via the existing `soma install claude-code` verb.
+
+**Rejected:**
+- (b) would invert the stated mission — Soma would be a packaging tool, not the canonical home.
+- (c) is genuinely powerful but introduces coupling that breaks Soma's "filesystem-native, no-daemon-required" principle. Tracked as a possible future direction; not a prerequisite.
+
+**Implications:**
+- Migration from PAI to Soma is fundamentally a **translation** (PAI memory taxonomy → Soma taxonomy, PAI skill format → Soma skill format), not a copy.
+- Once migrated, PAI continues to work iff the user runs `soma install claude-code --apply` so Soma's projection covers PAI's runtime surface.
+- The "perfect world" dual-write (`(c)`) is a deferred follow-on, not a blocker.
+
+**Discussion:** `/grill-with-docs` session 2026-05-17 (Q6).
+
+---
+
+## 2. Memory Taxonomy
+
+### DD-2: Adopt PAI v5.0.0 memory taxonomy wholesale, mark PAI-specific categories
+
+**Status:** Decided (2026-05-17)
+
+**Context:** Soma currently bootstraps 5 memory categories (`WORK`, `KNOWLEDGE`, `LEARNING`, `RELATIONSHIP`, `STATE`). PAI v5.0.0 canonical form has ~17 categories (the above plus `OBSERVABILITY`, `SECURITY`, `SCRATCHPAD`, `BOOKMARKS`, `RESEARCH`, `PROJECT`, `WISDOM`, `VERIFICATION`, `DATA`, `RAW`, `REFERENCE`, `SKILLS`, plus PAI-specific `PAISYSTEMUPDATES` and `AUTO`).
+
+PAI's v5.0.0 hooks actively write to several categories Soma does not bootstrap (`OBSERVABILITY`, `SECURITY` are referenced by `ToolActivityTracker.hook.ts`, `ConfigAudit.hook.ts`, `StopFailureHandler.hook.ts`, `TaskGovernance.hook.ts`). Soma's existing 5-category bootstrap is pre-v5.0.0 PAI taxonomy.
+
+Three candidates:
+- **(a) Wholesale** — adopt all v5.0.0 categories verbatim including PAI-specific ones.
+- **(b) Substrate-neutral subset** — adopt the categories that have substrate-neutral meaning; skip `PAISYSTEMUPDATES`/`AUTO`; allow free-form extension.
+- **(c) Wholesale + mark PAI-specific** — adopt all, tag PAI-bound categories in their READMEs.
+
+**Decision:** **(c)** — wholesale adoption of v5.0.0 taxonomy, with READMEs in `PAISYSTEMUPDATES/`, `AUTO/`, and any other PAI-bound categories explicitly marking them as substrate-bound. Soma's canonical taxonomy includes both portable and substrate-bound categories; READMEs do the explanatory work.
+
+**Rejected:**
+- (a) wholesale-without-marking weakens Soma's portability claim by smuggling PAI-specific categories in unannotated.
+- (b)'s purity is academic — every Soma user today is migrating from PAI; the PAI-specific categories will be populated regardless.
+
+**Implications:**
+- `SOMA_BOOTSTRAP_DIRECTORIES` in `src/install.ts` grows from 5 to ~17 categories.
+- New entries each ship a `README.md` describing what belongs there. PAI-bound ones additionally state "this category is populated by the PAI substrate; portable Soma cores may leave it empty".
+- No backcompat migration needed (pre-release per principal directive).
+- The 1:1 alignment with v5.0.0 means PAI hooks writing to `MEMORY/SECURITY/...` resolve to `~/.soma/memory/SECURITY/...` cleanly after `soma install claude-code` projection.
+
+**Discussion:** `/grill-with-docs` session 2026-05-17 (Q5, Q7).
+
+---
+
+## 3. Glossary
+
+### DD-3: `migrate` reinstated for system-to-system orchestration
+
+**Status:** Decided (2026-05-17)
+
+**Context:** An earlier glossary lock (`CONTEXT.md` Q10) killed `migrate` as a synonym for [[upgrade]], on the principle of "one canonical term per concept". This conflicted with the existing CLI verb `soma migrate pai` (PR #67) and with the natural prose for moving an existing PAI installation into Soma.
+
+After [[DD-1]] established Soma as the new canonical home, the verb describes a real, distinct operation that `upgrade` cannot:
+- `upgrade` = same system, new version
+- `migrate` = move ownership from one system-of-record to another
+
+Three candidates:
+- **(a) Rename CLI to `soma import pai`** — drop `migrate` entirely, subsume into existing `import` verb.
+- **(b) Un-ban `migrate`** with sharper meaning.
+- **(c) Keep `migrate pai` as legacy alias** while building forward under `import`.
+
+**Decision:** **(b)** — `migrate` reinstated with sharper meaning. Glossary updated inline (`CONTEXT.md` new `## migrate (system-to-system orchestration)` section).
+
+| Term | Direction | Scope |
+| --- | --- | --- |
+| **import** | external source → Soma | one artifact (one pack, one identity file, one algorithm) |
+| **migrate** | external system → Soma | full orchestration: multiple imports + structural alignment + manifest |
+| **upgrade** | Soma → Soma (or adapter → adapter) | new version of same thing |
+
+**Rejected:**
+- (a) loses the principal-facing simplicity of "I want to move from PAI to Soma" as one verb.
+- (c) keeps two names for one concept — drift later; principal directed "no backcompat worry pre-release" so cleaner to commit to one verb.
+
+**Killed synonyms (still banned):**
+- `transfer`, `move`, `port`, `convert` → `migrate`
+
+**Naming for future migrations:** `soma migrate <source-system>` where `<source-system>` is the system being moved out of (`migrate pai`, future: `migrate cortex`, `migrate <other-personal-ai>`).
+
+**Supersedes:** `CONTEXT.md` line 235 ("`migrate`, `republish`, `bump` → `upgrade`") — `migrate` removed from that kill-list; `republish` and `bump` remain killed.
+
+**Discussion:** `/grill-with-docs` session 2026-05-17 (Q8).

--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -49,7 +49,7 @@ Three candidates surfaced:
 
 **Status:** Decided (2026-05-17)
 
-**Context:** Soma currently bootstraps 5 memory categories (`WORK`, `KNOWLEDGE`, `LEARNING`, `RELATIONSHIP`, `STATE`). PAI v5.0.0 canonical form has ~17 categories (the above plus `OBSERVABILITY`, `SECURITY`, `SCRATCHPAD`, `BOOKMARKS`, `RESEARCH`, `PROJECT`, `WISDOM`, `VERIFICATION`, `DATA`, `RAW`, `REFERENCE`, `SKILLS`, plus PAI-specific `PAISYSTEMUPDATES` and `AUTO`).
+**Context:** Soma currently bootstraps 5 memory categories (`WORK`, `KNOWLEDGE`, `LEARNING`, `RELATIONSHIP`, `STATE`). PAI v5.0.0 canonical form has 19 categories — the above 5 plus 12 substrate-neutral (`OBSERVABILITY`, `SECURITY`, `SCRATCHPAD`, `BOOKMARKS`, `RESEARCH`, `PROJECT`, `WISDOM`, `VERIFICATION`, `DATA`, `RAW`, `REFERENCE`, `SKILLS`) plus 2 PAI-specific (`PAISYSTEMUPDATES`, `AUTO`).
 
 PAI's v5.0.0 hooks actively write to several categories Soma does not bootstrap (`OBSERVABILITY`, `SECURITY` are referenced by `ToolActivityTracker.hook.ts`, `ConfigAudit.hook.ts`, `StopFailureHandler.hook.ts`, `TaskGovernance.hook.ts`). Soma's existing 5-category bootstrap is pre-v5.0.0 PAI taxonomy.
 
@@ -65,7 +65,7 @@ Three candidates:
 - (b)'s purity is academic — every Soma user today is migrating from PAI; the PAI-specific categories will be populated regardless.
 
 **Implications:**
-- `SOMA_BOOTSTRAP_DIRECTORIES` in `src/install.ts` grows from 5 to ~17 categories.
+- `SOMA_BOOTSTRAP_DIRECTORIES` in `src/install.ts` grows from 5 to 19 categories (14 new: 12 substrate-neutral + 2 PAI-bound).
 - New entries each ship a `README.md` describing what belongs there. PAI-bound ones additionally state "this category is populated by the PAI substrate; portable Soma cores may leave it empty".
 - No backcompat migration needed (pre-release per principal directive).
 - The 1:1 alignment with v5.0.0 means PAI hooks writing to `MEMORY/SECURITY/...` resolve to `~/.soma/memory/SECURITY/...` cleanly after `soma install claude-code` projection.


### PR DESCRIPTION
## Summary

Crystallizes the `/grill-with-docs` session outcomes from 2026-05-17 into durable, fresh-session-pickup-able artifacts. Three docs/decision files, no executable surface change.

## What ships

**`design/design-decisions.md`** (new file — first DD record for soma):

- **DD-1**: Soma is the new canonical home of personal AI state. PAI's `~/.claude/` becomes a projection that Soma writes via `soma install claude-code`. Migration is a *translation*, not a copy.
- **DD-2**: Adopt PAI v5.0.0 memory taxonomy wholesale (17 categories); mark PAI-bound categories (`PAISYSTEMUPDATES`, `AUTO`) in their READMEs. No backcompat (pre-release).
- **DD-3**: `migrate` reinstated for system-to-system orchestration. Distinct from `upgrade` (same system, new version). CLI verb `soma migrate <source>` is the principal-facing orchestration; `import` is the per-artifact verb.

Format mirrors the metafactory DD pattern (see `meta-factory/design/design-decisions.md` DD-1..DD-10).

**`CONTEXT.md`** (edited):

- New `## migrate (system-to-system orchestration)` section formalizing the import / migrate / upgrade distinction.
- Removed `migrate` from the killed-synonyms list (DD-3 supersedes the prior glossary lock; `republish` + `bump` still killed).

**`Plans/2026-05-17-pai-canonical-migration.md`** (new):

Self-contained sprint plan to ship the four work items filed immediately after the grilling: #88 #89 #90 #91. Includes:

- Cold-start onboarding (what to read first)
- DDs-in-force list (do not relitigate)
- Strict dependency queue (#88 || #89 → #90 → #91)
- Per-issue development cycle adapted to the `pilot-review-loop` pattern with Sage via NATS as reviewer
- Per-issue implementation notes
- Failure-mode escalation table
- Session-end stress-test contract (re-run the CreateSkill import that triggered this whole arc; zero UNMAPPED warnings = the full chain closes)

## Note for Sage reviewers

These files are decisions + plan, not implementation. The Sage lenses that apply meaningfully here are **Architecture** (does the glossary update + DDs cohere with existing `CONTEXT.md` and the shipped CLI surface?) and **EcosystemCompliance** (does the DD format match the metafactory DD pattern used elsewhere in the org — see `meta-factory/design/design-decisions.md` DD-1..DD-10 as format reference). CodeQuality / Security / Performance / Maintainability lenses have no executable surface to review.

## Test plan

- [x] `bun run typecheck` — clean (no code changes)
- [x] `bun test` — 537/537 pass (no code changes)
- [x] Three referenced issues (#88, #89, #90, #91) all exist and have the cross-refs the plan claims
- [x] DD-1..DD-3 anchor links in the plan resolve to the DD file