### PR TITLE
feat(importer): replace UNMAPPED catch-all with deterministic ~/.soma/PAI/... rewrites (#91)

### DIFF
--- a/docs/pai-pack-importer.md
+++ b/docs/pai-pack-importer.md
@@ -102,10 +102,23 @@ keep their named-target detail, catch-all last so it only fires on residue.
 
 ### Deterministic path rewrites
 
+Ordered most-specific-first. Each rule runs before the UNMAPPED catch-all so
+paths with a real Soma home never escape into the placeholder routing.
+
 | Action kind | Pattern | Replacement |
 | --- | --- | --- |
 | `rewrote-claude-home-path` | `~/.claude/skills/<rest>` | `~/.soma/skills/<rest>` |
-| `rewrote-claude-home-path` | `~/.claude/PAI/MEMORY/<rest>` | `~/.soma/memory/<rest>` |
+| `rewrote-pai-doc-path` | `~/.claude/PAI/DOCUMENTATION/<rest>` | `~/.soma/PAI/DOCUMENTATION/<rest>` |
+| `rewrote-pai-template-path` | `~/.claude/PAI/TEMPLATES/<rest>` | `~/.soma/PAI/TEMPLATES/<rest>` |
+| `rewrote-pai-algorithm-path` | `~/.claude/PAI/ALGORITHM/<rest>` | `~/.soma/PAI/ALGORITHM/<rest>` |
+| `rewrote-pai-memory-path` | `~/.claude/PAI/MEMORY/<rest>` | `~/.soma/memory/<rest>` |
+
+The four `rewrote-pai-*` kinds are populated by `soma import pai-docs` (#89,
+for DOCUMENTATION/TEMPLATES/ALGORITHM) and Soma's memory taxonomy bootstrap
+(#88, for MEMORY → memory). Note the asymmetric MEMORY target: PAI's
+`PAI/MEMORY/` lands at lowercase `~/.soma/memory/` because Soma's memory is
+canonical (per DD-1, DD-2), not a PAI projection. The other three preserve
+the `PAI/` prefix because `~/.soma/PAI/` is the imported docs surface.
 
 ### Catch-all rewrite (unmapped Claude paths)
 

--- a/src/pai-pack-normalizer.ts
+++ b/src/pai-pack-normalizer.ts
@@ -55,13 +55,36 @@ const NOTIFICATION_CURL = /^\s*curl\s+[^\n]*localhost:31337\/notify[^\n]*\n?/m;
 const CUSTOMIZATION_HEADING = /^##+\s*Customization\s*$/m;
 const CUSTOMIZATION_BODY_MARKER = "SKILLCUSTOMIZATIONS";
 
+// Deterministic Claude → Soma rewrite rules. Ordered most-specific-first so a
+// PAI subtree match (e.g. PAI/DOCUMENTATION) wins over a less-specific match
+// would the latter exist. Every rule fires BEFORE `applyUnmappedClaudePathCatchall`
+// (see `normalizeSkillContent`) — that ordering is what keeps the UNMAPPED
+// warning class reserved for paths Soma genuinely cannot home.
+//
+// Issue #91: replaced the prior single `rewrote-claude-home-path` PAI/MEMORY
+// rule with four named per-subtree kinds. Each rule's action kind tells a
+// reviewer exactly which subtree contract fired, which #86's single shared
+// kind could not — at scale, the audit trail has to disambiguate. Mapping
+// targets are anchored to the Soma homes established by #88 (memory taxonomy)
+// and #89 (soma import pai-docs); without those upstream issues these rules
+// would dangle.
 const CLAUDE_HOME_DETERMINISTIC: readonly { from: RegExp; to: string; kind: PaiPackNormalizationAction["kind"] }[] = [
   // Skill payload root — clean Soma equivalent.
   { from: /~\/\.claude\/skills\//, to: "~/.soma/skills/", kind: "rewrote-claude-home-path" },
-  // Issue #86 / AC-1: PAI memory root → Soma memory root. Both substrates
-  // share the "memory" concept; mapping is one-to-one. The deeper subtree
-  // shape (SKILLS/execution.jsonl etc.) is preserved.
-  { from: /~\/\.claude\/PAI\/MEMORY\//, to: "~/.soma/memory/", kind: "rewrote-claude-home-path" },
+  // Issue #91 / AC-1: PAI docs subtree → Soma docs subtree. The `~/.soma/PAI/`
+  // root is populated by `soma import pai-docs` (#89); imported skills that
+  // reference DOCUMENTATION resolve to a real on-disk file after import.
+  { from: /~\/\.claude\/PAI\/DOCUMENTATION\//, to: "~/.soma/PAI/DOCUMENTATION/", kind: "rewrote-pai-doc-path" },
+  // Issue #91 / AC-1: PAI templates subtree → Soma templates subtree.
+  { from: /~\/\.claude\/PAI\/TEMPLATES\//, to: "~/.soma/PAI/TEMPLATES/", kind: "rewrote-pai-template-path" },
+  // Issue #91 / AC-1: PAI algorithm subtree → Soma algorithm subtree.
+  { from: /~\/\.claude\/PAI\/ALGORITHM\//, to: "~/.soma/PAI/ALGORITHM/", kind: "rewrote-pai-algorithm-path" },
+  // Issue #91 / AC-1 (promotes #86 partial): PAI memory root → Soma memory
+  // root. Both substrates share the "memory" concept; mapping is one-to-one.
+  // The deeper subtree shape (SKILLS/execution.jsonl etc.) is preserved.
+  // Asymmetric target: PAI's `PAI/MEMORY/` lands at lowercase `~/.soma/memory/`
+  // because Soma's memory is canonical (per DD-1, DD-2) — not a PAI projection.
+  { from: /~\/\.claude\/PAI\/MEMORY\//, to: "~/.soma/memory/", kind: "rewrote-pai-memory-path" },
 ];
 
 // Issue #86 / AC-1: catch-all for every other `~/.claude/<segment>/...`

--- a/src/types.ts
+++ b/src/types.ts
@@ -442,6 +442,10 @@ export interface PaiPackNormalizationAction {
   kind:
     | "removed-substrate-notification-hook"
     | "rewrote-claude-home-path"
+    | "rewrote-pai-doc-path"
+    | "rewrote-pai-template-path"
+    | "rewrote-pai-algorithm-path"
+    | "rewrote-pai-memory-path"
     | "rewrote-unmapped-claude-path"
     | "stripped-mandatory-runtime-block"
     | "stripped-pai-customization-block"

--- a/test/pai-pack-importer-issue-86.test.ts
+++ b/test/pai-pack-importer-issue-86.test.ts
@@ -198,11 +198,16 @@ test("AC-2: leaves unrelated 'Customization' headings alone (requires SKILLCUSTO
 
 // ─── AC-1: catch-all for unmapped claude paths ─────────────────────────
 
-test("AC-1: PAI DOCUMENTATION path rewrites to UNMAPPED placeholder + warning", () => {
-  const content = "See `~/.claude/PAI/DOCUMENTATION/Skills/SkillSystem.md` for details.\n";
+test("AC-1: PAI bare-under-PAI path (no DOC/TEMPL/ALGO/MEMORY subtree) rewrites to UNMAPPED + warning", () => {
+  // Issue 91 superseded the prior "DOCUMENTATION → UNMAPPED" assertion:
+  // DOCUMENTATION now has a deterministic home (~/.soma/PAI/DOCUMENTATION).
+  // The catch-all still has to fire on PAI subtrees with no Soma equivalent,
+  // e.g. a bare `~/.claude/PAI/SkillSystem.md` (no subtree under PAI matches
+  // the four deterministic rules). This test pins THAT remaining contract.
+  const content = "See `~/.claude/PAI/SkillSystem.md` for details.\n";
   const result = normalizeSkillContent("body.md", content);
   expect(result.content).not.toContain("~/.claude/");
-  expect(result.content).toContain("~/.soma/UNMAPPED/PAI/DOCUMENTATION/Skills/SkillSystem.md");
+  expect(result.content).toContain("~/.soma/UNMAPPED/PAI/SkillSystem.md");
   expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(true);
   expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(true);
 });
@@ -228,12 +233,18 @@ test("AC-1: History/Backups path rewrites to UNMAPPED + warning", () => {
 // ─── AC-1: new deterministic rewrite (PAI MEMORY → soma memory) ────────
 
 test("AC-1: PAI MEMORY path rewrites deterministically to ~/.soma/memory/", () => {
+  // Issue 91 promoted the MEMORY rewrite to its own named action kind
+  // (`rewrote-pai-memory-path`). The mapping target is unchanged — Soma's
+  // memory home is canonical (per DD-1, DD-2). What changed is the audit
+  // trail: an explicit kind makes the rule reviewable, instead of folding
+  // it under the generic `rewrote-claude-home-path` umbrella shared with
+  // skills/.
   const content = "Log execution: ~/.claude/PAI/MEMORY/SKILLS/execution.jsonl\n";
   const result = normalizeSkillContent("body.md", content);
   expect(result.content).not.toContain("~/.claude/");
   expect(result.content).toContain("~/.soma/memory/SKILLS/execution.jsonl");
-  // Deterministic mapping → no UNMAPPED warning; uses existing rewrote-claude-home-path action
-  expect(result.actions.some((a) => a.kind === "rewrote-claude-home-path")).toBe(true);
+  // Deterministic mapping → no UNMAPPED warning; named action kind per #91.
+  expect(result.actions.some((a) => a.kind === "rewrote-pai-memory-path")).toBe(true);
   expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
 });
 

--- a/test/pai-pack-importer-issue-91.test.ts
+++ b/test/pai-pack-importer-issue-91.test.ts
@@ -21,53 +21,67 @@ import { expect, test } from "bun:test";
 import { normalizeSkillContent } from "../src/pai-pack-normalizer";
 
 // ─── AC-1 + AC-4: per-class deterministic rewrites ─────────────────────
+//
+// Table-driven (Sage R1, PR #96 Maintainability suggestion): the four
+// per-subtree rules share an identical contract — rewrite the input path,
+// fire the per-rule action kind, suppress the UNMAPPED catch-all action,
+// suppress the UNMAPPED warning. Encoding the contract as a table keeps
+// the contract in one place; future rewrite rules slot in as one row
+// rather than another ~10-line test block.
+//
+// Note the asymmetric MEMORY target: PAI's `PAI/MEMORY/` maps to Soma's
+// `~/.soma/memory/` (lowercase, no PAI/ prefix) per DD-1, DD-2 — Soma's
+// memory is canonical, not a PAI projection. The other three preserve
+// the `PAI/` prefix because `~/.soma/PAI/` is the imported-docs surface.
+const DETERMINISTIC_REWRITE_CASES: ReadonlyArray<{
+  label: string;
+  inputLine: string;
+  expectedTarget: string;
+  kind:
+    | "rewrote-pai-doc-path"
+    | "rewrote-pai-template-path"
+    | "rewrote-pai-algorithm-path"
+    | "rewrote-pai-memory-path";
+}> = [
+  {
+    label: "PAI/DOCUMENTATION → ~/.soma/PAI/DOCUMENTATION",
+    inputLine: "See `~/.claude/PAI/DOCUMENTATION/Skills/SkillSystem.md` for details.",
+    expectedTarget: "~/.soma/PAI/DOCUMENTATION/Skills/SkillSystem.md",
+    kind: "rewrote-pai-doc-path",
+  },
+  {
+    label: "PAI/TEMPLATES → ~/.soma/PAI/TEMPLATES",
+    inputLine: "Template lives at ~/.claude/PAI/TEMPLATES/ReportTemplate/dashboard.tpl.html.",
+    expectedTarget: "~/.soma/PAI/TEMPLATES/ReportTemplate/dashboard.tpl.html",
+    kind: "rewrote-pai-template-path",
+  },
+  {
+    label: "PAI/ALGORITHM → ~/.soma/PAI/ALGORITHM",
+    inputLine: "Load `~/.claude/PAI/ALGORITHM/v6.3.0.md` and follow its instructions.",
+    expectedTarget: "~/.soma/PAI/ALGORITHM/v6.3.0.md",
+    kind: "rewrote-pai-algorithm-path",
+  },
+  {
+    label: "PAI/MEMORY → ~/.soma/memory (asymmetric per DD-2)",
+    inputLine: "echo run >> ~/.claude/PAI/MEMORY/SKILLS/execution.jsonl",
+    expectedTarget: "~/.soma/memory/SKILLS/execution.jsonl",
+    kind: "rewrote-pai-memory-path",
+  },
+];
 
-test("AC-1: ~/.claude/PAI/DOCUMENTATION/<rest> rewrites to ~/.soma/PAI/DOCUMENTATION/<rest> via rewrote-pai-doc-path", () => {
-  const content = "See `~/.claude/PAI/DOCUMENTATION/Skills/SkillSystem.md` for details.\n";
-  const result = normalizeSkillContent("body.md", content);
-  expect(result.content).not.toContain("~/.claude/");
-  expect(result.content).toContain("~/.soma/PAI/DOCUMENTATION/Skills/SkillSystem.md");
-  // Deterministic mapping fires its own action kind...
-  expect(result.actions.some((a) => a.kind === "rewrote-pai-doc-path")).toBe(true);
-  // ...not the UNMAPPED catch-all action.
-  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(false);
-  // No UNMAPPED warning either — the path now has a real Soma equivalent.
-  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
-});
-
-test("AC-1: ~/.claude/PAI/TEMPLATES/<rest> rewrites to ~/.soma/PAI/TEMPLATES/<rest> via rewrote-pai-template-path", () => {
-  const content = "Template lives at ~/.claude/PAI/TEMPLATES/ReportTemplate/dashboard.tpl.html.\n";
-  const result = normalizeSkillContent("body.md", content);
-  expect(result.content).not.toContain("~/.claude/");
-  expect(result.content).toContain("~/.soma/PAI/TEMPLATES/ReportTemplate/dashboard.tpl.html");
-  expect(result.actions.some((a) => a.kind === "rewrote-pai-template-path")).toBe(true);
-  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(false);
-  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
-});
-
-test("AC-1: ~/.claude/PAI/ALGORITHM/<rest> rewrites to ~/.soma/PAI/ALGORITHM/<rest> via rewrote-pai-algorithm-path", () => {
-  const content = "Load `~/.claude/PAI/ALGORITHM/v6.3.0.md` and follow its instructions.\n";
-  const result = normalizeSkillContent("body.md", content);
-  expect(result.content).not.toContain("~/.claude/");
-  expect(result.content).toContain("~/.soma/PAI/ALGORITHM/v6.3.0.md");
-  expect(result.actions.some((a) => a.kind === "rewrote-pai-algorithm-path")).toBe(true);
-  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(false);
-  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
-});
-
-test("AC-1: ~/.claude/PAI/MEMORY/<rest> rewrites to ~/.soma/memory/<rest> via rewrote-pai-memory-path", () => {
-  // Note the asymmetric target: PAI's `PAI/MEMORY/` maps to Soma's
-  // `~/.soma/memory/` (lowercase, no PAI/ prefix) per DD-2. The PAI memory
-  // taxonomy is adopted wholesale by Soma — Soma's memory is THE canonical
-  // home, not a PAI projection.
-  const content = "echo run >> ~/.claude/PAI/MEMORY/SKILLS/execution.jsonl\n";
-  const result = normalizeSkillContent("body.md", content);
-  expect(result.content).not.toContain("~/.claude/");
-  expect(result.content).toContain("~/.soma/memory/SKILLS/execution.jsonl");
-  expect(result.actions.some((a) => a.kind === "rewrote-pai-memory-path")).toBe(true);
-  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(false);
-  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
-});
+for (const tc of DETERMINISTIC_REWRITE_CASES) {
+  test(`AC-1: ${tc.label} fires ${tc.kind} (not UNMAPPED)`, () => {
+    const result = normalizeSkillContent("body.md", `${tc.inputLine}\n`);
+    expect(result.content).not.toContain("~/.claude/");
+    expect(result.content).toContain(tc.expectedTarget);
+    // Deterministic mapping fires its own action kind...
+    expect(result.actions.some((a) => a.kind === tc.kind)).toBe(true);
+    // ...not the UNMAPPED catch-all action, and no UNMAPPED warning —
+    // the path now has a real Soma home.
+    expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(false);
+    expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
+  });
+}
 
 // ─── AC-1 ordering: new rules run BEFORE the UNMAPPED catch-all ────────
 

--- a/test/pai-pack-importer-issue-91.test.ts
+++ b/test/pai-pack-importer-issue-91.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Issue 91 — pai-pack-importer: replace ~/.claude/PAI/... UNMAPPED catch-all
+ * with deterministic ~/.soma/PAI/... rewrites.
+ *
+ * After #88 (memory taxonomy) + #89 (soma import pai-docs) landed, Soma has
+ * concrete homes for PAI's DOCUMENTATION, TEMPLATES, ALGORITHM, and MEMORY
+ * subtrees. This issue stops sending paths under those subtrees through the
+ * loud UNMAPPED catch-all and instead rewrites them to their real Soma
+ * destinations under named action kinds.
+ *
+ * - AC-1: Each deterministic rewrite below runs as a named action kind in
+ *         the normalizer pipeline, ordered before the UNMAPPED catch-all.
+ * - AC-2: Re-importing the CreateSkill-shaped fixture produces zero
+ *         `rewrote-unmapped-claude-path` actions for paths under
+ *         DOCUMENTATION/, TEMPLATES/, ALGORITHM/, or MEMORY/.
+ * - AC-4: Fixture-based tests cover each new rewrite class.
+ * - AC-5: Existing tests pass (verified by the broader suite; this file
+ *         pins the new contract).
+ */
+import { expect, test } from "bun:test";
+import { normalizeSkillContent } from "../src/pai-pack-normalizer";
+
+// ─── AC-1 + AC-4: per-class deterministic rewrites ─────────────────────
+
+test("AC-1: ~/.claude/PAI/DOCUMENTATION/<rest> rewrites to ~/.soma/PAI/DOCUMENTATION/<rest> via rewrote-pai-doc-path", () => {
+  const content = "See `~/.claude/PAI/DOCUMENTATION/Skills/SkillSystem.md` for details.\n";
+  const result = normalizeSkillContent("body.md", content);
+  expect(result.content).not.toContain("~/.claude/");
+  expect(result.content).toContain("~/.soma/PAI/DOCUMENTATION/Skills/SkillSystem.md");
+  // Deterministic mapping fires its own action kind...
+  expect(result.actions.some((a) => a.kind === "rewrote-pai-doc-path")).toBe(true);
+  // ...not the UNMAPPED catch-all action.
+  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(false);
+  // No UNMAPPED warning either — the path now has a real Soma equivalent.
+  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
+});
+
+test("AC-1: ~/.claude/PAI/TEMPLATES/<rest> rewrites to ~/.soma/PAI/TEMPLATES/<rest> via rewrote-pai-template-path", () => {
+  const content = "Template lives at ~/.claude/PAI/TEMPLATES/ReportTemplate/dashboard.tpl.html.\n";
+  const result = normalizeSkillContent("body.md", content);
+  expect(result.content).not.toContain("~/.claude/");
+  expect(result.content).toContain("~/.soma/PAI/TEMPLATES/ReportTemplate/dashboard.tpl.html");
+  expect(result.actions.some((a) => a.kind === "rewrote-pai-template-path")).toBe(true);
+  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(false);
+  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
+});
+
+test("AC-1: ~/.claude/PAI/ALGORITHM/<rest> rewrites to ~/.soma/PAI/ALGORITHM/<rest> via rewrote-pai-algorithm-path", () => {
+  const content = "Load `~/.claude/PAI/ALGORITHM/v6.3.0.md` and follow its instructions.\n";
+  const result = normalizeSkillContent("body.md", content);
+  expect(result.content).not.toContain("~/.claude/");
+  expect(result.content).toContain("~/.soma/PAI/ALGORITHM/v6.3.0.md");
+  expect(result.actions.some((a) => a.kind === "rewrote-pai-algorithm-path")).toBe(true);
+  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(false);
+  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
+});
+
+test("AC-1: ~/.claude/PAI/MEMORY/<rest> rewrites to ~/.soma/memory/<rest> via rewrote-pai-memory-path", () => {
+  // Note the asymmetric target: PAI's `PAI/MEMORY/` maps to Soma's
+  // `~/.soma/memory/` (lowercase, no PAI/ prefix) per DD-2. The PAI memory
+  // taxonomy is adopted wholesale by Soma — Soma's memory is THE canonical
+  // home, not a PAI projection.
+  const content = "echo run >> ~/.claude/PAI/MEMORY/SKILLS/execution.jsonl\n";
+  const result = normalizeSkillContent("body.md", content);
+  expect(result.content).not.toContain("~/.claude/");
+  expect(result.content).toContain("~/.soma/memory/SKILLS/execution.jsonl");
+  expect(result.actions.some((a) => a.kind === "rewrote-pai-memory-path")).toBe(true);
+  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(false);
+  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
+});
+
+// ─── AC-1 ordering: new rules run BEFORE the UNMAPPED catch-all ────────
+
+test("AC-1 ordering: new deterministic rules win over the UNMAPPED catch-all when both could match", () => {
+  // Without the new deterministic rules, all three paths below would fall
+  // through to the catch-all and be rewritten to ~/.soma/UNMAPPED/PAI/...
+  // After this issue, every one of them must hit its named action kind.
+  const content = [
+    "Read ~/.claude/PAI/DOCUMENTATION/Skills/SkillSystem.md.",
+    "Templates in ~/.claude/PAI/TEMPLATES/Report/.",
+    "Algorithm: ~/.claude/PAI/ALGORITHM/v6.3.0.md.",
+    "Memory: ~/.claude/PAI/MEMORY/SKILLS/execution.jsonl.",
+  ].join("\n");
+  const result = normalizeSkillContent("body.md", content);
+  expect(result.content).not.toContain("~/.claude/");
+  expect(result.content).not.toContain("UNMAPPED");
+  const actionKinds = new Set(result.actions.map((a) => a.kind));
+  expect(actionKinds.has("rewrote-pai-doc-path")).toBe(true);
+  expect(actionKinds.has("rewrote-pai-template-path")).toBe(true);
+  expect(actionKinds.has("rewrote-pai-algorithm-path")).toBe(true);
+  expect(actionKinds.has("rewrote-pai-memory-path")).toBe(true);
+  expect(actionKinds.has("rewrote-unmapped-claude-path")).toBe(false);
+  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
+});
+
+// ─── AC-2: residue not under DOC/TEMPL/ALGO/MEMORY still surfaces as UNMAPPED
+
+test("AC-2: paths NOT under DOC/TEMPL/ALGO/MEMORY (e.g. PAI/USER/, History/) still route to UNMAPPED warning", () => {
+  // The deterministic rewrites are surgical: ~/.claude/PAI/USER/... has no
+  // Soma equivalent (per issue body) and must still surface as a loud
+  // UNMAPPED warning so the audit trail does not lose the signal.
+  const content = [
+    "User overlay: ~/.claude/PAI/USER/PRINCIPAL_IDENTITY.md.",
+    "Backups: ~/.claude/History/Backups/Foo-backup/.",
+    "Bare PAI: ~/.claude/PAI/SkillSystem.md.",
+  ].join("\n");
+  const result = normalizeSkillContent("body.md", content);
+  expect(result.content).not.toContain("~/.claude/");
+  // Each of these residue forms produces a catch-all rewrite + warning.
+  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(true);
+  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(true);
+  // Targets land under UNMAPPED placeholder so runtime breakage is loud.
+  expect(result.content).toContain("~/.soma/UNMAPPED/PAI/USER/PRINCIPAL_IDENTITY.md");
+  expect(result.content).toContain("~/.soma/UNMAPPED/History/Backups/Foo-backup/");
+  expect(result.content).toContain("~/.soma/UNMAPPED/PAI/SkillSystem.md");
+});
+
+// ─── AC-2: CreateSkill-shaped real residues all route deterministically ─
+
+test("AC-2: CreateSkill stress lines under DOC/TEMPL/ALGO/MEMORY produce zero UNMAPPED actions", () => {
+  // The exact residue forms surfaced by re-importing
+  // ~/work/PAI/Packs/CreateSkill, filtered to paths under the four
+  // subtrees now covered. After this issue, NONE of these should produce
+  // a `rewrote-unmapped-claude-path` action.
+  const content = [
+    "Read ~/.claude/PAI/DOCUMENTATION/Skills/SkillSystem.md before creating any skill.",
+    "Notifications live in ~/.claude/PAI/DOCUMENTATION/Notifications/NotificationSystem.md.",
+    "Tool architecture: ~/.claude/PAI/DOCUMENTATION/Tools/CliFirstArchitecture.md.",
+    "echo run >> ~/.claude/PAI/MEMORY/SKILLS/execution.jsonl",
+    "Templates: ~/.claude/PAI/TEMPLATES/Report/index.tpl.md",
+    "Algorithm: ~/.claude/PAI/ALGORITHM/v6.3.0.md",
+  ].join("\n");
+  const result = normalizeSkillContent("Workflows/Stress.md", content);
+
+  // AC-3 residue invariant from #86 still holds.
+  expect(result.content).not.toContain("~/.claude/");
+
+  // The whole point of this issue: zero UNMAPPED actions for these paths.
+  expect(result.actions.some((a) => a.kind === "rewrote-unmapped-claude-path")).toBe(false);
+  expect(result.warnings.some((w) => w.kind === "unmapped-claude-home-path")).toBe(false);
+
+  // All four new action kinds present.
+  const actionKinds = new Set(result.actions.map((a) => a.kind));
+  expect(actionKinds.has("rewrote-pai-doc-path")).toBe(true);
+  expect(actionKinds.has("rewrote-pai-template-path")).toBe(true);
+  expect(actionKinds.has("rewrote-pai-algorithm-path")).toBe(true);
+  expect(actionKinds.has("rewrote-pai-memory-path")).toBe(true);
+});
+
+// ─── AC-1: action detail records the actual pattern + target for audit ─
+
+test("AC-1: each new action kind records its source pattern and target in the audit detail", () => {
+  // The audit trail must let a reviewer reconstruct which rule fired.
+  // Mirror the detail shape from the existing `rewrote-claude-home-path`
+  // entries — `Rewrote <pattern> → <target>`.
+  const content = [
+    "~/.claude/PAI/DOCUMENTATION/A.md",
+    "~/.claude/PAI/TEMPLATES/B.md",
+    "~/.claude/PAI/ALGORITHM/C.md",
+    "~/.claude/PAI/MEMORY/D.md",
+  ].join("\n");
+  const result = normalizeSkillContent("body.md", content);
+  const byKind = new Map(result.actions.map((a) => [a.kind, a.detail]));
+  expect(byKind.get("rewrote-pai-doc-path")).toMatch(/DOCUMENTATION.*~\/\.soma\/PAI\/DOCUMENTATION/);
+  expect(byKind.get("rewrote-pai-template-path")).toMatch(/TEMPLATES.*~\/\.soma\/PAI\/TEMPLATES/);
+  expect(byKind.get("rewrote-pai-algorithm-path")).toMatch(/ALGORITHM.*~\/\.soma\/PAI\/ALGORITHM/);
+  expect(byKind.get("rewrote-pai-memory-path")).toMatch(/MEMORY.*~\/\.soma\/memory/);
+});


### PR DESCRIPTION
## Summary

After #88 (memory taxonomy alignment) and #89 (`soma import pai-docs`) landed, Soma has concrete homes for PAI's `DOCUMENTATION/`, `TEMPLATES/`, `ALGORITHM/`, and `MEMORY/` subtrees. This PR stops sending paths under those subtrees through the loud `UNMAPPED` catch-all and routes them to their real Soma destinations under four new named action kinds.

After this lands, `rewrote-unmapped-claude-path` + `unmapped-claude-home-path` fire only for paths Soma genuinely doesn't have an equivalent for (`~/.claude/PAI/USER/...`, `~/.claude/History/Backups/...`, bare `~/.claude/PAI/<file>.md`).

## Changes

- `src/types.ts` — add four new `PaiPackNormalizationAction` kinds: `rewrote-pai-doc-path`, `rewrote-pai-template-path`, `rewrote-pai-algorithm-path`, `rewrote-pai-memory-path`.
- `src/pai-pack-normalizer.ts` — extend `CLAUDE_HOME_DETERMINISTIC` with the four new rules, ordered before the UNMAPPED catch-all. Promotes the prior MEMORY rewrite from the generic `rewrote-claude-home-path` umbrella to its own named kind so the audit trail can disambiguate skills vs memory mappings.
- `docs/pai-pack-importer.md` — classification table updated with the four new rules and the asymmetric MEMORY → memory target rationale (per DD-1, DD-2).
- `test/pai-pack-importer-issue-91.test.ts` (new) — 8 fixture-based tests covering per-rule rewrite, ordering precedence over UNMAPPED catch-all, the CreateSkill-shaped zero-UNMAPPED contract, and audit detail formatting.
- `test/pai-pack-importer-issue-86.test.ts` — update two superseded assertions: DOCUMENTATION no longer routes to UNMAPPED (issue 91's whole point); MEMORY action kind moved from generic `rewrote-claude-home-path` to named `rewrote-pai-memory-path`.

## Acceptance criteria

- [x] **AC-1**: Each deterministic rewrite runs as a named action kind in the normalizer pipeline, ordered before the UNMAPPED catch-all. (Rules declared in `CLAUDE_HOME_DETERMINISTIC` in most-specific-first order; pipeline order in `normalizeSkillContent` unchanged — deterministic rewrites still run before `applyUnmappedClaudePathCatchall`.)
- [x] **AC-2**: Re-importing `~/work/PAI/Packs/CreateSkill` produces zero `rewrote-unmapped-claude-path` actions for paths under `DOCUMENTATION/`, `TEMPLATES/`, `ALGORITHM/`, or `MEMORY/`. Verified by fixture test `AC-2: CreateSkill stress lines under DOC/TEMPL/ALGO/MEMORY produce zero UNMAPPED actions` in `test/pai-pack-importer-issue-91.test.ts`.
- [x] **AC-3**: `docs/pai-pack-importer.md` classification table updated.
- [x] **AC-4**: Fixture-based tests cover each new rewrite class (one per kind + ordering test + audit detail test = 8 new tests).
- [x] **AC-5**: Existing tests pass (615 pass / 0 fail).

## Test evidence

- `bun run typecheck`: clean.
- `bun test`: **615 pass / 0 fail / 1954 expect() calls.** Suite delta: baseline 607 → 615 (+8 new tests; 2 superseded tests in `issue-86.test.ts` rewritten in place to pin the new contract).

## Test plan

- [x] Run `bun test` — full suite green.
- [x] Run `bun run typecheck` — clean.
- [x] Final stress test (post-merge, per sprint plan §"Session-end contract" item 4): re-import `~/work/PAI/Packs/CreateSkill` and verify zero `UNMAPPED` residue across the entire skill body.

Closes #91