### PR TITLE
feat(migrate): extend soma migrate pai with memory translation + bulk skills + docs wrap (#90)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -292,7 +292,7 @@ const TOP_LEVEL_COMMANDS = [
 ] as const;
 
 const MIGRATE_PAI_USAGE =
-  "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-pack-dir <dir>]";
+  "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-install <dir>] [--pai-source-dir <dir>] [--pai-packs-dir <dir>] [--pai-pack-dir <dir>] [--skip-memory] [--skip-skills] [--skip-docs] [--overwrite-reserved]";
 const ADOPT_CLAUDE_USAGE =
   "Usage: soma adopt claude [--dry-run] [--apply] [--uninstall] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string, string> }> = {
@@ -1488,13 +1488,43 @@ function parseMigrateArgs(args: string[]): ParsedMigrateArgs {
         options.claudeHome = readOption(rest, index, arg);
         index += 1;
         break;
+      // #90 — `--pai-install` is the principal-facing alias for
+      // `--claude-home`. Both target the same option field; the alias
+      // exists because the issue body specifies `--pai-install` as the
+      // canonical flag for the full-migrate surface.
+      case "--pai-install":
+        options.claudeHome = readOption(rest, index, arg);
+        index += 1;
+        break;
       case "--soma-home":
         options.somaHome = readOption(rest, index, arg);
         index += 1;
         break;
       case "--pai-pack-dir":
+        // #28 back-compat — explicit per-pack paths (one flag per pack).
         packPaths.push(readOption(rest, index, arg));
         index += 1;
+        break;
+      case "--pai-packs-dir":
+        // #90 — single directory of many packs.
+        options.paiPacksDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--pai-source-dir":
+        options.paiSourceDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--skip-memory":
+        options.skipMemory = true;
+        break;
+      case "--skip-skills":
+        options.skipSkills = true;
+        break;
+      case "--skip-docs":
+        options.skipDocs = true;
+        break;
+      case "--overwrite-reserved":
+        options.overwriteReserved = true;
         break;
       default:
         throw new Error(`Unknown option: ${arg}`);
@@ -1668,6 +1698,14 @@ function formatPaiMigrationPlan(plan: PaiMigrationPlan): string {
   const algorithmLine = plan.algorithm
     ? `  - algorithm: ${plan.algorithm.sourceFiles.length} source file(s)`
     : "  - algorithm: not present";
+  const memoryLine = plan.memory === null
+    ? "  - memory:   skipped"
+    : plan.memory.memoryDir === null
+      ? "  - memory:   no PAI MEMORY tree present"
+      : `  - memory:   ${plan.memory.files.length} file(s) to translate`;
+  const docsLine = plan.docs === null
+    ? "  - docs:     skipped (pass --pai-source-dir to enable)"
+    : `  - docs:     ${plan.docs.files.length} file(s) from ${plan.docs.releaseVersion ?? "(no version)"}`;
   return [
     "soma migrate pai — plan (dry-run; pass --apply to execute)",
     "",
@@ -1678,12 +1716,22 @@ function formatPaiMigrationPlan(plan: PaiMigrationPlan): string {
     "Categories:",
     `  - identity: ${plan.identity.sourceFiles.length} source file(s)`,
     algorithmLine,
+    memoryLine,
+    docsLine,
     `  - packs:    ${plan.packs.length} discovered`,
     "",
   ].join("\n");
 }
 
 function formatPaiMigrationResult(result: PaiMigrationResult): string {
+  const memoryLine = result.memory === null
+    ? "  - memory:   skipped"
+    : result.memory.memoryDir === null
+      ? "  - memory:   no PAI MEMORY tree present"
+      : `  - memory:   ${result.memory.writtenCount} written, ${result.memory.skippedCount} unchanged`;
+  const docsLine = result.docs === null
+    ? "  - docs:     skipped"
+    : `  - docs:     ${result.docs.writtenCount} written, ${result.docs.files.length - result.docs.writtenCount} unchanged`;
   return [
     "soma migrate pai — applied",
     "",
@@ -1694,6 +1742,8 @@ function formatPaiMigrationResult(result: PaiMigrationResult): string {
     "Written:",
     `  - identity: ${result.identity.files.length} file(s)`,
     result.algorithm ? `  - algorithm: ${result.algorithm.files.length} file(s)` : "  - algorithm: skipped (not present)",
+    memoryLine,
+    docsLine,
     `  - packs:    ${result.packs.length} pack(s), ${result.packs.reduce((sum, p) => sum + p.files.length, 0)} file(s)`,
     "",
     `Total files written: ${result.filesWritten.length}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,10 +209,11 @@ export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
 export { importPaiPack, planPaiPackImport } from "./pai-pack-importer";
 export { importPaiDocs, planPaiDocsImport } from "./pai-docs-importer";
-// PAI MEMORY → Soma memory translator (#90). Standalone module
-// surfaced for tests and for callers that want to translate memory
-// without going through the full migrate orchestration.
-export { migratePaiMemory, planPaiMemoryMigration } from "./pai-memory-migrator";
+// PAI MEMORY → Soma memory translator (#90) is intentionally NOT
+// re-exported from the package root — it is an internal phase of
+// `migratePai` and its public boundary is not yet stable (Sage r2
+// #95 Architecture finding). Tests that need direct access import
+// from `./pai-memory-migrator` explicitly.
 // PAI → Soma migration orchestrator (#28 minimal scope, extended
 // for full migrate in #90).
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,12 @@ export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
 export { importPaiPack, planPaiPackImport } from "./pai-pack-importer";
 export { importPaiDocs, planPaiDocsImport } from "./pai-docs-importer";
-// PAI → Soma migration orchestrator (#28 minimal scope).
+// PAI MEMORY → Soma memory translator (#90). Standalone module
+// surfaced for tests and for callers that want to translate memory
+// without going through the full migrate orchestration.
+export { migratePaiMemory, planPaiMemoryMigration } from "./pai-memory-migrator";
+// PAI → Soma migration orchestrator (#28 minimal scope, extended
+// for full migrate in #90).
 export {
   migratePai,
   planPaiMigration,

--- a/src/internal-concurrency.ts
+++ b/src/internal-concurrency.ts
@@ -1,0 +1,43 @@
+/**
+ * Internal concurrency helper used by importers and migrators.
+ *
+ * Not exported from `src/index.ts` — this is plumbing for the
+ * pai-pack-importer, pai-memory-migrator, pai-migration modules.
+ * Sage r2 #95 Maintainability nit (avoid two copies of the same
+ * worker-loop generic that could drift in limit / error-ordering
+ * semantics).
+ */
+
+/**
+ * Run async per-item work with a bounded concurrency window. Results
+ * are returned in input order regardless of when individual workers
+ * resolve, which keeps downstream code (manifests, audits) stable
+ * across runs.
+ *
+ * Behavior:
+ *   - Empty input → empty output, no workers started.
+ *   - `limit` is capped at `items.length` so we never spawn more
+ *     workers than work.
+ *   - Errors propagate to the first awaiter; remaining in-flight
+ *     work continues to settle before `Promise.all` rejects, so
+ *     no orphan FDs from already-started reads.
+ */
+export async function runBoundedConcurrent<T, R>(
+  items: readonly T[],
+  fn: (item: T) => Promise<R>,
+  limit: number,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const results: R[] = new Array<R>(items.length);
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index]);
+    }
+  }
+  const workerCount = Math.min(limit, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}

--- a/src/pai-memory-migrator.ts
+++ b/src/pai-memory-migrator.ts
@@ -306,32 +306,62 @@ export async function migratePaiMemory(
   // import phase and the docs importer's footprint. The original
   // plan.files order is preserved in `outcomes` so the manifest and
   // returned target list stay deterministic.
-  // Sage r5 #95 Security important: harden the target side against
-  // symlink-redirected writes. Lexical isWithinPath is not enough —
-  // an attacker who can pre-create a symlink at
-  // <somaHome>/memory/<rel> (or any of its parents) can otherwise
-  // redirect the copyFile into an arbitrary destination on disk.
-  // Resolve once per migration; the realpath stays constant for the
-  // duration of the call. The per-file guard checks every existing
-  // ancestor + the final-target leaf for symlinks before any IO.
+  // Sage r5+r6 #95 Security important: harden the target side against
+  // symlink-redirected writes. Two attack shapes need to be refused:
+  //   (a) ancestor symlink that escapes Soma home → would write
+  //       PAI memory bytes outside Soma entirely.
+  //   (b) ancestor symlink that stays inside Soma home but points
+  //       at an unrelated subtree (e.g., `<somaHome>/memory/LEARNING
+  //       -> <somaHome>/profile`) → would clobber unrelated Soma
+  //       files. Round-5's "escapes Soma home" check missed this.
+  // The round-6 contract: refuse ANY symlink in the target ancestor
+  // chain or at the target leaf, regardless of where it resolves.
+  // `<somaHome>/memory/<rel>` must consist of regular dirs all the
+  // way down. realpath(somaHome) is computed once per call so a
+  // legitimate setup where the Soma home itself is reachable via a
+  // symlinked parent path still works.
   const realSomaHome = await realpath(plan.somaHome);
 
-  type Outcome = { written: boolean; target: string };
-  async function processFile(file: PaiMemoryMigrationFile): Promise<Outcome> {
-    // Target-side parent must be inside the Soma home root. The plan
-    // builder already constructed `file.target` relative to
-    // `<somaHome>/memory/<rel>`; verify once more before any IO.
-    if (!isWithinPath(plan.somaHome, file.target)) {
+  // Sage r6 Maintainability: the target-safety routine used to live
+  // inline inside processFile; lifting it to a named helper keeps the
+  // per-file worker focused on copy/idempotency logic.
+  // Sage r6 Performance: validated-ancestor memo so MEMORY trees with
+  // many files under the same category directory (LEARNING/, WORK/,
+  // KNOWLEDGE/) pay the lstat+realpath cost once per parent instead
+  // of per-file. Concurrency-safe under the bounded worker pool —
+  // the validation is idempotent and storing a Promise in the cache
+  // dedupes overlapping workers.
+  const validatedAncestors = new Map<string, Promise<void>>();
+
+  async function assertSafeAncestor(ancestor: string): Promise<void> {
+    if (!(await pathExists(ancestor))) return;
+    const stat = await lstat(ancestor);
+    if (stat.isSymbolicLink()) {
       throw new Error(
-        `PAI memory migration refused target outside Soma home: ${file.target}`,
+        `PAI memory migration refused symlinked target ancestor: ${ancestor}`,
+      );
+    }
+  }
+
+  function validateAncestor(ancestor: string): Promise<void> {
+    const cached = validatedAncestors.get(ancestor);
+    if (cached) return cached;
+    const promise = assertSafeAncestor(ancestor);
+    validatedAncestors.set(ancestor, promise);
+    return promise;
+  }
+
+  async function assertSafeMemoryTarget(target: string): Promise<void> {
+    if (!isWithinPath(plan.somaHome, target)) {
+      throw new Error(
+        `PAI memory migration refused target outside Soma home: ${target}`,
       );
     }
     // Walk every existing ancestor of the target up to the Soma home
-    // root and refuse any ancestor that is a symlink whose realpath
-    // escapes the Soma home. Stops at the first ancestor that does
-    // not yet exist — that and everything underneath it will be
-    // created by `mkdir` below, so no symlink can pre-exist there.
-    const parent = join(file.target, "..");
+    // root. Stops at the first ancestor that does not yet exist —
+    // that and everything underneath will be created by `mkdir`
+    // below, so no symlink can pre-exist there.
+    const parent = join(target, "..");
     const ancestors: string[] = [];
     let cursor = parent;
     while (true) {
@@ -341,75 +371,18 @@ export async function migratePaiMemory(
       if (next === cursor) break;
       cursor = next;
     }
+    // Top-down: parent of <somaHome> back down to immediate parent.
     for (const ancestor of ancestors.reverse()) {
-      if (!(await pathExists(ancestor))) continue;
-      const stat = await lstat(ancestor);
-      if (stat.isSymbolicLink()) {
-        const realLink = await realpath(ancestor);
-        if (realLink !== realSomaHome && !realLink.startsWith(realSomaHome + sep)) {
-          throw new Error(
-            `PAI memory migration refused to follow a symlink that escapes Soma home: ${file.target}`,
-          );
-        }
-      }
+      await validateAncestor(ancestor);
     }
+  }
 
-    const priorSha = previous?.map.get(file.relativePath);
-    if (priorSha && priorSha === file.sha256 && (await pathExists(file.target))) {
-      // Re-hash the target's current bytes. Manifest agreement alone
-      // is not enough — a user edit since import would otherwise
-      // leave a "successful" migration with the wrong target bytes.
-      // Sage r5 security: also refuse a leaf target that is a
-      // symlink whose realpath escapes the Soma home, even on the
-      // idempotency-skip path (a symlink whose bytes happen to match
-      // the prior SHA would otherwise be silently accepted).
-      const targetStat = await lstat(file.target);
-      if (targetStat.isSymbolicLink()) {
-        const realTarget = await realpath(file.target);
-        if (realTarget !== realSomaHome && !realTarget.startsWith(realSomaHome + sep)) {
-          throw new Error(
-            `PAI memory migration refused to overwrite through a symlink that escapes Soma home: ${file.target}`,
-          );
-        }
-        throw new Error(
-          `PAI memory migration refused to overwrite an existing symlink at the target path: ${file.target}`,
-        );
-      }
-      if (targetStat.isFile()) {
-        const targetSha = sha256Hex(await readFile(file.target));
-        if (targetSha === file.sha256) {
-          return { written: false, target: file.target };
-        }
-      }
-    }
-    await mkdir(parent, { recursive: true });
-    // After mkdir, re-check the parent's realpath against the Soma
-    // home's realpath. This re-catches both the standard symlink-in-
-    // the-middle case (e.g., a regular dir replaced by a symlink
-    // between walk and mkdir) and a parent that is a symlink pointing
-    // inside the home (legal — caught by the equality check).
-    const realParent = await realpath(parent);
-    if (realParent !== realSomaHome && !realParent.startsWith(realSomaHome + sep)) {
-      throw new Error(
-        `PAI memory migration refused to follow a symlink that escapes Soma home: ${file.target}`,
-      );
-    }
-    // Final-target leaf check: if a pre-existing symlink sits at the
-    // exact target path, `copyFile` would follow it and overwrite an
-    // attacker-chosen file. Refuse any symlink at the leaf — even
-    // one that resolves inside the Soma home, since the importer's
-    // contract is to write regular files at these paths.
+  async function refuseLeafSymlink(target: string): Promise<void> {
     try {
-      const leafStat = await lstat(file.target);
+      const leafStat = await lstat(target);
       if (leafStat.isSymbolicLink()) {
-        const realLeaf = await realpath(file.target);
-        if (realLeaf !== realSomaHome && !realLeaf.startsWith(realSomaHome + sep)) {
-          throw new Error(
-            `PAI memory migration refused to overwrite through a symlink that escapes Soma home: ${file.target}`,
-          );
-        }
         throw new Error(
-          `PAI memory migration refused to overwrite an existing symlink at the target path: ${file.target}`,
+          `PAI memory migration refused to overwrite an existing symlink at the target path: ${target}`,
         );
       }
     } catch (error) {
@@ -417,6 +390,38 @@ export async function migratePaiMemory(
         throw error;
       }
     }
+  }
+
+  type Outcome = { written: boolean; target: string };
+  async function processFile(file: PaiMemoryMigrationFile): Promise<Outcome> {
+    await assertSafeMemoryTarget(file.target);
+
+    const priorSha = previous?.map.get(file.relativePath);
+    if (priorSha && priorSha === file.sha256 && (await pathExists(file.target))) {
+      // Re-hash the target's current bytes. Manifest agreement alone
+      // is not enough — a user edit since import would otherwise
+      // leave a "successful" migration with the wrong target bytes.
+      await refuseLeafSymlink(file.target);
+      const targetStat = await lstat(file.target);
+      if (targetStat.isFile()) {
+        const targetSha = sha256Hex(await readFile(file.target));
+        if (targetSha === file.sha256) {
+          return { written: false, target: file.target };
+        }
+      }
+    }
+    const parent = join(file.target, "..");
+    await mkdir(parent, { recursive: true });
+    // After mkdir, re-check the parent's realpath against the Soma
+    // home's realpath. Catches a race where a regular dir is swapped
+    // for a symlink between the ancestor walk and the mkdir.
+    const realParent = await realpath(parent);
+    if (realParent !== realSomaHome && !realParent.startsWith(realSomaHome + sep)) {
+      throw new Error(
+        `PAI memory migration refused to follow a symlink that escapes Soma home: ${file.target}`,
+      );
+    }
+    await refuseLeafSymlink(file.target);
     await copyFile(file.source, file.target);
     // Preserve source mtime on the target file.
     const mtimeSeconds = file.mtimeMs / 1000;

--- a/src/pai-memory-migrator.ts
+++ b/src/pai-memory-migrator.ts
@@ -256,7 +256,12 @@ export async function migratePaiMemory(
 
   if (plan.memoryDir === null) {
     // Nothing to migrate. Write an empty manifest only when one
-    // doesn't already exist, so the no-op contract holds.
+    // doesn't already exist, so subsequent reruns are pure no-ops.
+    // Sage r4 #95 important: distinguish the first-write from a true
+    // no-op via `unchanged`. A real no-op (no source, manifest
+    // already there) reports `unchanged: true`; a first-write of the
+    // empty manifest touches disk and must report `unchanged: false`
+    // so callers don't conflate the two on the per-run accounting.
     const existing = await readExistingManifest(plan.somaHome);
     if (existing === null) {
       const importedAt = new Date().toISOString();
@@ -272,7 +277,7 @@ export async function migratePaiMemory(
         importedAt,
         writtenCount: 0,
         skippedCount: 0,
-        unchanged: true,
+        unchanged: false, // newly created the manifest — disk touched.
         manifestPath,
         files: [],
         writtenTargets: [],

--- a/src/pai-memory-migrator.ts
+++ b/src/pai-memory-migrator.ts
@@ -76,6 +76,32 @@ async function pathExists(path: string): Promise<boolean> {
   }
 }
 
+/**
+ * Run async per-item work with a bounded concurrency window. Preserves
+ * input order in the returned results array. Matches the pattern used
+ * in `src/pai-migration.ts` and `src/pai-pack-importer.ts` for I/O
+ * fan-out.
+ */
+async function runBoundedConcurrent<T, R>(
+  items: readonly T[],
+  fn: (item: T) => Promise<R>,
+  limit: number,
+): Promise<R[]> {
+  if (items.length === 0) return [];
+  const results: R[] = new Array<R>(items.length);
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index]);
+    }
+  }
+  const workerCount = Math.min(limit, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
 // Recursively enumerate files under `<memoryDir>/<category>/...`.
 // Files directly under `memoryDir` are skipped — #88 owns the README
 // at `<somaHome>/memory/` and we must not clobber it.
@@ -282,29 +308,28 @@ export async function migratePaiMemory(
   }
 
   const previous = await readExistingManifest(plan.somaHome);
-  let writtenCount = 0;
-  let skippedCount = 0;
-  const writtenTargets: string[] = [];
 
-  for (const file of plan.files) {
+  // Sage r1 #95 Performance suggestion: process per-file work with a
+  // small bounded concurrency window so large MEMORY trees don't pay
+  // one file's full I/O latency at a time. Per-file work is
+  // independent and dominated by syscalls — 4-wide matches the pack
+  // import phase and the docs importer's footprint. The original
+  // plan.files order is preserved in `outcomes` so the manifest and
+  // returned target list stay deterministic.
+  type Outcome = { written: boolean; target: string };
+  async function processFile(file: PaiMemoryMigrationFile): Promise<Outcome> {
     const priorSha = previous?.map.get(file.relativePath);
-    let mustWrite = true;
     if (priorSha && priorSha === file.sha256 && (await pathExists(file.target))) {
       // Re-hash the target's current bytes. Manifest agreement alone
-      // is not enough — a user edit since import would otherwise leave
-      // a "successful" migration with the wrong target bytes.
+      // is not enough — a user edit since import would otherwise
+      // leave a "successful" migration with the wrong target bytes.
       const targetStat = await lstat(file.target);
       if (targetStat.isFile()) {
         const targetSha = sha256Hex(await readFile(file.target));
         if (targetSha === file.sha256) {
-          mustWrite = false;
+          return { written: false, target: file.target };
         }
       }
-    }
-    if (!mustWrite) {
-      skippedCount += 1;
-      writtenTargets.push(file.target);
-      continue;
     }
     // Target-side parent must be inside the Soma home root. The plan
     // builder already constructed `file.target` relative to
@@ -319,8 +344,17 @@ export async function migratePaiMemory(
     // Preserve source mtime on the target file.
     const mtimeSeconds = file.mtimeMs / 1000;
     await utimes(file.target, mtimeSeconds, mtimeSeconds);
-    writtenCount += 1;
-    writtenTargets.push(file.target);
+    return { written: true, target: file.target };
+  }
+
+  const outcomes = await runBoundedConcurrent(plan.files, processFile, 4);
+  let writtenCount = 0;
+  let skippedCount = 0;
+  const writtenTargets: string[] = [];
+  for (const outcome of outcomes) {
+    if (outcome.written) writtenCount += 1;
+    else skippedCount += 1;
+    writtenTargets.push(outcome.target);
   }
 
   // Decide manifest timestamp:

--- a/src/pai-memory-migrator.ts
+++ b/src/pai-memory-migrator.ts
@@ -306,21 +306,18 @@ export async function migratePaiMemory(
   // import phase and the docs importer's footprint. The original
   // plan.files order is preserved in `outcomes` so the manifest and
   // returned target list stay deterministic.
+  // Sage r5 #95 Security important: harden the target side against
+  // symlink-redirected writes. Lexical isWithinPath is not enough —
+  // an attacker who can pre-create a symlink at
+  // <somaHome>/memory/<rel> (or any of its parents) can otherwise
+  // redirect the copyFile into an arbitrary destination on disk.
+  // Resolve once per migration; the realpath stays constant for the
+  // duration of the call. The per-file guard checks every existing
+  // ancestor + the final-target leaf for symlinks before any IO.
+  const realSomaHome = await realpath(plan.somaHome);
+
   type Outcome = { written: boolean; target: string };
   async function processFile(file: PaiMemoryMigrationFile): Promise<Outcome> {
-    const priorSha = previous?.map.get(file.relativePath);
-    if (priorSha && priorSha === file.sha256 && (await pathExists(file.target))) {
-      // Re-hash the target's current bytes. Manifest agreement alone
-      // is not enough — a user edit since import would otherwise
-      // leave a "successful" migration with the wrong target bytes.
-      const targetStat = await lstat(file.target);
-      if (targetStat.isFile()) {
-        const targetSha = sha256Hex(await readFile(file.target));
-        if (targetSha === file.sha256) {
-          return { written: false, target: file.target };
-        }
-      }
-    }
     // Target-side parent must be inside the Soma home root. The plan
     // builder already constructed `file.target` relative to
     // `<somaHome>/memory/<rel>`; verify once more before any IO.
@@ -329,7 +326,97 @@ export async function migratePaiMemory(
         `PAI memory migration refused target outside Soma home: ${file.target}`,
       );
     }
-    await mkdir(join(file.target, ".."), { recursive: true });
+    // Walk every existing ancestor of the target up to the Soma home
+    // root and refuse any ancestor that is a symlink whose realpath
+    // escapes the Soma home. Stops at the first ancestor that does
+    // not yet exist — that and everything underneath it will be
+    // created by `mkdir` below, so no symlink can pre-exist there.
+    const parent = join(file.target, "..");
+    const ancestors: string[] = [];
+    let cursor = parent;
+    while (true) {
+      ancestors.push(cursor);
+      if (cursor === plan.somaHome) break;
+      const next = join(cursor, "..");
+      if (next === cursor) break;
+      cursor = next;
+    }
+    for (const ancestor of ancestors.reverse()) {
+      if (!(await pathExists(ancestor))) continue;
+      const stat = await lstat(ancestor);
+      if (stat.isSymbolicLink()) {
+        const realLink = await realpath(ancestor);
+        if (realLink !== realSomaHome && !realLink.startsWith(realSomaHome + sep)) {
+          throw new Error(
+            `PAI memory migration refused to follow a symlink that escapes Soma home: ${file.target}`,
+          );
+        }
+      }
+    }
+
+    const priorSha = previous?.map.get(file.relativePath);
+    if (priorSha && priorSha === file.sha256 && (await pathExists(file.target))) {
+      // Re-hash the target's current bytes. Manifest agreement alone
+      // is not enough — a user edit since import would otherwise
+      // leave a "successful" migration with the wrong target bytes.
+      // Sage r5 security: also refuse a leaf target that is a
+      // symlink whose realpath escapes the Soma home, even on the
+      // idempotency-skip path (a symlink whose bytes happen to match
+      // the prior SHA would otherwise be silently accepted).
+      const targetStat = await lstat(file.target);
+      if (targetStat.isSymbolicLink()) {
+        const realTarget = await realpath(file.target);
+        if (realTarget !== realSomaHome && !realTarget.startsWith(realSomaHome + sep)) {
+          throw new Error(
+            `PAI memory migration refused to overwrite through a symlink that escapes Soma home: ${file.target}`,
+          );
+        }
+        throw new Error(
+          `PAI memory migration refused to overwrite an existing symlink at the target path: ${file.target}`,
+        );
+      }
+      if (targetStat.isFile()) {
+        const targetSha = sha256Hex(await readFile(file.target));
+        if (targetSha === file.sha256) {
+          return { written: false, target: file.target };
+        }
+      }
+    }
+    await mkdir(parent, { recursive: true });
+    // After mkdir, re-check the parent's realpath against the Soma
+    // home's realpath. This re-catches both the standard symlink-in-
+    // the-middle case (e.g., a regular dir replaced by a symlink
+    // between walk and mkdir) and a parent that is a symlink pointing
+    // inside the home (legal — caught by the equality check).
+    const realParent = await realpath(parent);
+    if (realParent !== realSomaHome && !realParent.startsWith(realSomaHome + sep)) {
+      throw new Error(
+        `PAI memory migration refused to follow a symlink that escapes Soma home: ${file.target}`,
+      );
+    }
+    // Final-target leaf check: if a pre-existing symlink sits at the
+    // exact target path, `copyFile` would follow it and overwrite an
+    // attacker-chosen file. Refuse any symlink at the leaf — even
+    // one that resolves inside the Soma home, since the importer's
+    // contract is to write regular files at these paths.
+    try {
+      const leafStat = await lstat(file.target);
+      if (leafStat.isSymbolicLink()) {
+        const realLeaf = await realpath(file.target);
+        if (realLeaf !== realSomaHome && !realLeaf.startsWith(realSomaHome + sep)) {
+          throw new Error(
+            `PAI memory migration refused to overwrite through a symlink that escapes Soma home: ${file.target}`,
+          );
+        }
+        throw new Error(
+          `PAI memory migration refused to overwrite an existing symlink at the target path: ${file.target}`,
+        );
+      }
+    } catch (error) {
+      if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+        throw error;
+      }
+    }
     await copyFile(file.source, file.target);
     // Preserve source mtime on the target file.
     const mtimeSeconds = file.mtimeMs / 1000;

--- a/src/pai-memory-migrator.ts
+++ b/src/pai-memory-migrator.ts
@@ -1,0 +1,347 @@
+/**
+ * PAI MEMORY → Soma memory translator (#90).
+ *
+ * Moves `<claudeHome>/PAI/MEMORY/<CATEGORY>/...` files into
+ * `<somaHome>/memory/<CATEGORY>/...`. Content-preserving by contract
+ * (DD-2 + plan §"Failure modes"): no body rewriting in this pass, only
+ * directory remapping. Preserves source mtimes. Records per-file SHA in
+ * `<somaHome>/imports/pai-migration/.manifest.json`. Idempotent — a
+ * second run with no source drift writes zero files.
+ *
+ * What is NOT migrated:
+ *   - Files directly under `<claudeHome>/PAI/MEMORY/` (no enclosing
+ *     category dir). Those tend to be readmes or index files that
+ *     #88's bootstrap owns at the Soma side; clobbering them silently
+ *     would conflict with the canonical taxonomy contract.
+ *   - Symlinks anywhere in the tree — rejected loud (matches the
+ *     pack/docs importers' stance).
+ *
+ * Idempotency model (mirrors `pai-docs-importer.ts`):
+ *   - Compare source SHA against prior manifest entry.
+ *   - When SHA matches AND the target file's current bytes still hash
+ *     to that SHA, skip the copy. A target that has been edited or
+ *     replaced since the import is restored from the source.
+ *   - The manifest's `importedAt` updates only when at least one file
+ *     was written this run; otherwise the prior timestamp is preserved
+ *     so the manifest is byte-stable on a no-op rerun.
+ */
+import { createHash } from "node:crypto";
+import {
+  copyFile,
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  realpath,
+  utimes,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import type {
+  PaiMemoryMigrationFile,
+  PaiMemoryMigrationManifest,
+  PaiMemoryMigrationOptions,
+  PaiMemoryMigrationPlan,
+  PaiMemoryMigrationResult,
+} from "./types";
+
+const MANIFEST_SCHEMA = "soma.pai-memory-migration.v1";
+const MANIFEST_RELATIVE = "imports/pai-migration/.manifest.json";
+
+function resolveHomes(options: PaiMemoryMigrationOptions): { claudeHome: string; somaHome: string } {
+  const home = resolve(options.homeDir ?? homedir());
+  return {
+    claudeHome: resolve(options.claudeHome ?? join(home, ".claude")),
+    somaHome: resolve(options.somaHome ?? join(home, ".soma")),
+  };
+}
+
+function isWithinPath(root: string, target: string): boolean {
+  const rel = relative(root, target);
+  return rel === "" || (!rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel));
+}
+
+function sha256Hex(content: Buffer | string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+// Recursively enumerate files under `<memoryDir>/<category>/...`.
+// Files directly under `memoryDir` are skipped — #88 owns the README
+// at `<somaHome>/memory/` and we must not clobber it.
+async function collectCategoryFiles(memoryDir: string): Promise<string[]> {
+  const realRoot = await realpath(memoryDir);
+  const files: string[] = [];
+
+  async function visit(dir: string, depth: number): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.name.includes("\\")) {
+        throw new Error(
+          `PAI memory migration refused ambiguous path separator: ${relative(memoryDir, fullPath).split(sep).join("/")}`,
+        );
+      }
+      if (entry.isSymbolicLink()) {
+        throw new Error(
+          `PAI memory migration refused symlink path: ${relative(memoryDir, fullPath).split(sep).join("/")}`,
+        );
+      }
+      if (entry.isDirectory()) {
+        if (entry.name === ".git" || entry.name === ".hg" || entry.name === ".svn") {
+          throw new Error(
+            `PAI memory migration refused VCS metadata directory: ${relative(memoryDir, fullPath).split(sep).join("/")}`,
+          );
+        }
+        await visit(fullPath, depth + 1);
+        continue;
+      }
+      if (entry.isFile()) {
+        // depth 0 = files directly under MEMORY/ (no category). Those
+        // would collide with `<somaHome>/memory/<file>` — bootstrap
+        // territory. Skip.
+        if (depth === 0) continue;
+        const realFile = await realpath(fullPath);
+        if (!isWithinPath(realRoot, realFile)) {
+          throw new Error(
+            `PAI memory migration refused path outside MEMORY root: ${relative(memoryDir, fullPath).split(sep).join("/")}`,
+          );
+        }
+        files.push(relative(memoryDir, fullPath).split(sep).join("/"));
+      }
+    }
+  }
+
+  await visit(memoryDir, 0);
+  return files.sort();
+}
+
+async function buildPlan(
+  options: PaiMemoryMigrationOptions,
+  flags: { withSha: boolean },
+): Promise<PaiMemoryMigrationPlan> {
+  const homes = resolveHomes(options);
+  const memoryDirCandidate = join(homes.claudeHome, "PAI/MEMORY");
+  if (!(await pathExists(memoryDirCandidate))) {
+    return {
+      apply: false,
+      claudeHome: homes.claudeHome,
+      somaHome: homes.somaHome,
+      memoryDir: null,
+      files: [],
+    };
+  }
+  // Refuse a symlinked PAI MEMORY root with the same loud-fail bar as
+  // every other source the importer reads. A malicious or accidental
+  // symlink at this top-level path would otherwise let the importer
+  // walk an arbitrary directory.
+  const memoryStat = await lstat(memoryDirCandidate);
+  if (memoryStat.isSymbolicLink()) {
+    throw new Error("PAI memory migration refused symlink path: PAI/MEMORY");
+  }
+  if (!memoryStat.isDirectory()) {
+    throw new Error(
+      `PAI memory migration: ${memoryDirCandidate} exists but is not a directory.`,
+    );
+  }
+
+  const relPaths = await collectCategoryFiles(memoryDirCandidate);
+  const files: PaiMemoryMigrationFile[] = [];
+  for (const rel of relPaths) {
+    const source = join(memoryDirCandidate, ...rel.split("/"));
+    const target = join(homes.somaHome, "memory", ...rel.split("/"));
+    const stat = await lstat(source);
+    const file: PaiMemoryMigrationFile = {
+      source,
+      target,
+      relativePath: rel,
+      mtimeMs: stat.mtimeMs,
+    };
+    if (flags.withSha) {
+      file.sha256 = sha256Hex(await readFile(source));
+    }
+    files.push(file);
+  }
+
+  return {
+    apply: false,
+    claudeHome: homes.claudeHome,
+    somaHome: homes.somaHome,
+    memoryDir: memoryDirCandidate,
+    files,
+  };
+}
+
+export async function planPaiMemoryMigration(
+  options: PaiMemoryMigrationOptions = {},
+): Promise<PaiMemoryMigrationPlan> {
+  return buildPlan(options, { withSha: false });
+}
+
+// Read existing manifest. Returns null when missing / corrupt so the
+// apply path re-copies every file. Map key is the manifest
+// `relativePath` (POSIX path under PAI/MEMORY/).
+async function readExistingManifest(
+  somaHome: string,
+): Promise<{ map: Map<string, string>; importedAt: string } | null> {
+  const path = join(somaHome, MANIFEST_RELATIVE);
+  if (!(await pathExists(path))) return null;
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as PaiMemoryMigrationManifest;
+    if (parsed.schema !== MANIFEST_SCHEMA || !Array.isArray(parsed.files)) return null;
+    const map = new Map<string, string>();
+    for (const entry of parsed.files) {
+      map.set(entry.relativePath, entry.sha256);
+    }
+    return { map, importedAt: parsed.importedAt };
+  } catch {
+    return null;
+  }
+}
+
+function renderManifest(
+  plan: PaiMemoryMigrationPlan,
+  importedAt: string,
+): string {
+  const manifest: PaiMemoryMigrationManifest = {
+    schema: MANIFEST_SCHEMA,
+    claudeHome: plan.claudeHome,
+    somaHome: plan.somaHome,
+    importedAt,
+    files: plan.files.map((file) => {
+      if (!file.sha256) {
+        throw new Error(
+          `PAI memory migration: manifest renderer expected file.sha256 to be populated (file: ${file.relativePath}).`,
+        );
+      }
+      return {
+        relativePath: file.relativePath,
+        target: relative(join(plan.somaHome, "memory"), file.target).split(sep).join("/"),
+        sha256: file.sha256,
+        mtimeMs: file.mtimeMs,
+      };
+    }),
+  };
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+export async function migratePaiMemory(
+  options: PaiMemoryMigrationOptions = {},
+): Promise<PaiMemoryMigrationResult> {
+  const plan = await buildPlan(options, { withSha: true });
+  const manifestPath = join(plan.somaHome, MANIFEST_RELATIVE);
+  // Always ensure the manifest dir exists so a no-op rerun on an empty
+  // PAI MEMORY tree still produces a deterministic surface.
+  await mkdir(join(plan.somaHome, "imports/pai-migration"), { recursive: true });
+
+  if (plan.memoryDir === null) {
+    // Nothing to migrate. Write an empty manifest only when one
+    // doesn't already exist, so the no-op contract holds.
+    const existing = await readExistingManifest(plan.somaHome);
+    if (existing === null) {
+      const importedAt = new Date().toISOString();
+      await writeFile(
+        manifestPath,
+        renderManifest(plan, importedAt),
+        "utf8",
+      );
+      return {
+        claudeHome: plan.claudeHome,
+        somaHome: plan.somaHome,
+        memoryDir: null,
+        importedAt,
+        writtenCount: 0,
+        skippedCount: 0,
+        unchanged: true,
+        manifestPath,
+        files: [],
+      };
+    }
+    return {
+      claudeHome: plan.claudeHome,
+      somaHome: plan.somaHome,
+      memoryDir: null,
+      importedAt: existing.importedAt,
+      writtenCount: 0,
+      skippedCount: 0,
+      unchanged: true,
+      manifestPath,
+      files: [],
+    };
+  }
+
+  const previous = await readExistingManifest(plan.somaHome);
+  let writtenCount = 0;
+  let skippedCount = 0;
+  const writtenTargets: string[] = [];
+
+  for (const file of plan.files) {
+    const priorSha = previous?.map.get(file.relativePath);
+    let mustWrite = true;
+    if (priorSha && priorSha === file.sha256 && (await pathExists(file.target))) {
+      // Re-hash the target's current bytes. Manifest agreement alone
+      // is not enough — a user edit since import would otherwise leave
+      // a "successful" migration with the wrong target bytes.
+      const targetStat = await lstat(file.target);
+      if (targetStat.isFile()) {
+        const targetSha = sha256Hex(await readFile(file.target));
+        if (targetSha === file.sha256) {
+          mustWrite = false;
+        }
+      }
+    }
+    if (!mustWrite) {
+      skippedCount += 1;
+      writtenTargets.push(file.target);
+      continue;
+    }
+    // Target-side parent must be inside the Soma home root. The plan
+    // builder already constructed `file.target` relative to
+    // `<somaHome>/memory/<rel>`; verify once more before any IO.
+    if (!isWithinPath(plan.somaHome, file.target)) {
+      throw new Error(
+        `PAI memory migration refused target outside Soma home: ${file.target}`,
+      );
+    }
+    await mkdir(join(file.target, ".."), { recursive: true });
+    await copyFile(file.source, file.target);
+    // Preserve source mtime on the target file.
+    const mtimeSeconds = file.mtimeMs / 1000;
+    await utimes(file.target, mtimeSeconds, mtimeSeconds);
+    writtenCount += 1;
+    writtenTargets.push(file.target);
+  }
+
+  // Decide manifest timestamp:
+  //   - At least one write this run → bump timestamp.
+  //   - Zero writes (idempotent no-op) → preserve prior timestamp so
+  //     the manifest is byte-stable across reruns.
+  const importedAt =
+    writtenCount === 0 && previous
+      ? previous.importedAt
+      : new Date().toISOString();
+  await writeFile(manifestPath, renderManifest(plan, importedAt), "utf8");
+
+  return {
+    claudeHome: plan.claudeHome,
+    somaHome: plan.somaHome,
+    memoryDir: plan.memoryDir,
+    importedAt,
+    writtenCount,
+    skippedCount,
+    unchanged: writtenCount === 0,
+    manifestPath,
+    files: writtenTargets,
+  };
+}

--- a/src/pai-memory-migrator.ts
+++ b/src/pai-memory-migrator.ts
@@ -38,6 +38,7 @@ import {
 } from "node:fs/promises";
 import { homedir } from "node:os";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { runBoundedConcurrent } from "./internal-concurrency";
 import type {
   PaiMemoryMigrationFile,
   PaiMemoryMigrationManifest,
@@ -74,32 +75,6 @@ async function pathExists(path: string): Promise<boolean> {
     if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
     throw error;
   }
-}
-
-/**
- * Run async per-item work with a bounded concurrency window. Preserves
- * input order in the returned results array. Matches the pattern used
- * in `src/pai-migration.ts` and `src/pai-pack-importer.ts` for I/O
- * fan-out.
- */
-async function runBoundedConcurrent<T, R>(
-  items: readonly T[],
-  fn: (item: T) => Promise<R>,
-  limit: number,
-): Promise<R[]> {
-  if (items.length === 0) return [];
-  const results: R[] = new Array<R>(items.length);
-  let cursor = 0;
-  async function worker(): Promise<void> {
-    for (;;) {
-      const index = cursor++;
-      if (index >= items.length) return;
-      results[index] = await fn(items[index]);
-    }
-  }
-  const workerCount = Math.min(limit, items.length);
-  await Promise.all(Array.from({ length: workerCount }, () => worker()));
-  return results;
 }
 
 // Recursively enumerate files under `<memoryDir>/<category>/...`.
@@ -182,22 +157,30 @@ async function buildPlan(
   }
 
   const relPaths = await collectCategoryFiles(memoryDirCandidate);
-  const files: PaiMemoryMigrationFile[] = [];
-  for (const rel of relPaths) {
-    const source = join(memoryDirCandidate, ...rel.split("/"));
-    const target = join(homes.somaHome, "memory", ...rel.split("/"));
-    const stat = await lstat(source);
-    const file: PaiMemoryMigrationFile = {
-      source,
-      target,
-      relativePath: rel,
-      mtimeMs: stat.mtimeMs,
-    };
-    if (flags.withSha) {
-      file.sha256 = sha256Hex(await readFile(source));
-    }
-    files.push(file);
-  }
+  // Sage r2 #95 Performance: per-file stat+read for SHA was serialized
+  // in this builder loop. Bounded-concurrency the same as the copy
+  // phase — input order is preserved by `runBoundedConcurrent` so the
+  // returned plan stays deterministic (manifest entries are sorted
+  // by `relativePath` already, but per-input order would match anyway).
+  const files = await runBoundedConcurrent(
+    relPaths,
+    async (rel): Promise<PaiMemoryMigrationFile> => {
+      const source = join(memoryDirCandidate, ...rel.split("/"));
+      const target = join(homes.somaHome, "memory", ...rel.split("/"));
+      const stat = await lstat(source);
+      const file: PaiMemoryMigrationFile = {
+        source,
+        target,
+        relativePath: rel,
+        mtimeMs: stat.mtimeMs,
+      };
+      if (flags.withSha) {
+        file.sha256 = sha256Hex(await readFile(source));
+      }
+      return file;
+    },
+    4,
+  );
 
   return {
     apply: false,
@@ -292,6 +275,7 @@ export async function migratePaiMemory(
         unchanged: true,
         manifestPath,
         files: [],
+        writtenTargets: [],
       };
     }
     return {
@@ -304,6 +288,7 @@ export async function migratePaiMemory(
       unchanged: true,
       manifestPath,
       files: [],
+      writtenTargets: [],
     };
   }
 
@@ -350,11 +335,16 @@ export async function migratePaiMemory(
   const outcomes = await runBoundedConcurrent(plan.files, processFile, 4);
   let writtenCount = 0;
   let skippedCount = 0;
+  const allTargets: string[] = [];
   const writtenTargets: string[] = [];
   for (const outcome of outcomes) {
-    if (outcome.written) writtenCount += 1;
-    else skippedCount += 1;
-    writtenTargets.push(outcome.target);
+    if (outcome.written) {
+      writtenCount += 1;
+      writtenTargets.push(outcome.target);
+    } else {
+      skippedCount += 1;
+    }
+    allTargets.push(outcome.target);
   }
 
   // Decide manifest timestamp:
@@ -376,6 +366,7 @@ export async function migratePaiMemory(
     skippedCount,
     unchanged: writtenCount === 0,
     manifestPath,
-    files: writtenTargets,
+    files: allTargets,
+    writtenTargets,
   };
 }

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -268,6 +268,12 @@ async function discoverMigrationSources(
 ): Promise<MigrationSources> {
   const algorithmDirCandidate = join(claudeHome, "PAI/Algorithm");
   const algorithmDir = (await exists(algorithmDirCandidate)) ? algorithmDirCandidate : null;
+  // Sage r3 #95 important: pack discovery must not run when the skill
+  // phase is explicitly skipped. Otherwise a bad/unreadable
+  // `paiPacksDir` throws even though `--skip-skills` was set.
+  if (options.skipSkills === true) {
+    return { algorithmDir, packPaths: [] };
+  }
   const packsRoot = await resolvePacksDir(options, claudeHome);
   const discovered = packsRoot ? await autoDiscoverPackPaths(packsRoot) : [];
   const explicit = options.paiPackPaths ?? [];
@@ -432,6 +438,80 @@ function renderManifest(result: ManifestInputs): string {
     .join("\n");
 }
 
+// Compose the migration's content fingerprints, render the manifest
+// body, and decide whether to preserve the prior `Last migrated at:`
+// timestamp or bump it.
+//
+// Idempotency model (Sage r1+r2 #95):
+//   1. Compute content fingerprints over identity / algorithm /
+//      per-pack-entry-SKILL.md bytes so the manifest body reflects
+//      content-level changes (not just file-count changes) in
+//      phases whose underlying importers don't expose a per-file
+//      "wrote vs skipped" signal.
+//   2. Render the manifest body with a sentinel timestamp.
+//   3. Read the prior manifest (if any), substitute the same
+//      sentinel for its timestamp line.
+//   4. If sentinel-bodies are byte-equal, the migration is fully
+//      idempotent — reuse the prior timestamp.
+//   5. Otherwise, write the new manifest with `new Date()`.
+//
+// This covers all phases by construction: any phase that changed
+// counts, names, file lists, OR file content produces a different
+// body and forces a timestamp bump. Pack fingerprint is restricted
+// to the entry SKILL.md (Sage r2 #95 Performance) — the only file
+// the pack importer rewrites, sufficient for the contract.
+interface StableManifestInputs {
+  claudeHome: string;
+  somaHome: string;
+  identity: PaiImportResult;
+  algorithm: AlgorithmImportResult | null;
+  packs: PaiPackImportResult[];
+  memory: PaiMemoryMigrationResult | null;
+  docs: PaiDocsImportResult | null;
+  paiSourceDir: string | undefined;
+  manifestPath: string;
+}
+
+async function renderStableMigrationManifest(
+  inputs: StableManifestInputs,
+): Promise<{ manifest: string; lastMigratedAt: string }> {
+  const identityFingerprint = await fingerprintFiles(inputs.identity.files);
+  const algorithmFingerprint = inputs.algorithm
+    ? await fingerprintFiles(inputs.algorithm.files)
+    : null;
+  const packFingerprints = await Promise.all(
+    inputs.packs.map((p) => fingerprintPackEntry(p)),
+  );
+  const sentinelTs = "__PAI_MIGRATION_TS_SENTINEL__";
+  const newBodyWithSentinel = renderManifest({
+    claudeHome: inputs.claudeHome,
+    somaHome: inputs.somaHome,
+    identity: inputs.identity,
+    algorithm: inputs.algorithm,
+    packs: inputs.packs,
+    memory: inputs.memory,
+    docs: inputs.docs,
+    paiSourceDir: inputs.paiSourceDir,
+    lastMigratedAt: sentinelTs,
+    identityFingerprint,
+    algorithmFingerprint,
+    packFingerprints,
+  });
+  const priorBytes = await readManifestBytes(inputs.manifestPath);
+  const priorWithSentinel = priorBytes === null
+    ? null
+    : priorBytes.replace(/^Last migrated at: .+$/m, `Last migrated at: ${sentinelTs}`);
+  const priorTs = priorBytes === null ? null : extractMigrationTimestamp(priorBytes);
+  const lastMigratedAt =
+    priorWithSentinel !== null && priorWithSentinel === newBodyWithSentinel && priorTs !== null
+      ? priorTs
+      : new Date().toISOString();
+  return {
+    manifest: newBodyWithSentinel.replace(sentinelTs, lastMigratedAt),
+    lastMigratedAt,
+  };
+}
+
 /**
  * Execute the migration plan. Runs identity → algorithm → memory →
  * packs → docs in order, then writes the MIGRATION.md manifest. The
@@ -522,44 +602,15 @@ export async function migratePai(options: PaiMigrationOptions = {}): Promise<Pai
     : null;
   if (docs) filesWritten.push(...docs.files);
 
-  // Timestamp / idempotency gate (Sage r1 #95 important):
-  //
-  // The previous gate only considered `memory.unchanged &&
-  // docs.unchanged`, which incorrectly preserved the prior timestamp
-  // when identity / algorithm / packs DID write bytes. The fix is to
-  // make the gate manifest-content-equivalent rather than
-  // phase-flag-based:
-  //
-  //   1. Compute content fingerprints over identity / algorithm /
-  //      per-pack entry-SKILL.md bytes so the manifest body reflects
-  //      content-level changes (not just file-count changes) in
-  //      phases whose underlying importers don't expose a per-file
-  //      "wrote vs skipped" signal.
-  //   2. Render the manifest body with a sentinel timestamp.
-  //   3. Read the prior manifest (if any), substitute the same
-  //      sentinel for its timestamp line.
-  //   4. If the two bodies are byte-equal, the migration is fully
-  //      idempotent — reuse the prior timestamp.
-  //   5. Otherwise, write the new manifest with `new Date()`.
-  //
-  // This covers all five phases by construction: any phase that
-  // changed counts, names, file lists, OR file content will produce
-  // a different body and force a timestamp bump.
-  // Sage r2 #95 Performance: pack fingerprints used to hash every
-  // imported pack file (workflows, tools, source-doc copies) which
-  // doubled the I/O on the apply path. The entry `SKILL.md` is the
-  // only file the pack importer rewrites (frontmatter normalization
-  // + skill identity), and it's where content drift between pack
-  // versions actually shows up; fingerprinting just that file is
-  // sufficient for the timestamp-bump contract and avoids the
-  // duplicate-read scaling pitfall.
-  const identityFingerprint = await fingerprintFiles(identity.files);
-  const algorithmFingerprint = algorithm ? await fingerprintFiles(algorithm.files) : null;
-  const packFingerprints = await Promise.all(packs.map((p) => fingerprintPackEntry(p)));
+  // Sage r3 #95 Maintainability: the timestamp gate + fingerprint
+  // composition lives in `renderStableMigrationManifest` so this
+  // orchestrator stays focused on phase composition. The helper
+  // returns the manifest bytes ready to write + the resolved
+  // timestamp (preserved on idempotent rerun, freshly bumped
+  // otherwise).
   const manifestPath = manifestPathFor(somaHome);
   await mkdir(dirname(manifestPath), { recursive: true });
-  const sentinelTs = "__PAI_MIGRATION_TS_SENTINEL__";
-  const newBodyWithSentinel = renderManifest({
+  const { manifest } = await renderStableMigrationManifest({
     claudeHome,
     somaHome,
     identity,
@@ -568,21 +619,8 @@ export async function migratePai(options: PaiMigrationOptions = {}): Promise<Pai
     memory,
     docs,
     paiSourceDir: options.paiSourceDir,
-    lastMigratedAt: sentinelTs,
-    identityFingerprint,
-    algorithmFingerprint,
-    packFingerprints,
+    manifestPath,
   });
-  const priorBytes = await readManifestBytes(manifestPath);
-  const priorWithSentinel = priorBytes === null
-    ? null
-    : priorBytes.replace(/^Last migrated at: .+$/m, `Last migrated at: ${sentinelTs}`);
-  const priorTs = priorBytes === null ? null : extractMigrationTimestamp(priorBytes);
-  const lastMigratedAt =
-    priorWithSentinel !== null && priorWithSentinel === newBodyWithSentinel && priorTs !== null
-      ? priorTs
-      : new Date().toISOString();
-  const manifest = newBodyWithSentinel.replace(sentinelTs, lastMigratedAt);
   await writeFile(manifestPath, manifest, "utf8");
   filesWritten.push(manifestPath);
 

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -23,6 +23,7 @@
  * single directory containing many packs) over `paiPackPaths` (an
  * explicit array).
  */
+import { createHash } from "node:crypto";
 import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -30,7 +31,7 @@ import { importAlgorithm, planAlgorithmImport } from "./algorithm-importer";
 import { importPaiDocs, planPaiDocsImport } from "./pai-docs-importer";
 import { importPaiIdentity, planPaiImport } from "./pai-importer";
 import { migratePaiMemory, planPaiMemoryMigration } from "./pai-memory-migrator";
-import { importPaiPack, planPaiPackImport } from "./pai-pack-importer";
+import { importPaiPack, planPaiPackImport, slugifySkillName } from "./pai-pack-importer";
 import type {
   AlgorithmImportPlan,
   AlgorithmImportResult,
@@ -201,38 +202,31 @@ function manifestPathFor(somaHome: string): string {
   return join(somaHome, "profile/imports/claude/MIGRATION.md");
 }
 
-// Read the prior `Last migrated at: <iso>` line from an existing
-// MIGRATION.md so idempotent reruns can preserve the timestamp. Returns
-// null when the manifest is missing or the line cannot be parsed.
-async function readPriorMigrationTimestamp(manifestPath: string): Promise<string | null> {
+// Read the full bytes of an existing MIGRATION.md so the orchestrator
+// can compare body-equivalence (minus the timestamp line) before
+// deciding whether to preserve or bump the `Last migrated at:` value.
+// Returns null when the manifest is missing or unreadable.
+async function readManifestBytes(manifestPath: string): Promise<string | null> {
   try {
-    const raw = await readFile(manifestPath, "utf8");
-    const match = raw.match(/^Last migrated at: (.+)$/m);
-    return match ? match[1] : null;
+    return await readFile(manifestPath, "utf8");
   } catch (error) {
     if (isEnoent(error)) return null;
     return null; // Don't let a malformed prior manifest poison the rerun.
   }
 }
 
-// Mirror `slugifySkillName` from `src/pai-pack-importer.ts`. The
-// pack importer is the authoritative slugifier; we replicate it here
-// to detect reserved-name collisions before invoking the importer.
-function slugifySkillName(value: string): string {
-  return value
-    .trim()
-    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+function extractMigrationTimestamp(manifest: string): string | null {
+  const match = manifest.match(/^Last migrated at: (.+)$/m);
+  return match ? match[1] : null;
 }
 
 // Read the pack metadata's `name` field the same way
 // `readPackMetadata` does — frontmatter or top heading. We only need
 // enough to derive the slug; the pack importer does the heavy lifting
-// during the actual import.
+// during the actual import. The slug function is the importer's own
+// (`slugifySkillName`), imported above, so the orchestrator's
+// reserved-name check can never drift from the importer's behavior.
 async function readPackSkillSlug(packDir: string): Promise<string> {
-  const { readFile } = await import("node:fs/promises");
   const readme = await readFile(join(packDir, "README.md"), "utf8");
   const match = readme.match(/^---\n([\s\S]*?)\n---/);
   if (match) {
@@ -256,18 +250,21 @@ async function refuseReservedPacks(
   overwriteReserved: boolean,
 ): Promise<string[]> {
   if (overwriteReserved) return [...packPaths];
-  const allowed: string[] = [];
-  for (const packDir of packPaths) {
-    const slug = await readPackSkillSlug(packDir);
-    if (MIGRATE_RESERVED_SKILL_NAMES.has(slug)) {
+  // Sage r1 #95 Performance suggestion: parallelize the README reads
+  // so installs with many packs don't pay serial filesystem latency
+  // before the import phase even starts. 4-wide concurrency mirrors
+  // the actual import phase below; per-call work is one small file
+  // read.
+  const slugs = await runBoundedConcurrent(packPaths, readPackSkillSlug, 4);
+  for (let i = 0; i < packPaths.length; i += 1) {
+    if (MIGRATE_RESERVED_SKILL_NAMES.has(slugs[i])) {
       throw new Error(
-        `soma migrate pai refused reserved Soma skill '${slug}' from pack '${packDir}'. ` +
+        `soma migrate pai refused reserved Soma skill '${slugs[i]}' from pack '${packPaths[i]}'. ` +
           `Re-run with --overwrite-reserved to permit.`,
       );
     }
-    allowed.push(packDir);
   }
-  return allowed;
+  return [...packPaths];
 }
 
 /**
@@ -368,6 +365,35 @@ interface ManifestInputs {
   docs: PaiDocsImportResult | null;
   paiSourceDir: string | undefined;
   lastMigratedAt: string;
+  // Sage r1 #95: content fingerprint over identity + algorithm + per-pack
+  // entry SKILL.md bytes. Embedded into the manifest body so any
+  // content-level drift in those phases (not just file-count changes)
+  // produces a different body and forces a timestamp bump on rerun.
+  identityFingerprint: string;
+  algorithmFingerprint: string | null;
+  packFingerprints: string[];
+}
+
+// Compute a stable SHA-256 fingerprint over a set of file paths. Used
+// to detect content-level drift in phases whose underlying importers
+// don't expose a per-file "wrote vs skipped" signal. We hash the files
+// in sorted order so the fingerprint is independent of write order
+// and concurrency timing.
+async function fingerprintFiles(paths: readonly string[]): Promise<string> {
+  if (paths.length === 0) return "empty";
+  const hash = createHash("sha256");
+  for (const path of [...paths].sort()) {
+    hash.update(path);
+    hash.update(":");
+    try {
+      hash.update(await readFile(path));
+    } catch (error) {
+      // Missing target = part of the fingerprint (no swallow).
+      hash.update(error instanceof Error ? error.message : String(error));
+    }
+    hash.update("\n");
+  }
+  return hash.digest("hex").slice(0, 16);
 }
 
 function renderManifest(result: ManifestInputs): string {
@@ -392,6 +418,11 @@ function renderManifest(result: ManifestInputs): string {
       ? "- docs:     not requested (pass --pai-source-dir to import)"
       : "- docs:     skipped"
     : `- docs:     ${result.docs.files.length} file(s) under ${result.docs.releaseVersion ?? "(no version)"}`;
+  const packFingerprintLines = result.packs.length === 0
+    ? ""
+    : "\n" + result.packs
+        .map((p, idx) => `  - pack ${idx + 1} fingerprint: ${result.packFingerprints[idx] ?? "empty"}`)
+        .join("\n");
   return [
     "# PAI Migration",
     "",
@@ -401,11 +432,13 @@ function renderManifest(result: ManifestInputs): string {
     "",
     "## Categories",
     `- identity: ${result.identity.files.length} files`,
+    `  - identity fingerprint: ${result.identityFingerprint}`,
     `- algorithm: ${result.algorithm ? `${result.algorithm.files.length} files` : "not present"}`,
+    result.algorithm ? `  - algorithm fingerprint: ${result.algorithmFingerprint ?? "empty"}` : null,
     memoryLine,
     docsLine,
     `- packs:`,
-    packLines.split("\n").map((l) => `  ${l}`).join("\n"),
+    packLines.split("\n").map((l) => `  ${l}`).join("\n") + packFingerprintLines,
     "",
     "## How to re-run",
     "- `soma migrate pai` is idempotent at the importer level — each underlying",
@@ -497,28 +530,39 @@ export async function migratePai(options: PaiMigrationOptions = {}): Promise<Pai
     : null;
   if (docs) filesWritten.push(...docs.files);
 
-  // Per-phase no-op detection so the manifest timestamp only bumps
-  // when something actually changed on disk. AC-6 + Sage r1 (#28):
-  // status output must include a timestamp, but the manifest itself
-  // must be byte-stable across pure-idempotent reruns. We treat the
-  // run as no-op when memory wrote zero files AND docs wrote zero
-  // files. Identity + algorithm + packs reuse the underlying
-  // importer's overwrite-with-same-bytes pattern, so we read back
-  // identity output bytes to gate the timestamp bump as well.
+  // Timestamp / idempotency gate (Sage r1 #95 important):
   //
-  // Practically: if memory.unchanged AND docs.unchanged (or skipped)
-  // AND a prior manifest exists, we preserve the prior timestamp.
-  const memoryUnchanged = memory === null || memory.unchanged;
-  const docsUnchanged = docs === null || docs.unchanged;
-  const everythingUnchanged = memoryUnchanged && docsUnchanged;
+  // The previous gate only considered `memory.unchanged &&
+  // docs.unchanged`, which incorrectly preserved the prior timestamp
+  // when identity / algorithm / packs DID write bytes. The fix is to
+  // make the gate manifest-content-equivalent rather than
+  // phase-flag-based:
+  //
+  //   1. Compute content fingerprints over identity / algorithm /
+  //      per-pack entry-SKILL.md bytes so the manifest body reflects
+  //      content-level changes (not just file-count changes) in
+  //      phases whose underlying importers don't expose a per-file
+  //      "wrote vs skipped" signal.
+  //   2. Render the manifest body with a sentinel timestamp.
+  //   3. Read the prior manifest (if any), substitute the same
+  //      sentinel for its timestamp line.
+  //   4. If the two bodies are byte-equal, the migration is fully
+  //      idempotent — reuse the prior timestamp.
+  //   5. Otherwise, write the new manifest with `new Date()`.
+  //
+  // This covers all five phases by construction: any phase that
+  // changed counts, names, file lists, OR file content will produce
+  // a different body and force a timestamp bump.
+  const identityFingerprint = await fingerprintFiles(identity.files);
+  const algorithmFingerprint = algorithm ? await fingerprintFiles(algorithm.files) : null;
+  // Each pack's fingerprint includes every imported file under the
+  // skill root, so pack content drift surfaces regardless of file
+  // count.
+  const packFingerprints = await Promise.all(packs.map((p) => fingerprintFiles(p.files)));
   const manifestPath = manifestPathFor(somaHome);
   await mkdir(dirname(manifestPath), { recursive: true });
-  let lastMigratedAt = new Date().toISOString();
-  if (everythingUnchanged) {
-    const prior = await readPriorMigrationTimestamp(manifestPath);
-    if (prior) lastMigratedAt = prior;
-  }
-  const manifest = renderManifest({
+  const sentinelTs = "__PAI_MIGRATION_TS_SENTINEL__";
+  const newBodyWithSentinel = renderManifest({
     claudeHome,
     somaHome,
     identity,
@@ -527,8 +571,21 @@ export async function migratePai(options: PaiMigrationOptions = {}): Promise<Pai
     memory,
     docs,
     paiSourceDir: options.paiSourceDir,
-    lastMigratedAt,
+    lastMigratedAt: sentinelTs,
+    identityFingerprint,
+    algorithmFingerprint,
+    packFingerprints,
   });
+  const priorBytes = await readManifestBytes(manifestPath);
+  const priorWithSentinel = priorBytes === null
+    ? null
+    : priorBytes.replace(/^Last migrated at: .+$/m, `Last migrated at: ${sentinelTs}`);
+  const priorTs = priorBytes === null ? null : extractMigrationTimestamp(priorBytes);
+  const lastMigratedAt =
+    priorWithSentinel !== null && priorWithSentinel === newBodyWithSentinel && priorTs !== null
+      ? priorTs
+      : new Date().toISOString();
+  const manifest = newBodyWithSentinel.replace(sentinelTs, lastMigratedAt);
   await writeFile(manifestPath, manifest, "utf8");
   filesWritten.push(manifestPath);
 

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -1,51 +1,113 @@
 /**
- * PAI → Soma migration orchestrator (#28 minimal scope).
+ * PAI → Soma migration orchestrator.
  *
- * Wraps the three existing importers (`importPaiIdentity`,
- * `importAlgorithm`, `importPaiPack`) behind a single `migratePai`
- * call + writes a human-readable MIGRATION.md manifest at
- * `~/.soma/profile/imports/claude/MIGRATION.md`.
+ * #28 (PR #69) shipped the minimal orchestrator: identity + algorithm +
+ * per-pack `importPaiPack` + a human-readable MIGRATION.md manifest.
+ * #90 extends that orchestrator with the three remaining phases:
  *
- * Out of scope for this minimal cut (filed as follow-ups on #28):
- *   - per-category importers for skills/agents/commands/hooks
- *   - auto-memory copy
- *   - idempotency conflict detection beyond what the underlying
- *     importers already provide
- *   - TTY auto-detect prompt
- *   - CLI integration (lands in soma#67 `soma migrate pai`)
+ *   1. **Memory translation** — copies `<claudeHome>/PAI/MEMORY/*` into
+ *      `<somaHome>/memory/*` per DD-2's 1:1 mapping. Content-preserving;
+ *      preserves mtimes; per-file SHA recorded in a JSON manifest at
+ *      `<somaHome>/imports/pai-migration/.manifest.json`. Idempotent.
+ *   2. **Bulk skill import** — iterates `<paiPacksDir>/*` and calls
+ *      `importPaiPack` per pack. Reserved skill names (`isa`,
+ *      `the-algorithm`, `knowledge`, `telos`) are refused unless the
+ *      principal opts in via `overwriteReserved`.
+ *   3. **PAI docs import** — when `paiSourceDir` is supplied, wraps the
+ *      #89 verb (`importPaiDocs`) to land DOCUMENTATION/, TEMPLATES/,
+ *      ALGORITHM/ under `<somaHome>/PAI/`.
  *
- * The thin orchestrator is enough to:
- *   - Land the canonical `soma migrate pai` integration point.
- *   - Give a single manifest the user can read to confirm what was
- *     imported in one place.
- *   - Unblock #29's full Claude Code install path.
+ * The pre-#90 minimal orchestrator's `paiPackPaths` option is retained
+ * for back-compat with #67's CLI tests and external callers that pass
+ * explicit pack paths. New callers should prefer `paiPacksDir` (a
+ * single directory containing many packs) over `paiPackPaths` (an
+ * explicit array).
  */
-import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { importAlgorithm, planAlgorithmImport } from "./algorithm-importer";
+import { importPaiDocs, planPaiDocsImport } from "./pai-docs-importer";
 import { importPaiIdentity, planPaiImport } from "./pai-importer";
+import { migratePaiMemory, planPaiMemoryMigration } from "./pai-memory-migrator";
 import { importPaiPack, planPaiPackImport } from "./pai-pack-importer";
 import type {
   AlgorithmImportPlan,
   AlgorithmImportResult,
+  PaiDocsImportPlan,
+  PaiDocsImportResult,
   PaiImportPlan,
   PaiImportResult,
+  PaiMemoryMigrationPlan,
+  PaiMemoryMigrationResult,
   PaiPackImportPlan,
   PaiPackImportResult,
 } from "./types";
+
+// Skill names that the bulk pack importer refuses to land. These are
+// canonical Soma surfaces that the principal must not unintentionally
+// clobber with an imported pack. Override with `overwriteReserved`.
+//
+// `the-algorithm` already lives in the pack importer's reserved list
+// (`src/pai-pack-importer.ts:RESERVED_SKILL_NAMES`); duplicating it
+// here is harmless and keeps the migrate-level list authoritative when
+// `overwriteReserved` flips. The pack importer reserves `soma` as
+// well; we leave that as the pack importer's job to refuse.
+const MIGRATE_RESERVED_SKILL_NAMES: ReadonlySet<string> = new Set([
+  "isa",
+  "the-algorithm",
+  "knowledge",
+  "telos",
+]);
 
 export interface PaiMigrationOptions {
   homeDir?: string;
   claudeHome?: string;
   somaHome?: string;
   /**
-   * When provided, each pack at this list of paths is imported via the
-   * existing pack-importer. When omitted, packs are auto-discovered
-   * under `<claudeHome>/PAI/Packs/` (no-op when the directory does not
-   * exist).
+   * #28 back-compat. When provided, each pack at this list of paths is
+   * imported via the existing pack-importer. Mutually compatible with
+   * `paiPacksDir`; explicit paths are appended after directory scan.
    */
   paiPackPaths?: string[];
+  /**
+   * #90 — single directory containing many packs. Each immediate
+   * subdirectory is treated as one pack and routed through
+   * `importPaiPack`. Defaults: `<paiSourceDir>/Packs` when
+   * `paiSourceDir` is set, else `<claudeHome>/PAI/Packs`.
+   */
+  paiPacksDir?: string;
+  /**
+   * #90 — optional path to an unpacked PAI release tree (e.g.,
+   * `~/work/PAI/Releases/v5.0.0/.claude/PAI`). When provided, the
+   * orchestrator additionally runs the #89 docs-import verb to land
+   * DOCUMENTATION/, TEMPLATES/, ALGORITHM/ under `<somaHome>/PAI/`.
+   * Must point at a directory with a `DOCUMENTATION/` subdir — the
+   * #89 importer refuses anything else loud (matches plan §"Failure
+   * modes": no heuristic guessing).
+   */
+  paiSourceDir?: string;
+  /**
+   * #90 — skip the memory-translation phase. Identity, algorithm,
+   * packs, and docs still run.
+   */
+  skipMemory?: boolean;
+  /**
+   * #90 — skip the bulk skill-import phase. Identity, algorithm,
+   * memory, and docs still run.
+   */
+  skipSkills?: boolean;
+  /**
+   * #90 — skip the PAI docs-import phase. Has no effect when
+   * `paiSourceDir` is not set.
+   */
+  skipDocs?: boolean;
+  /**
+   * #90 — permit the bulk skill importer to land packs whose
+   * normalized skill name appears in `MIGRATE_RESERVED_SKILL_NAMES`.
+   * Without this flag the orchestrator refuses such packs loud.
+   */
+  overwriteReserved?: boolean;
 }
 
 export interface PaiMigrationPlan {
@@ -55,6 +117,8 @@ export interface PaiMigrationPlan {
   identity: PaiImportPlan;
   algorithm: AlgorithmImportPlan | null;
   packs: PaiPackImportPlan[];
+  memory: PaiMemoryMigrationPlan | null;
+  docs: PaiDocsImportPlan | null;
   manifestPath: string;
 }
 
@@ -64,6 +128,8 @@ export interface PaiMigrationResult {
   identity: PaiImportResult;
   algorithm: AlgorithmImportResult | null;
   packs: PaiPackImportResult[];
+  memory: PaiMemoryMigrationResult | null;
+  docs: PaiDocsImportResult | null;
   manifestPath: string;
   filesWritten: string[];
 }
@@ -81,10 +147,11 @@ async function exists(path: string): Promise<boolean> {
     await stat(path);
     return true;
   } catch (error) {
-    // Sage r3: only ENOENT/ENOTDIR (path absent / parent is a file)
-    // mean "not present" — those are normal control-flow signals.
-    // EACCES or other I/O errors must surface so a silent miss can't
-    // produce a "successful" migration that quietly drops a category.
+    // Sage r3 (#28): only ENOENT/ENOTDIR (path absent / parent is a
+    // file) mean "not present" — those are normal control-flow
+    // signals. EACCES or other I/O errors must surface so a silent
+    // miss can't produce a "successful" migration that quietly drops
+    // a category.
     if (isEnoent(error)) return false;
     if (typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOTDIR") {
       return false;
@@ -97,13 +164,29 @@ function isEnoent(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT";
 }
 
-async function autoDiscoverPackPaths(claudeHome: string): Promise<string[]> {
-  const packsRoot = join(claudeHome, "PAI/Packs");
+// Auto-discover packs under a packs root. Order: explicit
+// `paiPacksDir` > `<paiSourceDir>/Packs` (when docs imports are
+// enabled) > `<claudeHome>/PAI/Packs` (legacy #28 behavior).
+async function resolvePacksDir(
+  options: PaiMigrationOptions,
+  claudeHome: string,
+): Promise<string | null> {
+  if (options.paiPacksDir) return resolve(options.paiPacksDir);
+  if (options.paiSourceDir) {
+    // Prefer the release-tree's own Packs/ when the principal supplied
+    // a `--pai-source-dir`. Falls through if it doesn't exist.
+    const release = join(resolve(options.paiSourceDir), "Packs");
+    if (await exists(release)) return release;
+  }
+  return join(claudeHome, "PAI/Packs");
+}
+
+async function autoDiscoverPackPaths(packsRoot: string): Promise<string[]> {
   if (!(await exists(packsRoot))) return [];
-  // Sage r2: only treat ENOENT (raced delete) as "no packs". Other
-  // errors (EACCES on the packs dir, transient I/O failure) must
-  // surface — a silent miss would produce a "successful" migration
-  // that quietly omits the pack category.
+  // Sage r2 (#28): only treat ENOENT (raced delete) as "no packs".
+  // Other errors (EACCES on the packs dir, transient I/O failure)
+  // must surface — a silent miss would produce a "successful"
+  // migration that quietly omits the pack category.
   let entries;
   try {
     entries = await readdir(packsRoot, { withFileTypes: true });
@@ -118,9 +201,78 @@ function manifestPathFor(somaHome: string): string {
   return join(somaHome, "profile/imports/claude/MIGRATION.md");
 }
 
+// Read the prior `Last migrated at: <iso>` line from an existing
+// MIGRATION.md so idempotent reruns can preserve the timestamp. Returns
+// null when the manifest is missing or the line cannot be parsed.
+async function readPriorMigrationTimestamp(manifestPath: string): Promise<string | null> {
+  try {
+    const raw = await readFile(manifestPath, "utf8");
+    const match = raw.match(/^Last migrated at: (.+)$/m);
+    return match ? match[1] : null;
+  } catch (error) {
+    if (isEnoent(error)) return null;
+    return null; // Don't let a malformed prior manifest poison the rerun.
+  }
+}
+
+// Mirror `slugifySkillName` from `src/pai-pack-importer.ts`. The
+// pack importer is the authoritative slugifier; we replicate it here
+// to detect reserved-name collisions before invoking the importer.
+function slugifySkillName(value: string): string {
+  return value
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+// Read the pack metadata's `name` field the same way
+// `readPackMetadata` does — frontmatter or top heading. We only need
+// enough to derive the slug; the pack importer does the heavy lifting
+// during the actual import.
+async function readPackSkillSlug(packDir: string): Promise<string> {
+  const { readFile } = await import("node:fs/promises");
+  const readme = await readFile(join(packDir, "README.md"), "utf8");
+  const match = readme.match(/^---\n([\s\S]*?)\n---/);
+  if (match) {
+    const nameLine = match[1].split("\n").find((line) => /^name\s*:/.test(line));
+    if (nameLine) {
+      const raw = nameLine.split(":").slice(1).join(":").trim().replace(/^["']|["']$/g, "");
+      const slug = slugifySkillName(raw);
+      if (slug) return slug;
+    }
+  }
+  const heading = /^#\s+(.+)$/m.exec(readme)?.[1]?.trim();
+  if (heading) {
+    const slug = slugifySkillName(heading);
+    if (slug) return slug;
+  }
+  return slugifySkillName("pai-pack");
+}
+
+async function refuseReservedPacks(
+  packPaths: readonly string[],
+  overwriteReserved: boolean,
+): Promise<string[]> {
+  if (overwriteReserved) return [...packPaths];
+  const allowed: string[] = [];
+  for (const packDir of packPaths) {
+    const slug = await readPackSkillSlug(packDir);
+    if (MIGRATE_RESERVED_SKILL_NAMES.has(slug)) {
+      throw new Error(
+        `soma migrate pai refused reserved Soma skill '${slug}' from pack '${packDir}'. ` +
+          `Re-run with --overwrite-reserved to permit.`,
+      );
+    }
+    allowed.push(packDir);
+  }
+  return allowed;
+}
+
 /**
- * Run async work with a bounded concurrency window (sage r4: prevent
- * unlimited pack-import fan-out on large installs).
+ * Run async work with a bounded concurrency window (sage r4 #28:
+ * prevent unlimited pack-import fan-out on large installs).
  */
 async function runBoundedConcurrent<T, R>(
   items: readonly T[],
@@ -142,25 +294,32 @@ async function runBoundedConcurrent<T, R>(
   return results;
 }
 
-/**
- * Shared discovery between dry-run and apply paths (sage r1 finding):
- * resolves algorithm presence and pack paths once so the two surfaces
- * cannot drift as new categories are added.
- */
+interface MigrationSources {
+  algorithmDir: string | null;
+  packPaths: string[];
+}
+
 async function discoverMigrationSources(
   claudeHome: string,
   options: PaiMigrationOptions,
-): Promise<{ algorithmDir: string | null; packPaths: string[] }> {
+): Promise<MigrationSources> {
   const algorithmDirCandidate = join(claudeHome, "PAI/Algorithm");
   const algorithmDir = (await exists(algorithmDirCandidate)) ? algorithmDirCandidate : null;
-  const packPaths = options.paiPackPaths ?? (await autoDiscoverPackPaths(claudeHome));
-  return { algorithmDir, packPaths };
+  const packsRoot = await resolvePacksDir(options, claudeHome);
+  const discovered = packsRoot ? await autoDiscoverPackPaths(packsRoot) : [];
+  const explicit = options.paiPackPaths ?? [];
+  // Explicit `paiPackPaths` take precedence; we still append directory
+  // scan results (deduped) so a #67-style call that omitted `paiPacksDir`
+  // continues to behave as before.
+  const dedup = new Set([...explicit, ...discovered]);
+  return { algorithmDir, packPaths: Array.from(dedup) };
 }
 
 /**
  * Plan what migratePai would do. Same-shape sub-plans as the
- * underlying importers + the manifest target. `apply: false` is
- * always false for plans — to execute call migratePai.
+ * underlying importers + memory/docs phases + the manifest target.
+ * `apply: false` is always false for plans — to execute call
+ * migratePai.
  */
 export async function planPaiMigration(options: PaiMigrationOptions = {}): Promise<PaiMigrationPlan> {
   const { claudeHome, somaHome } = resolvePaths(options);
@@ -170,9 +329,21 @@ export async function planPaiMigration(options: PaiMigrationOptions = {}): Promi
   const algorithm = algorithmDir === null
     ? null
     : planAlgorithmImport({ homeDir: options.homeDir, paiAlgorithmDir: algorithmDir, somaHome });
-  const packs = await Promise.all(
-    packPaths.map((paiPackDir) => planPaiPackImport({ homeDir: options.homeDir, paiPackDir, somaHome })),
-  );
+  const packs = options.skipSkills === true
+    ? []
+    : await Promise.all(
+        packPaths.map((paiPackDir) => planPaiPackImport({ homeDir: options.homeDir, paiPackDir, somaHome })),
+      );
+  const memory = options.skipMemory === true
+    ? null
+    : await planPaiMemoryMigration({ homeDir: options.homeDir, claudeHome, somaHome });
+  const docs = options.paiSourceDir && options.skipDocs !== true
+    ? await planPaiDocsImport({
+        homeDir: options.homeDir,
+        paiSourceDir: options.paiSourceDir,
+        somaHome,
+      })
+    : null;
 
   return {
     apply: false,
@@ -181,48 +352,88 @@ export async function planPaiMigration(options: PaiMigrationOptions = {}): Promi
     identity,
     algorithm,
     packs,
+    memory,
+    docs,
     manifestPath: manifestPathFor(somaHome),
   };
 }
 
-function renderManifest(result: Omit<PaiMigrationResult, "manifestPath" | "filesWritten">): string {
-  // Sage r1: the manifest used to embed a fresh timestamp on every
-  // rerun, breaking the documented idempotency. Now the manifest is a
-  // pure function of the import results — second rerun with identical
-  // imports produces byte-identical bytes.
+interface ManifestInputs {
+  claudeHome: string;
+  somaHome: string;
+  identity: PaiImportResult;
+  algorithm: AlgorithmImportResult | null;
+  packs: PaiPackImportResult[];
+  memory: PaiMemoryMigrationResult | null;
+  docs: PaiDocsImportResult | null;
+  paiSourceDir: string | undefined;
+  lastMigratedAt: string;
+}
+
+function renderManifest(result: ManifestInputs): string {
+  // Sage r1 (#28): the manifest used to embed a fresh timestamp on
+  // every rerun, breaking the documented idempotency. The manifest is
+  // a pure function of the import results — second rerun with
+  // identical imports produces byte-identical bytes.
   const packLines = result.packs.length === 0
     ? "- (none discovered)"
-    : result.packs.map((p, idx) => `- pack ${idx + 1}: ${p.files.length} files`).join("\n");
+    : result.packs.map((p, idx) => `- pack ${idx + 1}: ${p.skillName} (${p.files.length} files)`).join("\n");
+  // The MIGRATION.md body must be byte-stable across reruns (Sage r1
+  // #28 finding); per-run "written N / unchanged M" deltas live in
+  // the result object, not on disk. Total file counts are end-state
+  // facts and stay stable.
+  const memoryLine = result.memory === null
+    ? "- memory:   skipped"
+    : result.memory.memoryDir === null
+      ? "- memory:   no PAI MEMORY tree present"
+      : `- memory:   ${result.memory.writtenCount + result.memory.skippedCount} file(s)`;
+  const docsLine = result.docs === null
+    ? result.paiSourceDir === undefined
+      ? "- docs:     not requested (pass --pai-source-dir to import)"
+      : "- docs:     skipped"
+    : `- docs:     ${result.docs.files.length} file(s) under ${result.docs.releaseVersion ?? "(no version)"}`;
   return [
     "# PAI Migration",
     "",
     `Source: ${result.claudeHome}`,
+    result.paiSourceDir ? `Release: ${result.paiSourceDir}` : null,
+    `Last migrated at: ${result.lastMigratedAt}`,
     "",
     "## Categories",
     `- identity: ${result.identity.files.length} files`,
     `- algorithm: ${result.algorithm ? `${result.algorithm.files.length} files` : "not present"}`,
+    memoryLine,
+    docsLine,
     `- packs:`,
     packLines.split("\n").map((l) => `  ${l}`).join("\n"),
-    "",
-    "## What was skipped",
-    "- Skills / agents / commands / hooks / auto-memory: not yet covered by the",
-    "  minimal orchestrator. Per-category importers will follow in incremental PRs",
-    "  layered on top of #28.",
     "",
     "## How to re-run",
     "- `soma migrate pai` is idempotent at the importer level — each underlying",
     "  importer compares source vs. target and writes only changed files.",
+    "- The memory phase tracks per-file SHA at",
+    "  `~/.soma/imports/pai-migration/.manifest.json`. The docs phase tracks",
+    "  per-file SHA at `~/.soma/PAI/.import-manifest.json`.",
     "- To roll back the Claude Code projection (not the Soma home itself) run",
-    "  `soma adopt claude --uninstall` (soma#68).",
+    "  `soma adopt claude --uninstall`.",
     "",
-  ].join("\n");
+  ]
+    .filter((line) => line !== null)
+    .join("\n");
 }
 
 /**
- * Execute the migration plan. Runs identity → algorithm → packs in
- * order, then writes the MIGRATION.md manifest. Idempotency comes
- * from the underlying importers; this wrapper does not re-implement
- * it.
+ * Execute the migration plan. Runs identity → algorithm → memory →
+ * packs → docs in order, then writes the MIGRATION.md manifest. The
+ * order matters:
+ *   - Identity + algorithm first (they live in `<somaHome>/profile/`
+ *     and `<somaHome>/algorithm/`, no dependency on anything else).
+ *   - Memory before packs so a pack importer that reads from
+ *     `<somaHome>/memory/` (none today, but the layering invariant is
+ *     cheap to keep) sees consistent state.
+ *   - Docs last because it's the heaviest read pass.
+ *
+ * Idempotency comes from the underlying importers + the memory/docs
+ * SHA manifests. This wrapper does not re-implement it.
  *
  * Throws only if an underlying importer throws — there is no
  * partial-success swallow. The caller decides whether to retry.
@@ -240,22 +451,96 @@ export async function migratePai(options: PaiMigrationOptions = {}): Promise<Pai
     : await importAlgorithm({ homeDir: options.homeDir, paiAlgorithmDir: algorithmDir, somaHome });
   if (algorithm) filesWritten.push(...algorithm.files);
 
-  // Sage r1: parallelize independent pack imports. Sage r4: bound the
-  // fan-out so large installs don't burst FD limits or thrash the FS.
-  // Per-pack work is mostly I/O; 4 workers is enough to hide latency
-  // without unbounded parallelism.
+  const memory = options.skipMemory === true
+    ? null
+    : await migratePaiMemory({ homeDir: options.homeDir, claudeHome, somaHome });
+  if (memory) filesWritten.push(...memory.files, memory.manifestPath);
+
+  // Reserved-skill collision happens BEFORE any pack import runs so
+  // a single offending pack stops the whole bulk phase rather than
+  // half-importing.
+  const allowedPackPaths = options.skipSkills === true
+    ? []
+    : await refuseReservedPacks(packPaths, options.overwriteReserved === true);
+
+  // Sage r1+r4 (#28): parallelize independent pack imports with a
+  // bounded fan-out. Per-pack work is mostly I/O; 4 workers is enough
+  // to hide latency without bursting FD limits.
+  //
+  // `overwrite: true` is unconditional here (and only here — the
+  // standalone `soma import pai-pack` CLI keeps the strict default).
+  // Migration is a "move my whole PAI install into Soma" operation,
+  // so re-running it must not blow up because a previous run already
+  // imported the pack. The pack importer's per-pack rollback contract
+  // (rename-into-backup, restore-on-failure) keeps the operation safe
+  // even with overwrite enabled. Reserved-skill collisions are caught
+  // by `refuseReservedPacks` above before any pack import runs.
   const packs = await runBoundedConcurrent(
-    packPaths,
-    (paiPackDir) => importPaiPack({ homeDir: options.homeDir, paiPackDir, somaHome }),
+    allowedPackPaths,
+    (paiPackDir) =>
+      importPaiPack({
+        homeDir: options.homeDir,
+        paiPackDir,
+        somaHome,
+        overwrite: true,
+      }),
     4,
   );
   for (const r of packs) filesWritten.push(...r.files);
 
+  const docs = options.paiSourceDir && options.skipDocs !== true
+    ? await importPaiDocs({
+        homeDir: options.homeDir,
+        paiSourceDir: options.paiSourceDir,
+        somaHome,
+      })
+    : null;
+  if (docs) filesWritten.push(...docs.files);
+
+  // Per-phase no-op detection so the manifest timestamp only bumps
+  // when something actually changed on disk. AC-6 + Sage r1 (#28):
+  // status output must include a timestamp, but the manifest itself
+  // must be byte-stable across pure-idempotent reruns. We treat the
+  // run as no-op when memory wrote zero files AND docs wrote zero
+  // files. Identity + algorithm + packs reuse the underlying
+  // importer's overwrite-with-same-bytes pattern, so we read back
+  // identity output bytes to gate the timestamp bump as well.
+  //
+  // Practically: if memory.unchanged AND docs.unchanged (or skipped)
+  // AND a prior manifest exists, we preserve the prior timestamp.
+  const memoryUnchanged = memory === null || memory.unchanged;
+  const docsUnchanged = docs === null || docs.unchanged;
+  const everythingUnchanged = memoryUnchanged && docsUnchanged;
   const manifestPath = manifestPathFor(somaHome);
   await mkdir(dirname(manifestPath), { recursive: true });
-  const manifest = renderManifest({ claudeHome, somaHome, identity, algorithm, packs });
+  let lastMigratedAt = new Date().toISOString();
+  if (everythingUnchanged) {
+    const prior = await readPriorMigrationTimestamp(manifestPath);
+    if (prior) lastMigratedAt = prior;
+  }
+  const manifest = renderManifest({
+    claudeHome,
+    somaHome,
+    identity,
+    algorithm,
+    packs,
+    memory,
+    docs,
+    paiSourceDir: options.paiSourceDir,
+    lastMigratedAt,
+  });
   await writeFile(manifestPath, manifest, "utf8");
   filesWritten.push(manifestPath);
 
-  return { claudeHome, somaHome, identity, algorithm, packs, manifestPath, filesWritten };
+  return {
+    claudeHome,
+    somaHome,
+    identity,
+    algorithm,
+    packs,
+    memory,
+    docs,
+    manifestPath,
+    filesWritten,
+  };
 }

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -300,8 +300,14 @@ export async function planPaiMigration(options: PaiMigrationOptions = {}): Promi
     : planAlgorithmImport({ homeDir: options.homeDir, paiAlgorithmDir: algorithmDir, somaHome });
   const packs = options.skipSkills === true
     ? []
-    : await Promise.all(
-        packPaths.map((paiPackDir) => planPaiPackImport({ homeDir: options.homeDir, paiPackDir, somaHome })),
+    // Sage r5 #95 Performance: bound the per-pack plan reads to 4
+    // workers (matches the apply path's import fan-out). The previous
+    // Promise.all opened one async pack-plan per discovered pack
+    // regardless of count.
+    : await runBoundedConcurrent(
+        packPaths,
+        (paiPackDir) => planPaiPackImport({ homeDir: options.homeDir, paiPackDir, somaHome }),
+        4,
       );
   const memory = options.skipMemory === true
     ? null
@@ -606,7 +612,21 @@ export async function migratePai(options: PaiMigrationOptions = {}): Promise<Pai
         somaHome,
       })
     : null;
-  if (docs) filesWritten.push(...docs.files);
+  // Sage r5 #95 important (mirrors r2 memory bug): the docs importer's
+  // `files: string[]` is "every in-scope target" (written + skipped),
+  // so pushing it wholesale over-reports writes after idempotent
+  // reruns. The importer exposes `writtenCount` but not a per-file
+  // written-targets list. Until that surface lands, omit the docs
+  // targets from `filesWritten` — the docs phase's own manifest at
+  // <somaHome>/PAI/.import-manifest.json is the authoritative
+  // per-file record, and `result.docs.writtenCount` is the per-run
+  // accounting. The behavior matches how memory is recorded.
+  if (docs && docs.writtenCount > 0) {
+    // We don't know which specific files were written, but the
+    // manifest path is always touched on apply. Recording it gives
+    // the principal a single anchor for "docs did write this run".
+    filesWritten.push(join(somaHome, "PAI/.import-manifest.json"));
+  }
 
   // Sage r3 #95 Maintainability: the timestamp gate + fingerprint
   // composition lives in `renderStableMigrationManifest` so this

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -479,8 +479,14 @@ async function renderStableMigrationManifest(
   const algorithmFingerprint = inputs.algorithm
     ? await fingerprintFiles(inputs.algorithm.files)
     : null;
-  const packFingerprints = await Promise.all(
-    inputs.packs.map((p) => fingerprintPackEntry(p)),
+  // Sage r4 #95 Performance: bound the per-pack fingerprint reads to
+  // 4 workers (matches the import + preflight fan-out). Promise.all
+  // over `packs.map` opens one async file read per pack regardless of
+  // count, which could burst FD limits on large installs.
+  const packFingerprints = await runBoundedConcurrent(
+    inputs.packs,
+    fingerprintPackEntry,
+    4,
   );
   const sentinelTs = "__PAI_MIGRATION_TS_SENTINEL__";
   const newBodyWithSentinel = renderManifest({

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -28,10 +28,16 @@ import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { importAlgorithm, planAlgorithmImport } from "./algorithm-importer";
+import { runBoundedConcurrent } from "./internal-concurrency";
 import { importPaiDocs, planPaiDocsImport } from "./pai-docs-importer";
 import { importPaiIdentity, planPaiImport } from "./pai-importer";
 import { migratePaiMemory, planPaiMemoryMigration } from "./pai-memory-migrator";
-import { importPaiPack, planPaiPackImport, slugifySkillName } from "./pai-pack-importer";
+import {
+  importPaiPack,
+  planPaiPackImport,
+  readPackMetadata,
+  slugifySkillName,
+} from "./pai-pack-importer";
 import type {
   AlgorithmImportPlan,
   AlgorithmImportResult,
@@ -220,29 +226,13 @@ function extractMigrationTimestamp(manifest: string): string | null {
   return match ? match[1] : null;
 }
 
-// Read the pack metadata's `name` field the same way
-// `readPackMetadata` does — frontmatter or top heading. We only need
-// enough to derive the slug; the pack importer does the heavy lifting
-// during the actual import. The slug function is the importer's own
-// (`slugifySkillName`), imported above, so the orchestrator's
-// reserved-name check can never drift from the importer's behavior.
+// Derive a pack's canonical slug using the importer's own metadata
+// reader + slugifier. Single-source — Sage r2 #95 Maintainability
+// finding (no second parser that can drift when pack frontmatter
+// rules change).
 async function readPackSkillSlug(packDir: string): Promise<string> {
-  const readme = await readFile(join(packDir, "README.md"), "utf8");
-  const match = readme.match(/^---\n([\s\S]*?)\n---/);
-  if (match) {
-    const nameLine = match[1].split("\n").find((line) => /^name\s*:/.test(line));
-    if (nameLine) {
-      const raw = nameLine.split(":").slice(1).join(":").trim().replace(/^["']|["']$/g, "");
-      const slug = slugifySkillName(raw);
-      if (slug) return slug;
-    }
-  }
-  const heading = /^#\s+(.+)$/m.exec(readme)?.[1]?.trim();
-  if (heading) {
-    const slug = slugifySkillName(heading);
-    if (slug) return slug;
-  }
-  return slugifySkillName("pai-pack");
+  const meta = await readPackMetadata(packDir);
+  return slugifySkillName(meta.name);
 }
 
 async function refuseReservedPacks(
@@ -265,30 +255,6 @@ async function refuseReservedPacks(
     }
   }
   return [...packPaths];
-}
-
-/**
- * Run async work with a bounded concurrency window (sage r4 #28:
- * prevent unlimited pack-import fan-out on large installs).
- */
-async function runBoundedConcurrent<T, R>(
-  items: readonly T[],
-  fn: (item: T) => Promise<R>,
-  limit: number,
-): Promise<R[]> {
-  if (items.length === 0) return [];
-  const results: R[] = new Array<R>(items.length);
-  let cursor = 0;
-  async function worker(): Promise<void> {
-    for (;;) {
-      const index = cursor++;
-      if (index >= items.length) return;
-      results[index] = await fn(items[index]);
-    }
-  }
-  const workerCount = Math.min(limit, items.length);
-  await Promise.all(Array.from({ length: workerCount }, () => worker()));
-  return results;
 }
 
 interface MigrationSources {
@@ -396,6 +362,18 @@ async function fingerprintFiles(paths: readonly string[]): Promise<string> {
   return hash.digest("hex").slice(0, 16);
 }
 
+// Fingerprint a single pack by hashing its entry SKILL.md only — the
+// file the pack importer rewrites with skill identity + normalized
+// frontmatter. Sage r2 #95 Performance: full-pack fingerprinting
+// doubled the I/O on the apply path; restricting to the entry file
+// keeps the timestamp-bump contract intact while avoiding a duplicate
+// read pass over every workflow / tool / source-doc copy.
+async function fingerprintPackEntry(pack: PaiPackImportResult): Promise<string> {
+  const skillRoot = join(pack.somaHome, "skills", pack.skillName);
+  const entryPath = join(skillRoot, "SKILL.md");
+  return fingerprintFiles([entryPath]);
+}
+
 function renderManifest(result: ManifestInputs): string {
   // Sage r1 (#28): the manifest used to embed a fresh timestamp on
   // every rerun, breaking the documented idempotency. The manifest is
@@ -487,7 +465,21 @@ export async function migratePai(options: PaiMigrationOptions = {}): Promise<Pai
   const memory = options.skipMemory === true
     ? null
     : await migratePaiMemory({ homeDir: options.homeDir, claudeHome, somaHome });
-  if (memory) filesWritten.push(...memory.files, memory.manifestPath);
+  // Sage r2 #95 important: `memory.files` lists every in-scope target
+  // (both written and idempotency-skipped). `filesWritten` is the
+  // per-run "things touched on disk this invocation" log; pushing
+  // every memory target over-reported writes after idempotent reruns.
+  // We push only the per-phase write count's worth — see
+  // `memory.result.writtenTargets` for the canonical list. The
+  // result object's writtenCount/skippedCount remains authoritative;
+  // `filesWritten`'s length should match actual writes so a fully
+  // idempotent rerun reports `Total files written: 1` (manifest only).
+  if (memory) {
+    if (memory.writtenTargets.length > 0) {
+      filesWritten.push(...memory.writtenTargets);
+    }
+    filesWritten.push(memory.manifestPath);
+  }
 
   // Reserved-skill collision happens BEFORE any pack import runs so
   // a single offending pack stops the whole bulk phase rather than
@@ -553,12 +545,17 @@ export async function migratePai(options: PaiMigrationOptions = {}): Promise<Pai
   // This covers all five phases by construction: any phase that
   // changed counts, names, file lists, OR file content will produce
   // a different body and force a timestamp bump.
+  // Sage r2 #95 Performance: pack fingerprints used to hash every
+  // imported pack file (workflows, tools, source-doc copies) which
+  // doubled the I/O on the apply path. The entry `SKILL.md` is the
+  // only file the pack importer rewrites (frontmatter normalization
+  // + skill identity), and it's where content drift between pack
+  // versions actually shows up; fingerprinting just that file is
+  // sufficient for the timestamp-bump contract and avoids the
+  // duplicate-read scaling pitfall.
   const identityFingerprint = await fingerprintFiles(identity.files);
   const algorithmFingerprint = algorithm ? await fingerprintFiles(algorithm.files) : null;
-  // Each pack's fingerprint includes every imported file under the
-  // skill root, so pack content drift surfaces regardless of file
-  // count.
-  const packFingerprints = await Promise.all(packs.map((p) => fingerprintFiles(p.files)));
+  const packFingerprints = await Promise.all(packs.map((p) => fingerprintPackEntry(p)));
   const manifestPath = manifestPathFor(somaHome);
   await mkdir(dirname(manifestPath), { recursive: true });
   const sentinelTs = "__PAI_MIGRATION_TS_SENTINEL__";

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -77,7 +77,16 @@ function resolvePackHomes(options: PaiPackImportOptions = {}): { paiPackDir: str
   };
 }
 
-function slugifySkillName(value: string): string {
+/**
+ * Slugify a pack name into the canonical Soma skill folder name.
+ *
+ * Exported so the migrate orchestrator (and any future reserved-name
+ * preflight) can derive the same slug without duplicating the
+ * function — Sage #95 Maintainability finding (avoid drift between
+ * the importer's reserved check and the orchestrator's reserved
+ * check).
+ */
+export function slugifySkillName(value: string): string {
   return value
     .trim()
     .replace(/([a-z0-9])([A-Z])/g, "$1-$2")

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -121,7 +121,15 @@ function parseFrontmatter(content: string): Partial<Record<string, string>> {
   return fields;
 }
 
-async function readPackMetadata(paiPackDir: string): Promise<PackMetadata> {
+/**
+ * Read a pack's `README.md` frontmatter + top heading to derive its
+ * canonical name + description. Exported so the migrate orchestrator
+ * (and any future reserved-name preflight) can read pack identity
+ * with the same parser as the importer itself — Sage r2 #95
+ * Maintainability finding (avoid second metadata parser that can
+ * drift when pack frontmatter rules change).
+ */
+export async function readPackMetadata(paiPackDir: string): Promise<PackMetadata> {
   const readme = await readFile(join(paiPackDir, "README.md"), "utf8");
   const fields = parseFrontmatter(readme);
   const heading = /^#\s+(.+)$/m.exec(readme)?.[1]?.trim();

--- a/src/types.ts
+++ b/src/types.ts
@@ -638,6 +638,11 @@ export interface PaiMemoryMigrationResult {
   // Absolute target paths for every in-scope file (whether written or
   // skipped). Always matches `plan.files.length` on the apply path.
   files: string[];
+  // Subset of `files` that were actually copied this run. Sage r2 #95
+  // important: callers that want a per-run "files I touched" list
+  // (e.g., the orchestrator's `filesWritten` log) must use this
+  // instead of `files`, which over-reports on idempotent reruns.
+  writtenTargets: string[];
 }
 
 export interface PaiMemoryMigrationManifestFile {

--- a/src/types.ts
+++ b/src/types.ts
@@ -586,6 +586,79 @@ export interface PaiDocsImportResult {
   files: string[];
 }
 
+// soma migrate pai memory phase (#90) — translates
+// <claudeHome>/PAI/MEMORY/* → <somaHome>/memory/* per DD-2's 1:1
+// canonical mapping. Content-preserving; preserves mtimes; per-file
+// SHA recorded in <somaHome>/imports/pai-migration/.manifest.json.
+export interface PaiMemoryMigrationOptions {
+  homeDir?: string;
+  claudeHome?: string;
+  somaHome?: string;
+}
+
+export interface PaiMemoryMigrationFile {
+  // Absolute path of the file inside the PAI MEMORY tree.
+  source: string;
+  // Absolute path the file will land at under <somaHome>/memory/.
+  target: string;
+  // POSIX-style path relative to <claudeHome>/PAI/MEMORY/ — i.e.
+  // "<CATEGORY>/<rest>". Manifest key.
+  relativePath: string;
+  // Source mtime preserved on the target file. Recorded in the
+  // manifest so idempotency checks need only one stat per file.
+  mtimeMs: number;
+  // SHA-256 of the source bytes, hex-encoded. Always populated on the
+  // apply path; optional in dry-run plans so plan-only callers do not
+  // pay the read cost for every file.
+  sha256?: string;
+}
+
+export interface PaiMemoryMigrationPlan {
+  apply: boolean;
+  claudeHome: string;
+  somaHome: string;
+  // Absolute path of the source directory under inspection
+  // (<claudeHome>/PAI/MEMORY/). Null when the PAI install has no
+  // MEMORY tree to migrate (nothing to do).
+  memoryDir: string | null;
+  files: PaiMemoryMigrationFile[];
+}
+
+export interface PaiMemoryMigrationResult {
+  claudeHome: string;
+  somaHome: string;
+  memoryDir: string | null;
+  importedAt: string;
+  // Files actually copied this run (skipped-by-SHA files do not count).
+  writtenCount: number;
+  // Files inspected and confirmed already in sync (target SHA matched).
+  skippedCount: number;
+  unchanged: boolean;
+  manifestPath: string;
+  // Absolute target paths for every in-scope file (whether written or
+  // skipped). Always matches `plan.files.length` on the apply path.
+  files: string[];
+}
+
+export interface PaiMemoryMigrationManifestFile {
+  // Manifest key. POSIX-style path relative to <claudeHome>/PAI/MEMORY/.
+  relativePath: string;
+  // POSIX-style path relative to <somaHome>/memory/ (the target home).
+  target: string;
+  sha256: string;
+  mtimeMs: number;
+}
+
+export interface PaiMemoryMigrationManifest {
+  schema: "soma.pai-memory-migration.v1";
+  claudeHome: string;
+  somaHome: string;
+  // ISO-8601 timestamp of the last successful migration. Stable across
+  // reruns when nothing changed.
+  importedAt: string;
+  files: PaiMemoryMigrationManifestFile[];
+}
+
 export interface SomaMemoryEventInput {
   id?: string;
   timestamp?: string;

--- a/test/cli-migrate.test.ts
+++ b/test/cli-migrate.test.ts
@@ -111,3 +111,283 @@ test("soma migrate pai --apply is idempotent (rerun produces no manifest content
     expect(after).toBe(before);
   });
 });
+
+// ---- #90 CLI surface ----
+
+async function writeMemoryFixture(homeDir: string): Promise<void> {
+  const root = join(homeDir, ".claude/PAI/MEMORY");
+  await mkdir(join(root, "LEARNING"), { recursive: true });
+  await writeFile(join(root, "LEARNING/lesson.md"), "# Lesson\n", "utf8");
+}
+
+async function writePackFixture(packsDir: string, packName: string): Promise<void> {
+  const packDir = join(packsDir, packName);
+  await mkdir(join(packDir, "src"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    `---\nname: ${packName}\ndescription: tiny pack\n---\n\n# ${packName}\n\nFixture.\n`,
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    `---\nname: ${packName}\ndescription: tiny pack\n---\n\n# ${packName}\n\nFixture skill body.\n`,
+    "utf8",
+  );
+}
+
+async function writePaiSourceFixture(homeDir: string): Promise<string> {
+  const sourceDir = join(homeDir, "PAI/Releases/v5.0.0/.claude/PAI");
+  await mkdir(join(sourceDir, "DOCUMENTATION/Skills"), { recursive: true });
+  await writeFile(
+    join(sourceDir, "DOCUMENTATION/Skills/SkillSystem.md"),
+    "# Skill System\n",
+    "utf8",
+  );
+  return sourceDir;
+}
+
+test("soma migrate pai --pai-install <alias for --claude-home>", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    const output = await runSomaCli([
+      "migrate",
+      "pai",
+      "--home-dir",
+      homeDir,
+      "--pai-install",
+      join(homeDir, ".claude"),
+    ]);
+    expect(output).toContain("dry-run");
+    expect(output).toContain(join(homeDir, ".claude"));
+  });
+});
+
+test("soma migrate pai plan reports memory phase counts", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    await writeMemoryFixture(homeDir);
+    const output = await runSomaCli(["migrate", "pai", "--home-dir", homeDir]);
+    expect(output).toContain("memory:");
+    expect(output).toMatch(/memory:\s+1 file/);
+  });
+});
+
+test("soma migrate pai --skip-memory honored at the CLI level", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    await writeMemoryFixture(homeDir);
+    const output = await runSomaCli([
+      "migrate",
+      "pai",
+      "--apply",
+      "--skip-memory",
+      "--home-dir",
+      homeDir,
+    ]);
+    expect(output).toContain("memory:   skipped");
+    await expect(stat(join(homeDir, ".soma/memory/LEARNING/lesson.md"))).rejects.toThrow();
+  });
+});
+
+test("soma migrate pai --pai-packs-dir bulk-imports packs", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await writePackFixture(packsDir, "Gamma");
+    await writePackFixture(packsDir, "Delta");
+    const output = await runSomaCli([
+      "migrate",
+      "pai",
+      "--apply",
+      "--pai-packs-dir",
+      packsDir,
+      "--home-dir",
+      homeDir,
+    ]);
+    expect(output).toContain("packs:    2 pack(s)");
+    await stat(join(homeDir, ".soma/skills/gamma/SKILL.md"));
+    await stat(join(homeDir, ".soma/skills/delta/SKILL.md"));
+  });
+});
+
+test("soma migrate pai --skip-skills suppresses bulk skill import", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await writePackFixture(packsDir, "Gamma");
+    const output = await runSomaCli([
+      "migrate",
+      "pai",
+      "--apply",
+      "--pai-packs-dir",
+      packsDir,
+      "--skip-skills",
+      "--home-dir",
+      homeDir,
+    ]);
+    expect(output).toContain("packs:    0 pack(s)");
+    await expect(stat(join(homeDir, ".soma/skills/gamma"))).rejects.toThrow();
+  });
+});
+
+test("soma migrate pai --pai-source-dir triggers docs phase", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    const output = await runSomaCli([
+      "migrate",
+      "pai",
+      "--apply",
+      "--pai-source-dir",
+      sourceDir,
+      "--home-dir",
+      homeDir,
+    ]);
+    expect(output).toContain("docs:");
+    await stat(join(homeDir, ".soma/PAI/DOCUMENTATION/Skills/SkillSystem.md"));
+  });
+});
+
+test("soma migrate pai --skip-docs honored even when --pai-source-dir is set", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    const output = await runSomaCli([
+      "migrate",
+      "pai",
+      "--apply",
+      "--pai-source-dir",
+      sourceDir,
+      "--skip-docs",
+      "--home-dir",
+      homeDir,
+    ]);
+    expect(output).toContain("docs:     skipped");
+    await expect(
+      stat(join(homeDir, ".soma/PAI/DOCUMENTATION/Skills/SkillSystem.md")),
+    ).rejects.toThrow();
+  });
+});
+
+test("soma migrate pai --overwrite-reserved permits reserved-skill packs", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    // Pack whose name slugifies to a reserved canonical skill name.
+    await writePackFixture(packsDir, "telos");
+    await expect(
+      runSomaCli([
+        "migrate",
+        "pai",
+        "--apply",
+        "--pai-packs-dir",
+        packsDir,
+        "--home-dir",
+        homeDir,
+      ]),
+    ).rejects.toThrow(/reserved Soma skill 'telos'/);
+    // With the override flag the same call succeeds.
+    const output = await runSomaCli([
+      "migrate",
+      "pai",
+      "--apply",
+      "--pai-packs-dir",
+      packsDir,
+      "--overwrite-reserved",
+      "--home-dir",
+      homeDir,
+    ]);
+    expect(output).toContain("packs:    1 pack(s)");
+  });
+});
+
+test("soma migrate pai --status after full apply reports memory + docs lines", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    await writeMemoryFixture(homeDir);
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    await runSomaCli([
+      "migrate",
+      "pai",
+      "--apply",
+      "--pai-source-dir",
+      sourceDir,
+      "--home-dir",
+      homeDir,
+    ]);
+    const status = await runSomaCli([
+      "migrate",
+      "pai",
+      "--status",
+      "--home-dir",
+      homeDir,
+    ]);
+    expect(status).toContain("# PAI Migration");
+    expect(status).toContain("memory:");
+    expect(status).toContain("docs:");
+    expect(status).toContain("identity:");
+  });
+});
+
+test("soma migrate pai full-apply idempotent: rerun = same MIGRATION.md bytes", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    await writeMemoryFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await writePackFixture(packsDir, "Gamma");
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    await runSomaCli([
+      "migrate",
+      "pai",
+      "--apply",
+      "--pai-packs-dir",
+      packsDir,
+      "--pai-source-dir",
+      sourceDir,
+      "--home-dir",
+      homeDir,
+    ]);
+    const before = await readFile(
+      join(homeDir, ".soma/profile/imports/claude/MIGRATION.md"),
+      "utf8",
+    );
+    await runSomaCli([
+      "migrate",
+      "pai",
+      "--apply",
+      "--pai-packs-dir",
+      packsDir,
+      "--pai-source-dir",
+      sourceDir,
+      "--home-dir",
+      homeDir,
+    ]);
+    const after = await readFile(
+      join(homeDir, ".soma/profile/imports/claude/MIGRATION.md"),
+      "utf8",
+    );
+    expect(after).toBe(before);
+  });
+});
+
+test("soma migrate pai --pai-source-dir bogus dir refused loud at CLI", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    const bogus = join(homeDir, "not-pai");
+    await mkdir(bogus, { recursive: true });
+    await writeFile(join(bogus, "anything.md"), "x\n", "utf8");
+    await expect(
+      runSomaCli([
+        "migrate",
+        "pai",
+        "--apply",
+        "--pai-source-dir",
+        bogus,
+        "--home-dir",
+        homeDir,
+      ]),
+    ).rejects.toThrow(/does not look like a PAI release tree/);
+  });
+});

--- a/test/cli-migrate.test.ts
+++ b/test/cli-migrate.test.ts
@@ -114,39 +114,14 @@ test("soma migrate pai --apply is idempotent (rerun produces no manifest content
 
 // ---- #90 CLI surface ----
 
-async function writeMemoryFixture(homeDir: string): Promise<void> {
-  const root = join(homeDir, ".claude/PAI/MEMORY");
-  await mkdir(join(root, "LEARNING"), { recursive: true });
-  await writeFile(join(root, "LEARNING/lesson.md"), "# Lesson\n", "utf8");
-}
-
-async function writePackFixture(packsDir: string, packName: string): Promise<void> {
-  const packDir = join(packsDir, packName);
-  await mkdir(join(packDir, "src"), { recursive: true });
-  await writeFile(
-    join(packDir, "README.md"),
-    `---\nname: ${packName}\ndescription: tiny pack\n---\n\n# ${packName}\n\nFixture.\n`,
-    "utf8",
-  );
-  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
-  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
-  await writeFile(
-    join(packDir, "src/SKILL.md"),
-    `---\nname: ${packName}\ndescription: tiny pack\n---\n\n# ${packName}\n\nFixture skill body.\n`,
-    "utf8",
-  );
-}
-
-async function writePaiSourceFixture(homeDir: string): Promise<string> {
-  const sourceDir = join(homeDir, "PAI/Releases/v5.0.0/.claude/PAI");
-  await mkdir(join(sourceDir, "DOCUMENTATION/Skills"), { recursive: true });
-  await writeFile(
-    join(sourceDir, "DOCUMENTATION/Skills/SkillSystem.md"),
-    "# Skill System\n",
-    "utf8",
-  );
-  return sourceDir;
-}
+// Shared fixture builders (Sage r1 #95 Maintainability nit:
+// deduplicate the pack/source/memory builders across migration test
+// files).
+import {
+  writePaiMemoryFixture as writeMemoryFixture,
+  writePaiPackFixture as writePackFixture,
+  writePaiReleaseFixture as writePaiSourceFixture,
+} from "./fixtures/pai-migration-fixtures";
 
 test("soma migrate pai --pai-install <alias for --claude-home>", async () => {
   await withTempHome(async (homeDir) => {
@@ -170,7 +145,8 @@ test("soma migrate pai plan reports memory phase counts", async () => {
     await writeMemoryFixture(homeDir);
     const output = await runSomaCli(["migrate", "pai", "--home-dir", homeDir]);
     expect(output).toContain("memory:");
-    expect(output).toMatch(/memory:\s+1 file/);
+    // Shared fixture plants 2 files (LEARNING/lesson.md + WORK/.../notes.md).
+    expect(output).toMatch(/memory:\s+2 file/);
   });
 });
 

--- a/test/cli-migrate.test.ts
+++ b/test/cli-migrate.test.ts
@@ -4,43 +4,17 @@
  * Validates dry-run, --apply, --status, and unknown-flag behavior
  * against a synthetic PAI fixture.
  */
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { runSomaCli } from "../src/cli";
+import {
+  withTempHome as withSharedTempHome,
+  writePaiIdentityFixture as writePaiFixture,
+} from "./fixtures/pai-migration-fixtures";
 
-async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
-  const homeDir = await mkdtemp(join(tmpdir(), "soma-cli-67-"));
-  try {
-    return await fn(homeDir);
-  } finally {
-    await rm(homeDir, { recursive: true, force: true });
-  }
-}
-
-async function writePaiFixture(homeDir: string, opts: { withAlgorithm?: boolean } = {}): Promise<void> {
-  const userRoot = join(homeDir, ".claude/PAI/USER");
-  await mkdir(join(userRoot, "TELOS"), { recursive: true });
-  await writeFile(
-    join(userRoot, "PRINCIPAL_IDENTITY.md"),
-    "# Principal\n\n- **Name:** Test User\n- **Pronunciation:** Test\n- **Location:** Nowhere\n- **Timezone:** UTC\n- **Role:** Tester\n- **Focus:** Testing\n",
-    "utf8",
-  );
-  await writeFile(
-    join(userRoot, "DA_IDENTITY.md"),
-    "# DA Identity\n\n- **Full Name:** Bot\n- **Name:** Bot\n- **Display Name:** Bot\n- **Color:** #000\n- **Voice ID:** v\n- **Role:** assistant\n- **Operating Environment:** test\n",
-    "utf8",
-  );
-  for (const file of ["MISSION.md", "GOALS.md", "STRATEGIES.md", "BELIEFS.md"]) {
-    await writeFile(join(userRoot, "TELOS", file), `# ${file}\n\nFixture\n`, "utf8");
-  }
-  if (opts.withAlgorithm) {
-    const algoDir = join(homeDir, ".claude/PAI/Algorithm");
-    await mkdir(algoDir, { recursive: true });
-    await writeFile(join(algoDir, "v6.3.0.md"), "# Algorithm v6.3.0\n", "utf8");
-  }
-}
+const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
+  withSharedTempHome(fn, "soma-cli-67-");
 
 test("soma migrate pai (no flags) → dry-run plan", async () => {
   await withTempHome(async (homeDir) => {

--- a/test/fixtures/pai-migration-fixtures.ts
+++ b/test/fixtures/pai-migration-fixtures.ts
@@ -11,8 +11,27 @@
  *
  * Test-only helpers; not part of the public package surface.
  */
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+
+/**
+ * Run a callback inside a freshly-minted temp home dir; clean up
+ * unconditionally even on test failure. Sage r3 #95 Maintainability:
+ * single-source the temp-home lifecycle so prefix / cleanup / failure
+ * diagnostic changes propagate to every migration test at once.
+ */
+export async function withTempHome<T>(
+  fn: (homeDir: string) => Promise<T>,
+  prefix = "soma-migrate-",
+): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), prefix));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
 
 /**
  * Write a minimal PAI identity tree under `<homeDir>/.claude/PAI/USER`

--- a/test/fixtures/pai-migration-fixtures.ts
+++ b/test/fixtures/pai-migration-fixtures.ts
@@ -1,0 +1,107 @@
+/**
+ * Shared fixture builders for PAI → Soma migration tests (#90).
+ *
+ * Three test files exercise overlapping fixture shapes:
+ *   - `test/pai-migration.test.ts` (#28 minimal scope)
+ *   - `test/pai-migration-issue-90.test.ts` (#90 orchestration)
+ *   - `test/cli-migrate.test.ts` (#67 CLI surface)
+ *
+ * Centralizing the builders here keeps the pack/source/memory contract
+ * single-sourced — Sage round 1 #95 Maintainability nit.
+ *
+ * Test-only helpers; not part of the public package surface.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Write a minimal PAI identity tree under `<homeDir>/.claude/PAI/USER`
+ * sufficient for `importPaiIdentity` to accept it. Optionally also
+ * plants an `Algorithm/v6.3.0.md` so the algorithm phase exercises.
+ */
+export async function writePaiIdentityFixture(
+  homeDir: string,
+  opts: { withAlgorithm?: boolean } = {},
+): Promise<void> {
+  const userRoot = join(homeDir, ".claude/PAI/USER");
+  await mkdir(join(userRoot, "TELOS"), { recursive: true });
+  await writeFile(
+    join(userRoot, "PRINCIPAL_IDENTITY.md"),
+    "# Principal\n\n- **Name:** Test User\n- **Pronunciation:** Test\n- **Location:** Nowhere\n- **Timezone:** UTC\n- **Role:** Tester\n- **Focus:** Testing\n",
+    "utf8",
+  );
+  await writeFile(
+    join(userRoot, "DA_IDENTITY.md"),
+    "# DA Identity\n\n- **Full Name:** Bot\n- **Name:** Bot\n- **Display Name:** Bot\n- **Color:** #000\n- **Voice ID:** v\n- **Role:** assistant\n- **Operating Environment:** test\n",
+    "utf8",
+  );
+  for (const file of ["MISSION.md", "GOALS.md", "STRATEGIES.md", "BELIEFS.md"]) {
+    await writeFile(join(userRoot, "TELOS", file), `# ${file}\n\nFixture\n`, "utf8");
+  }
+  if (opts.withAlgorithm) {
+    const algoDir = join(homeDir, ".claude/PAI/Algorithm");
+    await mkdir(algoDir, { recursive: true });
+    await writeFile(join(algoDir, "v6.3.0.md"), "# Algorithm v6.3.0\n", "utf8");
+  }
+}
+
+/**
+ * Write a minimal PAI MEMORY tree under `<homeDir>/.claude/PAI/MEMORY`
+ * for memory-translation tests. Default content covers the canonical
+ * 3-cat layout the user's local install ships with.
+ */
+export async function writePaiMemoryFixture(homeDir: string): Promise<void> {
+  const root = join(homeDir, ".claude/PAI/MEMORY");
+  await mkdir(join(root, "LEARNING"), { recursive: true });
+  await writeFile(join(root, "LEARNING/lesson.md"), "# Lesson\n", "utf8");
+  await mkdir(join(root, "WORK/20260117_test"), { recursive: true });
+  await writeFile(join(root, "WORK/20260117_test/notes.md"), "notes\n", "utf8");
+}
+
+/**
+ * Write a tiny PAI pack tree under `<packsDir>/<packName>` valid
+ * enough for `importPaiPack` to accept. The pack's slug is derived
+ * from `skillName` (defaults to `packName`), which means callers can
+ * collide the slug against the orchestrator's reserved-name set by
+ * passing `skillName: "ISA"` etc.
+ */
+export async function writePaiPackFixture(
+  packsDir: string,
+  packName: string,
+  options: { skillName?: string; description?: string } = {},
+): Promise<string> {
+  const packDir = join(packsDir, packName);
+  const skillName = options.skillName ?? packName;
+  const description = options.description ?? `Tiny ${packName} pack.`;
+  await mkdir(join(packDir, "src"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    `---\nname: ${skillName}\ndescription: ${description}\n---\n\n# ${packName}\n\nFixture.\n`,
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    `---\nname: ${skillName}\ndescription: ${description}\n---\n\n# ${packName}\n\nFixture skill body.\n`,
+    "utf8",
+  );
+  return packDir;
+}
+
+/**
+ * Write a minimal PAI release tree under
+ * `<homeDir>/PAI/Releases/v5.0.0/.claude/PAI` sufficient for
+ * `importPaiDocs` to recognize via its `DOCUMENTATION/` guard.
+ * Returns the source dir.
+ */
+export async function writePaiReleaseFixture(homeDir: string): Promise<string> {
+  const sourceDir = join(homeDir, "PAI/Releases/v5.0.0/.claude/PAI");
+  await mkdir(join(sourceDir, "DOCUMENTATION/Skills"), { recursive: true });
+  await writeFile(
+    join(sourceDir, "DOCUMENTATION/Skills/SkillSystem.md"),
+    "# Skill System\n",
+    "utf8",
+  );
+  return sourceDir;
+}

--- a/test/pai-memory-migrator.test.ts
+++ b/test/pai-memory-migrator.test.ts
@@ -103,6 +103,25 @@ test("planPaiMemoryMigration with no MEMORY dir returns memoryDir=null, files=[]
   });
 });
 
+test("migratePaiMemory with no MEMORY dir: first run reports unchanged=false (manifest written), rerun reports unchanged=true — Sage r4 #95", async () => {
+  await withTempHome(async (homeDir) => {
+    // No PAI MEMORY tree present. The first call must create the
+    // empty manifest at <somaHome>/imports/pai-migration/.manifest.json
+    // and report `unchanged: false` so callers can tell a disk
+    // touch happened. The second call must observe the prior
+    // manifest and report `unchanged: true` (no disk touch).
+    const first = await migratePaiMemory({ homeDir });
+    expect(first.memoryDir).toBeNull();
+    expect(first.writtenCount).toBe(0);
+    // Sage r4 important: first manifest write is NOT a no-op even
+    // though writtenCount === 0.
+    expect(first.unchanged).toBe(false);
+    await stat(first.manifestPath);
+    const second = await migratePaiMemory({ homeDir });
+    expect(second.unchanged).toBe(true);
+  });
+});
+
 test("planPaiMemoryMigration enumerates every file under PAI/MEMORY", async () => {
   await withTempHome(async (homeDir) => {
     await writePaiMemoryFixture(homeDir, {

--- a/test/pai-memory-migrator.test.ts
+++ b/test/pai-memory-migrator.test.ts
@@ -311,6 +311,41 @@ test("migratePaiMemory refuses symlinks inside the MEMORY tree", async () => {
   });
 });
 
+test("migratePaiMemory refuses target-leaf symlink that escapes Soma home — Sage r5 #95 security", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiMemoryFixture(homeDir, { withLearning: true });
+    // Bootstrap the soma memory tree, then plant a target-side
+    // symlink at the path the migrator wants to write to. Without
+    // the round-5 hardening, copyFile would follow the link and
+    // overwrite /tmp/sentinel (an attacker-chosen file) with PAI
+    // memory content.
+    const externalSentinel = join(homeDir, "external-sentinel.txt");
+    await writeFile(externalSentinel, "untouched\n", "utf8");
+    const targetDir = join(homeDir, ".soma/memory/LEARNING");
+    await mkdir(targetDir, { recursive: true });
+    await symlink(externalSentinel, join(targetDir, "lesson-001.md"));
+    await expect(migratePaiMemory({ homeDir })).rejects.toThrow(/symlink/i);
+    // External file must NOT have been overwritten.
+    const after = await readFile(externalSentinel, "utf8");
+    expect(after).toBe("untouched\n");
+  });
+});
+
+test("migratePaiMemory refuses target-parent symlink that escapes Soma home — Sage r5 #95 security", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiMemoryFixture(homeDir, { withLearning: true });
+    // Plant a target PARENT symlink. <somaHome>/memory/LEARNING/
+    // points at an external attacker-controlled dir.
+    const externalDir = join(homeDir, "external");
+    await mkdir(externalDir, { recursive: true });
+    await mkdir(join(homeDir, ".soma/memory"), { recursive: true });
+    await symlink(externalDir, join(homeDir, ".soma/memory/LEARNING"));
+    await expect(migratePaiMemory({ homeDir })).rejects.toThrow(/symlink/i);
+    // External dir must NOT contain the migrated file.
+    await expect(stat(join(externalDir, "lesson-001.md"))).rejects.toThrow();
+  });
+});
+
 test("planPaiMemoryMigration handles extra v5.0.0 cats (KNOWLEDGE, RESEARCH) cleanly", async () => {
   await withTempHome(async (homeDir) => {
     await writePaiMemoryFixture(homeDir, {

--- a/test/pai-memory-migrator.test.ts
+++ b/test/pai-memory-migrator.test.ts
@@ -331,6 +331,32 @@ test("migratePaiMemory refuses target-leaf symlink that escapes Soma home — Sa
   });
 });
 
+test("migratePaiMemory refuses target-parent symlink that points INSIDE Soma home — Sage r6 #95 security", async () => {
+  // Round-5 fix only refused parent symlinks that escaped the Soma
+  // home. An attacker who can pre-create
+  // <somaHome>/memory/LEARNING -> <somaHome>/profile would have
+  // bypassed that check and written PAI memory bytes into the
+  // identity tree. The round-6 hardening: refuse ANY symlink in the
+  // ancestor chain regardless of where it resolves.
+  await withTempHome(async (homeDir) => {
+    await writePaiMemoryFixture(homeDir, { withLearning: true });
+    // Bootstrap a real Soma home with a separate `profile` subtree.
+    const somaHome = join(homeDir, ".soma");
+    const profileDir = join(somaHome, "profile");
+    await mkdir(profileDir, { recursive: true });
+    await writeFile(join(profileDir, "principal.md"), "identity\n", "utf8");
+    await mkdir(join(somaHome, "memory"), { recursive: true });
+    // Plant a symlink whose realpath resolves INSIDE soma home.
+    await symlink(profileDir, join(somaHome, "memory/LEARNING"));
+    await expect(migratePaiMemory({ homeDir })).rejects.toThrow(/symlink/i);
+    // The principal.md content must NOT have been overwritten.
+    const after = await readFile(join(profileDir, "principal.md"), "utf8");
+    expect(after).toBe("identity\n");
+    // The lesson must NOT have been written into the profile dir.
+    await expect(stat(join(profileDir, "lesson-001.md"))).rejects.toThrow();
+  });
+});
+
 test("migratePaiMemory refuses target-parent symlink that escapes Soma home — Sage r5 #95 security", async () => {
   await withTempHome(async (homeDir) => {
     await writePaiMemoryFixture(homeDir, { withLearning: true });

--- a/test/pai-memory-migrator.test.ts
+++ b/test/pai-memory-migrator.test.ts
@@ -1,0 +1,314 @@
+/**
+ * #90 — PAI memory translation phase.
+ *
+ * `<claudeHome>/PAI/MEMORY/*` → `<somaHome>/memory/*` is a 1:1
+ * directory remap by DD-2 contract. Content-preserving (no rewrites
+ * in the first pass), mtime-preserving, per-file SHA recorded in
+ * the manifest at `<somaHome>/imports/pai-migration/.manifest.json`,
+ * idempotent on rerun.
+ *
+ * Fixture-based. Sage round 0 preempt: idempotency + reserved-skill
+ * collision get strong tests before opening the PR.
+ */
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { migratePaiMemory, planPaiMemoryMigration } from "../src/pai-memory-migrator";
+import type { PaiMemoryMigrationManifest } from "../src/types";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-90-mem-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+function sha256(content: string | Buffer): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+interface MemoryFixtureOptions {
+  withLearning?: boolean;
+  withReflections?: boolean;
+  withSkills?: boolean;
+  withWork?: boolean;
+  // Extra v5.0.0 cats the user already keeps locally.
+  withKnowledge?: boolean;
+  withResearch?: boolean;
+  // Out-of-scope sentinel files at MEMORY root (must not be migrated).
+  withRootReadme?: boolean;
+}
+
+async function writePaiMemoryFixture(
+  homeDir: string,
+  opts: MemoryFixtureOptions = {},
+): Promise<string> {
+  const root = join(homeDir, ".claude/PAI/MEMORY");
+  await mkdir(root, { recursive: true });
+  if (opts.withRootReadme) {
+    // PAI ships a README.md at MEMORY/ — we DO migrate it as a
+    // top-level file under <somaHome>/memory/, BUT only if a similar
+    // file isn't already there. The README at memory/ root in Soma
+    // is owned by #88 — we must not overwrite it. So this fixture
+    // case exercises the "files at MEMORY root that map nowhere" path.
+    await writeFile(join(root, "README.md"), "# PAI MEMORY root readme\n", "utf8");
+  }
+  if (opts.withLearning) {
+    await mkdir(join(root, "LEARNING"), { recursive: true });
+    await writeFile(join(root, "LEARNING/lesson-001.md"), "# Lesson 001\nBe careful.\n", "utf8");
+  }
+  if (opts.withReflections) {
+    await mkdir(join(root, "LEARNING/REFLECTIONS"), { recursive: true });
+    await writeFile(
+      join(root, "LEARNING/REFLECTIONS/2026-01.md"),
+      "# January reflection\nFelt good.\n",
+      "utf8",
+    );
+  }
+  if (opts.withSkills) {
+    await mkdir(join(root, "SKILLS/CreateSkill"), { recursive: true });
+    await writeFile(
+      join(root, "SKILLS/CreateSkill/state.json"),
+      JSON.stringify({ runs: 3 }),
+      "utf8",
+    );
+  }
+  if (opts.withWork) {
+    await mkdir(join(root, "WORK/20260117-103045_test-task"), { recursive: true });
+    await writeFile(
+      join(root, "WORK/20260117-103045_test-task/ISA.md"),
+      "# Test task ISA\n",
+      "utf8",
+    );
+  }
+  if (opts.withKnowledge) {
+    await mkdir(join(root, "KNOWLEDGE/People"), { recursive: true });
+    await writeFile(
+      join(root, "KNOWLEDGE/People/alice.md"),
+      "# Alice\nfriend.\n",
+      "utf8",
+    );
+  }
+  if (opts.withResearch) {
+    await mkdir(join(root, "RESEARCH"), { recursive: true });
+    await writeFile(join(root, "RESEARCH/topic-1.md"), "# Topic 1\n", "utf8");
+  }
+  return root;
+}
+
+test("planPaiMemoryMigration with no MEMORY dir returns memoryDir=null, files=[]", async () => {
+  await withTempHome(async (homeDir) => {
+    const plan = await planPaiMemoryMigration({ homeDir });
+    expect(plan.apply).toBe(false);
+    expect(plan.memoryDir).toBeNull();
+    expect(plan.files).toEqual([]);
+  });
+});
+
+test("planPaiMemoryMigration enumerates every file under PAI/MEMORY", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiMemoryFixture(homeDir, {
+      withLearning: true,
+      withReflections: true,
+      withSkills: true,
+      withWork: true,
+    });
+    const plan = await planPaiMemoryMigration({ homeDir });
+    expect(plan.memoryDir).toBe(join(homeDir, ".claude/PAI/MEMORY"));
+    const targets = plan.files.map((f) => f.relativePath).sort();
+    expect(targets).toEqual([
+      "LEARNING/REFLECTIONS/2026-01.md",
+      "LEARNING/lesson-001.md",
+      "SKILLS/CreateSkill/state.json",
+      "WORK/20260117-103045_test-task/ISA.md",
+    ]);
+    // Dry-run plan must not populate SHAs (cheap planning).
+    expect(plan.files.every((f) => f.sha256 === undefined)).toBe(true);
+  });
+});
+
+test("planPaiMemoryMigration computes target as <somaHome>/memory/<relative>", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiMemoryFixture(homeDir, { withLearning: true });
+    const plan = await planPaiMemoryMigration({ homeDir });
+    expect(plan.files[0].target).toBe(
+      join(homeDir, ".soma/memory/LEARNING/lesson-001.md"),
+    );
+  });
+});
+
+test("migratePaiMemory copies every in-scope file content-preserving", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiMemoryFixture(homeDir, {
+      withLearning: true,
+      withReflections: true,
+      withSkills: true,
+      withWork: true,
+    });
+    const result = await migratePaiMemory({ homeDir });
+    expect(result.writtenCount).toBe(4);
+    expect(result.skippedCount).toBe(0);
+    expect(result.unchanged).toBe(false);
+    for (const target of result.files) {
+      // Every recorded target must exist on disk.
+      await stat(target);
+    }
+    // Content preserved byte-for-byte.
+    const learning = await readFile(
+      join(homeDir, ".soma/memory/LEARNING/lesson-001.md"),
+      "utf8",
+    );
+    expect(learning).toBe("# Lesson 001\nBe careful.\n");
+    const reflection = await readFile(
+      join(homeDir, ".soma/memory/LEARNING/REFLECTIONS/2026-01.md"),
+      "utf8",
+    );
+    expect(reflection).toBe("# January reflection\nFelt good.\n");
+  });
+});
+
+test("migratePaiMemory preserves source mtimes on target files", async () => {
+  await withTempHome(async (homeDir) => {
+    const root = await writePaiMemoryFixture(homeDir, { withLearning: true });
+    // Pin a known mtime so the test is deterministic.
+    const known = new Date("2024-06-15T12:34:56Z");
+    await utimes(join(root, "LEARNING/lesson-001.md"), known, known);
+    await migratePaiMemory({ homeDir });
+    const stats = await stat(join(homeDir, ".soma/memory/LEARNING/lesson-001.md"));
+    expect(Math.floor(stats.mtimeMs / 1000)).toBe(Math.floor(known.getTime() / 1000));
+  });
+});
+
+test("migratePaiMemory writes per-file SHA manifest at imports/pai-migration/.manifest.json", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiMemoryFixture(homeDir, { withLearning: true, withReflections: true });
+    const result = await migratePaiMemory({ homeDir });
+    expect(result.manifestPath).toBe(
+      join(homeDir, ".soma/imports/pai-migration/.manifest.json"),
+    );
+    const raw = await readFile(result.manifestPath, "utf8");
+    const manifest = JSON.parse(raw) as PaiMemoryMigrationManifest;
+    expect(manifest.schema).toBe("soma.pai-memory-migration.v1");
+    expect(manifest.files.length).toBe(2);
+    // Every manifest entry must carry a non-empty 64-hex SHA.
+    for (const entry of manifest.files) {
+      expect(entry.sha256).toMatch(/^[0-9a-f]{64}$/);
+      expect(entry.relativePath.length).toBeGreaterThan(0);
+      expect(entry.mtimeMs).toBeGreaterThan(0);
+    }
+    // SHAs must match the actual source bytes.
+    const lessonSha = sha256("# Lesson 001\nBe careful.\n");
+    const lessonEntry = manifest.files.find((f) => f.relativePath === "LEARNING/lesson-001.md");
+    expect(lessonEntry).toBeDefined();
+    expect(lessonEntry!.sha256).toBe(lessonSha);
+  });
+});
+
+test("migratePaiMemory is idempotent: second run with same source = no writes", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiMemoryFixture(homeDir, {
+      withLearning: true,
+      withSkills: true,
+      withWork: true,
+    });
+    const first = await migratePaiMemory({ homeDir });
+    expect(first.writtenCount).toBeGreaterThan(0);
+    const second = await migratePaiMemory({ homeDir });
+    expect(second.writtenCount).toBe(0);
+    expect(second.skippedCount).toBe(first.writtenCount);
+    expect(second.unchanged).toBe(true);
+  });
+});
+
+test("migratePaiMemory manifest is stable across reruns when source unchanged", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiMemoryFixture(homeDir, { withLearning: true, withReflections: true });
+    const first = await migratePaiMemory({ homeDir });
+    const beforeManifest = await readFile(first.manifestPath, "utf8");
+    await migratePaiMemory({ homeDir });
+    const afterManifest = await readFile(first.manifestPath, "utf8");
+    expect(afterManifest).toBe(beforeManifest);
+  });
+});
+
+test("migratePaiMemory re-copies when target file has been mutated since import", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiMemoryFixture(homeDir, { withLearning: true });
+    const first = await migratePaiMemory({ homeDir });
+    expect(first.writtenCount).toBe(1);
+    // Mutate the target after import. Source bytes unchanged.
+    const target = join(homeDir, ".soma/memory/LEARNING/lesson-001.md");
+    await writeFile(target, "MUTATED\n", "utf8");
+    // The manifest says target SHA = original SHA; new target bytes
+    // differ. Re-running must restore the source over the corrupted
+    // target — manifest agreement alone is not enough.
+    const second = await migratePaiMemory({ homeDir });
+    expect(second.writtenCount).toBe(1);
+    const restored = await readFile(target, "utf8");
+    expect(restored).toBe("# Lesson 001\nBe careful.\n");
+  });
+});
+
+test("migratePaiMemory re-copies when source bytes change", async () => {
+  await withTempHome(async (homeDir) => {
+    const root = await writePaiMemoryFixture(homeDir, { withLearning: true });
+    await migratePaiMemory({ homeDir });
+    // Source drifts. Idempotent contract: the source wins.
+    await writeFile(join(root, "LEARNING/lesson-001.md"), "# Lesson 001\nUpdated.\n", "utf8");
+    const second = await migratePaiMemory({ homeDir });
+    expect(second.writtenCount).toBe(1);
+    const target = await readFile(
+      join(homeDir, ".soma/memory/LEARNING/lesson-001.md"),
+      "utf8",
+    );
+    expect(target).toBe("# Lesson 001\nUpdated.\n");
+  });
+});
+
+test("migratePaiMemory does NOT overwrite the README.md at <somaHome>/memory/ root", async () => {
+  // #88 owns the README at memory/ root. The memory translator must
+  // not touch files directly at <claudeHome>/PAI/MEMORY/<file> when
+  // those paths would collide with #88's bootstrap-owned files at the
+  // <somaHome>/memory/ root. The contract: only files INSIDE a category
+  // directory get migrated; files at the MEMORY/ root are ignored.
+  await withTempHome(async (homeDir) => {
+    // Bootstrap the canonical Soma README at memory/ root.
+    await mkdir(join(homeDir, ".soma/memory"), { recursive: true });
+    await writeFile(join(homeDir, ".soma/memory/README.md"), "# Soma memory (bootstrap)\n", "utf8");
+    await writePaiMemoryFixture(homeDir, { withRootReadme: true, withLearning: true });
+    const result = await migratePaiMemory({ homeDir });
+    // README at MEMORY root must not have been migrated.
+    const somaReadme = await readFile(join(homeDir, ".soma/memory/README.md"), "utf8");
+    expect(somaReadme).toBe("# Soma memory (bootstrap)\n");
+    // The lesson under LEARNING did get migrated.
+    expect(result.writtenCount).toBe(1);
+  });
+});
+
+test("migratePaiMemory refuses symlinks inside the MEMORY tree", async () => {
+  await withTempHome(async (homeDir) => {
+    const root = await writePaiMemoryFixture(homeDir, { withLearning: true });
+    // Plant a symlink inside the tree.
+    await symlink("/etc/hostname", join(root, "LEARNING/escape.md"));
+    await expect(migratePaiMemory({ homeDir })).rejects.toThrow(/symlink/i);
+  });
+});
+
+test("planPaiMemoryMigration handles extra v5.0.0 cats (KNOWLEDGE, RESEARCH) cleanly", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiMemoryFixture(homeDir, {
+      withKnowledge: true,
+      withResearch: true,
+      withLearning: true,
+    });
+    const plan = await planPaiMemoryMigration({ homeDir });
+    const cats = new Set(plan.files.map((f) => f.relativePath.split("/")[0]));
+    expect(cats.has("KNOWLEDGE")).toBe(true);
+    expect(cats.has("RESEARCH")).toBe(true);
+    expect(cats.has("LEARNING")).toBe(true);
+  });
+});

--- a/test/pai-memory-migrator.test.ts
+++ b/test/pai-memory-migrator.test.ts
@@ -11,21 +11,15 @@
  * collision get strong tests before opening the PR.
  */
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, readFile, stat, symlink, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { migratePaiMemory, planPaiMemoryMigration } from "../src/pai-memory-migrator";
 import type { PaiMemoryMigrationManifest } from "../src/types";
+import { withTempHome as withSharedTempHome } from "./fixtures/pai-migration-fixtures";
 
-async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
-  const homeDir = await mkdtemp(join(tmpdir(), "soma-90-mem-"));
-  try {
-    return await fn(homeDir);
-  } finally {
-    await rm(homeDir, { recursive: true, force: true });
-  }
-}
+const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
+  withSharedTempHome(fn, "soma-90-mem-");
 
 function sha256(content: string | Buffer): string {
   return createHash("sha256").update(content).digest("hex");

--- a/test/pai-migration-issue-90.test.ts
+++ b/test/pai-migration-issue-90.test.ts
@@ -247,6 +247,36 @@ test("migratePai MIGRATION.md includes a Last migrated at timestamp", async () =
   });
 });
 
+test("migratePai filesWritten on idempotent rerun = manifest only (no over-reporting) — Sage r2 #95 important", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    await writeMemoryFixture(homeDir);
+    const first = await migratePai({ homeDir });
+    // First run: identity files + memory files + manifest path + memory manifest.
+    const firstWrite = first.filesWritten.length;
+    expect(firstWrite).toBeGreaterThan(2);
+    // Second run, fully idempotent. The previous bug pushed every
+    // in-scope memory target into filesWritten regardless of whether
+    // it was actually copied, so a zero-write idempotent rerun was
+    // reporting len(filesWritten) ≈ in-scope count. Contract: the
+    // only file the orchestrator unconditionally writes on a no-op
+    // rerun is the MIGRATION.md (and the memory manifest, which is
+    // also always re-rendered for byte-stability). filesWritten
+    // therefore reflects exactly the per-run touches.
+    const second = await migratePai({ homeDir });
+    // Identity importer always writes (no SHA gate yet) — that's 6
+    // identity files + memory.manifestPath + MIGRATION.md = 8 typical.
+    // The KEY invariant is: filesWritten on a no-op rerun must NOT
+    // include the memory targets themselves (those were skipped).
+    expect(second.memory!.writtenCount).toBe(0);
+    expect(second.memory!.writtenTargets).toEqual([]);
+    // Memory targets are NOT in filesWritten on the second run.
+    for (const target of second.memory!.files) {
+      expect(second.filesWritten).not.toContain(target);
+    }
+  });
+});
+
 test("migratePai timestamp bumps when identity content changes (file count unchanged) — Sage r1 #95 important", async () => {
   await withTempHome(async (homeDir) => {
     await writeIdentityFixture(homeDir);

--- a/test/pai-migration-issue-90.test.ts
+++ b/test/pai-migration-issue-90.test.ts
@@ -17,6 +17,12 @@ import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { migratePai, planPaiMigration } from "../src/pai-migration";
 import type { PaiMemoryMigrationManifest } from "../src/types";
+import {
+  writePaiIdentityFixture as writeIdentityFixture,
+  writePaiMemoryFixture as writeMemoryFixture,
+  writePaiPackFixture as writePackFixture,
+  writePaiReleaseFixture as writePaiSourceFixture,
+} from "./fixtures/pai-migration-fixtures";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-90-orch-"));
@@ -25,69 +31,6 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
   } finally {
     await rm(homeDir, { recursive: true, force: true });
   }
-}
-
-async function writeIdentityFixture(homeDir: string): Promise<void> {
-  const userRoot = join(homeDir, ".claude/PAI/USER");
-  await mkdir(join(userRoot, "TELOS"), { recursive: true });
-  await writeFile(
-    join(userRoot, "PRINCIPAL_IDENTITY.md"),
-    "# Principal\n\n- **Name:** Test User\n- **Pronunciation:** Test\n- **Location:** Nowhere\n- **Timezone:** UTC\n- **Role:** Tester\n- **Focus:** Testing\n",
-    "utf8",
-  );
-  await writeFile(
-    join(userRoot, "DA_IDENTITY.md"),
-    "# DA Identity\n\n- **Full Name:** Bot\n- **Name:** Bot\n- **Display Name:** Bot\n- **Color:** #000\n- **Voice ID:** v\n- **Role:** assistant\n- **Operating Environment:** test\n",
-    "utf8",
-  );
-  for (const file of ["MISSION.md", "GOALS.md", "STRATEGIES.md", "BELIEFS.md"]) {
-    await writeFile(join(userRoot, "TELOS", file), `# ${file}\n\nFixture\n`, "utf8");
-  }
-}
-
-async function writeMemoryFixture(homeDir: string): Promise<void> {
-  const root = join(homeDir, ".claude/PAI/MEMORY");
-  await mkdir(join(root, "LEARNING"), { recursive: true });
-  await writeFile(join(root, "LEARNING/lesson.md"), "# Lesson\n", "utf8");
-  await mkdir(join(root, "WORK/20260117_test"), { recursive: true });
-  await writeFile(join(root, "WORK/20260117_test/notes.md"), "notes\n", "utf8");
-}
-
-// Build a tiny PAI pack tree under `<packsDir>/<name>`, valid enough
-// for `importPaiPack` to accept it (matches the V0 contract).
-async function writePackFixture(
-  packsDir: string,
-  packName: string,
-  options: { skillName?: string; description?: string } = {},
-): Promise<string> {
-  const packDir = join(packsDir, packName);
-  const skillName = options.skillName ?? packName;
-  const description = options.description ?? `Tiny ${packName} pack.`;
-  await mkdir(join(packDir, "src"), { recursive: true });
-  await writeFile(
-    join(packDir, "README.md"),
-    `---\nname: ${skillName}\ndescription: ${description}\n---\n\n# ${packName}\n\nFixture.\n`,
-    "utf8",
-  );
-  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
-  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
-  await writeFile(
-    join(packDir, "src/SKILL.md"),
-    `---\nname: ${skillName}\ndescription: ${description}\n---\n\n# ${packName}\n\nFixture skill body.\n`,
-    "utf8",
-  );
-  return packDir;
-}
-
-async function writePaiSourceFixture(homeDir: string): Promise<string> {
-  const sourceDir = join(homeDir, "PAI/Releases/v5.0.0/.claude/PAI");
-  await mkdir(join(sourceDir, "DOCUMENTATION/Skills"), { recursive: true });
-  await writeFile(
-    join(sourceDir, "DOCUMENTATION/Skills/SkillSystem.md"),
-    "# Skill System\n",
-    "utf8",
-  );
-  return sourceDir;
 }
 
 test("planPaiMigration includes memory phase counts when MEMORY dir exists", async () => {
@@ -301,6 +244,35 @@ test("migratePai MIGRATION.md includes a Last migrated at timestamp", async () =
     const result = await migratePai({ homeDir });
     const manifest = await readFile(result.manifestPath, "utf8");
     expect(manifest).toMatch(/Last migrated at: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+  });
+});
+
+test("migratePai timestamp bumps when identity content changes (file count unchanged) — Sage r1 #95 important", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const first = await migratePai({ homeDir });
+    const firstManifest = await readFile(first.manifestPath, "utf8");
+    const firstTs = firstManifest.match(/^Last migrated at: (.+)$/m)?.[1];
+    const firstFp = firstManifest.match(/identity fingerprint: ([0-9a-f]+)/)?.[1];
+    expect(firstTs).toBeDefined();
+    expect(firstFp).toBeDefined();
+    await new Promise((r) => setTimeout(r, 5));
+    // Mutate identity SOURCE — file count stays the same, content
+    // changes. The previous gate (memory.unchanged && docs.unchanged)
+    // would have preserved the timestamp. The fingerprint embedded
+    // in the manifest body changes, which forces a body-equivalence
+    // failure and a timestamp bump.
+    await writeFile(
+      join(homeDir, ".claude/PAI/USER/PRINCIPAL_IDENTITY.md"),
+      "# Principal\n\n- **Name:** Mutated User\n- **Pronunciation:** Test\n- **Location:** Nowhere\n- **Timezone:** UTC\n- **Role:** Tester\n- **Focus:** Testing\n",
+      "utf8",
+    );
+    const second = await migratePai({ homeDir });
+    const secondManifest = await readFile(second.manifestPath, "utf8");
+    const secondTs = secondManifest.match(/^Last migrated at: (.+)$/m)?.[1];
+    const secondFp = secondManifest.match(/identity fingerprint: ([0-9a-f]+)/)?.[1];
+    expect(secondTs).not.toBe(firstTs);
+    expect(secondFp).not.toBe(firstFp);
   });
 });
 

--- a/test/pai-migration-issue-90.test.ts
+++ b/test/pai-migration-issue-90.test.ts
@@ -11,27 +11,21 @@
  *
  * Fixture-only; no network or real PAI install touched.
  */
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { migratePai, planPaiMigration } from "../src/pai-migration";
 import type { PaiMemoryMigrationManifest } from "../src/types";
 import {
+  withTempHome as withSharedTempHome,
   writePaiIdentityFixture as writeIdentityFixture,
   writePaiMemoryFixture as writeMemoryFixture,
   writePaiPackFixture as writePackFixture,
   writePaiReleaseFixture as writePaiSourceFixture,
 } from "./fixtures/pai-migration-fixtures";
 
-async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
-  const homeDir = await mkdtemp(join(tmpdir(), "soma-90-orch-"));
-  try {
-    return await fn(homeDir);
-  } finally {
-    await rm(homeDir, { recursive: true, force: true });
-  }
-}
+const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
+  withSharedTempHome(fn, "soma-90-orch-");
 
 test("planPaiMigration includes memory phase counts when MEMORY dir exists", async () => {
   await withTempHome(async (homeDir) => {
@@ -106,6 +100,30 @@ test("migratePai skipSkills honored — packs not imported even when packsDir gi
     const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipSkills: true });
     expect(result.packs).toEqual([]);
     await expect(stat(join(homeDir, ".soma/skills/alpha-skill"))).rejects.toThrow();
+  });
+});
+
+test("migratePai skipSkills short-circuits pack discovery (bad packs dir is not read) — Sage r3 #95 important", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    // Use a `paiPacksDir` that exists but is unreadable. Without the
+    // skipSkills short-circuit in discoverMigrationSources, the
+    // orchestrator would throw EACCES while reading the dir even
+    // though the skill phase is explicitly skipped.
+    const packsDir = join(homeDir, "locked-packs");
+    await mkdir(packsDir, { recursive: true });
+    const { chmod } = await import("node:fs/promises");
+    await chmod(packsDir, 0o000);
+    try {
+      const result = await migratePai({
+        homeDir,
+        paiPacksDir: packsDir,
+        skipSkills: true,
+      });
+      expect(result.packs).toEqual([]);
+    } finally {
+      await chmod(packsDir, 0o700);
+    }
   });
 });
 

--- a/test/pai-migration-issue-90.test.ts
+++ b/test/pai-migration-issue-90.test.ts
@@ -1,0 +1,341 @@
+/**
+ * #90 — soma migrate pai full orchestration tests.
+ *
+ * Exercises the orchestrator extensions over the #28 minimal scope:
+ *   - Memory translation phase (PAI MEMORY → soma memory).
+ *   - Bulk skill import from a packs root (iterate + per-pack import).
+ *   - Docs import phase via the #89 verb when `paiSourceDir` is given.
+ *   - Reserved-skill collision: refused unless `overwriteReserved`.
+ *   - `skipMemory` / `skipSkills` / `skipDocs` flags.
+ *   - `--pai-source-dir` pointing at a non-PAI dir is refused loud.
+ *
+ * Fixture-only; no network or real PAI install touched.
+ */
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { migratePai, planPaiMigration } from "../src/pai-migration";
+import type { PaiMemoryMigrationManifest } from "../src/types";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-90-orch-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function writeIdentityFixture(homeDir: string): Promise<void> {
+  const userRoot = join(homeDir, ".claude/PAI/USER");
+  await mkdir(join(userRoot, "TELOS"), { recursive: true });
+  await writeFile(
+    join(userRoot, "PRINCIPAL_IDENTITY.md"),
+    "# Principal\n\n- **Name:** Test User\n- **Pronunciation:** Test\n- **Location:** Nowhere\n- **Timezone:** UTC\n- **Role:** Tester\n- **Focus:** Testing\n",
+    "utf8",
+  );
+  await writeFile(
+    join(userRoot, "DA_IDENTITY.md"),
+    "# DA Identity\n\n- **Full Name:** Bot\n- **Name:** Bot\n- **Display Name:** Bot\n- **Color:** #000\n- **Voice ID:** v\n- **Role:** assistant\n- **Operating Environment:** test\n",
+    "utf8",
+  );
+  for (const file of ["MISSION.md", "GOALS.md", "STRATEGIES.md", "BELIEFS.md"]) {
+    await writeFile(join(userRoot, "TELOS", file), `# ${file}\n\nFixture\n`, "utf8");
+  }
+}
+
+async function writeMemoryFixture(homeDir: string): Promise<void> {
+  const root = join(homeDir, ".claude/PAI/MEMORY");
+  await mkdir(join(root, "LEARNING"), { recursive: true });
+  await writeFile(join(root, "LEARNING/lesson.md"), "# Lesson\n", "utf8");
+  await mkdir(join(root, "WORK/20260117_test"), { recursive: true });
+  await writeFile(join(root, "WORK/20260117_test/notes.md"), "notes\n", "utf8");
+}
+
+// Build a tiny PAI pack tree under `<packsDir>/<name>`, valid enough
+// for `importPaiPack` to accept it (matches the V0 contract).
+async function writePackFixture(
+  packsDir: string,
+  packName: string,
+  options: { skillName?: string; description?: string } = {},
+): Promise<string> {
+  const packDir = join(packsDir, packName);
+  const skillName = options.skillName ?? packName;
+  const description = options.description ?? `Tiny ${packName} pack.`;
+  await mkdir(join(packDir, "src"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    `---\nname: ${skillName}\ndescription: ${description}\n---\n\n# ${packName}\n\nFixture.\n`,
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    `---\nname: ${skillName}\ndescription: ${description}\n---\n\n# ${packName}\n\nFixture skill body.\n`,
+    "utf8",
+  );
+  return packDir;
+}
+
+async function writePaiSourceFixture(homeDir: string): Promise<string> {
+  const sourceDir = join(homeDir, "PAI/Releases/v5.0.0/.claude/PAI");
+  await mkdir(join(sourceDir, "DOCUMENTATION/Skills"), { recursive: true });
+  await writeFile(
+    join(sourceDir, "DOCUMENTATION/Skills/SkillSystem.md"),
+    "# Skill System\n",
+    "utf8",
+  );
+  return sourceDir;
+}
+
+test("planPaiMigration includes memory phase counts when MEMORY dir exists", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    await writeMemoryFixture(homeDir);
+    const plan = await planPaiMigration({ homeDir });
+    expect(plan.memory).toBeDefined();
+    expect(plan.memory!.files.length).toBe(2);
+  });
+});
+
+test("planPaiMigration sets memory to null when no MEMORY dir", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const plan = await planPaiMigration({ homeDir });
+    expect(plan.memory).toBeDefined();
+    expect(plan.memory!.memoryDir).toBeNull();
+  });
+});
+
+test("migratePai runs memory phase end-to-end", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    await writeMemoryFixture(homeDir);
+    const result = await migratePai({ homeDir });
+    expect(result.memory).toBeDefined();
+    expect(result.memory!.writtenCount).toBe(2);
+    await stat(join(homeDir, ".soma/memory/LEARNING/lesson.md"));
+    await stat(join(homeDir, ".soma/memory/WORK/20260117_test/notes.md"));
+    // Memory manifest must exist.
+    const mem = await readFile(
+      join(homeDir, ".soma/imports/pai-migration/.manifest.json"),
+      "utf8",
+    );
+    const parsed = JSON.parse(mem) as PaiMemoryMigrationManifest;
+    expect(parsed.files.length).toBe(2);
+  });
+});
+
+test("migratePai skipMemory honored — no memory files written", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    await writeMemoryFixture(homeDir);
+    const result = await migratePai({ homeDir, skipMemory: true });
+    expect(result.memory).toBeNull();
+    await expect(
+      stat(join(homeDir, ".soma/memory/LEARNING/lesson.md")),
+    ).rejects.toThrow();
+  });
+});
+
+test("migratePai bulk imports packs from paiPacksDir", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await writePackFixture(packsDir, "AlphaSkill");
+    await writePackFixture(packsDir, "BetaSkill");
+    const result = await migratePai({ homeDir, paiPacksDir: packsDir });
+    expect(result.packs.length).toBe(2);
+    const names = result.packs.map((p) => p.skillName).sort();
+    expect(names).toEqual(["alpha-skill", "beta-skill"]);
+    await stat(join(homeDir, ".soma/skills/alpha-skill/SKILL.md"));
+    await stat(join(homeDir, ".soma/skills/beta-skill/SKILL.md"));
+  });
+});
+
+test("migratePai skipSkills honored — packs not imported even when packsDir given", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await writePackFixture(packsDir, "AlphaSkill");
+    const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipSkills: true });
+    expect(result.packs).toEqual([]);
+    await expect(stat(join(homeDir, ".soma/skills/alpha-skill"))).rejects.toThrow();
+  });
+});
+
+test("migratePai refuses reserved skill names ('isa', 'the-algorithm', 'knowledge', 'telos') without overwriteReserved", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    // Pack whose normalized skill name slugifies to a reserved name.
+    await writePackFixture(packsDir, "ISA", { skillName: "ISA" });
+    await expect(
+      migratePai({ homeDir, paiPacksDir: packsDir }),
+    ).rejects.toThrow(/reserved Soma skill 'isa'/i);
+  });
+});
+
+test("migratePai skips reserved skill name when --overwriteReserved is set, importing the rest", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await writePackFixture(packsDir, "ISA", { skillName: "ISA" });
+    await writePackFixture(packsDir, "Alpha", { skillName: "Alpha" });
+    const result = await migratePai({
+      homeDir,
+      paiPacksDir: packsDir,
+      overwriteReserved: true,
+    });
+    // ISA must be imported (the flag explicitly permits clobbering
+    // reserved names — Sage may push back; we record the resolution
+    // here so the contract is unambiguous).
+    const names = result.packs.map((p) => p.skillName).sort();
+    expect(names).toEqual(["alpha", "isa"]);
+  });
+});
+
+test("migratePai auto-discovers packs at <claudeHome>/PAI/Packs when paiPacksDir omitted", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    // Plant packs at the canonical auto-discovery location.
+    const packsDir = join(homeDir, ".claude/PAI/Packs");
+    await writePackFixture(packsDir, "Gamma");
+    const result = await migratePai({ homeDir });
+    expect(result.packs.length).toBe(1);
+    expect(result.packs[0].skillName).toBe("gamma");
+  });
+});
+
+test("migratePai with paiSourceDir invokes docs phase, writes <somaHome>/PAI/DOCUMENTATION/*", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    const result = await migratePai({ homeDir, paiSourceDir: sourceDir });
+    expect(result.docs).toBeDefined();
+    expect(result.docs!.writtenCount).toBeGreaterThan(0);
+    await stat(join(homeDir, ".soma/PAI/DOCUMENTATION/Skills/SkillSystem.md"));
+  });
+});
+
+test("migratePai paiSourceDir pointing at non-PAI dir refuses loud", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const bogus = join(homeDir, "definitely-not-pai");
+    await mkdir(bogus, { recursive: true });
+    await writeFile(join(bogus, "README.md"), "not pai\n", "utf8");
+    await expect(
+      migratePai({ homeDir, paiSourceDir: bogus }),
+    ).rejects.toThrow(/does not look like a PAI release tree/);
+  });
+});
+
+test("migratePai skipDocs honored — docs phase not run even when paiSourceDir given", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    const result = await migratePai({ homeDir, paiSourceDir: sourceDir, skipDocs: true });
+    expect(result.docs).toBeNull();
+    await expect(
+      stat(join(homeDir, ".soma/PAI/DOCUMENTATION/Skills/SkillSystem.md")),
+    ).rejects.toThrow();
+  });
+});
+
+test("migratePai is idempotent across full phases (rerun = same on-disk state)", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    await writeMemoryFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await writePackFixture(packsDir, "Alpha");
+    const sourceDir = await writePaiSourceFixture(homeDir);
+
+    const first = await migratePai({ homeDir, paiPacksDir: packsDir, paiSourceDir: sourceDir });
+    const firstManifest = await readFile(first.manifestPath, "utf8");
+    const firstMemManifest = await readFile(
+      join(homeDir, ".soma/imports/pai-migration/.manifest.json"),
+      "utf8",
+    );
+
+    const second = await migratePai({
+      homeDir,
+      paiPacksDir: packsDir,
+      paiSourceDir: sourceDir,
+    });
+    expect(second.memory!.writtenCount).toBe(0);
+    expect(second.memory!.unchanged).toBe(true);
+    // Docs phase: writtenCount=0 means idempotent skip per #89's
+    // contract.
+    expect(second.docs!.writtenCount).toBe(0);
+    expect(second.docs!.unchanged).toBe(true);
+    // Migration manifest byte-stable.
+    const secondManifest = await readFile(first.manifestPath, "utf8");
+    expect(secondManifest).toBe(firstManifest);
+    // Memory manifest byte-stable.
+    const secondMemManifest = await readFile(
+      join(homeDir, ".soma/imports/pai-migration/.manifest.json"),
+      "utf8",
+    );
+    expect(secondMemManifest).toBe(firstMemManifest);
+  });
+});
+
+test("planPaiMigration with paiSourceDir includes docs plan; without it docs is null", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    const withSource = await planPaiMigration({ homeDir, paiSourceDir: sourceDir });
+    expect(withSource.docs).not.toBeNull();
+    expect(withSource.docs!.files.length).toBeGreaterThan(0);
+
+    const withoutSource = await planPaiMigration({ homeDir });
+    expect(withoutSource.docs).toBeNull();
+  });
+});
+
+test("migratePai MIGRATION.md includes a Last migrated at timestamp", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const result = await migratePai({ homeDir });
+    const manifest = await readFile(result.manifestPath, "utf8");
+    expect(manifest).toMatch(/Last migrated at: \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+  });
+});
+
+test("migratePai timestamp preserved across idempotent rerun (no writes)", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    await writeMemoryFixture(homeDir);
+    const first = await migratePai({ homeDir });
+    const firstManifest = await readFile(first.manifestPath, "utf8");
+    const firstTs = firstManifest.match(/^Last migrated at: (.+)$/m)?.[1];
+    expect(firstTs).toBeDefined();
+    // Wait a real moment so a non-preserved timestamp would diverge.
+    await new Promise((r) => setTimeout(r, 5));
+    await migratePai({ homeDir });
+    const secondManifest = await readFile(first.manifestPath, "utf8");
+    const secondTs = secondManifest.match(/^Last migrated at: (.+)$/m)?.[1];
+    expect(secondTs).toBe(firstTs!);
+  });
+});
+
+test("migratePai records memory + docs + packs counts in MIGRATION.md", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    await writeMemoryFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await writePackFixture(packsDir, "Alpha");
+    const sourceDir = await writePaiSourceFixture(homeDir);
+    const result = await migratePai({
+      homeDir,
+      paiPacksDir: packsDir,
+      paiSourceDir: sourceDir,
+    });
+    const manifest = await readFile(result.manifestPath, "utf8");
+    expect(manifest).toContain("memory:");
+    expect(manifest).toContain("docs:");
+    expect(manifest).toContain("packs:");
+  });
+});


### PR DESCRIPTION
## Summary

Extends the #28/#69 minimal migrate orchestrator with the three remaining phases that turn `soma migrate pai` into a full PAI → Soma move per [DD-1](https://github.com/the-metafactory/soma/blob/main/design/design-decisions.md#dd-1-soma-is-the-new-canonical-home-of-personal-ai-state) (Soma is the new canonical home of personal AI state). Closes #90.

### New phases on top of identity + algorithm

- **Memory translation** — `src/pai-memory-migrator.ts` (new). Translates `<claudeHome>/PAI/MEMORY/*` → `<somaHome>/memory/*` per [DD-2](https://github.com/the-metafactory/soma/blob/main/design/design-decisions.md#dd-2-adopt-pai-v500-memory-taxonomy-wholesale-mark-pai-specific-categories)'s 1:1 mapping. Content-preserving (no body rewriting in this pass), mtime-preserving, per-file SHA in `<somaHome>/imports/pai-migration/.manifest.json`. Idempotent: prior manifest SHA + target re-hash gate the copy. A target edited since import is restored from source.
- **Bulk skill import** — orchestrator iterates `<paiPacksDir>/*` with bounded concurrency. Default: `<paiSourceDir>/Packs` when source given, else `<claudeHome>/PAI/Packs`. Reserved skill names (`isa`, `the-algorithm`, `knowledge`, `telos`) refused loud unless `--overwrite-reserved`. Check runs before any pack import so the phase is all-or-nothing.
- **PAI docs import** — when `--pai-source-dir` set, wraps #89's `importPaiDocs` to land DOCUMENTATION/, TEMPLATES/, ALGORITHM/ under `<somaHome>/PAI/`. Non-PAI source dirs refused loud by #89's `assertPaiReleaseTree` (plan §"Failure modes": no heuristic guessing).

### CLI surface

- `--pai-install <dir>` (alias for `--claude-home` — issue body uses `--pai-install`).
- `--pai-source-dir <release>` (optional; triggers docs phase).
- `--pai-packs-dir <dir>` (single dir of many packs).
- `--skip-memory`, `--skip-skills`, `--skip-docs` for partial migrate.
- `--overwrite-reserved` to permit reserved-name pack imports.
- Plan + apply formatters extended to surface memory + docs counts.
- `--status` reads back manifest verbatim; manifest now includes `Last migrated at: <iso>` timestamp preserved across idempotent reruns (Sage r1 lesson from #28 — timestamp in status output without breaking byte-stable-rerun contract).

### Idempotency model

- **Memory manifest** byte-stable when source SHAs unchanged (timestamp preserved when `writtenCount == 0`).
- **MIGRATION.md** byte-stable when `memory.unchanged && docs.unchanged` (timestamp preserved when nothing wrote).
- Pack importer continues to overwrite-with-same-bytes; final on-disk state is unchanged across reruns.

## Acceptance criteria

- [x] AC-1: `soma migrate pai --pai-install <path> --apply` orchestrates identity + algorithm + memory translation + bulk skill import. Idempotent.
- [x] AC-2: `--pai-source-dir <release>` additionally imports docs via the #89 verb. Optional.
- [x] AC-3: Memory translation moves `~/.claude/PAI/MEMORY/*` to `~/.soma/memory/*` per DD-2. Preserves content + mtimes. Per-file SHA in `~/.soma/imports/pai-migration/.manifest.json`.
- [x] AC-4: Bulk skill import iterates packs dir. Reserved skills (`isa`, `the-algorithm`, `knowledge`, `telos`) refused unless `--overwrite-reserved`.
- [x] AC-5: `--skip-memory`, `--skip-skills`, `--skip-docs` honored.
- [x] AC-6: `--status` reports source paths, timestamp, file counts per phase. Reads from manifest.
- [x] AC-7: Plan mode (default) prints what would change without writing.
- [x] AC-8: Tests cover full migrate, partial migrate with `--skip-*`, idempotency, reserved-skill collision refusal, manifest emission.

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 600 pass, 0 fail (559 baseline after #89/#94 + 41 new tests).

### Test files added / extended

| File | Count | Coverage |
|---|---|---|
| `test/pai-memory-migrator.test.ts` (new) | 13 | mapping, content preservation, mtime preservation, per-file SHA manifest, idempotency (no-op, byte-stable, target-edit recovery, source-drift re-copy), symlink refusal, README no-clobber |
| `test/pai-migration-issue-90.test.ts` (new) | 17 | orchestration with memory + packs + docs, `skip-*` flags, reserved-skill refusal + override, `paiSourceDir` non-PAI refusal, full-phase idempotency, MIGRATION.md content + timestamp stability |
| `test/cli-migrate.test.ts` (extended) | +11 | CLI plumbing for every new flag, end-to-end idempotency, `--pai-install` alias, `--status` after full apply shows memory + docs, bogus `--pai-source-dir` refused |

## Sage round 0 preempts (per plan §#90)

- **Idempotency edges**: target re-hash on every "skip by SHA" path so a user-edited target is restored from source — manifest agreement alone is insufficient. Tested explicitly in `test/pai-memory-migrator.test.ts` "re-copies when target file has been mutated".
- **Reserved-skill collision**: refusal check runs before any pack import. `MIGRATE_RESERVED_SKILL_NAMES` is the migrate-level set; pack importer's own reserved set is independent and stricter. `--overwrite-reserved` is the only escape valve. Tested both rejection and override paths.

Closes #90