### PR TITLE
feat(cli): add soma import pai-docs verb (#89)

### DIFF
--- a/docs/pai-docs-importer.md
+++ b/docs/pai-docs-importer.md
@@ -1,0 +1,125 @@
+# PAI Docs Importer
+
+`soma import pai-docs` imports a subset of a PAI release tree into
+`~/.soma/PAI/`. It is the first step of the PAI → Soma migration chain
+(per [DD-1](../design/design-decisions.md#dd-1-soma-is-the-new-canonical-home-of-personal-ai-state)):
+Soma is the canonical home of personal AI state, and the PAI release
+tree is the source we translate from.
+
+The problem this solves: imported PAI skills reference PAI documentation
+paths (`~/.claude/PAI/DOCUMENTATION/Skills/SkillSystem.md`, etc.) that
+do not exist under Soma. The normalizer added in #86 rewrites these to
+`~/.soma/UNMAPPED/PAI/...` and surfaces them as warnings — making the
+gap loud rather than silent. This verb is the deterministic fix:
+populate `~/.soma/PAI/` so the references resolve to real files.
+
+## Contract
+
+```
+soma import pai-docs --pai-source-dir <path>
+soma import pai-docs --pai-source-dir <path> --apply
+soma import pai-docs --pai-source-dir <path> --apply --soma-home /custom
+```
+
+`<path>` points at a PAI release tree root, for example
+`~/work/PAI/Releases/v5.0.0/.claude/PAI`. The flag is required — the
+verb refuses to guess a source location.
+
+Dry-run is the default. `--apply` writes files.
+
+## Scope
+
+| Subdir                  | Imported? | Why                                                                |
+| ----------------------- | --------- | ------------------------------------------------------------------ |
+| `DOCUMENTATION/`        | yes (required) | Resolves the broken doc references in imported skills.        |
+| `TEMPLATES/`            | yes       | Referenced by `CreateSkill` workflows that scaffold from templates. |
+| `ALGORITHM/`            | yes       | Referenced by skills that produce phase markers; aligns with Soma's `the-algorithm`. |
+| `PAI_SYSTEM_PROMPT.md`  | no        | Reference only. Soma has its own assistant identity.               |
+| `MEMORY/`               | no        | Soma has its own memory model (see issue #88).                     |
+| `USER/`                 | no        | User state, not release content.                                   |
+| `PULSE/`                | no        | Runtime, not portable.                                             |
+| `bin/`, `PAI-Install/`, `statusline-command.sh` | no | Install/runtime infrastructure.                |
+| `TOOLS/`                | no        | Likely Claude-specific runtime; deferred.                          |
+
+## Target Layout
+
+Imported files land under `~/.soma/PAI/` with the source subdirs preserved:
+
+```text
+.soma/PAI/
+  DOCUMENTATION/
+    Skills/SkillSystem.md
+    Memory/MemoryArchitecture.md
+    ...
+  TEMPLATES/
+    User/PRINCIPAL_IDENTITY.md
+    ...
+  ALGORITHM/
+    v6.3.0.md
+    LATEST
+    ...
+  .import-manifest.json
+```
+
+## Manifest
+
+After `--apply`, the importer writes
+`~/.soma/PAI/.import-manifest.json`:
+
+```json
+{
+  "schema": "soma.pai-docs-import.v1",
+  "paiSourceDir": "/Users/fischer/work/PAI/Releases/v5.0.0/.claude/PAI",
+  "releaseVersion": "v5.0.0",
+  "importedAt": "2026-05-17T15:00:00.000Z",
+  "files": [
+    {
+      "target": "DOCUMENTATION/Skills/SkillSystem.md",
+      "source": "DOCUMENTATION/Skills/SkillSystem.md",
+      "sha256": "..."
+    }
+  ]
+}
+```
+
+`releaseVersion` is detected in this order:
+
+1. A `VERSION` file at the source root (`<pai-source-dir>/VERSION`),
+   trimmed of whitespace.
+2. The path hint `Releases/<version>/` — matches the canonical PAI
+   release layout `~/work/PAI/Releases/v5.0.0/.claude/PAI`.
+3. `null` when neither is present. The manifest stays explicit about
+   not knowing rather than guessing.
+
+## Idempotency
+
+`--apply` is content-addressed: each source file's SHA-256 is compared
+against the previous manifest entry. A re-run with unchanged sources
+copies zero files and reports `writtenCount: 0 (idempotent no-op —
+source SHAs unchanged)`. The manifest is always rewritten so the
+`importedAt` timestamp reflects the most recent run.
+
+## Refusals
+
+The verb refuses, with a loud error, on:
+
+- **Non-PAI source.** Missing a `DOCUMENTATION/` subdir or it is not a
+  directory. The verb does no heuristic guessing.
+- **Symlinks inside the source tree.** Mirrors `soma import pai-pack`'s
+  hardening and matches `soma export --out`'s symlink-realpath guard.
+- **Targets that escape the Soma home.** Lexical and symlink-realpath
+  checks both run before every write, including the manifest itself.
+  Mirrors `writeProjectionExportFile` in `src/cli.ts` (added in #54,
+  reinforced in Sage round 1 on PR #81).
+- **VCS metadata directories.** `.git/`, `.hg/`, `.svn/` are refused
+  outright inside the source tree.
+
+## Follow-ups
+
+- The `unmapped-claude-home-path` warning class added in #86 will be
+  replaced by a deterministic `~/.claude/PAI/<rest>` →
+  `~/.soma/PAI/<rest>` rewrite in #91 — once this verb has shipped and
+  `~/.soma/PAI/` exists in the target layout.
+- The wider PAI migration orchestrator (`soma migrate pai`) wraps this
+  verb plus the memory and pack importers in a single principal-facing
+  command (issue #90).

--- a/docs/pai-docs-importer.md
+++ b/docs/pai-docs-importer.md
@@ -99,6 +99,12 @@ copies zero files and reports `writtenCount: 0 (idempotent no-op —
 source SHAs unchanged)`. The manifest is always rewritten so the
 `importedAt` timestamp reflects the most recent run.
 
+Dry-run plans list files without reading their bytes. SHA-256 is
+computed on the apply path only — where it is needed for both the
+manifest (AC-5) and the idempotency comparison against any prior
+manifest. Plan callers that only want paths and counts pay no
+content-read cost.
+
 ## Refusals
 
 The verb refuses, with a loud error, on:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,7 @@ import {
   importPaiDocs,
   importPaiIdentity,
   importPaiPack,
+  PAI_DOCS_IMPORT_SUBDIRS,
   migratePai,
   planPaiMigration,
   type PaiMigrationOptions,
@@ -1879,9 +1880,10 @@ function formatPaiDocsImportPlan(plan: PaiDocsImportPlan): string {
     `releaseVersion: ${plan.releaseVersion ?? "<unknown>"}`,
     "",
     "Counts:",
-    `- DOCUMENTATION: ${counts.DOCUMENTATION ?? 0}`,
-    `- TEMPLATES: ${counts.TEMPLATES ?? 0}`,
-    `- ALGORITHM: ${counts.ALGORITHM ?? 0}`,
+    // Sage round 3 (Maintainability): drive the counts list from the
+    // shared subtree constant so adding a subtree only requires
+    // touching `PAI_DOCS_IMPORT_SUBDIRS`.
+    ...PAI_DOCS_IMPORT_SUBDIRS.map((subdir) => `- ${subdir}: ${counts[subdir] ?? 0}`),
     "",
     "Files:",
     ...plan.files.map((file) => `- ${file.relativePath} -> ${file.target}`),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import {
   captureSomaFeedback,
   createAlgorithmRun,
   importAlgorithm,
+  importPaiDocs,
   importPaiIdentity,
   importPaiPack,
   migratePai,
@@ -29,6 +30,7 @@ import {
   loadSomaHome,
   listAlgorithmRunSummaries,
   planAlgorithmImport,
+  planPaiDocsImport,
   planPaiImport,
   planPaiPackImport,
   planSomaForCodexInstall,
@@ -63,6 +65,9 @@ import type {
   PaiPackImportOptions,
   PaiPackImportPlan,
   PaiPackImportResult,
+  PaiDocsImportOptions,
+  PaiDocsImportPlan,
+  PaiDocsImportResult,
   ProjectionInput,
   SomaInstallOptions,
   SomaInstallPlan,
@@ -144,9 +149,9 @@ interface ParsedDaemonArgs {
 
 interface ParsedImportArgs {
   command: "import";
-  source: "pai" | "algorithm" | "pai-pack";
+  source: "pai" | "algorithm" | "pai-pack" | "pai-docs";
   apply: boolean;
-  options: PaiImportOptions | AlgorithmImportOptions | PaiPackImportOptions;
+  options: PaiImportOptions | AlgorithmImportOptions | PaiPackImportOptions | PaiDocsImportOptions;
 }
 
 interface ParsedMigrateArgs {
@@ -356,11 +361,12 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
     usage: "Usage: soma daemon  (not yet implemented — placeholder reserves the runtime mode)",
   },
   import: {
-    usage: "Usage: soma import <pai|algorithm|pai-pack> ...",
+    usage: "Usage: soma import <pai|algorithm|pai-pack|pai-docs> ...",
     subcommands: {
       pai: "Usage: soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>]",
       algorithm: "Usage: soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
       "pai-pack": "Usage: soma import pai-pack [--dry-run] [--apply] [--home-dir <dir>] [--source <dir>] [--soma-home <dir>]",
+      "pai-docs": "Usage: soma import pai-docs [--dry-run] [--apply] [--home-dir <dir>] --pai-source-dir <dir> [--soma-home <dir>]",
     },
   },
   migrate: {
@@ -560,18 +566,28 @@ function parseDaemonArgs(args: string[]): ParsedDaemonArgs {
 function parseImportArgs(args: string[]): ParsedImportArgs {
   const [command, source, ...rest] = args;
 
-  if (command !== "import" || (source !== "pai" && source !== "algorithm" && source !== "pai-pack")) {
+  if (
+    command !== "import" ||
+    (source !== "pai" &&
+      source !== "algorithm" &&
+      source !== "pai-pack" &&
+      source !== "pai-docs")
+  ) {
     throw new Error(
       [
         "Usage:",
         "  soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>]",
         "  soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
         "  soma import pai-pack [--dry-run] [--apply] [--home-dir <dir>] --pai-pack-dir <dir> [--soma-home <dir>] [--skill-name <name>] [--overwrite] [--include-substrate-specific]",
+        "  soma import pai-docs [--dry-run] [--apply] [--home-dir <dir>] --pai-source-dir <dir> [--soma-home <dir>]",
       ].join("\n"),
     );
   }
 
-  const options: PaiImportOptions & AlgorithmImportOptions & PaiPackImportOptions = {};
+  const options: PaiImportOptions &
+    AlgorithmImportOptions &
+    PaiPackImportOptions &
+    PaiDocsImportOptions = {};
   let apply = false;
 
   for (let index = 0; index < rest.length; index += 1) {
@@ -607,6 +623,13 @@ function parseImportArgs(args: string[]): ParsedImportArgs {
           throw new Error("--pai-pack-dir is only valid for soma import pai-pack.");
         }
         options.paiPackDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--pai-source-dir":
+        if (source !== "pai-docs") {
+          throw new Error("--pai-source-dir is only valid for soma import pai-docs.");
+        }
+        options.paiSourceDir = readOption(rest, index, arg);
         index += 1;
         break;
       case "--skill-name":
@@ -1841,6 +1864,44 @@ function formatPaiPackImportResult(result: PaiPackImportResult): string {
   ].join("\n");
 }
 
+function formatPaiDocsImportPlan(plan: PaiDocsImportPlan): string {
+  const counts = plan.files.reduce<Partial<Record<string, number>>>((acc, file) => {
+    acc[file.subdir] = (acc[file.subdir] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return [
+    "Soma PAI docs import plan",
+    "source: pai-docs",
+    `mode: ${plan.apply ? "apply" : "dry-run"}`,
+    `paiSourceDir: ${plan.paiSourceDir}`,
+    `somaHome: ${plan.somaHome}`,
+    `releaseVersion: ${plan.releaseVersion ?? "<unknown>"}`,
+    "",
+    "Counts:",
+    `- DOCUMENTATION: ${counts.DOCUMENTATION ?? 0}`,
+    `- TEMPLATES: ${counts.TEMPLATES ?? 0}`,
+    `- ALGORITHM: ${counts.ALGORITHM ?? 0}`,
+    "",
+    "Files:",
+    ...plan.files.map((file) => `- ${file.relativePath} -> ${file.target}`),
+  ].join("\n");
+}
+
+function formatPaiDocsImportResult(result: PaiDocsImportResult): string {
+  return [
+    "Soma PAI docs import applied",
+    `paiSourceDir: ${result.paiSourceDir}`,
+    `somaHome: ${result.somaHome}`,
+    `releaseVersion: ${result.releaseVersion ?? "<unknown>"}`,
+    `importedAt: ${result.importedAt}`,
+    `writtenCount: ${result.writtenCount}${result.unchanged ? " (idempotent no-op — source SHAs unchanged)" : ""}`,
+    "",
+    "Files:",
+    ...result.files.map((path) => `- ${path}`),
+  ].join("\n");
+}
+
 function quoteShellArg(value: string): string {
   if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) {
     return value;
@@ -2215,6 +2276,16 @@ export async function runSomaCli(args: string[]): Promise<string> {
       }
 
       return formatPaiPackImportResult(await importPaiPack(options));
+    }
+
+    if (parsed.source === "pai-docs") {
+      const options = parsed.options as PaiDocsImportOptions;
+
+      if (!parsed.apply) {
+        return formatPaiDocsImportPlan(await planPaiDocsImport(options));
+      }
+
+      return formatPaiDocsImportResult(await importPaiDocs(options));
     }
 
     const options = parsed.options as PaiImportOptions;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,6 @@ import {
   importPaiDocs,
   importPaiIdentity,
   importPaiPack,
-  PAI_DOCS_IMPORT_SUBDIRS,
   migratePai,
   planPaiMigration,
   type PaiMigrationOptions,
@@ -89,6 +88,11 @@ import type {
 } from "./types";
 import { SOMA_FEEDBACK_STDIN_MAX_BYTES } from "./feedback-contract";
 import { ISA_SUBCOMMAND_HELP, ISA_USAGE_HEADER, runIsaCli } from "./cli-isa";
+// CLI formatter for `import pai-docs` needs the same in-scope subtree
+// list the importer iterates. Importing directly from the module
+// keeps the constant a module-internal contract rather than promoting
+// importer policy through the package root surface.
+import { PAI_DOCS_IMPORT_SUBDIRS } from "./pai-docs-importer";
 
 /**
  * Typed CLI error carrying an exit code distinct from the default 1.
@@ -1880,9 +1884,8 @@ function formatPaiDocsImportPlan(plan: PaiDocsImportPlan): string {
     `releaseVersion: ${plan.releaseVersion ?? "<unknown>"}`,
     "",
     "Counts:",
-    // Sage round 3 (Maintainability): drive the counts list from the
-    // shared subtree constant so adding a subtree only requires
-    // touching `PAI_DOCS_IMPORT_SUBDIRS`.
+    // Drive the counts from the shared subtree constant so adding a
+    // subtree only requires touching `PAI_DOCS_IMPORT_SUBDIRS`.
     ...PAI_DOCS_IMPORT_SUBDIRS.map((subdir) => `- ${subdir}: ${counts[subdir] ?? 0}`),
     "",
     "Files:",

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,6 +208,7 @@ export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from ".
 export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
 export { importPaiPack, planPaiPackImport } from "./pai-pack-importer";
+export { importPaiDocs, planPaiDocsImport } from "./pai-docs-importer";
 // PAI → Soma migration orchestrator (#28 minimal scope).
 export {
   migratePai,

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,7 +208,7 @@ export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from ".
 export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
 export { importPaiPack, planPaiPackImport } from "./pai-pack-importer";
-export { importPaiDocs, planPaiDocsImport } from "./pai-docs-importer";
+export { importPaiDocs, planPaiDocsImport, PAI_DOCS_IMPORT_SUBDIRS } from "./pai-docs-importer";
 // PAI → Soma migration orchestrator (#28 minimal scope).
 export {
   migratePai,

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,7 +208,7 @@ export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from ".
 export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
 export { importPaiPack, planPaiPackImport } from "./pai-pack-importer";
-export { importPaiDocs, planPaiDocsImport, PAI_DOCS_IMPORT_SUBDIRS } from "./pai-docs-importer";
+export { importPaiDocs, planPaiDocsImport } from "./pai-docs-importer";
 // PAI → Soma migration orchestrator (#28 minimal scope).
 export {
   migratePai,

--- a/src/pai-docs-importer.ts
+++ b/src/pai-docs-importer.ts
@@ -47,10 +47,11 @@ import type {
 // broken doc refs that #86 currently shunts to `~/.soma/UNMAPPED/PAI/`).
 // TEMPLATES + ALGORITHM are optional but copied when present.
 //
-// Exported (Sage round 3, Maintainability) so CLI formatters and any
-// future caller share the same list. The exported tuple is the single
-// runtime source of truth; the `PaiDocsImportSubdir` type in
-// `src/types.ts` mirrors its members.
+// Single source of truth. The CLI formatter and the apply loop both
+// iterate this tuple; the `PaiDocsImportSubdir` union in
+// `src/types.ts` mirrors its members. Module-internal — not exported
+// from the package root, since the in-scope subtree set is importer
+// policy, not part of the public API.
 export const PAI_DOCS_IMPORT_SUBDIRS = ["DOCUMENTATION", "TEMPLATES", "ALGORITHM"] as const satisfies readonly PaiDocsImportSubdir[];
 
 const REQUIRED_SUBDIR: PaiDocsImportSubdir = "DOCUMENTATION";
@@ -124,10 +125,10 @@ async function collectFiles(root: string): Promise<string[]> {
             `PAI docs import refused path outside source root: ${relative(root, fullPath).split(sep).join("/")}`,
           );
         }
-        // Sage round 3 (CodeQuality suggestion): the realpath check
-        // above is the authoritative traversal guard. A `rel.startsWith("..")`
-        // string filter both adds nothing and silently drops legitimate
-        // filenames like `..notes.md`.
+        // The `isWithinPath(realRoot, realFile)` check above is the
+        // authoritative traversal guard — no extra string filter on
+        // the relative path is needed, and adding one would silently
+        // drop legitimate filenames such as `..notes.md`.
         files.push(relative(root, fullPath).split(sep).join("/"));
       }
     }
@@ -147,12 +148,12 @@ async function collectFiles(root: string): Promise<string[]> {
 async function detectReleaseVersion(sourceDir: string): Promise<string | null> {
   const versionPath = join(sourceDir, "VERSION");
   if (await pathExists(versionPath)) {
-    // Sage round 3 (Security, important): refuse symlinks here just
-    // like everywhere else in the importer. A malicious source could
-    // otherwise plant `VERSION -> /etc/hostname` and smuggle its
-    // contents into CLI output + `.import-manifest.json`. Also
-    // require a regular file — a directory at this path is a sign of
-    // a malformed source, not a release marker.
+    // Refuse symlinks at this path with the same bar as every other
+    // file the importer reads. A malicious source could otherwise
+    // plant `VERSION -> /etc/hostname` and smuggle its contents into
+    // CLI output + `.import-manifest.json`. Require a regular file —
+    // a directory at this path is a sign of a malformed source, not a
+    // release marker.
     const versionStat = await lstat(versionPath);
     if (versionStat.isSymbolicLink()) {
       throw new Error("soma import pai-docs refused symlink path: VERSION");
@@ -198,10 +199,9 @@ async function assertPaiReleaseTree(sourceDir: string): Promise<void> {
 // Build a plan: collect every file under each in-scope subdir and
 // pair it with its eventual target under ~/.soma/PAI/. By default the
 // plan lists files without reading their bytes — dry-run callers only
-// need paths and counts (Sage round 2 performance finding). Pass
-// `withSha: true` to populate per-file SHA-256, which the apply path
-// needs for the manifest and for idempotency comparisons against any
-// prior manifest.
+// need paths and counts. Pass `withSha: true` to populate per-file
+// SHA-256, which the apply path needs for both the manifest (AC-5)
+// and idempotency comparisons against any prior manifest.
 async function buildPlan(
   options: PaiDocsImportOptions,
   flags: { withSha: boolean },
@@ -215,13 +215,12 @@ async function buildPlan(
   for (const subdir of PAI_DOCS_IMPORT_SUBDIRS) {
     const subdirPath = join(homes.paiSourceDir, subdir);
     if (!(await pathExists(subdirPath))) continue;
-    // Sage round 1 (Security, important): `collectFiles` lstat-checks
-    // every child entry but never its own root. Without this guard, a
-    // PAI source with `TEMPLATES/` or `ALGORITHM/` planted as a
-    // symlink would be followed and imported — violating the
-    // documented refusal for symlinks inside the source tree. Refuse
-    // here at the subtree boundary, before `collectFiles` recurses
-    // into anything.
+    // `collectFiles` lstat-checks every child entry but never its
+    // own root. Without this guard, a PAI source with `TEMPLATES/` or
+    // `ALGORITHM/` planted as a symlink would be followed and
+    // imported — violating the documented refusal for symlinks inside
+    // the source tree. Check the subtree boundary here, before
+    // `collectFiles` recurses into anything.
     const subdirStat = await lstat(subdirPath);
     if (subdirStat.isSymbolicLink()) {
       throw new Error(
@@ -270,10 +269,9 @@ export async function planPaiDocsImport(
   return buildPlan(options, { withSha: false });
 }
 
-// Sage round 4 (Maintainability nit): the prior `ExistingManifestEntry`
-// shape stored `target` twice — once as the map key and once as a
-// field never read again. A `Map<target, sha256>` carries exactly the
-// state idempotency needs.
+// Idempotency only needs `target -> sha256`. Returns null when the
+// manifest is missing or unreadable (a missing manifest is a first
+// import; an unreadable one falls through to a full re-copy).
 async function readExistingManifest(
   somaHome: string,
 ): Promise<Map<string, string> | null> {
@@ -293,20 +291,23 @@ async function readExistingManifest(
   }
 }
 
-// Lexical + symlink-realpath escape guard, mirroring
-// `writeProjectionExportFile` in src/cli.ts. The realpath of the
-// resolved Soma home is computed once and reused for every file write.
-//
-// Sage round 1 (Maintainability suggestion): both write paths
-// (manifest write and source-copy) need exactly the same target-side
-// hardening. Centralizing the guard here means future tightening
-// happens in one place instead of two.
+// Centralized target-side escape guard for every write the importer
+// performs (manifest write + per-file copy). The contract:
+//   1. The target must lexically resolve inside `somaHomeRoot` before
+//      any IO is attempted.
+//   2. No directory creation may follow a symlink that escapes
+//      `realSomaHomeRoot`. We walk the existing ancestors of the
+//      target *before* `mkdir`, refuse if any ancestor is a symlink
+//      that points outside the Soma home, and only create new
+//      directories underneath a verified ancestor.
+//   3. After mkdir completes, the parent's realpath is re-verified
+//      against `realSomaHomeRoot` so any race between the walk and the
+//      mkdir is still caught.
 async function prepareSafeTargetParent(
   realSomaHomeRoot: string,
   somaHomeRoot: string,
   targetAbs: string,
 ): Promise<string> {
-  // Lexical: the target must resolve inside somaHomeRoot before any IO.
   const resolved = resolve(targetAbs);
   if (
     resolved !== somaHomeRoot &&
@@ -317,12 +318,45 @@ async function prepareSafeTargetParent(
     );
   }
   const parent = dirname(resolved);
+
+  // Walk the chain of existing ancestors from the parent up toward
+  // the Soma home root, refusing symlinks that point outside the home.
+  // Stop at the first ancestor that does not yet exist — that and
+  // everything underneath it will be created by the targeted `mkdir`
+  // below, so no symlink can pre-exist on those segments.
+  const ancestors: string[] = [];
+  let cursor = parent;
+  while (true) {
+    ancestors.push(cursor);
+    if (cursor === somaHomeRoot) break;
+    const next = dirname(cursor);
+    if (next === cursor) break;
+    cursor = next;
+  }
+  // Top-down: verify the highest existing ancestor first.
+  for (const ancestor of ancestors.reverse()) {
+    if (!(await pathExists(ancestor))) continue;
+    const stat = await lstat(ancestor);
+    if (stat.isSymbolicLink()) {
+      const realLink = await realpath(ancestor);
+      if (
+        realLink !== realSomaHomeRoot &&
+        !realLink.startsWith(realSomaHomeRoot + sep)
+      ) {
+        throw new Error(
+          `soma import pai-docs refused to follow a symlink that escapes Soma home (path: ${targetAbs}).`,
+        );
+      }
+    }
+  }
+
   await mkdir(parent, { recursive: true });
-  // Symlink-realpath: after mkdir, the parent's realpath must still be
-  // under the soma home's realpath. A symlink anywhere on the path
-  // (e.g. somaHome/PAI/DOCUMENTATION -> ~/.ssh) would otherwise let
-  // the write land outside the home even though the lexical check
-  // passed.
+  // After mkdir, re-check the parent's realpath against the Soma
+  // home's realpath. This re-catches both the standard
+  // symlink-in-the-middle case (e.g. a regular dir replaced by a
+  // symlink between walk and mkdir) and the case where the parent
+  // itself is a symlink pointing inside the home (legal — caught by
+  // the equality check).
   const realParent = await realpath(parent);
   if (
     realParent !== realSomaHomeRoot &&
@@ -416,8 +450,7 @@ export async function importPaiDocs(
 ): Promise<PaiDocsImportResult> {
   // Apply path needs per-file SHAs for both the manifest (AC-5) and
   // idempotency comparison against any prior manifest. Plan-only
-  // callers go through `planPaiDocsImport` and skip the read+hash —
-  // Sage round 2 performance finding.
+  // callers go through `planPaiDocsImport` and skip the read+hash.
   const plan = await buildPlan(options, { withSha: true });
 
   await mkdir(plan.somaHome, { recursive: true });
@@ -434,18 +467,23 @@ export async function importPaiDocs(
   const previous = await readExistingManifest(plan.somaHome);
   let writtenCount = 0;
 
-  // Sage round 2 (Maintainability suggestion): drop the redundant
-  // pre-flight `nearestExistingAncestor` check. `copyFileSafely` calls
-  // `prepareSafeTargetParent`, which lexically checks the target,
-  // `mkdir`s the parent, and re-resolves `realpath(parent)` against
-  // the Soma home root — the same symlink-escape behavior the
-  // pre-flight check provided, in one place.
+  // Skip a copy only when both the prior manifest SHA matches the new
+  // source SHA AND the target file's current bytes still hash to that
+  // SHA. Trusting the manifest alone leaves a correctness gap: if a
+  // user edits or corrupts an imported file, a re-run with unchanged
+  // source bytes would otherwise report a no-op and leave the target
+  // wrong. Re-hashing the target on idempotency-skip closes that.
   for (const file of plan.files) {
     const manifestKey = manifestRelativeTarget(file);
     const priorSha = previous?.get(manifestKey);
     if (priorSha && priorSha === file.sha256 && (await pathExists(file.target))) {
-      // Same source bytes, target still on disk — nothing to do.
-      continue;
+      const targetSha = sha256(await readFile(file.target));
+      if (targetSha === file.sha256) {
+        // Source bytes unchanged AND target still matches — nothing to do.
+        continue;
+      }
+      // Target drifted (user edit, partial-write corruption, …). Fall
+      // through to re-copy the source over it.
     }
     await copyFileSafely(realSourceRoot, realSomaHome, somaHomeAbs, file.source, file.target);
     writtenCount += 1;

--- a/src/pai-docs-importer.ts
+++ b/src/pai-docs-importer.ts
@@ -199,6 +199,24 @@ async function buildPlan(options: PaiDocsImportOptions): Promise<PaiDocsImportPl
   for (const subdir of IMPORT_SUBDIRS) {
     const subdirPath = join(homes.paiSourceDir, subdir);
     if (!(await pathExists(subdirPath))) continue;
+    // Sage round 1 (Security, important): `collectFiles` lstat-checks
+    // every child entry but never its own root. Without this guard, a
+    // PAI source with `TEMPLATES/` or `ALGORITHM/` planted as a
+    // symlink would be followed and imported — violating the
+    // documented refusal for symlinks inside the source tree. Refuse
+    // here at the subtree boundary, before `collectFiles` recurses
+    // into anything.
+    const subdirStat = await lstat(subdirPath);
+    if (subdirStat.isSymbolicLink()) {
+      throw new Error(
+        `soma import pai-docs refused symlink path: ${subdir}/`,
+      );
+    }
+    if (!subdirStat.isDirectory()) {
+      throw new Error(
+        `soma import pai-docs: ${subdirPath} exists but is not a directory.`,
+      );
+    }
     const relPaths = await collectFiles(subdirPath);
     for (const rel of relPaths) {
       const source = join(subdirPath, ...rel.split("/"));
@@ -258,12 +276,16 @@ async function readExistingManifest(
 // Lexical + symlink-realpath escape guard, mirroring
 // `writeProjectionExportFile` in src/cli.ts. The realpath of the
 // resolved Soma home is computed once and reused for every file write.
-async function writeFileSafely(
+//
+// Sage round 1 (Maintainability suggestion): both write paths
+// (manifest write and source-copy) need exactly the same target-side
+// hardening. Centralizing the guard here means future tightening
+// happens in one place instead of two.
+async function prepareSafeTargetParent(
   realSomaHomeRoot: string,
   somaHomeRoot: string,
   targetAbs: string,
-  content: Buffer,
-): Promise<void> {
+): Promise<string> {
   // Lexical: the target must resolve inside somaHomeRoot before any IO.
   const resolved = resolve(targetAbs);
   if (
@@ -278,8 +300,9 @@ async function writeFileSafely(
   await mkdir(parent, { recursive: true });
   // Symlink-realpath: after mkdir, the parent's realpath must still be
   // under the soma home's realpath. A symlink anywhere on the path
-  // (e.g. somaHome/PAI/DOCUMENTATION -> ~/.ssh) would otherwise let the
-  // write land outside the home even though the lexical check passed.
+  // (e.g. somaHome/PAI/DOCUMENTATION -> ~/.ssh) would otherwise let
+  // the write land outside the home even though the lexical check
+  // passed.
   const realParent = await realpath(parent);
   if (
     realParent !== realSomaHomeRoot &&
@@ -289,6 +312,16 @@ async function writeFileSafely(
       `soma import pai-docs refused to follow a symlink that escapes Soma home (path: ${targetAbs}).`,
     );
   }
+  return resolved;
+}
+
+async function writeFileSafely(
+  realSomaHomeRoot: string,
+  somaHomeRoot: string,
+  targetAbs: string,
+  content: Buffer,
+): Promise<void> {
+  const resolved = await prepareSafeTargetParent(realSomaHomeRoot, somaHomeRoot, targetAbs);
   await writeFile(resolved, content);
 }
 
@@ -313,27 +346,7 @@ async function copyFileSafely(
       `PAI docs import refused source outside source root during apply: ${sourceAbs}`,
     );
   }
-  // Apply the same write-side guards as `writeFileSafely`.
-  const resolved = resolve(targetAbs);
-  if (
-    resolved !== somaHomeRoot &&
-    !resolved.startsWith(somaHomeRoot + sep)
-  ) {
-    throw new Error(
-      `soma import pai-docs refused to write outside Soma home (path: ${targetAbs}).`,
-    );
-  }
-  const parent = dirname(resolved);
-  await mkdir(parent, { recursive: true });
-  const realParent = await realpath(parent);
-  if (
-    realParent !== realSomaHomeRoot &&
-    !realParent.startsWith(realSomaHomeRoot + sep)
-  ) {
-    throw new Error(
-      `soma import pai-docs refused to follow a symlink that escapes Soma home (path: ${targetAbs}).`,
-    );
-  }
+  const resolved = await prepareSafeTargetParent(realSomaHomeRoot, somaHomeRoot, targetAbs);
   await copyFile(realSource, resolved);
 }
 

--- a/src/pai-docs-importer.ts
+++ b/src/pai-docs-importer.ts
@@ -526,13 +526,25 @@ export async function importPaiDocs(
     const manifestKey = manifestRelativeTarget(file);
     const priorSha = previous?.get(manifestKey);
     if (priorSha && priorSha === file.sha256 && (await pathExists(file.target))) {
-      const targetSha = sha256(await readFile(file.target));
-      if (targetSha === file.sha256) {
-        // Source bytes unchanged AND target still matches — nothing to do.
-        continue;
+      // Idempotency-skip must apply the same target contract the
+      // copy path enforces: existing symlinks are refused. A target
+      // replaced by a symlink whose bytes happen to match (or could
+      // be made to match) the source would otherwise be silently
+      // accepted as "unchanged". `lstat` reveals the symlink before
+      // `readFile` follows it.
+      await refuseFinalTargetSymlink(realSomaHome, file.target);
+      const targetStat = await lstat(file.target);
+      if (targetStat.isFile()) {
+        const targetSha = sha256(await readFile(file.target));
+        if (targetSha === file.sha256) {
+          // Source bytes unchanged AND target still matches — nothing to do.
+          continue;
+        }
       }
-      // Target drifted (user edit, partial-write corruption, …). Fall
-      // through to re-copy the source over it.
+      // Target is not a regular file with the expected bytes (user
+      // edit, partial-write corruption, replaced by a directory, …).
+      // Fall through to re-copy the source over it — `copyFileSafely`
+      // re-runs the full target-side guard.
     }
     await copyFileSafely(realSourceRoot, realSomaHome, somaHomeAbs, file.source, file.target);
     writtenCount += 1;

--- a/src/pai-docs-importer.ts
+++ b/src/pai-docs-importer.ts
@@ -270,23 +270,22 @@ export async function planPaiDocsImport(
   return buildPlan(options, { withSha: false });
 }
 
-interface ExistingManifestEntry {
-  target: string;
-  sha256: string;
-}
-
+// Sage round 4 (Maintainability nit): the prior `ExistingManifestEntry`
+// shape stored `target` twice — once as the map key and once as a
+// field never read again. A `Map<target, sha256>` carries exactly the
+// state idempotency needs.
 async function readExistingManifest(
   somaHome: string,
-): Promise<Map<string, ExistingManifestEntry> | null> {
+): Promise<Map<string, string> | null> {
   const manifestPath = join(somaHome, "PAI", MANIFEST_FILENAME);
   if (!(await pathExists(manifestPath))) return null;
   const raw = await readFile(manifestPath, "utf8");
   try {
     const parsed = JSON.parse(raw) as PaiDocsImportManifest;
     if (parsed.schema !== MANIFEST_SCHEMA || !Array.isArray(parsed.files)) return null;
-    const map = new Map<string, ExistingManifestEntry>();
+    const map = new Map<string, string>();
     for (const entry of parsed.files) {
-      map.set(entry.target, { target: entry.target, sha256: entry.sha256 });
+      map.set(entry.target, entry.sha256);
     }
     return map;
   } catch {
@@ -443,8 +442,8 @@ export async function importPaiDocs(
   // pre-flight check provided, in one place.
   for (const file of plan.files) {
     const manifestKey = manifestRelativeTarget(file);
-    const prior = previous?.get(manifestKey);
-    if (prior && prior.sha256 === file.sha256 && (await pathExists(file.target))) {
+    const priorSha = previous?.get(manifestKey);
+    if (priorSha && priorSha === file.sha256 && (await pathExists(file.target))) {
       // Same source bytes, target still on disk — nothing to do.
       continue;
     }

--- a/src/pai-docs-importer.ts
+++ b/src/pai-docs-importer.ts
@@ -214,14 +214,22 @@ async function buildPlan(
 
   for (const subdir of PAI_DOCS_IMPORT_SUBDIRS) {
     const subdirPath = join(homes.paiSourceDir, subdir);
-    if (!(await pathExists(subdirPath))) continue;
     // `collectFiles` lstat-checks every child entry but never its
     // own root. Without this guard, a PAI source with `TEMPLATES/` or
     // `ALGORITHM/` planted as a symlink would be followed and
     // imported — violating the documented refusal for symlinks inside
-    // the source tree. Check the subtree boundary here, before
-    // `collectFiles` recurses into anything.
-    const subdirStat = await lstat(subdirPath);
+    // the source tree. lstat (not `pathExists`/`access`) is used so a
+    // dangling symlink is refused, not silently treated as absent.
+    let subdirStat;
+    try {
+      subdirStat = await lstat(subdirPath);
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+        // Optional subtree genuinely missing — fine, skip.
+        continue;
+      }
+      throw error;
+    }
     if (subdirStat.isSymbolicLink()) {
       throw new Error(
         `soma import pai-docs refused symlink path: ${subdir}/`,
@@ -369,6 +377,45 @@ async function prepareSafeTargetParent(
   return resolved;
 }
 
+// Refuse writing through a pre-existing symlink at the final path.
+// All parent-side guards can pass while the leaf entry itself is a
+// symlink to an outside file — `writeFile`/`copyFile` would then
+// follow the link and overwrite an attacker-chosen target. Removing
+// any existing symlink (or letting it through only when it points
+// inside the Soma home) is the only way to keep `--apply` from
+// becoming an arbitrary-overwrite primitive.
+async function refuseFinalTargetSymlink(
+  realSomaHomeRoot: string,
+  targetAbs: string,
+): Promise<void> {
+  let existing;
+  try {
+    existing = await lstat(targetAbs);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+    throw error;
+  }
+  if (!existing.isSymbolicLink()) return;
+  // The realpath of a symbolic link must still resolve inside the
+  // Soma home root for the importer to overwrite it. Anything
+  // pointing outside is rejected. (We do not silently `unlink` even
+  // an inside-home symlink; the importer's contract is to write
+  // regular files at these paths, so a pre-existing symlink is a
+  // configuration smell either way.)
+  const realTarget = await realpath(targetAbs);
+  if (
+    realTarget !== realSomaHomeRoot &&
+    !realTarget.startsWith(realSomaHomeRoot + sep)
+  ) {
+    throw new Error(
+      `soma import pai-docs refused to overwrite through a symlink that escapes Soma home (path: ${targetAbs}).`,
+    );
+  }
+  throw new Error(
+    `soma import pai-docs refused to overwrite an existing symlink at the target path (path: ${targetAbs}).`,
+  );
+}
+
 async function writeFileSafely(
   realSomaHomeRoot: string,
   somaHomeRoot: string,
@@ -376,6 +423,7 @@ async function writeFileSafely(
   content: Buffer,
 ): Promise<void> {
   const resolved = await prepareSafeTargetParent(realSomaHomeRoot, somaHomeRoot, targetAbs);
+  await refuseFinalTargetSymlink(realSomaHomeRoot, resolved);
   await writeFile(resolved, content);
 }
 
@@ -401,6 +449,7 @@ async function copyFileSafely(
     );
   }
   const resolved = await prepareSafeTargetParent(realSomaHomeRoot, somaHomeRoot, targetAbs);
+  await refuseFinalTargetSymlink(realSomaHomeRoot, resolved);
   await copyFile(realSource, resolved);
 }
 

--- a/src/pai-docs-importer.ts
+++ b/src/pai-docs-importer.ts
@@ -78,16 +78,6 @@ async function pathExists(path: string): Promise<boolean> {
     });
 }
 
-async function nearestExistingAncestor(path: string): Promise<string> {
-  let candidate = path;
-  while (!(await pathExists(candidate))) {
-    const parent = dirname(candidate);
-    if (parent === candidate) return candidate;
-    candidate = parent;
-  }
-  return candidate;
-}
-
 function sha256(content: Buffer | string): string {
   return createHash("sha256").update(content).digest("hex");
 }
@@ -184,12 +174,17 @@ async function assertPaiReleaseTree(sourceDir: string): Promise<void> {
   }
 }
 
-// Build a plan: collect every file under each in-scope subdir, compute
-// its SHA, and pair it with its eventual target under ~/.soma/PAI/.
-// The plan is content-addressed (per-file SHA in plan + manifest) so
-// re-import can detect drift in O(file_count) without re-reading the
-// previously-imported tree.
-async function buildPlan(options: PaiDocsImportOptions): Promise<PaiDocsImportPlan> {
+// Build a plan: collect every file under each in-scope subdir and
+// pair it with its eventual target under ~/.soma/PAI/. By default the
+// plan lists files without reading their bytes — dry-run callers only
+// need paths and counts (Sage round 2 performance finding). Pass
+// `withSha: true` to populate per-file SHA-256, which the apply path
+// needs for the manifest and for idempotency comparisons against any
+// prior manifest.
+async function buildPlan(
+  options: PaiDocsImportOptions,
+  flags: { withSha: boolean },
+): Promise<PaiDocsImportPlan> {
   const homes = resolveHomes(options);
   await assertPaiReleaseTree(homes.paiSourceDir);
 
@@ -221,14 +216,16 @@ async function buildPlan(options: PaiDocsImportOptions): Promise<PaiDocsImportPl
     for (const rel of relPaths) {
       const source = join(subdirPath, ...rel.split("/"));
       const target = join(homes.somaHome, "PAI", subdir, ...rel.split("/"));
-      const buf = await readFile(source);
-      files.push({
+      const file: PaiDocsImportFile = {
         source,
         target,
         relativePath: `${subdir}/${rel}`,
         subdir,
-        sha256: sha256(buf),
-      });
+      };
+      if (flags.withSha) {
+        file.sha256 = sha256(await readFile(source));
+      }
+      files.push(file);
     }
   }
 
@@ -246,7 +243,10 @@ async function buildPlan(options: PaiDocsImportOptions): Promise<PaiDocsImportPl
 export async function planPaiDocsImport(
   options: PaiDocsImportOptions = {},
 ): Promise<PaiDocsImportPlan> {
-  return buildPlan(options);
+  // Dry-run callers only need paths + counts — skip the per-file
+  // read + hash. The apply path computes SHAs as part of its own
+  // (re-checked) source-read pass.
+  return buildPlan(options, { withSha: false });
 }
 
 interface ExistingManifestEntry {
@@ -371,11 +371,22 @@ function renderManifest(
     paiSourceDir: plan.paiSourceDir,
     releaseVersion: plan.releaseVersion,
     importedAt,
-    files: plan.files.map((file) => ({
-      target: manifestRelativeTarget(file),
-      source: manifestRelativeSource(file, plan.paiSourceDir),
-      sha256: file.sha256,
-    })),
+    files: plan.files.map((file) => {
+      // Manifest is only rendered on the apply path, where every plan
+      // file is guaranteed to carry a SHA. Defensive guard so a future
+      // refactor that calls render-manifest off the dry-run plan fails
+      // loud instead of writing `sha256: undefined`.
+      if (!file.sha256) {
+        throw new Error(
+          `soma import pai-docs: manifest renderer expected file.sha256 to be populated (file: ${file.relativePath}).`,
+        );
+      }
+      return {
+        target: manifestRelativeTarget(file),
+        source: manifestRelativeSource(file, plan.paiSourceDir),
+        sha256: file.sha256,
+      };
+    }),
   };
   return `${JSON.stringify(manifest, null, 2)}\n`;
 }
@@ -383,7 +394,11 @@ function renderManifest(
 export async function importPaiDocs(
   options: PaiDocsImportOptions = {},
 ): Promise<PaiDocsImportResult> {
-  const plan = await buildPlan(options);
+  // Apply path needs per-file SHAs for both the manifest (AC-5) and
+  // idempotency comparison against any prior manifest. Plan-only
+  // callers go through `planPaiDocsImport` and skip the read+hash —
+  // Sage round 2 performance finding.
+  const plan = await buildPlan(options, { withSha: true });
 
   await mkdir(plan.somaHome, { recursive: true });
   const realSomaHome = await realpath(plan.somaHome);
@@ -399,25 +414,18 @@ export async function importPaiDocs(
   const previous = await readExistingManifest(plan.somaHome);
   let writtenCount = 0;
 
+  // Sage round 2 (Maintainability suggestion): drop the redundant
+  // pre-flight `nearestExistingAncestor` check. `copyFileSafely` calls
+  // `prepareSafeTargetParent`, which lexically checks the target,
+  // `mkdir`s the parent, and re-resolves `realpath(parent)` against
+  // the Soma home root — the same symlink-escape behavior the
+  // pre-flight check provided, in one place.
   for (const file of plan.files) {
     const manifestKey = manifestRelativeTarget(file);
     const prior = previous?.get(manifestKey);
     if (prior && prior.sha256 === file.sha256 && (await pathExists(file.target))) {
       // Same source bytes, target still on disk — nothing to do.
       continue;
-    }
-    // Re-check parent ancestry is still inside the Soma home root before
-    // copying. If the target's nearest existing ancestor is *outside*
-    // somaHomeRoot's realpath (e.g. via a planted symlink), refuse.
-    const ancestor = await nearestExistingAncestor(dirname(file.target));
-    const realAncestor = await realpath(ancestor);
-    if (
-      realAncestor !== realSomaHome &&
-      !realAncestor.startsWith(realSomaHome + sep)
-    ) {
-      throw new Error(
-        `soma import pai-docs refused to follow a symlink that escapes Soma home (path: ${file.target}).`,
-      );
     }
     await copyFileSafely(realSourceRoot, realSomaHome, somaHomeAbs, file.source, file.target);
     writtenCount += 1;

--- a/src/pai-docs-importer.ts
+++ b/src/pai-docs-importer.ts
@@ -39,16 +39,21 @@ import type {
   PaiDocsImportOptions,
   PaiDocsImportPlan,
   PaiDocsImportResult,
+  PaiDocsImportSubdir,
 } from "./types";
 
 // Sub-directories of a PAI release tree we import into ~/.soma/PAI/.
 // DOCUMENTATION is required (it is the whole point — it resolves the
 // broken doc refs that #86 currently shunts to `~/.soma/UNMAPPED/PAI/`).
 // TEMPLATES + ALGORITHM are optional but copied when present.
-const IMPORT_SUBDIRS = ["DOCUMENTATION", "TEMPLATES", "ALGORITHM"] as const;
-type ImportSubdir = (typeof IMPORT_SUBDIRS)[number];
+//
+// Exported (Sage round 3, Maintainability) so CLI formatters and any
+// future caller share the same list. The exported tuple is the single
+// runtime source of truth; the `PaiDocsImportSubdir` type in
+// `src/types.ts` mirrors its members.
+export const PAI_DOCS_IMPORT_SUBDIRS = ["DOCUMENTATION", "TEMPLATES", "ALGORITHM"] as const satisfies readonly PaiDocsImportSubdir[];
 
-const REQUIRED_SUBDIR: ImportSubdir = "DOCUMENTATION";
+const REQUIRED_SUBDIR: PaiDocsImportSubdir = "DOCUMENTATION";
 
 const MANIFEST_FILENAME = ".import-manifest.json";
 const MANIFEST_SCHEMA = "soma.pai-docs-import.v1";
@@ -119,10 +124,11 @@ async function collectFiles(root: string): Promise<string[]> {
             `PAI docs import refused path outside source root: ${relative(root, fullPath).split(sep).join("/")}`,
           );
         }
-        const rel = relative(root, fullPath).split(sep).join("/");
-        if (!rel.startsWith("..") && !rel.includes("../")) {
-          files.push(rel);
-        }
+        // Sage round 3 (CodeQuality suggestion): the realpath check
+        // above is the authoritative traversal guard. A `rel.startsWith("..")`
+        // string filter both adds nothing and silently drops legitimate
+        // filenames like `..notes.md`.
+        files.push(relative(root, fullPath).split(sep).join("/"));
       }
     }
   }
@@ -141,6 +147,21 @@ async function collectFiles(root: string): Promise<string[]> {
 async function detectReleaseVersion(sourceDir: string): Promise<string | null> {
   const versionPath = join(sourceDir, "VERSION");
   if (await pathExists(versionPath)) {
+    // Sage round 3 (Security, important): refuse symlinks here just
+    // like everywhere else in the importer. A malicious source could
+    // otherwise plant `VERSION -> /etc/hostname` and smuggle its
+    // contents into CLI output + `.import-manifest.json`. Also
+    // require a regular file — a directory at this path is a sign of
+    // a malformed source, not a release marker.
+    const versionStat = await lstat(versionPath);
+    if (versionStat.isSymbolicLink()) {
+      throw new Error("soma import pai-docs refused symlink path: VERSION");
+    }
+    if (!versionStat.isFile()) {
+      throw new Error(
+        `soma import pai-docs: VERSION at ${versionPath} is not a regular file.`,
+      );
+    }
     const raw = (await readFile(versionPath, "utf8")).trim();
     if (raw.length > 0) return raw;
   }
@@ -191,7 +212,7 @@ async function buildPlan(
   const releaseVersion = await detectReleaseVersion(homes.paiSourceDir);
   const files: PaiDocsImportFile[] = [];
 
-  for (const subdir of IMPORT_SUBDIRS) {
+  for (const subdir of PAI_DOCS_IMPORT_SUBDIRS) {
     const subdirPath = join(homes.paiSourceDir, subdir);
     if (!(await pathExists(subdirPath))) continue;
     // Sage round 1 (Security, important): `collectFiles` lstat-checks

--- a/src/pai-docs-importer.ts
+++ b/src/pai-docs-importer.ts
@@ -1,0 +1,432 @@
+// soma import pai-docs — import PAI DOCUMENTATION/, TEMPLATES/, ALGORITHM/
+// from a PAI release tree into ~/.soma/PAI/. First step of the PAI →
+// Soma migration chain (#89) per DD-1: Soma is the new canonical home
+// of personal AI state; PAI's release tree is the source we translate
+// from.
+//
+// Shape mirrors src/pai-pack-importer.ts (option types, dry-run vs
+// apply, audit shape). Reuses the lexical + symlink-realpath escape
+// guards from `soma export --out` (src/cli.ts `writeProjectionExportFile`):
+// every write must land under a pre-resolved realpath(somaHome).
+//
+// What gets imported (per issue #89 scope table):
+//   - DOCUMENTATION/  (required — sources without it are refused loud)
+//   - TEMPLATES/      (if present)
+//   - ALGORITHM/      (if present)
+//
+// What does NOT get imported: MEMORY/, USER/, PULSE/, TOOLS/, bin/,
+// PAI-Install/, statusline-command.sh, PAI_SYSTEM_PROMPT.md. Those are
+// runtime / user-state / install infrastructure or have explicit Soma
+// equivalents (memory taxonomy under #88, identity already handled by
+// `soma import pai`).
+
+import { createHash } from "node:crypto";
+import {
+  access,
+  copyFile,
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  realpath,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import type {
+  PaiDocsImportFile,
+  PaiDocsImportManifest,
+  PaiDocsImportOptions,
+  PaiDocsImportPlan,
+  PaiDocsImportResult,
+} from "./types";
+
+// Sub-directories of a PAI release tree we import into ~/.soma/PAI/.
+// DOCUMENTATION is required (it is the whole point — it resolves the
+// broken doc refs that #86 currently shunts to `~/.soma/UNMAPPED/PAI/`).
+// TEMPLATES + ALGORITHM are optional but copied when present.
+const IMPORT_SUBDIRS = ["DOCUMENTATION", "TEMPLATES", "ALGORITHM"] as const;
+type ImportSubdir = (typeof IMPORT_SUBDIRS)[number];
+
+const REQUIRED_SUBDIR: ImportSubdir = "DOCUMENTATION";
+
+const MANIFEST_FILENAME = ".import-manifest.json";
+const MANIFEST_SCHEMA = "soma.pai-docs-import.v1";
+
+function resolveHomes(options: PaiDocsImportOptions): { paiSourceDir: string; somaHome: string } {
+  if (!options.paiSourceDir) {
+    throw new Error("soma import pai-docs requires --pai-source-dir <dir>.");
+  }
+  const home = resolve(options.homeDir ?? homedir());
+  return {
+    paiSourceDir: resolve(options.paiSourceDir),
+    somaHome: resolve(options.somaHome ?? join(home, ".soma")),
+  };
+}
+
+function isWithinPath(root: string, target: string): boolean {
+  const rel = relative(root, target);
+  return rel === "" || (!rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel));
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  return access(path)
+    .then(() => true)
+    .catch((error: unknown) => {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+      throw error;
+    });
+}
+
+async function nearestExistingAncestor(path: string): Promise<string> {
+  let candidate = path;
+  while (!(await pathExists(candidate))) {
+    const parent = dirname(candidate);
+    if (parent === candidate) return candidate;
+    candidate = parent;
+  }
+  return candidate;
+}
+
+function sha256(content: Buffer | string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+// Recursively collect files under `root`, refusing symlinks at any level
+// (matches pai-pack-importer's stance and the symlink-realpath escape
+// guard from `soma export --out`). Returns POSIX-style relative paths.
+async function collectFiles(root: string): Promise<string[]> {
+  const realRoot = await realpath(root);
+  const files: string[] = [];
+
+  async function visit(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.name.includes("\\")) {
+        throw new Error(
+          `PAI docs import refused ambiguous path separator: ${relative(root, fullPath).split(sep).join("/")}`,
+        );
+      }
+      if (entry.isSymbolicLink()) {
+        throw new Error(
+          `PAI docs import refused symlink path: ${relative(root, fullPath).split(sep).join("/")}`,
+        );
+      }
+      if (entry.isDirectory()) {
+        if (entry.name === ".git" || entry.name === ".hg" || entry.name === ".svn") {
+          throw new Error(
+            `PAI docs import refused VCS metadata directory: ${relative(root, fullPath).split(sep).join("/")}`,
+          );
+        }
+        await visit(fullPath);
+        continue;
+      }
+      if (entry.isFile()) {
+        const realFile = await realpath(fullPath);
+        if (!isWithinPath(realRoot, realFile)) {
+          throw new Error(
+            `PAI docs import refused path outside source root: ${relative(root, fullPath).split(sep).join("/")}`,
+          );
+        }
+        const rel = relative(root, fullPath).split(sep).join("/");
+        if (!rel.startsWith("..") && !rel.includes("../")) {
+          files.push(rel);
+        }
+      }
+    }
+  }
+
+  await visit(root);
+  return files.sort();
+}
+
+// Infer release version from one of two sources, in order:
+//   1. A `VERSION` file at the source dir root.
+//   2. The path hint `Releases/<version>/` somewhere in the source dir
+//      (matches the canonical PAI release layout
+//      `~/work/PAI/Releases/v5.0.0/.claude/PAI`).
+// Returns null when neither is present so the manifest is explicit
+// about not knowing rather than guessing.
+async function detectReleaseVersion(sourceDir: string): Promise<string | null> {
+  const versionPath = join(sourceDir, "VERSION");
+  if (await pathExists(versionPath)) {
+    const raw = (await readFile(versionPath, "utf8")).trim();
+    if (raw.length > 0) return raw;
+  }
+  const segments = sourceDir.split(sep);
+  const releasesIndex = segments.lastIndexOf("Releases");
+  if (releasesIndex !== -1 && releasesIndex + 1 < segments.length) {
+    const candidate = segments[releasesIndex + 1];
+    if (candidate && candidate.length > 0) return candidate;
+  }
+  return null;
+}
+
+async function assertPaiReleaseTree(sourceDir: string): Promise<void> {
+  const requiredPath = join(sourceDir, REQUIRED_SUBDIR);
+  if (!(await pathExists(requiredPath))) {
+    throw new Error(
+      `soma import pai-docs: ${sourceDir} does not look like a PAI release tree ` +
+        `(missing required '${REQUIRED_SUBDIR}/' subdirectory).`,
+    );
+  }
+  const statRequired = await lstat(requiredPath);
+  if (statRequired.isSymbolicLink()) {
+    throw new Error(
+      `soma import pai-docs refused symlink path: ${REQUIRED_SUBDIR}/`,
+    );
+  }
+  if (!statRequired.isDirectory()) {
+    throw new Error(
+      `soma import pai-docs: ${sourceDir}/${REQUIRED_SUBDIR} exists but is not a directory.`,
+    );
+  }
+}
+
+// Build a plan: collect every file under each in-scope subdir, compute
+// its SHA, and pair it with its eventual target under ~/.soma/PAI/.
+// The plan is content-addressed (per-file SHA in plan + manifest) so
+// re-import can detect drift in O(file_count) without re-reading the
+// previously-imported tree.
+async function buildPlan(options: PaiDocsImportOptions): Promise<PaiDocsImportPlan> {
+  const homes = resolveHomes(options);
+  await assertPaiReleaseTree(homes.paiSourceDir);
+
+  const releaseVersion = await detectReleaseVersion(homes.paiSourceDir);
+  const files: PaiDocsImportFile[] = [];
+
+  for (const subdir of IMPORT_SUBDIRS) {
+    const subdirPath = join(homes.paiSourceDir, subdir);
+    if (!(await pathExists(subdirPath))) continue;
+    const relPaths = await collectFiles(subdirPath);
+    for (const rel of relPaths) {
+      const source = join(subdirPath, ...rel.split("/"));
+      const target = join(homes.somaHome, "PAI", subdir, ...rel.split("/"));
+      const buf = await readFile(source);
+      files.push({
+        source,
+        target,
+        relativePath: `${subdir}/${rel}`,
+        subdir,
+        sha256: sha256(buf),
+      });
+    }
+  }
+
+  files.sort((a, b) => a.target.localeCompare(b.target));
+
+  return {
+    apply: false,
+    paiSourceDir: homes.paiSourceDir,
+    somaHome: homes.somaHome,
+    releaseVersion,
+    files,
+  };
+}
+
+export async function planPaiDocsImport(
+  options: PaiDocsImportOptions = {},
+): Promise<PaiDocsImportPlan> {
+  return buildPlan(options);
+}
+
+interface ExistingManifestEntry {
+  target: string;
+  sha256: string;
+}
+
+async function readExistingManifest(
+  somaHome: string,
+): Promise<Map<string, ExistingManifestEntry> | null> {
+  const manifestPath = join(somaHome, "PAI", MANIFEST_FILENAME);
+  if (!(await pathExists(manifestPath))) return null;
+  const raw = await readFile(manifestPath, "utf8");
+  try {
+    const parsed = JSON.parse(raw) as PaiDocsImportManifest;
+    if (parsed.schema !== MANIFEST_SCHEMA || !Array.isArray(parsed.files)) return null;
+    const map = new Map<string, ExistingManifestEntry>();
+    for (const entry of parsed.files) {
+      map.set(entry.target, { target: entry.target, sha256: entry.sha256 });
+    }
+    return map;
+  } catch {
+    return null;
+  }
+}
+
+// Lexical + symlink-realpath escape guard, mirroring
+// `writeProjectionExportFile` in src/cli.ts. The realpath of the
+// resolved Soma home is computed once and reused for every file write.
+async function writeFileSafely(
+  realSomaHomeRoot: string,
+  somaHomeRoot: string,
+  targetAbs: string,
+  content: Buffer,
+): Promise<void> {
+  // Lexical: the target must resolve inside somaHomeRoot before any IO.
+  const resolved = resolve(targetAbs);
+  if (
+    resolved !== somaHomeRoot &&
+    !resolved.startsWith(somaHomeRoot + sep)
+  ) {
+    throw new Error(
+      `soma import pai-docs refused to write outside Soma home (path: ${targetAbs}).`,
+    );
+  }
+  const parent = dirname(resolved);
+  await mkdir(parent, { recursive: true });
+  // Symlink-realpath: after mkdir, the parent's realpath must still be
+  // under the soma home's realpath. A symlink anywhere on the path
+  // (e.g. somaHome/PAI/DOCUMENTATION -> ~/.ssh) would otherwise let the
+  // write land outside the home even though the lexical check passed.
+  const realParent = await realpath(parent);
+  if (
+    realParent !== realSomaHomeRoot &&
+    !realParent.startsWith(realSomaHomeRoot + sep)
+  ) {
+    throw new Error(
+      `soma import pai-docs refused to follow a symlink that escapes Soma home (path: ${targetAbs}).`,
+    );
+  }
+  await writeFile(resolved, content);
+}
+
+async function copyFileSafely(
+  realSourceRoot: string,
+  realSomaHomeRoot: string,
+  somaHomeRoot: string,
+  sourceAbs: string,
+  targetAbs: string,
+): Promise<void> {
+  // Re-check the source the same way `collectFiles` did before reading
+  // its bytes: lstat then realpath. We refused symlinks at scan time;
+  // re-verify here so a TOCTOU swap between plan and apply can't
+  // sneak one through.
+  const sourceStat = await lstat(sourceAbs);
+  if (sourceStat.isSymbolicLink()) {
+    throw new Error(`PAI docs import refused symlink source during apply: ${sourceAbs}`);
+  }
+  const realSource = await realpath(sourceAbs);
+  if (!isWithinPath(realSourceRoot, realSource)) {
+    throw new Error(
+      `PAI docs import refused source outside source root during apply: ${sourceAbs}`,
+    );
+  }
+  // Apply the same write-side guards as `writeFileSafely`.
+  const resolved = resolve(targetAbs);
+  if (
+    resolved !== somaHomeRoot &&
+    !resolved.startsWith(somaHomeRoot + sep)
+  ) {
+    throw new Error(
+      `soma import pai-docs refused to write outside Soma home (path: ${targetAbs}).`,
+    );
+  }
+  const parent = dirname(resolved);
+  await mkdir(parent, { recursive: true });
+  const realParent = await realpath(parent);
+  if (
+    realParent !== realSomaHomeRoot &&
+    !realParent.startsWith(realSomaHomeRoot + sep)
+  ) {
+    throw new Error(
+      `soma import pai-docs refused to follow a symlink that escapes Soma home (path: ${targetAbs}).`,
+    );
+  }
+  await copyFile(realSource, resolved);
+}
+
+function manifestRelativeTarget(file: PaiDocsImportFile): string {
+  // POSIX-style relative path under ~/.soma/PAI/, e.g.
+  // "DOCUMENTATION/Skills/SkillSystem.md". This is what `target` means
+  // in the manifest — paths are written relative to the PAI root so
+  // moving the soma home doesn't invalidate them.
+  return file.relativePath;
+}
+
+function manifestRelativeSource(file: PaiDocsImportFile, paiSourceDir: string): string {
+  return relative(paiSourceDir, file.source).split(sep).join("/");
+}
+
+function renderManifest(
+  plan: PaiDocsImportPlan,
+  importedAt: string,
+): string {
+  const manifest: PaiDocsImportManifest = {
+    schema: MANIFEST_SCHEMA,
+    paiSourceDir: plan.paiSourceDir,
+    releaseVersion: plan.releaseVersion,
+    importedAt,
+    files: plan.files.map((file) => ({
+      target: manifestRelativeTarget(file),
+      source: manifestRelativeSource(file, plan.paiSourceDir),
+      sha256: file.sha256,
+    })),
+  };
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+export async function importPaiDocs(
+  options: PaiDocsImportOptions = {},
+): Promise<PaiDocsImportResult> {
+  const plan = await buildPlan(options);
+
+  await mkdir(plan.somaHome, { recursive: true });
+  const realSomaHome = await realpath(plan.somaHome);
+  const somaHomeAbs = resolve(plan.somaHome);
+
+  // Source-side realpath, computed once per import. Re-used by every
+  // copy so a symlink that swaps in between plan and apply still gets
+  // refused by the per-file guard below.
+  const realSourceRoot = await realpath(plan.paiSourceDir);
+
+  // Idempotency: compare per-file SHA against any prior manifest.
+  // Files whose target SHA matches the new SHA are skipped.
+  const previous = await readExistingManifest(plan.somaHome);
+  let writtenCount = 0;
+
+  for (const file of plan.files) {
+    const manifestKey = manifestRelativeTarget(file);
+    const prior = previous?.get(manifestKey);
+    if (prior && prior.sha256 === file.sha256 && (await pathExists(file.target))) {
+      // Same source bytes, target still on disk — nothing to do.
+      continue;
+    }
+    // Re-check parent ancestry is still inside the Soma home root before
+    // copying. If the target's nearest existing ancestor is *outside*
+    // somaHomeRoot's realpath (e.g. via a planted symlink), refuse.
+    const ancestor = await nearestExistingAncestor(dirname(file.target));
+    const realAncestor = await realpath(ancestor);
+    if (
+      realAncestor !== realSomaHome &&
+      !realAncestor.startsWith(realSomaHome + sep)
+    ) {
+      throw new Error(
+        `soma import pai-docs refused to follow a symlink that escapes Soma home (path: ${file.target}).`,
+      );
+    }
+    await copyFileSafely(realSourceRoot, realSomaHome, somaHomeAbs, file.source, file.target);
+    writtenCount += 1;
+  }
+
+  const importedAt = new Date().toISOString();
+  const manifestPath = join(plan.somaHome, "PAI", MANIFEST_FILENAME);
+  await writeFileSafely(
+    realSomaHome,
+    somaHomeAbs,
+    manifestPath,
+    Buffer.from(renderManifest(plan, importedAt), "utf8"),
+  );
+
+  return {
+    applied: true,
+    paiSourceDir: plan.paiSourceDir,
+    somaHome: plan.somaHome,
+    releaseVersion: plan.releaseVersion,
+    importedAt,
+    writtenCount,
+    unchanged: writtenCount === 0,
+    files: plan.files.map((file) => file.target),
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -509,6 +509,75 @@ export interface PaiPackImportResult {
   normalization: PaiPackNormalizationReport;
 }
 
+// soma import pai-docs — see src/pai-docs-importer.ts. Imports a
+// subset of a PAI release tree (DOCUMENTATION/, TEMPLATES/, ALGORITHM/)
+// into ~/.soma/PAI/, with per-file SHA tracking for idempotent
+// re-import.
+export interface PaiDocsImportOptions {
+  homeDir?: string;
+  paiSourceDir?: string;
+  somaHome?: string;
+}
+
+export interface PaiDocsImportFile {
+  // Absolute path of the file on disk in the PAI source tree.
+  source: string;
+  // Absolute path where the file will land under ~/.soma/PAI/.
+  target: string;
+  // POSIX-style path relative to ~/.soma/PAI/, e.g.
+  // "DOCUMENTATION/Skills/SkillSystem.md". This is the manifest key.
+  relativePath: string;
+  // Which in-scope subdir the file came from.
+  subdir: "DOCUMENTATION" | "TEMPLATES" | "ALGORITHM";
+  // SHA-256 of the file's bytes, hex-encoded. Used to detect drift on
+  // re-import without re-reading every previously-imported file.
+  sha256: string;
+}
+
+export interface PaiDocsImportPlan {
+  apply: boolean;
+  paiSourceDir: string;
+  somaHome: string;
+  // PAI release version, inferred from a `VERSION` file at the source
+  // root or from a `Releases/<version>/` path hint. Null when neither
+  // is present — the manifest stays explicit about not guessing.
+  releaseVersion: string | null;
+  files: PaiDocsImportFile[];
+}
+
+export interface PaiDocsImportManifestFile {
+  // POSIX-style path under ~/.soma/PAI/ — see
+  // PaiDocsImportFile.relativePath.
+  target: string;
+  // POSIX-style path under the source dir.
+  source: string;
+  // SHA-256 of the source bytes at import time.
+  sha256: string;
+}
+
+export interface PaiDocsImportManifest {
+  schema: "soma.pai-docs-import.v1";
+  paiSourceDir: string;
+  releaseVersion: string | null;
+  // ISO-8601 timestamp.
+  importedAt: string;
+  files: PaiDocsImportManifestFile[];
+}
+
+export interface PaiDocsImportResult {
+  applied: true;
+  paiSourceDir: string;
+  somaHome: string;
+  releaseVersion: string | null;
+  importedAt: string;
+  // How many files were actually copied this run (0 = nothing to do).
+  writtenCount: number;
+  // True iff writtenCount === 0 — a re-import with no source drift.
+  unchanged: boolean;
+  // Absolute paths of every in-scope file (the projection target).
+  files: string[];
+}
+
 export interface SomaMemoryEventInput {
   id?: string;
   timestamp?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -519,11 +519,10 @@ export interface PaiDocsImportOptions {
   somaHome?: string;
 }
 
-// Sage round 3 (Maintainability suggestion): single source of truth
-// for the in-scope subtree list. The runtime constant lives in
-// `src/pai-docs-importer.ts` (`PAI_DOCS_IMPORT_SUBDIRS`); this type
-// derives from it via `typeof`-style listing so adding/renaming a
-// subtree touches one place.
+// Single source of truth for the in-scope subtree list. The runtime
+// constant lives in `src/pai-docs-importer.ts`
+// (`PAI_DOCS_IMPORT_SUBDIRS`); this type mirrors its members so
+// adding/renaming a subtree touches one place.
 export type PaiDocsImportSubdir = "DOCUMENTATION" | "TEMPLATES" | "ALGORITHM";
 
 export interface PaiDocsImportFile {
@@ -538,9 +537,8 @@ export interface PaiDocsImportFile {
   subdir: PaiDocsImportSubdir;
   // SHA-256 of the file's bytes, hex-encoded. Optional in dry-run
   // plans so listing the file set does not require reading every
-  // file's bytes (Sage round 2 performance finding). Always populated
-  // on the apply path, where the SHA is needed for both the manifest
-  // and idempotency checks.
+  // file's bytes. Always populated on the apply path, where the SHA
+  // is needed for both the manifest and the idempotency check.
   sha256?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -519,6 +519,13 @@ export interface PaiDocsImportOptions {
   somaHome?: string;
 }
 
+// Sage round 3 (Maintainability suggestion): single source of truth
+// for the in-scope subtree list. The runtime constant lives in
+// `src/pai-docs-importer.ts` (`PAI_DOCS_IMPORT_SUBDIRS`); this type
+// derives from it via `typeof`-style listing so adding/renaming a
+// subtree touches one place.
+export type PaiDocsImportSubdir = "DOCUMENTATION" | "TEMPLATES" | "ALGORITHM";
+
 export interface PaiDocsImportFile {
   // Absolute path of the file on disk in the PAI source tree.
   source: string;
@@ -528,7 +535,7 @@ export interface PaiDocsImportFile {
   // "DOCUMENTATION/Skills/SkillSystem.md". This is the manifest key.
   relativePath: string;
   // Which in-scope subdir the file came from.
-  subdir: "DOCUMENTATION" | "TEMPLATES" | "ALGORITHM";
+  subdir: PaiDocsImportSubdir;
   // SHA-256 of the file's bytes, hex-encoded. Optional in dry-run
   // plans so listing the file set does not require reading every
   // file's bytes (Sage round 2 performance finding). Always populated

--- a/src/types.ts
+++ b/src/types.ts
@@ -529,9 +529,12 @@ export interface PaiDocsImportFile {
   relativePath: string;
   // Which in-scope subdir the file came from.
   subdir: "DOCUMENTATION" | "TEMPLATES" | "ALGORITHM";
-  // SHA-256 of the file's bytes, hex-encoded. Used to detect drift on
-  // re-import without re-reading every previously-imported file.
-  sha256: string;
+  // SHA-256 of the file's bytes, hex-encoded. Optional in dry-run
+  // plans so listing the file set does not require reading every
+  // file's bytes (Sage round 2 performance finding). Always populated
+  // on the apply path, where the SHA is needed for both the manifest
+  // and idempotency checks.
+  sha256?: string;
 }
 
 export interface PaiDocsImportPlan {

--- a/test/pai-docs-importer.test.ts
+++ b/test/pai-docs-importer.test.ts
@@ -178,6 +178,38 @@ test("AC-2/AC-5 — apply writes files, manifest, and is idempotent on re-run", 
   });
 });
 
+test("Sage R3 Security — refuses VERSION file that is itself a symlink", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir, { versionFile: null });
+    // Plant a sensitive target outside the source tree, then symlink
+    // VERSION at it. detectReleaseVersion must refuse rather than
+    // copy its contents into the manifest.
+    const sensitive = join(homeDir, "sensitive.txt");
+    await writeFile(sensitive, "should-not-be-copied\n", "utf8");
+    await symlink(sensitive, join(sourceDir, "VERSION"));
+
+    await expect(
+      planPaiDocsImport({ homeDir, paiSourceDir: sourceDir }),
+    ).rejects.toThrow(/refused symlink path: VERSION/);
+  });
+});
+
+test("Sage R3 CodeQuality — accepts filenames that start with '..' as long as the realpath stays inside the source", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    // A legitimate file whose basename starts with `..` — the prior
+    // `rel.startsWith("..")` filter silently dropped this.
+    await writeFile(
+      join(sourceDir, "DOCUMENTATION/..notes.md"),
+      "# notes\nfile starts with dots\n",
+      "utf8",
+    );
+    const plan = await planPaiDocsImport({ homeDir, paiSourceDir: sourceDir });
+    const relPaths = plan.files.map((f) => f.relativePath);
+    expect(relPaths).toContain("DOCUMENTATION/..notes.md");
+  });
+});
+
 test("AC-5 — VERSION file overrides release version inferred from path", async () => {
   await withTempHome(async (homeDir) => {
     const sourceDir = await writePaiSourceFixture(homeDir, { versionFile: "5.0.1\n" });

--- a/test/pai-docs-importer.test.ts
+++ b/test/pai-docs-importer.test.ts
@@ -209,6 +209,44 @@ test("AC-4 — refuses symlink inside the source tree (escape rejection)", async
   });
 });
 
+test("AC-4 — refuses optional subtree root that is itself a symlink (Sage R1 Security)", async () => {
+  // Source-side trust boundary: collectFiles lstat-checks every child
+  // entry but never its own root. Without the per-subdir guard, a PAI
+  // source tree with TEMPLATES/ or ALGORITHM/ planted as a symlink
+  // would be followed and imported. Verify the guard at the subtree
+  // boundary refuses each in-scope subdir when it is a symlink.
+  for (const planted of ["TEMPLATES", "ALGORITHM"]) {
+    await withTempHome(async (homeDir) => {
+      const sourceDir = await writePaiSourceFixture(homeDir);
+      // Remove the real dir and replace with a symlink to a separate
+      // tree the source dir does not own.
+      await rm(join(sourceDir, planted), { recursive: true });
+      const elsewhere = join(homeDir, `${planted}-elsewhere`);
+      await mkdir(elsewhere, { recursive: true });
+      await writeFile(join(elsewhere, "smuggled.md"), "should not be imported\n", "utf8");
+      await symlink(elsewhere, join(sourceDir, planted));
+
+      await expect(
+        planPaiDocsImport({ homeDir, paiSourceDir: sourceDir }),
+      ).rejects.toThrow(new RegExp(`refused symlink path: ${planted}/`));
+    });
+  }
+});
+
+test("AC-3 — refuses required DOCUMENTATION subdir that is itself a symlink", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    await rm(join(sourceDir, "DOCUMENTATION"), { recursive: true });
+    const elsewhere = join(homeDir, "doc-elsewhere");
+    await mkdir(elsewhere, { recursive: true });
+    await symlink(elsewhere, join(sourceDir, "DOCUMENTATION"));
+
+    await expect(
+      planPaiDocsImport({ homeDir, paiSourceDir: sourceDir }),
+    ).rejects.toThrow(/refused symlink path: DOCUMENTATION\/?/);
+  });
+});
+
 test("AC-4 — refuses target path that escapes Soma home via custom soma-home symlink", async () => {
   await withTempHome(async (homeDir) => {
     const sourceDir = await writePaiSourceFixture(homeDir);

--- a/test/pai-docs-importer.test.ts
+++ b/test/pai-docs-importer.test.ts
@@ -210,6 +210,30 @@ test("accepts filenames that start with '..' as long as the realpath stays insid
   });
 });
 
+test("idempotency-skip refuses a target replaced by a symlink even when bytes match", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    const somaHome = join(homeDir, ".soma");
+    const first = await importPaiDocs({ homeDir, paiSourceDir: sourceDir, somaHome });
+    expect(first.writtenCount).toBeGreaterThan(0);
+
+    // Replace one imported file with a symlink whose target contents
+    // match the source bytes. Without a symlink check on the
+    // idempotency-skip path, this would be silently accepted as
+    // "unchanged".
+    const target = join(somaHome, "PAI/DOCUMENTATION/Skills/SkillSystem.md");
+    const masquerade = join(homeDir, "masquerade.md");
+    const sourceBytes = await readFile(join(sourceDir, "DOCUMENTATION/Skills/SkillSystem.md"), "utf8");
+    await writeFile(masquerade, sourceBytes, "utf8");
+    await rm(target);
+    await symlink(masquerade, target);
+
+    await expect(
+      importPaiDocs({ homeDir, paiSourceDir: sourceDir, somaHome }),
+    ).rejects.toThrow(/refused.*symlink/i);
+  });
+});
+
 test("AC-2 — idempotency repairs target drift even when source SHA is unchanged", async () => {
   await withTempHome(async (homeDir) => {
     const sourceDir = await writePaiSourceFixture(homeDir);

--- a/test/pai-docs-importer.test.ts
+++ b/test/pai-docs-importer.test.ts
@@ -303,6 +303,45 @@ test("AC-3 — refuses required DOCUMENTATION subdir that is itself a symlink", 
   });
 });
 
+test("AC-4 — refuses to overwrite a pre-existing symlink at the final target path", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    const somaHome = join(homeDir, ".soma");
+    // Pre-create the full target tree, then plant a symlink at one
+    // of the expected output files. All parent-side realpath checks
+    // would otherwise pass; the importer must refuse the write
+    // because the final entry itself is a symlink.
+    await mkdir(join(somaHome, "PAI/DOCUMENTATION/Skills"), { recursive: true });
+    const outside = join(homeDir, "outside.md");
+    await writeFile(outside, "OUTSIDE — must not be overwritten\n", "utf8");
+    await symlink(outside, join(somaHome, "PAI/DOCUMENTATION/Skills/SkillSystem.md"));
+
+    await expect(
+      importPaiDocs({ homeDir, paiSourceDir: sourceDir, somaHome }),
+    ).rejects.toThrow(/refused.*symlink/i);
+
+    // The outside file must still hold its original bytes — no
+    // overwrite through the symlink occurred.
+    const after = await readFile(outside, "utf8");
+    expect(after).toContain("OUTSIDE — must not be overwritten");
+  });
+});
+
+test("refuses a dangling optional subtree symlink (no silent skip)", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    // Plant a dangling symlink at TEMPLATES. `pathExists` (which
+    // uses `access`) reports it as absent because it follows the
+    // link; lstat reveals it.
+    await rm(join(sourceDir, "TEMPLATES"), { recursive: true });
+    await symlink(join(homeDir, "does-not-exist"), join(sourceDir, "TEMPLATES"));
+
+    await expect(
+      planPaiDocsImport({ homeDir, paiSourceDir: sourceDir }),
+    ).rejects.toThrow(/refused symlink path: TEMPLATES\/?/);
+  });
+});
+
 test("AC-4 — refuses target escape via existing symlink inside Soma home, before any mkdir or write", async () => {
   await withTempHome(async (homeDir) => {
     const sourceDir = await writePaiSourceFixture(homeDir);

--- a/test/pai-docs-importer.test.ts
+++ b/test/pai-docs-importer.test.ts
@@ -121,9 +121,9 @@ test("AC-1 — dry-run plan lists files without writing", async () => {
     expect(targets.some((t) => t.endsWith("PAI_SYSTEM_PROMPT.md"))).toBe(false);
     expect(targets.some((t) => t.endsWith("statusline-command.sh"))).toBe(false);
 
-    // Sage R2 performance finding: dry-run does NOT read+hash every
-    // file. SHA is populated on the apply path only (where it is
-    // needed for the manifest and idempotency).
+    // Dry-run does NOT read+hash every file — SHA is populated on
+    // the apply path only (where it is needed for the manifest and
+    // idempotency).
     for (const file of plan.files) {
       expect(file.sha256).toBeUndefined();
     }
@@ -178,7 +178,7 @@ test("AC-2/AC-5 — apply writes files, manifest, and is idempotent on re-run", 
   });
 });
 
-test("Sage R3 Security — refuses VERSION file that is itself a symlink", async () => {
+test("refuses VERSION file that is itself a symlink", async () => {
   await withTempHome(async (homeDir) => {
     const sourceDir = await writePaiSourceFixture(homeDir, { versionFile: null });
     // Plant a sensitive target outside the source tree, then symlink
@@ -194,7 +194,7 @@ test("Sage R3 Security — refuses VERSION file that is itself a symlink", async
   });
 });
 
-test("Sage R3 CodeQuality — accepts filenames that start with '..' as long as the realpath stays inside the source", async () => {
+test("accepts filenames that start with '..' as long as the realpath stays inside the source", async () => {
   await withTempHome(async (homeDir) => {
     const sourceDir = await writePaiSourceFixture(homeDir);
     // A legitimate file whose basename starts with `..` — the prior
@@ -207,6 +207,28 @@ test("Sage R3 CodeQuality — accepts filenames that start with '..' as long as 
     const plan = await planPaiDocsImport({ homeDir, paiSourceDir: sourceDir });
     const relPaths = plan.files.map((f) => f.relativePath);
     expect(relPaths).toContain("DOCUMENTATION/..notes.md");
+  });
+});
+
+test("AC-2 — idempotency repairs target drift even when source SHA is unchanged", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir);
+
+    const first = await importPaiDocs({ homeDir, paiSourceDir: sourceDir });
+    expect(first.writtenCount).toBeGreaterThan(0);
+
+    // User edits the imported file (or it is corrupted). With the
+    // source unchanged, the importer must re-copy rather than trust
+    // the manifest and leave the target stale.
+    const target = join(homeDir, ".soma/PAI/DOCUMENTATION/Skills/SkillSystem.md");
+    await writeFile(target, "TAMPERED — should be repaired on next import\n", "utf8");
+
+    const second = await importPaiDocs({ homeDir, paiSourceDir: sourceDir });
+    expect(second.writtenCount).toBe(1);
+
+    const repaired = await readFile(target, "utf8");
+    expect(repaired).toContain("Skill System");
+    expect(repaired).not.toContain("TAMPERED");
   });
 });
 
@@ -243,7 +265,7 @@ test("AC-4 — refuses symlink inside the source tree (escape rejection)", async
   });
 });
 
-test("AC-4 — refuses optional subtree root that is itself a symlink (Sage R1 Security)", async () => {
+test("AC-4 — refuses optional subtree root that is itself a symlink", async () => {
   // Source-side trust boundary: collectFiles lstat-checks every child
   // entry but never its own root. Without the per-subdir guard, a PAI
   // source tree with TEMPLATES/ or ALGORITHM/ planted as a symlink
@@ -281,11 +303,13 @@ test("AC-3 — refuses required DOCUMENTATION subdir that is itself a symlink", 
   });
 });
 
-test("AC-4 — refuses target path that escapes Soma home via custom soma-home symlink", async () => {
+test("AC-4 — refuses target escape via existing symlink inside Soma home, before any mkdir or write", async () => {
   await withTempHome(async (homeDir) => {
     const sourceDir = await writePaiSourceFixture(homeDir);
-    // Set up a real soma home dir, then put a symlink inside it that
-    // would let a write escape to a different location.
+    // Set up a real soma home, then plant an existing symlink at one
+    // of the target subtree paths. The importer must refuse the
+    // entire run before creating any subdirectories under the escape
+    // target — not merely refuse the final write.
     const realSoma = join(homeDir, "real-soma");
     await mkdir(join(realSoma, "PAI"), { recursive: true });
     const escape = join(homeDir, "escape-root");
@@ -296,10 +320,13 @@ test("AC-4 — refuses target path that escapes Soma home via custom soma-home s
       importPaiDocs({ homeDir, paiSourceDir: sourceDir, somaHome: realSoma }),
     ).rejects.toThrow(/refused to follow a symlink that escapes/i);
 
-    // The escape root must remain empty — no files were written through the symlink.
+    // The escape root must remain empty — no files OR directories
+    // were created through the symlink.
     await expect(
       stat(join(escape, "Skills/SkillSystem.md")),
     ).rejects.toThrow();
+    await expect(stat(join(escape, "Skills"))).rejects.toThrow();
+    await expect(stat(join(escape, "Memory"))).rejects.toThrow();
   });
 });
 

--- a/test/pai-docs-importer.test.ts
+++ b/test/pai-docs-importer.test.ts
@@ -121,9 +121,11 @@ test("AC-1 — dry-run plan lists files without writing", async () => {
     expect(targets.some((t) => t.endsWith("PAI_SYSTEM_PROMPT.md"))).toBe(false);
     expect(targets.some((t) => t.endsWith("statusline-command.sh"))).toBe(false);
 
-    // Each file has a per-file SHA in the plan.
+    // Sage R2 performance finding: dry-run does NOT read+hash every
+    // file. SHA is populated on the apply path only (where it is
+    // needed for the manifest and idempotency).
     for (const file of plan.files) {
-      expect(file.sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(file.sha256).toBeUndefined();
     }
 
     // Dry-run did not write the Soma home.

--- a/test/pai-docs-importer.test.ts
+++ b/test/pai-docs-importer.test.ts
@@ -1,0 +1,276 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { runSomaCli } from "../src/cli";
+import { importPaiDocs, planPaiDocsImport } from "../src/pai-docs-importer";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-pai-docs-import-"));
+
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+interface PaiSourceFixtureOptions {
+  versionFile?: string | null;
+  releasePath?: string; // e.g. "Releases/v5.0.0/.claude/PAI"
+}
+
+async function writePaiSourceFixture(
+  baseDir: string,
+  options: PaiSourceFixtureOptions = {},
+): Promise<string> {
+  const releasePath = options.releasePath ?? "Releases/v5.0.0/.claude/PAI";
+  const sourceDir = join(baseDir, releasePath);
+  await mkdir(join(sourceDir, "DOCUMENTATION/Skills"), { recursive: true });
+  await mkdir(join(sourceDir, "DOCUMENTATION/Memory"), { recursive: true });
+  await mkdir(join(sourceDir, "TEMPLATES/User"), { recursive: true });
+  await mkdir(join(sourceDir, "ALGORITHM"), { recursive: true });
+
+  await writeFile(
+    join(sourceDir, "DOCUMENTATION/Skills/SkillSystem.md"),
+    "# Skill System\n\nPAI Skill subsystem reference.\n",
+    "utf8",
+  );
+  await writeFile(
+    join(sourceDir, "DOCUMENTATION/Memory/MemoryArchitecture.md"),
+    "# Memory Architecture\n\nPAI memory layout.\n",
+    "utf8",
+  );
+  await writeFile(
+    join(sourceDir, "TEMPLATES/User/PRINCIPAL_IDENTITY.md"),
+    "# Principal Identity Template\n",
+    "utf8",
+  );
+  await writeFile(
+    join(sourceDir, "ALGORITHM/v6.3.0.md"),
+    "# Algorithm v6.3.0\n\nPhases.\n",
+    "utf8",
+  );
+  await writeFile(
+    join(sourceDir, "ALGORITHM/LATEST"),
+    "v6.3.0\n",
+    "utf8",
+  );
+
+  if (options.versionFile !== null) {
+    if (options.versionFile !== undefined) {
+      await writeFile(join(sourceDir, "VERSION"), options.versionFile, "utf8");
+    }
+  }
+
+  // A few out-of-scope dirs alongside the in-scope ones — verifies we
+  // don't pick up MEMORY/, USER/, PULSE/, TOOLS/, bin/, PAI-Install/,
+  // statusline-command.sh, PAI_SYSTEM_PROMPT.md.
+  await mkdir(join(sourceDir, "MEMORY/WORK"), { recursive: true });
+  await writeFile(join(sourceDir, "MEMORY/WORK/note.md"), "out of scope\n", "utf8");
+  await mkdir(join(sourceDir, "USER"), { recursive: true });
+  await writeFile(join(sourceDir, "USER/PRINCIPAL_IDENTITY.md"), "user state\n", "utf8");
+  await writeFile(join(sourceDir, "PAI_SYSTEM_PROMPT.md"), "system prompt\n", "utf8");
+  await writeFile(join(sourceDir, "statusline-command.sh"), "#!/bin/sh\n", "utf8");
+
+  return sourceDir;
+}
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+test("requires an explicit PAI source dir", async () => {
+  await expect(planPaiDocsImport({ homeDir: "/tmp/soma-pai-docs-noop" })).rejects.toThrow(
+    "requires --pai-source-dir",
+  );
+});
+
+test("AC-3 — refuses sources without a DOCUMENTATION/ subdir", async () => {
+  await withTempHome(async (homeDir) => {
+    const bogus = join(homeDir, "not-pai");
+    await mkdir(join(bogus, "TEMPLATES"), { recursive: true });
+    await mkdir(join(bogus, "ALGORITHM"), { recursive: true });
+    await expect(
+      planPaiDocsImport({ homeDir, paiSourceDir: bogus }),
+    ).rejects.toThrow(/does not look like a PAI release tree/i);
+  });
+});
+
+test("AC-1 — dry-run plan lists files without writing", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    const plan = await planPaiDocsImport({ homeDir, paiSourceDir: sourceDir });
+
+    expect(plan.apply).toBe(false);
+    expect(plan.paiSourceDir).toBe(sourceDir);
+    expect(plan.somaHome).toBe(join(homeDir, ".soma"));
+    expect(plan.releaseVersion).toBe("v5.0.0");
+
+    const targets = plan.files.map((file) => file.target);
+    expect(targets).toContain(join(homeDir, ".soma/PAI/DOCUMENTATION/Skills/SkillSystem.md"));
+    expect(targets).toContain(join(homeDir, ".soma/PAI/DOCUMENTATION/Memory/MemoryArchitecture.md"));
+    expect(targets).toContain(join(homeDir, ".soma/PAI/TEMPLATES/User/PRINCIPAL_IDENTITY.md"));
+    expect(targets).toContain(join(homeDir, ".soma/PAI/ALGORITHM/v6.3.0.md"));
+    expect(targets).toContain(join(homeDir, ".soma/PAI/ALGORITHM/LATEST"));
+
+    // Out-of-scope dirs do not appear.
+    expect(targets.some((t) => t.includes("/MEMORY/"))).toBe(false);
+    expect(targets.some((t) => t.includes("/USER/"))).toBe(false);
+    expect(targets.some((t) => t.endsWith("PAI_SYSTEM_PROMPT.md"))).toBe(false);
+    expect(targets.some((t) => t.endsWith("statusline-command.sh"))).toBe(false);
+
+    // Each file has a per-file SHA in the plan.
+    for (const file of plan.files) {
+      expect(file.sha256).toMatch(/^[0-9a-f]{64}$/);
+    }
+
+    // Dry-run did not write the Soma home.
+    await expect(stat(join(homeDir, ".soma"))).rejects.toThrow();
+  });
+});
+
+test("AC-2/AC-5 — apply writes files, manifest, and is idempotent on re-run", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir);
+
+    const result = await importPaiDocs({ homeDir, paiSourceDir: sourceDir });
+    expect(result.applied).toBe(true);
+    expect(result.releaseVersion).toBe("v5.0.0");
+
+    const skillDoc = await readFile(
+      join(homeDir, ".soma/PAI/DOCUMENTATION/Skills/SkillSystem.md"),
+      "utf8",
+    );
+    expect(skillDoc).toContain("Skill System");
+    const algo = await readFile(join(homeDir, ".soma/PAI/ALGORITHM/v6.3.0.md"), "utf8");
+    expect(algo).toContain("Algorithm v6.3.0");
+
+    // Manifest is recorded.
+    const manifestPath = join(homeDir, ".soma/PAI/.import-manifest.json");
+    const manifestRaw = await readFile(manifestPath, "utf8");
+    const manifest = JSON.parse(manifestRaw) as {
+      schema: string;
+      paiSourceDir: string;
+      releaseVersion: string | null;
+      importedAt: string;
+      files: { target: string; source: string; sha256: string }[];
+    };
+    expect(manifest.schema).toBe("soma.pai-docs-import.v1");
+    expect(manifest.paiSourceDir).toBe(sourceDir);
+    expect(manifest.releaseVersion).toBe("v5.0.0");
+    expect(typeof manifest.importedAt).toBe("string");
+    expect(new Date(manifest.importedAt).toISOString()).toBe(manifest.importedAt);
+
+    const skillEntry = manifest.files.find((f) => f.target === "DOCUMENTATION/Skills/SkillSystem.md");
+    expect(skillEntry).toBeDefined();
+    expect(skillEntry!.source).toBe("DOCUMENTATION/Skills/SkillSystem.md");
+    expect(skillEntry!.sha256).toBe(sha256(skillDoc));
+
+    // Idempotent: re-run with same source = no files rewritten.
+    const second = await importPaiDocs({ homeDir, paiSourceDir: sourceDir });
+    expect(second.applied).toBe(true);
+    expect(second.unchanged).toBe(true);
+    expect(second.writtenCount).toBe(0);
+  });
+});
+
+test("AC-5 — VERSION file overrides release version inferred from path", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir, { versionFile: "5.0.1\n" });
+    const plan = await planPaiDocsImport({ homeDir, paiSourceDir: sourceDir });
+    expect(plan.releaseVersion).toBe("5.0.1");
+  });
+});
+
+test("AC-5 — release version is null when neither VERSION file nor path hint exists", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir, {
+      versionFile: null,
+      releasePath: "custom/PAI",
+    });
+    const plan = await planPaiDocsImport({ homeDir, paiSourceDir: sourceDir });
+    expect(plan.releaseVersion).toBeNull();
+  });
+});
+
+test("AC-4 — refuses symlink inside the source tree (escape rejection)", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    // Plant a symlink inside the in-scope DOCUMENTATION/ that points outside the tree.
+    const outsideTarget = join(homeDir, "outside-target.md");
+    await writeFile(outsideTarget, "ESCAPE\n", "utf8");
+    await symlink(outsideTarget, join(sourceDir, "DOCUMENTATION/escape.md"));
+
+    await expect(
+      planPaiDocsImport({ homeDir, paiSourceDir: sourceDir }),
+    ).rejects.toThrow(/refused symlink/i);
+  });
+});
+
+test("AC-4 — refuses target path that escapes Soma home via custom soma-home symlink", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    // Set up a real soma home dir, then put a symlink inside it that
+    // would let a write escape to a different location.
+    const realSoma = join(homeDir, "real-soma");
+    await mkdir(join(realSoma, "PAI"), { recursive: true });
+    const escape = join(homeDir, "escape-root");
+    await mkdir(escape, { recursive: true });
+    await symlink(escape, join(realSoma, "PAI/DOCUMENTATION"));
+
+    await expect(
+      importPaiDocs({ homeDir, paiSourceDir: sourceDir, somaHome: realSoma }),
+    ).rejects.toThrow(/refused to follow a symlink that escapes/i);
+
+    // The escape root must remain empty — no files were written through the symlink.
+    await expect(
+      stat(join(escape, "Skills/SkillSystem.md")),
+    ).rejects.toThrow();
+  });
+});
+
+test("AC-1/AC-2 — CLI dispatches dry-run by default and --apply writes", async () => {
+  await withTempHome(async (homeDir) => {
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    const somaHome = join(homeDir, ".soma");
+
+    const planOut = await runSomaCli([
+      "import",
+      "pai-docs",
+      "--pai-source-dir",
+      sourceDir,
+      "--home-dir",
+      homeDir,
+      "--soma-home",
+      somaHome,
+    ]);
+    expect(planOut).toContain("Soma PAI docs import plan");
+    expect(planOut).toContain("mode: dry-run");
+    expect(planOut).toContain("DOCUMENTATION/Skills/SkillSystem.md");
+    await expect(stat(somaHome)).rejects.toThrow();
+
+    const applyOut = await runSomaCli([
+      "import",
+      "pai-docs",
+      "--pai-source-dir",
+      sourceDir,
+      "--home-dir",
+      homeDir,
+      "--soma-home",
+      somaHome,
+      "--apply",
+    ]);
+    expect(applyOut).toContain("Soma PAI docs import applied");
+    expect(applyOut).toContain("releaseVersion: v5.0.0");
+    await expect(stat(join(somaHome, "PAI/DOCUMENTATION/Skills/SkillSystem.md"))).resolves.toMatchObject({});
+    await expect(stat(join(somaHome, "PAI/.import-manifest.json"))).resolves.toMatchObject({});
+  });
+});
+
+test("CLI rejects unknown options for pai-docs source", async () => {
+  await expect(
+    runSomaCli(["import", "pai-docs", "--skill-name", "anything"]),
+  ).rejects.toThrow(/--skill-name is only valid/);
+});


### PR DESCRIPTION
## Summary

First deterministic step of the PAI → Soma migration chain per [DD-1](https://github.com/the-metafactory/soma/blob/main/design/design-decisions.md#dd-1-soma-is-the-new-canonical-home-of-personal-ai-state): adopt PAI's `DOCUMENTATION/`, `TEMPLATES/`, and `ALGORITHM/` subtrees into `~/.soma/PAI/` so the broken doc references that #86 currently shunts to `~/.soma/UNMAPPED/PAI/` can resolve to real files.

Shape mirrors `src/pai-pack-importer.ts` (option types, dry-run vs apply, audit shape). The lexical + symlink-realpath escape guards from `soma export --out` (PR #81 R1 hardening on #54) are reused — every write lands under a pre-computed `realpath(somaHome)`.

```
soma import pai-docs --pai-source-dir <path>          # dry-run plan (default)
soma import pai-docs --pai-source-dir <path> --apply  # writes files
```

## Acceptance Criteria

- [x] AC-1: `soma import pai-docs --pai-source-dir <path>` (no apply flag = dry-run) prints the file list.
- [x] AC-2: `--apply` writes the file list. Second run with same source SHAs is a no-op.
- [x] AC-3: Refuses sources without `DOCUMENTATION/` subdir — loud error, no heuristic guessing.
- [x] AC-4: Path-escape guards (lexical + symlink-realpath), same hardening as `soma export --out` from #54.
- [x] AC-5: `~/.soma/PAI/.import-manifest.json` records source path, release version (parsed from `VERSION` file or `Releases/<v>/` path hint; `null` when neither), ISO-8601 timestamp, and per-file SHA-256.
- [x] AC-6: `docs/pai-docs-importer.md` (new) documents the verb.
- [x] AC-7: Tests cover dry-run plan, apply, re-apply (idempotent no-op), refuse-non-pai-tree, symlink-escape rejection (both source-side and target-side via custom `--soma-home` symlink).

## Test Plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 547 pass / 0 fail (baseline 537 after #87, +10 new tests)
- [x] End-to-end smoke against the real `~/work/PAI/Releases/v5.0.0/.claude/PAI`:
  - Dry-run lists 57 files (35 DOCUMENTATION + 8 TEMPLATES + 14 ALGORITHM); `releaseVersion: v5.0.0` inferred from path hint.
  - `--apply` writes 57 files, manifest at `~/.soma/PAI/.import-manifest.json`.
  - Re-apply: `writtenCount: 0 (idempotent no-op — source SHAs unchanged)`.

## Scope

Imported subtrees (per issue #89 scope table):

| Subdir | Imported? | Why |
| --- | --- | --- |
| `DOCUMENTATION/` | yes (required) | Resolves the broken doc refs in imported skills — the original problem. |
| `TEMPLATES/` | yes (optional) | Referenced by `CreateSkill` workflows that scaffold from templates. |
| `ALGORITHM/` | yes (optional) | Referenced by skills that produce phase markers. |
| `MEMORY/`, `USER/`, `PULSE/`, `TOOLS/`, `bin/`, `PAI-Install/`, `statusline-command.sh`, `PAI_SYSTEM_PROMPT.md` | no | Memory taxonomy handled by #88; identity already in `soma import pai`; rest is runtime/install infrastructure. |

## Follow-ups

- #91 replaces the `unmapped-claude-home-path` warning with a deterministic `~/.claude/PAI/<rest>` → `~/.soma/PAI/<rest>` rewrite now that `~/.soma/PAI/` is reachable.
- #90 wraps this verb plus memory + skill importers in `soma migrate pai`.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)