### PR TITLE
feat(install): align memory bootstrap to PAI v5.0.0 canonical taxonomy (#88)

### DIFF
--- a/docs/memory-policy-v0.md
+++ b/docs/memory-policy-v0.md
@@ -6,16 +6,41 @@ projection.
 
 ## Memory V0
 
-Memory is a directory layout, not a database:
+Memory is a directory layout, not a database. Soma adopts the PAI v5.0.0
+canonical taxonomy wholesale ([DD-2](../design/design-decisions.md#dd-2-adopt-pai-v500-memory-taxonomy-wholesale-mark-pai-specific-categories)):
+17 substrate-neutral categories plus 2 PAI-bound categories whose READMEs
+self-declare their provenance.
 
 ```text
-MEMORY/
-  WORK/
-  KNOWLEDGE/
-  LEARNING/
-  RELATIONSHIP/
-  STATE/
+memory/
+  # Substrate-neutral (17)
+  WORK/            # one slug-named subdir per Algorithm run
+  STATE/           # live runtime state (events.jsonl, active-*.json)
+  LEARNING/        # candidate lessons from real work
+  RELATIONSHIP/    # learned interaction patterns
+  KNOWLEDGE/       # curated knowledge graph
+  OBSERVABILITY/   # tool-activity + config-audit telemetry
+  SECURITY/        # task-governance + stop-failure traces
+  SCRATCHPAD/      # ephemeral working space
+  BOOKMARKS/       # synced bookmark state
+  RESEARCH/        # synthesized research outputs
+  PROJECT/         # per-project memory subdirs
+  WISDOM/          # extracted high-signal insights
+  VERIFICATION/    # VERIFY-phase evidence artifacts
+  DATA/            # curated structured datasets
+  RAW/             # unprocessed source material
+  REFERENCE/       # curated lookup tables
+  SKILLS/          # per-skill runtime state
+  # PAI-bound (2) — populated by the PAI substrate; portable Soma cores may
+  # leave it empty
+  PAISYSTEMUPDATES/
+  AUTO/
 ```
+
+Each category ships a `README.md` describing what belongs there. The
+bootstrap is idempotent — re-running `soma install <substrate> --apply`
+backfills any missing category dir/README without overwriting principal
+edits.
 
 The initial portable operations are:
 

--- a/docs/writeback-and-policy.md
+++ b/docs/writeback-and-policy.md
@@ -20,8 +20,12 @@ substrates -> ~/.soma/memory/STATE/events.jsonl
 ```
 
 Substrates must not directly edit durable memory stores such as `KNOWLEDGE`,
-`LEARNING`, `RELATIONSHIP`, or task files until those stores have explicit merge
-rules.
+`LEARNING`, `RELATIONSHIP`, `WISDOM`, `RESEARCH`, or task files until those
+stores have explicit merge rules. The full canonical category list (17
+substrate-neutral + 2 PAI-bound) is documented in
+[memory-policy-v0.md](./memory-policy-v0.md#memory-v0) and bootstrapped by
+`soma install <substrate> --apply` per
+[DD-2](../design/design-decisions.md#dd-2-adopt-pai-v500-memory-taxonomy-wholesale-mark-pai-specific-categories).
 
 ## Projection Semantics
 

--- a/src/install.ts
+++ b/src/install.ts
@@ -9,6 +9,7 @@ import {
 } from "./adapters/pi-dev/skill-projection";
 import { installClaudeCodeHomeProjection, installCodexHomeProjection, installPiDevHomeProjection } from "./home-projection";
 import { buildSomaStartupContext, runSomaLifecycleAlgorithmUpdated } from "./lifecycle";
+import { SOMA_MEMORY_CATEGORIES } from "./memory-readmes";
 import { defaultSomaRepoPath } from "./repo-path";
 import { bootstrapSomaHome } from "./soma-home";
 import { installIsaSkill, installIsaSkillProjection } from "./isa-skill-installer";
@@ -24,12 +25,12 @@ const SOMA_BOOTSTRAP_FILES = [
   "projections/README.md",
 ] as const;
 
+// #88 / DD-2: canonical PAI v5.0.0 memory taxonomy. The per-category list
+// + README content live in `memory-readmes.ts` so install planner, soma-home
+// bootstrap, and tests share one source of truth. 17 substrate-neutral +
+// 2 PAI-bound = 19 categories.
 const SOMA_BOOTSTRAP_DIRECTORIES = [
-  "memory/WORK",
-  "memory/KNOWLEDGE",
-  "memory/LEARNING",
-  "memory/RELATIONSHIP",
-  "memory/STATE",
+  ...SOMA_MEMORY_CATEGORIES.map((category) => `memory/${category}`),
   "projections/codex",
   "projections/pi-dev",
   "projections/claude-code",

--- a/src/memory-readmes.ts
+++ b/src/memory-readmes.ts
@@ -1,0 +1,269 @@
+// Canonical PAI v5.0.0 memory taxonomy (#88 / DD-2).
+//
+// 19 categories: 17 substrate-neutral + 2 PAI-bound. Substrate-neutral
+// READMEs describe the directory contract in substrate-agnostic terms.
+// PAI-bound READMEs (`PAISYSTEMUPDATES`, `AUTO`) explicitly state the
+// directory is populated by the PAI substrate; portable Soma cores may
+// leave it empty.
+//
+// Substrate-neutral READMEs derive their text from the canonical PAI v5.0.0
+// source at `~/work/PAI/Releases/v5.0.0/.claude/PAI/MEMORY/<CAT>/README.md`
+// where one exists. Adaptations for Soma:
+//   - Reframe from "PAI" to "Soma" naming where the substrate would shadow
+//     portability (e.g., "PAI install" → "Soma install").
+//   - LEARNING / OBSERVABILITY / SECURITY / STATE READMEs are authored
+//     fresh — the v5.0.0 source ships them empty or hook-specific.
+//   - PAI-bound READMEs additionally include the mandatory provenance line
+//     so cross-substrate consumers know not to depend on these populating.
+
+export interface SomaMemoryCategoryReadme {
+  /** Category directory name (e.g., `WORK`, `PAISYSTEMUPDATES`). */
+  category: string;
+  /** Whether the category is populated by the PAI substrate (DD-2). */
+  paiBound: boolean;
+  /** Full Markdown body without a trailing newline. */
+  content: string;
+}
+
+const PAI_BOUND_PROVENANCE =
+  "This directory is populated by the PAI substrate; portable Soma cores may leave it empty.";
+
+function readme(category: string, body: string, options: { paiBound?: boolean } = {}): SomaMemoryCategoryReadme {
+  return {
+    category,
+    paiBound: options.paiBound ?? false,
+    content: body.trimEnd(),
+  };
+}
+
+// Order is the canonical documentation order; bootstrap iterates this list.
+export const SOMA_MEMORY_CATEGORY_READMES: readonly SomaMemoryCategoryReadme[] = [
+  readme(
+    "WORK",
+    `# WORK
+
+\`WORK/\` holds one subdirectory per Algorithm run, named with a slug of the form \`YYYYMMDD-HHMMSS_kebab-task-summary\`. Inside each slug live the artifacts that session produced: the canonical \`ISA.md\` (Ideal State Artifact), any \`PRD.md\`, intermediate notes, generated outputs, and tool-specific event files such as \`forge-events.jsonl\` or \`forge-final.txt\`.
+
+This is the operating record of every non-trivial task. ISA-aware hooks write the ISA here, agent helpers stream their JSONL events here, and follow-up sessions resume by reading the slug directory of the prior run.
+
+Empty in fresh installs. Populated automatically the first time you trigger Algorithm mode or any subagent that scopes its output by slug. Old slugs are safe to archive but should not be deleted while their work is still being referenced.
+`,
+  ),
+  readme(
+    "KNOWLEDGE",
+    `# KNOWLEDGE
+
+\`KNOWLEDGE/\` is the curated knowledge graph — a typed network of notes across entity domains such as People, Companies, Ideas, and Research, with cross-links between related entries. The \`Knowledge\` skill (and its equivalents on other substrates) manages add, search, and harvest operations against this directory.
+
+Where \`memory/\` overall is append-mostly raw record, \`KNOWLEDGE/\` is curated and structured. Entries follow a frontmatter contract, link to one another via wikilinks, and form the system's long-term semantic memory. Harvesters elsewhere in \`memory/\` propose candidates that get promoted into here only after curation.
+
+Empty in fresh installs. Populates as you add notes via knowledge skills or run harvest workflows that pull from \`LEARNING/\`, \`RESEARCH/\`, and other source layers. Treat structure here as load-bearing — schema changes ripple through every consumer.
+`,
+  ),
+  readme(
+    "LEARNING",
+    `# LEARNING
+
+\`LEARNING/\` is the staging area for lessons that emerged from real work — corrections the user made, failure modes the system observed, preferences inferred over time, and any other note worth promoting into durable memory after review. The Algorithm's LEARN phase and satisfaction-capture hooks write here.
+
+Entries in \`LEARNING/\` are candidate lessons, not yet structured \`KNOWLEDGE/\` entries. Harvest workflows read this directory, distill recurring patterns, and propose promotion into \`KNOWLEDGE/\`.
+
+Empty in fresh installs. Populates as Algorithm runs reach LEARN, as feedback events are reviewed, and as automated harvesters write candidate lessons. Periodic review encouraged so worthwhile lessons get promoted before the directory grows noisy.
+`,
+  ),
+  readme(
+    "RELATIONSHIP",
+    `# RELATIONSHIP
+
+\`RELATIONSHIP/\` stores the evolving record of how the principal and their assistant interact — communication patterns, preferences observed over time, agreements made, recurring frictions, and shared context that does not belong in static identity files. Relationship-memory hooks write here.
+
+Where the assistant and principal profiles under \`profile/\` hold declared identity and preferences, \`RELATIONSHIP/\` holds learned ones. The system uses these notes to adjust tone, anticipate needs, and avoid repeating mistakes the principal has already corrected.
+
+Empty in fresh installs. Begins accumulating once the relationship-memory hook fires for the first time. Sensitive by nature; treat it like any other personal data store.
+`,
+  ),
+  readme(
+    "STATE",
+    `# STATE
+
+\`STATE/\` holds the live operational state of the assistant across sessions — the append-only event log (\`events.jsonl\`), active Algorithm runs (\`active-algorithm-run.json\`), active ISA pointer (\`active.json\`), and similar single-source-of-truth records that hooks and tools read and update during normal use.
+
+Where \`WORK/\` is per-run artifacts, \`STATE/\` is global runtime state. Files here are intentionally small and structured: one JSONL per event stream, one JSON per active pointer. Substrates append events; promotion and harvest workflows read them.
+
+Created on first install. The \`events.jsonl\` writeback contract is documented in \`docs/memory-policy-v0.md\`. Never delete files here while a substrate is running — they back live behavior.
+`,
+  ),
+  readme(
+    "OBSERVABILITY",
+    `# OBSERVABILITY
+
+\`OBSERVABILITY/\` collects telemetry the substrate emits about itself — tool-activity traces, config-audit snapshots, idle-detection signals, hook-failure diagnostics, and other operational signals captured by observability hooks. PAI's \`ToolActivityTracker\`, \`ConfigAudit\`, and \`TeammateIdle\` hooks land their outputs here; substrate-equivalent hooks on other adapters do the same.
+
+This is the system's self-monitoring layer. Entries are typically timestamped JSONL or structured Markdown, indexed by session or by hook. Downstream skills read this directory to surface anomalies, summarize sessions, and detect drift.
+
+Empty in fresh installs. Populates the first time an observability hook fires. Safe to archive older entries; the latest entries back live dashboards and digests.
+`,
+  ),
+  readme(
+    "SECURITY",
+    `# SECURITY
+
+\`SECURITY/\` records security-relevant events the substrate captured — task-governance decisions, hook stop-failure diagnostics, permission-denial traces, and any other signal worth preserving for post-hoc review. PAI's \`TaskGovernance\` and \`StopFailureHandler\` hooks write here; substrate-equivalent hooks on other adapters do the same.
+
+Where \`OBSERVABILITY/\` is general operational telemetry, \`SECURITY/\` is the subset worth preserving for incident review and audit. Entries are typically structured JSONL with timestamps, actor, action, and decision.
+
+Empty in fresh installs. Populates the first time a security hook fires. Treat entries as sensitive — they may contain command excerpts, file paths, and policy decisions that reveal the principal's workflow.
+`,
+  ),
+  readme(
+    "SCRATCHPAD",
+    `# SCRATCHPAD
+
+\`SCRATCHPAD/\` is the ephemeral working space — drafts, intermediate calculations, throwaway notes, and any artifact that has no long-term value but needs a place to live during a session. Skills and agents that need a temp file outside their slug directory can write here.
+
+Treat everything in \`SCRATCHPAD/\` as deletable. Nothing here is canonical, nothing is referenced by hooks for downstream pipelines, and nothing should be relied on across sessions. If a scratchpad note turns out to matter, promote it to \`WORK/\`, \`KNOWLEDGE/\`, or \`RESEARCH/\`.
+
+Empty in fresh installs. Fills opportunistically as you work. Periodic cleanup is encouraged.
+`,
+  ),
+  readme(
+    "BOOKMARKS",
+    `# BOOKMARKS
+
+\`BOOKMARKS/\` is where bookmark-pulling skills land their synced state and parsed entries — typically as JSON or Markdown files keyed by source platform. Each platform integration owns its own subdirectory or file convention here.
+
+The system uses bookmarks as a signal of interest: items the principal explicitly saved are higher-priority candidates for upgrade analysis, content harvesting, and follow-up workflows.
+
+Empty in fresh installs. Populates the first time you run a bookmark-sync workflow. Re-running a sync is idempotent by design — state files track what has already been seen.
+`,
+  ),
+  readme(
+    "RESEARCH",
+    `# RESEARCH
+
+\`RESEARCH/\` stores the outputs of research-oriented skills and workflows — multi-source investigations, deep-dive reports, threat-model horizons, competitor analyses, and any other artifact whose primary value is the synthesized findings rather than the executing code. Research, threat-model, and similar deep-investigation skills target this directory.
+
+Content here is human-readable Markdown by convention, often timestamped and topic-slugged. Treat it as a personal research library — the system reads from it for context and the principal reads from it for reference.
+
+Empty in fresh installs. Populates the first time you run a research workflow. Safe to organize into subfolders by topic as the corpus grows.
+`,
+  ),
+  readme(
+    "PROJECT",
+    `# PROJECT
+
+\`PROJECT/\` is the per-project memory store — one subdirectory per project the principal works on, holding project-scoped notes, decisions, conventions, and accumulated context that should not pollute the global \`memory/\` namespace. Skills targeting a specific project read and write here.
+
+This pattern lets the assistant carry distinct memory for each codebase or initiative without the principal managing project-specific config. Each project subdirectory can grow its own internal structure as needed.
+
+Empty in fresh installs. Populates the first time a project-aware skill records project-specific context. Treat each project subdirectory as that project's working journal.
+`,
+  ),
+  readme(
+    "WISDOM",
+    `# WISDOM
+
+\`WISDOM/\` collects extracted wisdom artifacts — distilled insights, surprising ideas, quotable claims, and frame-shifting observations harvested from content the principal has consumed or produced. The \`ExtractWisdom\` skill and related fabric patterns write here.
+
+This is intentionally separate from \`KNOWLEDGE/\` (typed graph of entities and notes) and \`RESEARCH/\` (full investigative reports). \`WISDOM/\` is the high-signal, atomic-insight layer — short, sharp, attributable.
+
+Empty in fresh installs. Populates the first time a wisdom-extraction workflow runs. Safe to organize by source, topic, or date as the corpus grows.
+`,
+  ),
+  readme(
+    "VERIFICATION",
+    `# VERIFICATION
+
+\`VERIFICATION/\` stores evidence captured during the VERIFY phase of the Algorithm — screenshots, command outputs, test results, curl traces, and any other artifact that proves work was actually completed rather than merely claimed. Verification-focused skills and hooks write here with references back to the originating slug.
+
+This directory exists because "should work" is the system's least-trusted phrase. Verifiable evidence sits here so claims of completion can be audited after the fact. Soma's ISA verification model relies on this layer for durable artifact retention beyond the per-run \`WORK/\` slug.
+
+Empty in fresh installs. Populates whenever a workflow captures verification artifacts. Treat these files as evidence — preserve their original form and timestamps.
+`,
+  ),
+  readme(
+    "DATA",
+    `# DATA
+
+\`DATA/\` holds structured datasets that the system queries, analyzes, or reports on — economic indicators, public-data snapshots, custom JSON corpora, and similar tabular or document collections. Skills that pull from external data APIs land their canonical local copies here.
+
+Where \`RAW/\` is unstructured source material, \`DATA/\` is curated, schema-stable data ready for query and analysis. Think of it as the system's local data warehouse.
+
+Empty in fresh installs. Populates when you run any skill that maintains a local dataset. Schema discipline matters here — keep files versioned and document their shape.
+`,
+  ),
+  readme(
+    "RAW",
+    `# RAW
+
+\`RAW/\` stores unprocessed source material captured by the system before any parsing, classification, or summarization — raw HTML pulls, full API responses, transcript dumps, podcast audio metadata, original feed payloads, and similar inputs. Parsers and harvesters read from \`RAW/\` and write structured output elsewhere.
+
+Keeping the raw form lets the system re-parse with improved logic later without re-fetching, and lets the principal inspect the original data when a downstream artifact looks wrong.
+
+Empty in fresh installs. Populates when any ingestion workflow runs (feed pulls, transcript captures, scrapes). Files can be large — periodic cleanup of items already processed downstream is reasonable.
+`,
+  ),
+  readme(
+    "REFERENCE",
+    `# REFERENCE
+
+\`REFERENCE/\` holds curated reference material the system loads on demand — cheat sheets, API field maps, schema docs for external services, lookup tables, and other static information that supports skills without belonging in \`KNOWLEDGE/\` or substrate documentation directories. It is the system's working reference shelf.
+
+Content tends to be tool-specific and skill-adjacent: things a particular workflow needs to consult mid-run. Where \`KNOWLEDGE/\` is curated insight, \`REFERENCE/\` is curated lookup.
+
+Empty in fresh installs. Populates as skills that need reference material write or fetch their tables here. Safe to edit by hand for corrections.
+`,
+  ),
+  readme(
+    "SKILLS",
+    `# SKILLS
+
+\`SKILLS/\` holds runtime state owned by individual skills that does not fit neatly into \`STATE/\` or \`DATA/\` — skill-specific caches, accumulated user preferences for a given skill, evaluation histories, and per-skill working files. Each skill that needs persistent storage owns a subdirectory here.
+
+Where Soma's \`skills/\` tree (under \`~/.soma/skills/\`) and the substrate skills tree (e.g., \`~/.claude/skills/\`) are the code and definitions for skills, \`memory/SKILLS/\` is the lived data those skills accumulate during use.
+
+Empty in fresh installs. Populates as individual skills create their working subdirectories on first run. Inspect a skill's subdirectory to understand what state it is keeping.
+`,
+  ),
+  readme(
+    "PAISYSTEMUPDATES",
+    `# PAISYSTEMUPDATES
+
+${PAI_BOUND_PROVENANCE}
+
+\`PAISYSTEMUPDATES/\` is the queue and history of proposed and applied changes to the PAI system itself — Algorithm tweaks, hook adjustments, skill upgrades, configuration changes, and architectural refactors. PAI's \`PAIUpgrade\` skill writes prioritized recommendations here, and applied upgrades are recorded with their before/after state.
+
+This is how PAI improves itself across sessions: lessons in \`LEARNING/\` become candidate upgrades here, and the principal (or the system, with permission) promotes them into actual code and config changes. Other substrates do not write to this directory by default; portable Soma cores may leave it empty.
+
+Empty in fresh installs. Populates when you run the \`PAIUpgrade\` skill or when a PAI hook surfaces a structural improvement. Treat entries as proposals until explicitly applied.
+`,
+    { paiBound: true },
+  ),
+  readme(
+    "AUTO",
+    `# AUTO
+
+${PAI_BOUND_PROVENANCE}
+
+\`AUTO/\` collects outputs from automated, unattended workflows — scheduled jobs, cron-driven scans, periodic syncs, and any agent that runs without an interactive session. Where \`WORK/\` corresponds to principal-initiated Algorithm runs, \`AUTO/\` corresponds to background runs.
+
+PAI's auto-memory hook writes here. Files here are typically timestamped reports, scan results, and digest artifacts. The principal reads them on their own schedule rather than at execution time. Other substrates do not write to this directory by default; portable Soma cores may leave it empty.
+
+Empty in fresh installs. Populates the first time a scheduled or background workflow completes. Older entries can be archived or pruned without affecting live behavior.
+`,
+    { paiBound: true },
+  ),
+];
+
+/** Convenience accessor for substrate-neutral category names. */
+export const SOMA_SUBSTRATE_NEUTRAL_MEMORY_CATEGORIES = SOMA_MEMORY_CATEGORY_READMES.filter((entry) => !entry.paiBound).map(
+  (entry) => entry.category,
+);
+
+/** Convenience accessor for PAI-bound category names. */
+export const SOMA_PAI_BOUND_MEMORY_CATEGORIES = SOMA_MEMORY_CATEGORY_READMES.filter((entry) => entry.paiBound).map(
+  (entry) => entry.category,
+);
+
+/** All canonical memory category directory names (substrate-neutral + PAI-bound). */
+export const SOMA_MEMORY_CATEGORIES = SOMA_MEMORY_CATEGORY_READMES.map((entry) => entry.category);

--- a/src/soma-home.ts
+++ b/src/soma-home.ts
@@ -263,12 +263,18 @@ export async function bootstrapSomaHome(options: SomaHomeBootstrapOptions = {}):
 
   for (const entry of SOMA_MEMORY_CATEGORY_READMES) {
     const readmePath = join(somaHome, "memory", entry.category, "README.md");
-    await writeFile(readmePath, `${entry.content}\n`, { encoding: "utf8", flag: "wx" }).catch((error: unknown) => {
+    // `flag: "wx"` makes README writes idempotent — principal edits survive
+    // re-install (test AC-3). Sage R1: only record the path in `writtenFiles`
+    // when the write actually happened, so callers don't see a skipped EEXIST
+    // path masquerading as a fresh write.
+    try {
+      await writeFile(readmePath, `${entry.content}\n`, { encoding: "utf8", flag: "wx" });
+      writtenFiles.push(readmePath);
+    } catch (error: unknown) {
       if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") {
         throw error;
       }
-    });
-    writtenFiles.push(readmePath);
+    }
   }
 
   for (const projection of ["codex", "pi-dev", "claude-code"]) {

--- a/src/soma-home.ts
+++ b/src/soma-home.ts
@@ -1,9 +1,14 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, relative, resolve, sep } from "node:path";
+import { SOMA_MEMORY_CATEGORIES, SOMA_MEMORY_CATEGORY_READMES } from "./memory-readmes";
 import type { ProjectionInput, SomaHomeBootstrapOptions, SomaHomeBootstrapResult, SomaSkill } from "./types";
 
-const MEMORY_DIRS = ["WORK", "KNOWLEDGE", "LEARNING", "RELATIONSHIP", "STATE"] as const;
+// #88 / DD-2: canonical PAI v5.0.0 memory taxonomy (17 substrate-neutral +
+// 2 PAI-bound). The directory list and per-category README content live in
+// `memory-readmes.ts` so the install planner, bootstrap, and tests all share
+// one source of truth.
+const MEMORY_DIRS = SOMA_MEMORY_CATEGORIES;
 
 function resolveSomaHome(options: SomaHomeBootstrapOptions = {}): string {
   return resolve(options.somaHome ?? join(resolve(options.homeDir ?? homedir()), ".soma"));
@@ -247,8 +252,23 @@ export async function bootstrapSomaHome(options: SomaHomeBootstrapOptions = {}):
 
   await mkdir(somaHome, { recursive: true });
 
+  // #88 / DD-2: bootstrap the canonical PAI v5.0.0 memory taxonomy. Each
+  // category directory ships a README describing what belongs there;
+  // PAI-bound categories (`PAISYSTEMUPDATES`, `AUTO`) self-declare their
+  // substrate provenance. README write uses `flag: "wx"` so principal edits
+  // survive re-runs (idempotent contract — see test AC-3).
   for (const directory of MEMORY_DIRS) {
     await mkdir(join(somaHome, "memory", directory), { recursive: true });
+  }
+
+  for (const entry of SOMA_MEMORY_CATEGORY_READMES) {
+    const readmePath = join(somaHome, "memory", entry.category, "README.md");
+    await writeFile(readmePath, `${entry.content}\n`, { encoding: "utf8", flag: "wx" }).catch((error: unknown) => {
+      if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST") {
+        throw error;
+      }
+    });
+    writtenFiles.push(readmePath);
   }
 
   for (const projection of ["codex", "pi-dev", "claude-code"]) {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1,10 +1,41 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import { installSomaForCodex, installSomaForPiDev, planSomaForCodexInstall, planSomaForPiDevInstall } from "../src/index";
 import { renderStartupContextSummary } from "../src/adapters/codex/hooks/codex-hook-entry.mjs";
+
+// #88 — Canonical PAI v5.0.0 memory taxonomy (DD-2). 17 substrate-neutral +
+// 2 PAI-bound = 19. The order here is the order Soma documents; both
+// `SOMA_BOOTSTRAP_DIRECTORIES` (install.ts) and `MEMORY_DIRS` (soma-home.ts)
+// must enumerate all 19. Tests assert presence, not order.
+const SOMA_CANONICAL_MEMORY_DIRS = [
+  // Original 5 (pre-v5.0.0 Soma taxonomy, all substrate-neutral)
+  "WORK",
+  "KNOWLEDGE",
+  "LEARNING",
+  "RELATIONSHIP",
+  "STATE",
+  // 12 substrate-neutral additions from PAI v5.0.0
+  "OBSERVABILITY",
+  "SECURITY",
+  "SCRATCHPAD",
+  "BOOKMARKS",
+  "RESEARCH",
+  "PROJECT",
+  "WISDOM",
+  "VERIFICATION",
+  "DATA",
+  "RAW",
+  "REFERENCE",
+  "SKILLS",
+  // 2 PAI-bound additions (READMEs explicitly call this out)
+  "PAISYSTEMUPDATES",
+  "AUTO",
+] as const;
+
+const SOMA_PAI_BOUND_MEMORY_DIRS = ["PAISYSTEMUPDATES", "AUTO"] as const;
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-install-"));
@@ -1051,5 +1082,66 @@ test("installs soma source home and pi.dev home projection", async () => {
     expect(profile).toContain("Name: soma");
     expect(startupContext).toContain("Soma Startup Context");
     expect(somaRepo).toContain("soma");
+  });
+});
+
+// #88 AC-1 + AC-3 + AC-4 — Canonical memory taxonomy bootstrap.
+//
+// DD-2 binds the 19-category v5.0.0 taxonomy to every Soma install. The
+// install path tests cover AC-4 (any substrate's `--apply` creates the full
+// taxonomy under `~/.soma/memory/`); the README/marker tests cover AC-2
+// (README per category, PAI-bound categories self-declare provenance).
+test("#88 AC-1: codex install bootstraps the full PAI v5.0.0 memory taxonomy", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const somaHome = join(homeDir, ".soma");
+
+    for (const category of SOMA_CANONICAL_MEMORY_DIRS) {
+      const dirStat = await stat(join(somaHome, "memory", category));
+      expect(dirStat.isDirectory()).toBe(true);
+      const readme = await readFile(join(somaHome, "memory", category, "README.md"), "utf8");
+      expect(readme.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+test("#88 AC-4: pi.dev install bootstraps the full PAI v5.0.0 memory taxonomy", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForPiDev({ homeDir });
+    const somaHome = join(homeDir, ".soma");
+
+    for (const category of SOMA_CANONICAL_MEMORY_DIRS) {
+      const dirStat = await stat(join(somaHome, "memory", category));
+      expect(dirStat.isDirectory()).toBe(true);
+    }
+  });
+});
+
+test("#88 AC-2: PAI-bound category READMEs self-declare substrate provenance", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const somaHome = join(homeDir, ".soma");
+
+    for (const category of SOMA_PAI_BOUND_MEMORY_DIRS) {
+      const readme = await readFile(join(somaHome, "memory", category, "README.md"), "utf8");
+      // DD-2 implication: PAI-bound categories must explicitly state
+      // "populated by the PAI substrate; portable Soma cores may leave it empty".
+      expect(readme).toContain("PAI substrate");
+      expect(readme).toContain("portable Soma cores may leave it empty");
+    }
+  });
+});
+
+test("#88 AC-3: bootstrap is idempotent — re-running install does not overwrite edited READMEs", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const somaHome = join(homeDir, ".soma");
+    const readmePath = join(somaHome, "memory/OBSERVABILITY/README.md");
+    await writeFile(readmePath, "# OBSERVABILITY (user-edited)\n\nCustom notes.\n", "utf8");
+
+    await installSomaForCodex({ homeDir });
+
+    const second = await readFile(readmePath, "utf8");
+    expect(second).toBe("# OBSERVABILITY (user-edited)\n\nCustom notes.\n");
   });
 });

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -5,37 +5,17 @@ import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import { installSomaForCodex, installSomaForPiDev, planSomaForCodexInstall, planSomaForPiDevInstall } from "../src/index";
 import { renderStartupContextSummary } from "../src/adapters/codex/hooks/codex-hook-entry.mjs";
+import {
+  SOMA_MEMORY_CATEGORIES,
+  SOMA_PAI_BOUND_MEMORY_CATEGORIES,
+} from "../src/memory-readmes";
 
 // #88 — Canonical PAI v5.0.0 memory taxonomy (DD-2). 17 substrate-neutral +
-// 2 PAI-bound = 19. The order here is the order Soma documents; both
-// `SOMA_BOOTSTRAP_DIRECTORIES` (install.ts) and `MEMORY_DIRS` (soma-home.ts)
-// must enumerate all 19. Tests assert presence, not order.
-const SOMA_CANONICAL_MEMORY_DIRS = [
-  // Original 5 (pre-v5.0.0 Soma taxonomy, all substrate-neutral)
-  "WORK",
-  "KNOWLEDGE",
-  "LEARNING",
-  "RELATIONSHIP",
-  "STATE",
-  // 12 substrate-neutral additions from PAI v5.0.0
-  "OBSERVABILITY",
-  "SECURITY",
-  "SCRATCHPAD",
-  "BOOKMARKS",
-  "RESEARCH",
-  "PROJECT",
-  "WISDOM",
-  "VERIFICATION",
-  "DATA",
-  "RAW",
-  "REFERENCE",
-  "SKILLS",
-  // 2 PAI-bound additions (READMEs explicitly call this out)
-  "PAISYSTEMUPDATES",
-  "AUTO",
-] as const;
-
-const SOMA_PAI_BOUND_MEMORY_DIRS = ["PAISYSTEMUPDATES", "AUTO"] as const;
+// 2 PAI-bound = 19. Tests consume the production-exported lists from
+// `memory-readmes.ts` so the taxonomy split stays single-sourced (Sage R1
+// maintainability finding).
+const SOMA_CANONICAL_MEMORY_DIRS = SOMA_MEMORY_CATEGORIES;
+const SOMA_PAI_BOUND_MEMORY_DIRS = SOMA_PAI_BOUND_MEMORY_CATEGORIES;
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-install-"));


### PR DESCRIPTION
## Summary

Ships [DD-2](https://github.com/the-metafactory/soma/blob/main/design/design-decisions.md#dd-2-adopt-pai-v500-memory-taxonomy-wholesale-mark-pai-specific-categories): bootstrap the canonical PAI v5.0.0 memory taxonomy. Pre-v5.0.0 Soma shipped 5 memory categories; v5.0.0 canonical form has 19 — 17 substrate-neutral + 2 PAI-bound. Additive change, no backcompat shims (pre-release).

New canonical list (single source of truth: `src/memory-readmes.ts`):
- **Originals (5)**: `WORK`, `KNOWLEDGE`, `LEARNING`, `RELATIONSHIP`, `STATE`
- **Substrate-neutral additions (12)**: `OBSERVABILITY`, `SECURITY`, `SCRATCHPAD`, `BOOKMARKS`, `RESEARCH`, `PROJECT`, `WISDOM`, `VERIFICATION`, `DATA`, `RAW`, `REFERENCE`, `SKILLS`
- **PAI-bound (2)**: `PAISYSTEMUPDATES`, `AUTO` — READMEs include the mandatory `populated by the PAI substrate; portable Soma cores may leave it empty` provenance line.

`SOMA_BOOTSTRAP_DIRECTORIES` and `MEMORY_DIRS` both consume `SOMA_MEMORY_CATEGORIES` from the shared module so they cannot drift. README writes use `flag: "wx"` so principal edits survive re-install (idempotent contract — explicit AC-3 test).

Substrate-neutral READMEs adapted from `~/work/PAI/Releases/v5.0.0/.claude/PAI/MEMORY/<CAT>/README.md` where one exists; `LEARNING`, `OBSERVABILITY`, `SECURITY`, `STATE` authored fresh (the v5.0.0 source omits them or ships them empty). `OBSERVABILITY`/`SECURITY` reference the PAI v5.0.0 hooks (`ToolActivityTracker`, `ConfigAudit`, `TaskGovernance`, `StopFailureHandler`) that target each.

## Acceptance criteria

- [x] **AC-1**: `SOMA_BOOTSTRAP_DIRECTORIES` includes all 19 canonical categories (derived from `SOMA_MEMORY_CATEGORIES`).
- [x] **AC-2**: Each new category ships a `README.md`. PAI-bound (`PAISYSTEMUPDATES`, `AUTO`) explicitly state substrate-bound provenance; test asserts both marker phrases.
- [x] **AC-3**: Existing tests pass without modification (categories are additive). New bootstrap test asserts all 19 dirs + READMEs. README idempotency test pinned (edits survive re-install).
- [x] **AC-4**: Fresh `soma install codex --apply` (or any substrate) creates the full taxonomy under `~/.soma/memory/`. Manually verified end-to-end + asserted in `#88 AC-1` (codex) and `#88 AC-4` (pi.dev) tests.
- [x] **AC-5**: `docs/memory-policy-v0.md` enumerates the full 17+2 taxonomy with the PAI-bound provenance note. `docs/writeback-and-policy.md` references the broader durable-store list and links to DD-2.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 541 pass / 0 fail (537 baseline post-#87 + 4 new `#88 AC-*` tests in `test/install.test.ts`)
- [x] End-to-end: `rm -rf /tmp/soma-issue88-verify && bun src/cli.ts install codex --apply --soma-home /tmp/soma-issue88-verify/.soma --substrate-home /tmp/soma-issue88-verify/.codex` -> 19 memory dirs, 19 READMEs, exactly 2 self-declare PAI-bound provenance.
- [x] AC-3 idempotency: `installSomaForCodex` re-run preserves user-edited `memory/OBSERVABILITY/README.md` byte-for-byte.

## Out of scope

- Migration of existing `~/.soma/memory/` content (no backcompat per principal directive — pre-release; existing installs backfill via re-running `soma install <substrate> --apply` which is idempotent).
- Translating user's `~/.claude/PAI/MEMORY/*` data into Soma — that's #90 (`soma migrate pai` extension).
- Expanding `SEARCH_ROOTS` in `src/memory.ts` to cover new categories — kept scope-tight; can land as a follow-on if needed.

Closes #88

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)