### PR TITLE
feat(migrate): add --pai-repo to derive source-dir + packs-dir from canonical PAI layout (#98)

### DIFF
--- a/docs/migration-from-pai.md
+++ b/docs/migration-from-pai.md
@@ -1,0 +1,147 @@
+# Migrating from PAI to Soma
+
+This walkthrough takes a Personal AI Infrastructure (PAI) install and
+projects it into a substrate-portable Soma store at `~/.soma/`. It is
+the principal-facing companion to the four-issue canonical migration
+sprint (#88 / #89 / #90 / #91) and the `--pai-repo` simplification
+landed in #98.
+
+The orchestrator behind the walkthrough is `soma migrate pai`. Under
+the hood it runs identity import, the Algorithm import, memory
+translation, the bulk pack import, and the PAI docs import as ordered
+phases against your Claude home (`~/.claude` by default) and a PAI
+release checkout. Every phase is idempotent — rerun is safe.
+
+## Prerequisites
+
+- A PAI repo checked out somewhere on disk. The canonical location is
+  `~/work/PAI/`. The repo must have the canonical layout:
+    - `<pai-repo>/Releases/v<semver>/.claude/PAI/` — DOCUMENTATION,
+      TEMPLATES, ALGORITHM.
+    - `<pai-repo>/Packs/` — canonical pack source.
+- A PAI install rooted at `~/.claude/` (or a custom path supplied via
+  `--pai-install`). The orchestrator reads identity + memory from it.
+- Soma installed (`bun install` in this repo; the `soma` CLI on
+  `$PATH` or invoked via `bun src/cli.ts`).
+
+## Step 1 — Dry-run the migration
+
+Always start with a dry-run. It lists every file the orchestrator
+intends to touch and refuses loud on any setup problem (missing PAI
+identity, malformed release tree, etc.).
+
+```bash
+soma migrate pai --pai-repo ~/work/PAI
+```
+
+`--pai-repo` derives both paths the orchestrator needs from a single
+root:
+
+- `--pai-source-dir` → `<root>/Releases/<latest-semver>/.claude/PAI`
+  (where `<latest-semver>` is the highest 3-segment semver under
+  `Releases/`; non-semver siblings like `Pi` or `v2.3` are filtered
+  out).
+- `--pai-packs-dir` → `<root>/Packs`.
+
+If either path doesn't resolve, the command refuses loud — it does
+not silently fall back to defaults.
+
+You can still pass the underlying flags directly if you need to
+override either side (see [Step 4](#step-4--overriding-the-derivation)).
+
+## Step 2 — Apply the migration
+
+Once the dry-run looks right, apply it:
+
+```bash
+soma migrate pai --pai-repo ~/work/PAI --apply
+```
+
+The orchestrator writes:
+
+- `~/.soma/profile/principal.md` — identity projection (#28).
+- `~/.soma/the-algorithm/` — Algorithm import (#28).
+- `~/.soma/memory/<CATEGORY>/...` — translated PAI memory (#90).
+- `~/.soma/skills/<slug>/` — one per pack under `Packs/` (#28 / #90).
+- `~/.soma/PAI/DOCUMENTATION|TEMPLATES|ALGORITHM/...` — docs import
+  (#89).
+- `~/.soma/profile/imports/claude/MIGRATION.md` — the human-readable
+  manifest of what landed and when.
+
+Per-pack and per-phase fingerprints land in MIGRATION.md so rerunning
+without source drift leaves the file byte-stable (`--status` will
+report `Last migrated at:` unchanged).
+
+## Step 3 — Inspect the result
+
+```bash
+soma migrate pai --status
+```
+
+Prints MIGRATION.md as-is. It lists each phase's outcome, including
+any packs that were refused (substrate-specific, reserved-name, or
+genuine error) via the per-pack outcome table from #97.
+
+## Step 4 — Overriding the derivation
+
+Explicit `--pai-source-dir` and `--pai-packs-dir` always win over
+`--pai-repo` derivation. You can pass either or both:
+
+```bash
+# Override only the source-dir; packs still derived from --pai-repo.
+soma migrate pai \
+  --pai-repo ~/work/PAI \
+  --pai-source-dir ~/work/PAI/Releases/v4.0.3/.claude/PAI \
+  --apply
+
+# Override both; --pai-repo is then only used for existence checking.
+soma migrate pai \
+  --pai-repo ~/work/PAI \
+  --pai-source-dir ~/work/PAI/Releases/v4.0.3/.claude/PAI \
+  --pai-packs-dir /tmp/test-packs \
+  --apply
+
+# The pre-#98 verbose form still works without --pai-repo at all.
+soma migrate pai \
+  --pai-install ~/.claude \
+  --pai-source-dir ~/work/PAI/Releases/v5.0.0/.claude/PAI \
+  --pai-packs-dir ~/work/PAI/Packs \
+  --apply
+```
+
+## Failure modes
+
+| Symptom                                                             | Likely cause                                                                                          |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `--pai-repo: <path> does not exist`                                 | Root passed to `--pai-repo` is missing. Check the path; PAI lives at `~/work/PAI` on the canonical machine. |
+| `--pai-repo: <root>/Releases does not exist`                        | `<root>` doesn't have the canonical layout. Either fix it or pass `--pai-source-dir` explicitly.       |
+| `--pai-repo derivation: <root>/Releases contains no semver-named directories` | The Releases/ tree only has non-semver names (`Pi`, `v2.3`, `latest`). Pass `--pai-source-dir` explicitly to override. |
+| `--pai-repo: <root>/Packs does not exist`                           | Releases is fine but Packs/ is missing. Either fix it or pass `--pai-packs-dir` explicitly.            |
+| `soma migrate pai — N pack(s) failed with genuine errors`           | Per #97. Other packs proceeded; the failure detail is in the outcome table. The whole run was non-zero exit. |
+| `... refused-substrate-specific ...`                                | A pack ships files under `src/` that aren't `SKILL.md`, `Workflows/`, `Tools/`. Pass `--include-substrate-specific` to land them. |
+| `... refused-reserved ...`                                          | A pack's slug collides with `isa`, `the-algorithm`, `knowledge`, or `telos`. Pass `--overwrite-reserved` to permit. |
+
+## Skipping phases
+
+For partial reruns:
+
+```bash
+# Memory and docs only — skip identity/algorithm if those are stable.
+soma migrate pai --pai-repo ~/work/PAI --apply --skip-skills
+
+# Skip docs — useful if you're iterating only on packs.
+soma migrate pai --pai-repo ~/work/PAI --apply --skip-docs
+```
+
+`--skip-skills` also short-circuits pack discovery, so a malformed
+`Packs/` dir won't throw when you've explicitly opted out of that
+phase.
+
+## Related
+
+- #88 — memory taxonomy alignment.
+- #89 — `soma import pai-docs` (the docs phase, callable standalone).
+- #90 — full orchestration (memory + bulk packs + docs phases added).
+- #91 — importer deterministic rewrites for cross-references.
+- #97 — substrate-specific passthrough + log-and-continue per-pack.
+- #98 — `--pai-repo` single-flag derivation (this doc).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -296,7 +296,7 @@ const TOP_LEVEL_COMMANDS = [
 ] as const;
 
 const MIGRATE_PAI_USAGE =
-  "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-install <dir>] [--pai-source-dir <dir>] [--pai-packs-dir <dir>] [--pai-pack-dir <dir>] [--skip-memory] [--skip-skills] [--skip-docs] [--overwrite-reserved] [--include-substrate-specific]";
+  "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-install <dir>] [--pai-repo <root>] [--pai-source-dir <dir>] [--pai-packs-dir <dir>] [--pai-pack-dir <dir>] [--skip-memory] [--skip-skills] [--skip-docs] [--overwrite-reserved] [--include-substrate-specific]";
 const ADOPT_CLAUDE_USAGE =
   "Usage: soma adopt claude [--dry-run] [--apply] [--uninstall] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string, string> }> = {
@@ -1516,6 +1516,16 @@ function parseMigrateArgs(args: string[]): ParsedMigrateArgs {
         break;
       case "--pai-source-dir":
         options.paiSourceDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--pai-repo":
+        // #98 — single PAI repo root. The orchestrator derives both
+        // `paiSourceDir` (→ `<root>/Releases/<latest-semver>/.claude/PAI`)
+        // and `paiPacksDir` (→ `<root>/Packs`) from it BEFORE the
+        // phases run. Explicit `--pai-source-dir` / `--pai-packs-dir`
+        // always win — `--pai-repo` only fills the unset slots. See
+        // `applyPaiRepoDerivation` in `src/pai-migration.ts`.
+        options.paiRepo = readOption(rest, index, arg);
         index += 1;
         break;
       case "--skip-memory":

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -131,6 +131,25 @@ export interface PaiMigrationOptions {
    * `packOutcomes` as `refused-substrate-specific`.
    */
   includeSubstrateSpecific?: boolean;
+  /**
+   * #98 — single root pointing at a canonical PAI repo checkout. The
+   * orchestrator derives both `paiSourceDir` (→ `<root>/Releases/<latest-semver>/.claude/PAI`)
+   * and `paiPacksDir` (→ `<root>/Packs`) from it, BEFORE the planning
+   * or apply phases run. Explicit `paiSourceDir` / `paiPacksDir` in
+   * the same options object always win — derivation only fills the
+   * unset slots. Refusal is loud (thrown Error) when:
+   *   - `<root>` itself is missing.
+   *   - `<root>/Releases/` is missing (and `paiSourceDir` is unset).
+   *   - `<root>/Releases/` contains zero semver-named (`v?\d+\.\d+\.\d+`)
+   *     directories.
+   *   - `<root>/Packs/` is missing (and `paiPacksDir` is unset).
+   *
+   * Semver sort is real, not lexical — `v10.0.0 > v2.0.0`. Bare
+   * `1.2.3` and `v1.2.3` are accepted equivalently. Anything that
+   * isn't a parseable 3-segment semver (e.g. `Pi`, `v2.3`, `latest`)
+   * is filtered out before the highest is picked.
+   */
+  paiRepo?: string;
 }
 
 export interface PaiMigrationPlan {
@@ -233,6 +252,129 @@ async function autoDiscoverPackPaths(packsRoot: string): Promise<string[]> {
     throw error;
   }
   return entries.filter((e) => e.isDirectory()).map((e) => join(packsRoot, e.name));
+}
+
+// #98 — semver derivation for --pai-repo.
+//
+// PAI's canonical release layout is `<root>/Releases/v<major>.<minor>.<patch>/.claude/PAI`.
+// Sibling directories under `Releases/` may include non-semver names
+// (e.g. `Pi`, `README.md`, `v2.3`) — those are filtered out before
+// picking the highest version. We accept both bare `1.2.3` and the
+// `v` prefix because the real PAI repo on this machine mixes them.
+//
+// Sort is REAL semver, not lexical: `v10.0.0 > v2.0.0`. The previous
+// would-be lexical sort would happily report `v2.5.0` as latest when
+// `v10.0.0` exists.
+interface ParsedSemver {
+  raw: string;
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+function parseSemverDirName(name: string): ParsedSemver | null {
+  // Accept `1.2.3` or `v1.2.3`. Reject `v1.2`, `v1`, `latest`,
+  // `main`, `1.2.3-pre` (no pre-release support per issue scope).
+  const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(name);
+  if (match === null) return null;
+  return {
+    raw: name,
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  };
+}
+
+function compareSemver(a: ParsedSemver, b: ParsedSemver): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+}
+
+// Pick the highest semver-named directory under `releasesDir`. Returns
+// the entry name (e.g. `v5.0.0`) — the caller composes the full path.
+// Throws if no parseable semver dirs are present (refuse-loud per AC-3).
+async function pickLatestSemverDir(releasesDir: string): Promise<string> {
+  let entries;
+  try {
+    entries = await readdir(releasesDir, { withFileTypes: true });
+  } catch (error) {
+    if (isEnoent(error)) {
+      throw new Error(
+        `--pai-repo derivation: ${releasesDir} does not exist. Expected a directory of semver-named release subdirectories.`,
+      );
+    }
+    throw error;
+  }
+  const semverDirs = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => parseSemverDirName(e.name))
+    .filter((parsed): parsed is ParsedSemver => parsed !== null);
+  if (semverDirs.length === 0) {
+    const sample = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .slice(0, 5);
+    throw new Error(
+      `--pai-repo derivation: ${releasesDir} contains no semver-named directories ` +
+        `(expected names like \`v1.2.3\` or \`1.2.3\`). ` +
+        `${sample.length === 0 ? "Releases/ is empty." : `Saw: ${sample.join(", ")}.`} ` +
+        `Pass --pai-source-dir explicitly to override.`,
+    );
+  }
+  semverDirs.sort(compareSemver);
+  return semverDirs[semverDirs.length - 1].raw;
+}
+
+/**
+ * Apply --pai-repo derivation. Returns a NEW options object with
+ * `paiSourceDir` and `paiPacksDir` filled in from `paiRepo` when they
+ * are not already explicitly set. Mutates nothing — the caller passes
+ * the returned options forward.
+ *
+ * Refuse-loud contract:
+ *   - `<root>` must exist as a directory.
+ *   - If `paiSourceDir` is NOT explicit: `<root>/Releases/<latest-semver>/.claude/PAI`
+ *     must resolve; missing/empty/non-semver Releases throws.
+ *   - If `paiPacksDir` is NOT explicit: `<root>/Packs` must exist.
+ *
+ * No-op when `paiRepo` is unset. The result type's `paiRepo` field is
+ * stripped to make the derivation invisible to downstream phases.
+ */
+async function applyPaiRepoDerivation(
+  options: PaiMigrationOptions,
+): Promise<PaiMigrationOptions> {
+  if (!options.paiRepo) return options;
+  const root = resolve(options.paiRepo);
+  if (!(await exists(root))) {
+    throw new Error(
+      `--pai-repo: ${root} does not exist. Expected a PAI repo root with Releases/ and Packs/ subdirectories.`,
+    );
+  }
+  const derived: PaiMigrationOptions = { ...options };
+  // Source-dir derivation is only triggered when the explicit flag
+  // isn't set. Same for packs-dir below — explicit always wins per
+  // AC-5.
+  if (!derived.paiSourceDir) {
+    const releasesDir = join(root, "Releases");
+    if (!(await exists(releasesDir))) {
+      throw new Error(
+        `--pai-repo: ${releasesDir} does not exist. Either supply --pai-source-dir explicitly or fix the repo layout.`,
+      );
+    }
+    const latestName = await pickLatestSemverDir(releasesDir);
+    derived.paiSourceDir = join(releasesDir, latestName, ".claude/PAI");
+  }
+  if (!derived.paiPacksDir) {
+    const packsDir = join(root, "Packs");
+    if (!(await exists(packsDir))) {
+      throw new Error(
+        `--pai-repo: ${packsDir} does not exist. Either supply --pai-packs-dir explicitly or fix the repo layout.`,
+      );
+    }
+    derived.paiPacksDir = packsDir;
+  }
+  return derived;
 }
 
 function manifestPathFor(somaHome: string): string {
@@ -478,8 +620,15 @@ async function discoverMigrationSources(
  * migratePai.
  */
 export async function planPaiMigration(options: PaiMigrationOptions = {}): Promise<PaiMigrationPlan> {
-  const { claudeHome, somaHome } = resolvePaths(options);
-  const { algorithmDir, packPaths } = await discoverMigrationSources(claudeHome, options);
+  // #98 — derive paiSourceDir + paiPacksDir from --pai-repo before any
+  // phase runs. Explicit flags win; missing/empty/non-semver Releases
+  // and missing Packs both refuse loud here (per AC-3/AC-4) so the
+  // failure surfaces at the orchestrator entry point rather than as a
+  // cryptic downstream error in one of the phase importers.
+  const derived = await applyPaiRepoDerivation(options);
+  const { claudeHome, somaHome } = resolvePaths(derived);
+  const { algorithmDir, packPaths } = await discoverMigrationSources(claudeHome, derived);
+  options = derived;
 
   const identity = planPaiImport({ homeDir: options.homeDir, claudeHome, somaHome });
   const algorithm = algorithmDir === null
@@ -763,6 +912,10 @@ async function renderStableMigrationManifest(
  * partial-success swallow. The caller decides whether to retry.
  */
 export async function migratePai(options: PaiMigrationOptions = {}): Promise<PaiMigrationResult> {
+  // #98 — mirror planPaiMigration: derive paiSourceDir + paiPacksDir
+  // from --pai-repo before any phase runs.
+  const derived = await applyPaiRepoDerivation(options);
+  options = derived;
   const { claudeHome, somaHome } = resolvePaths(options);
   const { algorithmDir, packPaths } = await discoverMigrationSources(claudeHome, options);
   const filesWritten: string[] = [];

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -366,13 +366,23 @@ async function applyPaiRepoDerivation(
     derived.paiSourceDir = join(releasesDir, latestName, ".claude/PAI");
   }
   if (!derived.paiPacksDir) {
-    const packsDir = join(root, "Packs");
-    if (!(await exists(packsDir))) {
-      throw new Error(
-        `--pai-repo: ${packsDir} does not exist. Either supply --pai-packs-dir explicitly or fix the repo layout.`,
-      );
+    // Sage r1 #100 important: short-circuit Packs derivation when
+    // `--skip-skills` is set. Otherwise the documented recovery path
+    // ("skip-skills also short-circuits pack discovery, so a
+    // malformed Packs/ dir won't throw") is wrong — derivation
+    // refused before `discoverMigrationSources` got a chance to
+    // honor skipSkills. Mirrors that downstream skip exactly: when
+    // the skill phase is explicitly off, Packs/ existence is no
+    // longer a precondition.
+    if (derived.skipSkills !== true) {
+      const packsDir = join(root, "Packs");
+      if (!(await exists(packsDir))) {
+        throw new Error(
+          `--pai-repo: ${packsDir} does not exist. Either supply --pai-packs-dir explicitly or fix the repo layout.`,
+        );
+      }
+      derived.paiPacksDir = packsDir;
     }
-    derived.paiPacksDir = packsDir;
   }
   return derived;
 }

--- a/test/pai-migration-issue-98.test.ts
+++ b/test/pai-migration-issue-98.test.ts
@@ -321,6 +321,29 @@ test("#98 CLI: --help mentions --pai-repo", async () => {
   expect(output).toContain("--pai-repo");
 });
 
+// Sage r1 #100 regression — --skip-skills short-circuits Packs derivation.
+// The doc claims a missing/malformed Packs/ won't throw when the skill
+// phase is explicitly opted out. The orchestrator-level derivation
+// must honor that or the documented recovery path is wrong.
+test("#98 --pai-repo with --skip-skills no longer requires Packs/", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    // Releases is valid but Packs is intentionally missing.
+    const paiRoot = await plantPaiRepoFixture(homeDir, { plantPacks: false });
+
+    // Without --skip-skills this would throw (covered above). With it
+    // set, derivation must skip the Packs/ existence check entirely.
+    const plan = await planPaiMigration({
+      homeDir,
+      paiRepo: paiRoot,
+      skipSkills: true,
+    });
+
+    expect(plan.docs?.paiSourceDir).toContain(join("Releases/v5.0.0/.claude/PAI"));
+    expect(plan.packs).toEqual([]);
+  });
+});
+
 // migratePai (apply) — derivation propagates through to actual writes.
 test("#98 migratePai --apply with --pai-repo writes manifest referencing derived release", async () => {
   await withTempHome(async (homeDir) => {

--- a/test/pai-migration-issue-98.test.ts
+++ b/test/pai-migration-issue-98.test.ts
@@ -1,0 +1,339 @@
+/**
+ * #98 — `soma migrate pai --pai-repo <root>` derivation.
+ *
+ * Eight fixture scenarios from the issue's AC-6:
+ *   1. Clean derivation: `--pai-repo <root>` with valid layout, no
+ *      other flags → both paths derived (source-dir + packs-dir).
+ *   2. Latest-version selection: multiple semver dirs under Releases/,
+ *      including `v10.0.0` to pin SEMVER-not-lexical sort.
+ *   3. Ambiguous semver refusal: Releases/ exists but contains zero
+ *      semver-named dirs (or only non-semver names like `Pi`, `v2.3`).
+ *   4. Missing Packs refusal: Releases tree exists but no Packs/.
+ *   5. Missing Releases refusal: Packs/ exists but no Releases/.
+ *   6. Full explicit override: --pai-repo + --pai-source-dir + --pai-packs-dir →
+ *      explicit wins, root unused.
+ *   7. Partial explicit override: --pai-repo + --pai-source-dir only
+ *      → source explicit, packs derived from root.
+ *   8. Non-existent root refusal: --pai-repo <missing> → refuse loud.
+ *
+ * Targets both the library surface (`planPaiMigration` / `migratePai`
+ * accepts `paiRepo` on `PaiMigrationOptions`) and the CLI surface
+ * (`--pai-repo` reaches the same code path).
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { migratePai, planPaiMigration } from "../src/pai-migration";
+import { runSomaCli } from "../src/cli";
+import {
+  withTempHome as withSharedTempHome,
+  writePaiIdentityFixture as writeIdentityFixture,
+  writePaiPackFixture as writePackFixture,
+} from "./fixtures/pai-migration-fixtures";
+
+const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
+  withSharedTempHome(fn, "soma-98-");
+
+/**
+ * Plant a canonical PAI repo layout under `<homeDir>/PAI`:
+ *   <homeDir>/PAI/Releases/<version>/.claude/PAI/{DOCUMENTATION,TEMPLATES,ALGORITHM}/
+ *   <homeDir>/PAI/Packs/<packName>/  (one tiny pack for the bulk phase)
+ *
+ * Extra non-semver dirs under Releases/ may be planted to assert the
+ * semver-aware filter. `versions` controls which directories appear
+ * under Releases/.
+ */
+async function plantPaiRepoFixture(
+  homeDir: string,
+  options: {
+    versions?: string[];
+    plantPacks?: boolean;
+    plantReleases?: boolean;
+  } = {},
+): Promise<string> {
+  const root = join(homeDir, "PAI");
+  const versions = options.versions ?? ["v5.0.0"];
+  const plantPacks = options.plantPacks !== false;
+  const plantReleases = options.plantReleases !== false;
+
+  if (plantReleases) {
+    for (const v of versions) {
+      const release = join(root, "Releases", v, ".claude/PAI");
+      await mkdir(join(release, "DOCUMENTATION"), { recursive: true });
+      await writeFile(join(release, "DOCUMENTATION/SkillSystem.md"), "# Skills\n", "utf8");
+      await mkdir(join(release, "TEMPLATES"), { recursive: true });
+      await writeFile(join(release, "TEMPLATES/skill.md"), "# Template\n", "utf8");
+      await mkdir(join(release, "ALGORITHM"), { recursive: true });
+      await writeFile(join(release, "ALGORITHM/v6.3.0.md"), "# Algo\n", "utf8");
+    }
+  }
+  if (plantPacks) {
+    await writePackFixture(join(root, "Packs"), "TinyPack");
+  }
+  return root;
+}
+
+// AC-1 + AC-2 — clean derivation: --pai-repo only.
+test("#98 --pai-repo derives both source-dir and packs-dir (clean layout)", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir, { withAlgorithm: true });
+    const paiRoot = await plantPaiRepoFixture(homeDir);
+
+    const plan = await planPaiMigration({
+      homeDir,
+      paiRepo: paiRoot,
+    });
+
+    // Derived source-dir produced a docs phase plan.
+    expect(plan.docs).not.toBeNull();
+    expect(plan.docs?.paiSourceDir).toContain(join("Releases", "v5.0.0", ".claude/PAI"));
+    // Derived packs-dir picked up the tiny pack.
+    expect(plan.packs.length).toBeGreaterThan(0);
+    expect(plan.packs[0].paiPackDir).toContain(join("PAI/Packs", "TinyPack"));
+  });
+});
+
+// AC-1 + AC-2 — CLI surface end-to-end with --pai-repo.
+test("#98 CLI: soma migrate pai --pai-repo derives both paths", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir, { withAlgorithm: true });
+    const paiRoot = await plantPaiRepoFixture(homeDir);
+
+    const output = await runSomaCli([
+      "migrate",
+      "pai",
+      "--pai-repo",
+      paiRoot,
+      "--home-dir",
+      homeDir,
+    ]);
+    expect(output).toContain("dry-run");
+    // Derived source-dir is referenced in the plan summary via the
+    // docs-phase release version line. Packs discovery lands as
+    // "packs: 1 discovered" (formatter doesn't echo pack names).
+    expect(output).toContain("v5.0.0");
+    expect(output).toContain("packs:    1 discovered");
+  });
+});
+
+// AC-1 — latest-version selection uses SEMVER, not lexical sort.
+test("#98 --pai-repo picks latest semver (v10.0.0 > v2.5.0 > v2.0.0 > v1.0.0)", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const paiRoot = await plantPaiRepoFixture(homeDir, {
+      versions: ["v1.0.0", "v2.0.0", "v10.0.0", "v2.5.0"],
+    });
+
+    const plan = await planPaiMigration({
+      homeDir,
+      paiRepo: paiRoot,
+    });
+
+    expect(plan.docs?.paiSourceDir).toContain(join("Releases", "v10.0.0", ".claude/PAI"));
+    expect(plan.docs?.paiSourceDir).not.toContain(join("Releases", "v2.5.0"));
+  });
+});
+
+// AC-1 — also accepts bare `1.2.3` (no v prefix).
+test("#98 --pai-repo accepts bare semver and v-prefixed equivalently", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const paiRoot = await plantPaiRepoFixture(homeDir, {
+      versions: ["1.0.0", "v2.0.0"],
+    });
+
+    const plan = await planPaiMigration({ homeDir, paiRepo: paiRoot });
+
+    expect(plan.docs?.paiSourceDir).toContain(join("Releases", "v2.0.0", ".claude/PAI"));
+  });
+});
+
+// AC-3 — Releases/ exists but contains zero parseable semver dirs.
+test("#98 --pai-repo refuses loud when Releases/ has no semver-named dirs", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    // Plant ONLY non-semver-named directories under Releases/.
+    const paiRoot = await plantPaiRepoFixture(homeDir, {
+      versions: ["Pi", "v2.3", "latest", "main"],
+    });
+    // The fixture writer didn't reject those names; it created
+    // <root>/Releases/Pi/.claude/PAI etc. But none parse as 3-segment
+    // semver, so derivation must refuse.
+
+    await expect(planPaiMigration({ homeDir, paiRepo: paiRoot })).rejects.toThrow(
+      /semver|no.*version/i,
+    );
+  });
+});
+
+// AC-3 — Releases/ exists but is empty.
+test("#98 --pai-repo refuses loud when Releases/ exists but is empty", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const paiRoot = join(homeDir, "PAI");
+    await mkdir(join(paiRoot, "Releases"), { recursive: true });
+    await mkdir(join(paiRoot, "Packs"), { recursive: true });
+
+    await expect(planPaiMigration({ homeDir, paiRepo: paiRoot })).rejects.toThrow(
+      /semver|no.*version|empty/i,
+    );
+  });
+});
+
+// AC-4 — Releases/ valid but Packs/ missing.
+test("#98 --pai-repo refuses loud when Packs/ is missing", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const paiRoot = await plantPaiRepoFixture(homeDir, { plantPacks: false });
+
+    await expect(planPaiMigration({ homeDir, paiRepo: paiRoot })).rejects.toThrow(
+      /Packs/,
+    );
+  });
+});
+
+// AC-3 — Releases/ missing.
+test("#98 --pai-repo refuses loud when Releases/ is missing", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const paiRoot = await plantPaiRepoFixture(homeDir, { plantReleases: false });
+
+    await expect(planPaiMigration({ homeDir, paiRepo: paiRoot })).rejects.toThrow(
+      /Releases/,
+    );
+  });
+});
+
+// AC-5 — full explicit override: both --pai-source-dir and --pai-packs-dir
+// override derivation, root only used for existence (or even unused if both
+// explicit). Test by giving a root that lacks Releases/Packs but works
+// because both explicit flags are supplied.
+test("#98 explicit --pai-source-dir + --pai-packs-dir override --pai-repo derivation", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    // Plant a root with valid Releases/Packs (so --pai-repo passes the
+    // existence check) BUT with a different version on disk. Then
+    // explicitly point both to a DIFFERENT release tree to assert
+    // the explicit flags win.
+    const paiRoot = await plantPaiRepoFixture(homeDir, { versions: ["v5.0.0"] });
+    // Plant a second, "explicit" tree at a different root.
+    const explicitRoot = join(homeDir, "AltPAI");
+    const explicitSourceDir = join(explicitRoot, "Releases/v9.9.9/.claude/PAI");
+    await mkdir(join(explicitSourceDir, "DOCUMENTATION"), { recursive: true });
+    await writeFile(join(explicitSourceDir, "DOCUMENTATION/x.md"), "# x\n", "utf8");
+    await writePackFixture(join(explicitRoot, "Packs"), "AltPack");
+
+    const plan = await planPaiMigration({
+      homeDir,
+      paiRepo: paiRoot,
+      paiSourceDir: explicitSourceDir,
+      paiPacksDir: join(explicitRoot, "Packs"),
+    });
+
+    // Explicit flags wins: source resolves to v9.9.9, pack is AltPack.
+    expect(plan.docs?.paiSourceDir).toContain("v9.9.9");
+    expect(plan.docs?.paiSourceDir).not.toContain("v5.0.0");
+    expect(plan.packs.length).toBe(1);
+    expect(plan.packs[0].paiPackDir).toContain("AltPack");
+  });
+});
+
+// AC-5 partial — explicit --pai-source-dir only; packs still derived from
+// --pai-repo.
+test("#98 partial override: explicit --pai-source-dir wins, --pai-packs-dir still derived", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const paiRoot = await plantPaiRepoFixture(homeDir, { versions: ["v5.0.0"] });
+    const explicitSourceDir = join(homeDir, "ExplicitSrc/.claude/PAI");
+    await mkdir(join(explicitSourceDir, "DOCUMENTATION"), { recursive: true });
+    await writeFile(join(explicitSourceDir, "DOCUMENTATION/y.md"), "# y\n", "utf8");
+
+    const plan = await planPaiMigration({
+      homeDir,
+      paiRepo: paiRoot,
+      paiSourceDir: explicitSourceDir,
+    });
+
+    // Explicit source wins.
+    expect(plan.docs?.paiSourceDir).toContain("ExplicitSrc");
+    // Derived packs from paiRepo.
+    expect(plan.packs.length).toBeGreaterThan(0);
+    expect(plan.packs[0].paiPackDir).toContain(join("PAI/Packs", "TinyPack"));
+  });
+});
+
+// AC-5 partial — explicit --pai-packs-dir only; source derived from --pai-repo.
+test("#98 partial override: explicit --pai-packs-dir wins, --pai-source-dir still derived", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const paiRoot = await plantPaiRepoFixture(homeDir, { versions: ["v5.0.0"] });
+    const explicitPacksDir = join(homeDir, "ExplicitPacks");
+    await writePackFixture(explicitPacksDir, "ExplicitPack");
+
+    const plan = await planPaiMigration({
+      homeDir,
+      paiRepo: paiRoot,
+      paiPacksDir: explicitPacksDir,
+    });
+
+    // Derived source from paiRepo.
+    expect(plan.docs?.paiSourceDir).toContain(join("Releases/v5.0.0/.claude/PAI"));
+    // Explicit packs wins.
+    expect(plan.packs.length).toBe(1);
+    expect(plan.packs[0].paiPackDir).toContain("ExplicitPack");
+  });
+});
+
+// AC-3 — non-existent root.
+test("#98 --pai-repo refuses loud when root itself does not exist", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const missing = join(homeDir, "does-not-exist");
+
+    await expect(
+      planPaiMigration({ homeDir, paiRepo: missing }),
+    ).rejects.toThrow(/--pai-repo|does not exist|not found/);
+  });
+});
+
+// CLI — refusals propagate through runSomaCli.
+test("#98 CLI: --pai-repo with missing Releases throws non-zero", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const paiRoot = await plantPaiRepoFixture(homeDir, { plantReleases: false });
+
+    await expect(
+      runSomaCli([
+        "migrate",
+        "pai",
+        "--pai-repo",
+        paiRoot,
+        "--home-dir",
+        homeDir,
+      ]),
+    ).rejects.toThrow(/Releases/);
+  });
+});
+
+// CLI — `--pai-repo` is documented in --help.
+test("#98 CLI: --help mentions --pai-repo", async () => {
+  const output = await runSomaCli(["migrate", "pai", "--help"]);
+  expect(output).toContain("--pai-repo");
+});
+
+// migratePai (apply) — derivation propagates through to actual writes.
+test("#98 migratePai --apply with --pai-repo writes manifest referencing derived release", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir, { withAlgorithm: true });
+    const paiRoot = await plantPaiRepoFixture(homeDir, { versions: ["v5.0.0"] });
+
+    const result = await migratePai({
+      homeDir,
+      paiRepo: paiRoot,
+    });
+
+    expect(result.docs).not.toBeNull();
+    expect(result.docs?.paiSourceDir).toContain(join("Releases/v5.0.0/.claude/PAI"));
+    expect(result.packs.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `--pai-repo <root>` to `soma migrate pai`, collapsing the previous three-flag invocation into one:

```bash
# Before
soma migrate pai \
  --pai-install ~/.claude \
  --pai-source-dir ~/work/PAI/Releases/v5.0.0/.claude/PAI \
  --pai-packs-dir ~/work/PAI/Packs \
  --apply

# After
soma migrate pai --pai-repo ~/work/PAI --apply
```

The orchestrator derives both `paiSourceDir` (→ `<root>/Releases/<latest-semver>/.claude/PAI`) and `paiPacksDir` (→ `<root>/Packs`) BEFORE any phase runs. Explicit `--pai-source-dir` / `--pai-packs-dir` always win — the derivation only fills the unset slots.

Refusal is loud (thrown Error → non-zero CLI exit) when:
- `<root>` is missing.
- `<root>/Releases/` is missing OR contains zero parseable 3-segment semver dirs.
- `<root>/Packs/` is missing.

Semver compare is real, not lexical — `v10.0.0 > v2.0.0`. Bare `1.2.3` and `v1.2.3` accepted equivalently. Non-semver siblings like `Pi`, `v2.3`, `latest` are filtered out (matches the real layout on the canonical machine where `~/work/PAI/Releases/` contains mixed names).

## Acceptance criteria

- [x] **AC-1**: `--pai-repo <root>` derives `--pai-source-dir` to `<root>/Releases/<latest>/.claude/PAI` if not explicitly set.
- [x] **AC-2**: `--pai-repo <root>` derives `--pai-packs-dir` to `<root>/Packs` if not explicitly set.
- [x] **AC-3**: Refuses loud on missing/empty/non-semver Releases (incl. `<root>` itself missing).
- [x] **AC-4**: Refuses loud on missing Packs.
- [x] **AC-5**: Explicit `--pai-source-dir` / `--pai-packs-dir` override derivation; partial overrides supported.
- [x] **AC-6**: 15 fixture tests cover all 8 scenarios + CLI surface + idempotent apply.
- [x] **AC-7**: `docs/migration-from-pai.md` created — `--pai-repo` is the canonical example in Steps 1 & 2; verbose form documented but secondary.

## Test evidence

- Baseline: 625 pass.
- This PR: **640 pass** (+15 new in `test/pai-migration-issue-98.test.ts`), 0 fail, 2020 expect() calls.
- `bun run typecheck`: clean.

## Files changed

- `src/pai-migration.ts` — `paiRepo` field on `PaiMigrationOptions`; `parseSemverDirName` + `compareSemver` + `pickLatestSemverDir` + `applyPaiRepoDerivation` helpers; both `planPaiMigration` and `migratePai` apply derivation as first step.
- `src/cli.ts` — `--pai-repo` parse + usage line update.
- `test/pai-migration-issue-98.test.ts` — 15 fixture tests.
- `docs/migration-from-pai.md` — NEW principal-facing walkthrough.

## Test plan

- [x] Dry-run with `--pai-repo` against synthetic fixture derives both paths.
- [x] `v10.0.0 > v2.5.0 > v2.0.0 > v1.0.0` (semver, not lexical).
- [x] Bare `1.2.3` accepted equivalently to `v1.2.3`.
- [x] Releases/ with only non-semver names → refuse loud.
- [x] Empty Releases/ → refuse loud.
- [x] Missing Packs/ → refuse loud.
- [x] Missing Releases/ → refuse loud.
- [x] Non-existent root → refuse loud.
- [x] Full explicit override → `--pai-repo` unused for derivation.
- [x] Partial override (source only / packs only) → derivation fills the unset side.
- [x] CLI surface (`runSomaCli`) routes correctly + propagates refusals as non-zero.
- [x] `--help` mentions `--pai-repo`.
- [x] `migratePai --apply` (not just plan) produces a manifest referencing the derived release.

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)