### PR TITLE
fix(migrate): plan-mode log-and-continue per-pack — apply same wrapper as apply path (#102)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1730,6 +1730,18 @@ function formatPaiMigrationPlan(plan: PaiMigrationPlan): string {
   const docsLine = plan.docs === null
     ? "  - docs:     skipped (pass --pai-source-dir to enable)"
     : `  - docs:     ${plan.docs.files.length} file(s) from ${plan.docs.releaseVersion ?? "(no version)"}`;
+  // #102 — render the per-pack outcome table on the plan surface, same
+  // shape as the apply path (#97 AC-5). Single-sourced through
+  // `formatPackOutcomeLines` so apply + plan can't drift on labels /
+  // sort order / reason suffix. `labelKind: "path"` matches the
+  // surrounding `Source:` / `Target:` / `Manifest:` full-path style.
+  const outcomeLines = formatPackOutcomeLines(plan.packOutcomes, {
+    labelKind: "path",
+  });
+  // `packs.length` now reflects "successfully planned" only (refused
+  // packs live in `packOutcomes`); use `packOutcomes.length` for the
+  // discovery count so the principal sees the same "N discovered"
+  // total they got pre-#102 + the per-outcome breakdown.
   return [
     "soma migrate pai — plan (dry-run; pass --apply to execute)",
     "",
@@ -1742,7 +1754,10 @@ function formatPaiMigrationPlan(plan: PaiMigrationPlan): string {
     algorithmLine,
     memoryLine,
     docsLine,
-    `  - packs:    ${plan.packs.length} discovered`,
+    `  - packs:    ${plan.packOutcomes.length} discovered, ${plan.packs.length} to import`,
+    "",
+    "Pack outcomes:",
+    ...outcomeLines,
     "",
   ].join("\n");
 }
@@ -2393,7 +2408,27 @@ export async function runSomaCli(args: string[]): Promise<string> {
       return formatPaiMigrationStatus(await readPaiMigrationManifest(parsed.options));
     }
     if (parsed.mode === "plan") {
-      return formatPaiMigrationPlan(await planPaiMigration(parsed.options));
+      const plan = await planPaiMigration(parsed.options);
+      const formatted = formatPaiMigrationPlan(plan);
+      // #102 — AC-4 mirror: plan mode honors the same exit-code policy
+      // as the apply path. Genuine errors (`refused-other`) cause a
+      // non-zero exit AFTER the rest of the plan completes, so the
+      // principal sees the full plan body including the outcome table
+      // before the error message. Policy-respected refusals
+      // (`refused-substrate-specific`, `refused-reserved`) stay zero
+      // exit — the principal asked for them by NOT passing the
+      // relevant override flag.
+      const refusedOther = plan.packOutcomes.filter((o) => o.outcome === "refused-other");
+      if (refusedOther.length > 0) {
+        const detail = refusedOther
+          .map((o) => `  - ${o.skillName ?? o.paiPackDir}: ${o.reason ?? "(no detail)"}`)
+          .join("\n");
+        throw new SomaCliError(
+          `${formatted}\nsoma migrate pai — ${refusedOther.length} pack(s) failed with genuine errors:\n${detail}\n`,
+          1,
+        );
+      }
+      return formatted;
     }
     const result = await migratePai(parsed.options);
     const formatted = formatPaiMigrationResult(result);

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,7 @@ export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
 export {
   importPaiPack,
+  PaiPackReservedNameRefusal,
   PaiPackSubstrateSpecificRefusal,
   planPaiPackImport,
 } from "./pai-pack-importer";

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,10 +211,16 @@ export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
 export {
   importPaiPack,
-  PaiPackReservedNameRefusal,
   PaiPackSubstrateSpecificRefusal,
   planPaiPackImport,
 } from "./pai-pack-importer";
+// Sage r3 #103 Architecture: `PaiPackReservedNameRefusal` is an
+// internal migration-classification detail. The migration orchestrator
+// imports it directly from `./pai-pack-importer`; no demonstrated
+// external consumer needs to catch it. Keeping it off the barrel
+// avoids an irreversible public-API expansion. If a downstream caller
+// ever needs structural classification it can be promoted here in a
+// dedicated change with documented contract.
 export { importPaiDocs, planPaiDocsImport } from "./pai-docs-importer";
 // PAI MEMORY → Soma memory translator (#90) is intentionally NOT
 // re-exported from the package root — it is an internal phase of

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -34,6 +34,7 @@ import { importPaiIdentity, planPaiImport } from "./pai-importer";
 import { migratePaiMemory, planPaiMemoryMigration } from "./pai-memory-migrator";
 import {
   importPaiPack,
+  PaiPackReservedNameRefusal,
   PaiPackSubstrateSpecificRefusal,
   planPaiPackImport,
   readPackMetadata,
@@ -537,35 +538,49 @@ async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
     includeSubstrateSpecific: boolean;
   }) => Promise<TPayload>,
 ): Promise<{ payload?: TPayload; outcome: PaiPackOutcome }> {
-  let slug: string;
-  try {
-    slug = await readPackSkillSlug(inputs.paiPackDir);
-  } catch (error) {
-    // Couldn't even read the pack's metadata — surface the error
-    // verbatim; the principal needs the original reason in the
-    // summary table. No `skillName` because metadata read failed.
-    return {
-      outcome: { paiPackDir: inputs.paiPackDir, outcome: "refused-other", reason: errorMessage(error) },
-    };
-  }
+  // Sage r2 #103 Performance — defer the slug read to the only paths
+  // that actually need it: the migrate-level reserved pre-check
+  // (when `overwriteReserved` is false) and the refusal-classification
+  // path (when we want `outcome.skillName` for a refusal that doesn't
+  // carry its own slug). The success path uses `payload.skillName`
+  // returned by the inner operation, avoiding a duplicate
+  // `readPackMetadata` read that the inner planner already performs.
+  //
+  // When `overwriteReserved` is true, the migrate pre-check is a
+  // no-op, so the upfront read is skipped entirely — the inner pack
+  // importer's own (narrower, structurally-enforced) reserved check
+  // still fires for `soma` / `the-algorithm` and is classified via
+  // the typed `PaiPackReservedNameRefusal` below.
+  let upfrontSlug: string | null = null;
+  if (!inputs.overwriteReserved) {
+    try {
+      upfrontSlug = await readPackSkillSlug(inputs.paiPackDir);
+    } catch (error) {
+      // Couldn't even read the pack's metadata — surface the error
+      // verbatim; the principal needs the original reason in the
+      // summary table. No `skillName` because metadata read failed.
+      return {
+        outcome: { paiPackDir: inputs.paiPackDir, outcome: "refused-other", reason: errorMessage(error) },
+      };
+    }
 
-  // #102 — reserved-name pre-check happens BEFORE the operation call
-  // so the refusal semantics are clearer and faster: we don't depend
-  // on `importPaiPack` / `planPaiPackImport` happening to throw on
-  // the reserved name. Both paths do throw today (the pack importer's
-  // own `RESERVED_SKILL_NAMES` check at pai-pack-importer.ts:396 +
-  // the migrate-level set here), but the pre-check makes the
-  // migration-level reserved set authoritative without relying on
-  // that inner throw.
-  if (!inputs.overwriteReserved && MIGRATE_RESERVED_SKILL_NAMES.has(slug)) {
-    return {
-      outcome: {
-        paiPackDir: inputs.paiPackDir,
-        outcome: "refused-reserved",
-        skillName: slug,
-        reason: `reserved Soma skill '${slug}' — re-run with --overwrite-reserved to permit.`,
-      },
-    };
+    // #102 — reserved-name pre-check happens BEFORE the operation
+    // call so the refusal semantics are clearer and faster: we don't
+    // depend on the inner planner happening to throw on the reserved
+    // name (its set is narrower than the migrate-level set, and the
+    // outer set names like `isa` / `knowledge` / `telos` would
+    // otherwise import successfully and clobber canonical Soma
+    // surfaces).
+    if (MIGRATE_RESERVED_SKILL_NAMES.has(upfrontSlug)) {
+      return {
+        outcome: {
+          paiPackDir: inputs.paiPackDir,
+          outcome: "refused-reserved",
+          skillName: upfrontSlug,
+          reason: `reserved Soma skill '${upfrontSlug}' — re-run with --overwrite-reserved to permit.`,
+        },
+      };
+    }
   }
 
   try {
@@ -585,8 +600,26 @@ async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
         outcome: {
           paiPackDir: inputs.paiPackDir,
           outcome: "refused-substrate-specific",
-          skillName: slug,
+          skillName: upfrontSlug ?? (await safeReadSkillSlug(inputs.paiPackDir)),
           reason: `substrate-specific file(s): ${error.files.join(", ")}`,
+        },
+      };
+    }
+    // Sage r2 #103 CodeQuality important — the pack importer's own
+    // reserved check (narrower set: `soma`, `the-algorithm`) fires
+    // even when the outer migrate-level pre-check is bypassed by
+    // `--overwrite-reserved`. Without the typed catch here, the inner
+    // throw bubbled up as a plain `Error` and got mis-classified as
+    // `refused-other` instead of `refused-reserved`. The typed
+    // `PaiPackReservedNameRefusal` carries the offending slug so we
+    // don't need a second metadata read for `outcome.skillName`.
+    if (error instanceof PaiPackReservedNameRefusal) {
+      return {
+        outcome: {
+          paiPackDir: inputs.paiPackDir,
+          outcome: "refused-reserved",
+          skillName: error.skillName,
+          reason: `reserved by pack importer: '${error.skillName}'`,
         },
       };
     }
@@ -594,10 +627,27 @@ async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
       outcome: {
         paiPackDir: inputs.paiPackDir,
         outcome: "refused-other",
-        skillName: slug,
+        skillName: upfrontSlug ?? (await safeReadSkillSlug(inputs.paiPackDir)),
         reason: errorMessage(error),
       },
     };
+  }
+}
+
+/**
+ * Best-effort slug read for refusal classification. Used only when the
+ * upfront pre-check slug was skipped (because `overwriteReserved` was
+ * true) and a refusal still needs to populate `outcome.skillName`.
+ * Returns `undefined` on read failure — the outcome record permits a
+ * missing `skillName` and the orchestrator falls back to `paiPackDir`
+ * in the principal-facing render. Never throws: this is a label-only
+ * read on a path that already has a confirmed error to report.
+ */
+async function safeReadSkillSlug(paiPackDir: string): Promise<string | undefined> {
+  try {
+    return await readPackSkillSlug(paiPackDir);
+  } catch {
+    return undefined;
   }
 }
 

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -158,7 +158,24 @@ export interface PaiMigrationPlan {
   somaHome: string;
   identity: PaiImportPlan;
   algorithm: AlgorithmImportPlan | null;
+  /**
+   * Successfully planned packs only. Refused packs do NOT appear here
+   * — they live in `packOutcomes` instead. Mirrors the apply-side
+   * `PaiMigrationResult.packs` contract for byte-stable surfaces.
+   */
   packs: PaiPackImportPlan[];
+  /**
+   * #102 — per-pack outcome record for the plan phase, mirroring
+   * `PaiMigrationResult.packOutcomes` shipped in #97 for the apply
+   * phase. Same four buckets (`imported` / `refused-substrate-specific`
+   * / `refused-reserved` / `refused-other`); for plan mode `imported`
+   * means "would be imported" (the plan path doesn't write anything to
+   * disk). The CLI plan-mode formatter renders these via
+   * `formatPackOutcomeLines` so the principal sees the same per-pack
+   * table they get from `--apply`. CLI exit-code policy is identical
+   * to apply mode: zero unless any outcome is `refused-other`.
+   */
+  packOutcomes: PaiPackOutcome[];
   memory: PaiMemoryMigrationPlan | null;
   docs: PaiDocsImportPlan | null;
   manifestPath: string;
@@ -485,34 +502,65 @@ async function importPacksWithOutcomes(
 
 /**
  * Sage r1 #99 Maintainability finding — extracted per-pack pipeline so
- * each step (metadata read / reserved check / import / error
+ * each step (metadata read / reserved check / import-or-plan / error
  * classification) is locally legible and adding a new refusal kind
  * touches one function instead of the whole orchestration loop.
  *
- * Returns `{ pack }` only when the pack was successfully imported
- * (always paired with `outcome.outcome === "imported"`). Otherwise
- * returns just the outcome with the appropriate `refused-*` kind.
+ * #102 — shared between the apply path (`importOnePackWithOutcome`)
+ * and the plan path (`planOnePackWithOutcome`). The two surfaces are
+ * structurally identical except for the inner call (`importPaiPack`
+ * vs `planPaiPackImport`) and the success-payload type, so this
+ * helper takes a generic `operation` callback and a discriminated
+ * payload type. The reserved-name pre-check, error classification,
+ * and outcome record are single-sourced — neither path can drift on
+ * the refusal-bucket contract.
+ *
+ * Returns `{ payload }` only when the operation succeeded (always
+ * paired with `outcome.outcome === "imported"`; for the plan path,
+ * `imported` means "would be imported"). Otherwise returns just the
+ * outcome with the appropriate `refused-*` kind.
  */
-async function importOnePackWithOutcome(
-  inputs: BulkImportInputs,
-  paiPackDir: string,
-): Promise<{ pack?: PaiPackImportResult; outcome: PaiPackOutcome }> {
+interface OnePackInputs {
+  paiPackDir: string;
+  homeDir: string | undefined;
+  somaHome: string;
+  overwriteReserved: boolean;
+  includeSubstrateSpecific: boolean;
+}
+
+async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
+  inputs: OnePackInputs,
+  operation: (opts: {
+    homeDir: string | undefined;
+    paiPackDir: string;
+    somaHome: string;
+    includeSubstrateSpecific: boolean;
+  }) => Promise<TPayload>,
+): Promise<{ payload?: TPayload; outcome: PaiPackOutcome }> {
   let slug: string;
   try {
-    slug = await readPackSkillSlug(paiPackDir);
+    slug = await readPackSkillSlug(inputs.paiPackDir);
   } catch (error) {
     // Couldn't even read the pack's metadata — surface the error
     // verbatim; the principal needs the original reason in the
     // summary table. No `skillName` because metadata read failed.
     return {
-      outcome: { paiPackDir, outcome: "refused-other", reason: errorMessage(error) },
+      outcome: { paiPackDir: inputs.paiPackDir, outcome: "refused-other", reason: errorMessage(error) },
     };
   }
 
+  // #102 — reserved-name pre-check happens BEFORE the operation call
+  // so the refusal semantics are clearer and faster: we don't depend
+  // on `importPaiPack` / `planPaiPackImport` happening to throw on
+  // the reserved name. Both paths do throw today (the pack importer's
+  // own `RESERVED_SKILL_NAMES` check at pai-pack-importer.ts:396 +
+  // the migrate-level set here), but the pre-check makes the
+  // migration-level reserved set authoritative without relying on
+  // that inner throw.
   if (!inputs.overwriteReserved && MIGRATE_RESERVED_SKILL_NAMES.has(slug)) {
     return {
       outcome: {
-        paiPackDir,
+        paiPackDir: inputs.paiPackDir,
         outcome: "refused-reserved",
         skillName: slug,
         reason: `reserved Soma skill '${slug}' — re-run with --overwrite-reserved to permit.`,
@@ -521,27 +569,21 @@ async function importOnePackWithOutcome(
   }
 
   try {
-    // `overwrite: true` mirrors the pre-#97 behavior — migration is
-    // a "move my whole PAI install into Soma" operation and must not
-    // blow up because a previous run already imported the pack. The
-    // pack importer's per-pack rollback contract still protects
-    // on-disk safety.
-    const result = await importPaiPack({
+    const payload = await operation({
       homeDir: inputs.homeDir,
-      paiPackDir,
+      paiPackDir: inputs.paiPackDir,
       somaHome: inputs.somaHome,
-      overwrite: true,
       includeSubstrateSpecific: inputs.includeSubstrateSpecific,
     });
     return {
-      pack: result,
-      outcome: { paiPackDir, outcome: "imported", skillName: result.skillName },
+      payload,
+      outcome: { paiPackDir: inputs.paiPackDir, outcome: "imported", skillName: payload.skillName },
     };
   } catch (error) {
     if (error instanceof PaiPackSubstrateSpecificRefusal) {
       return {
         outcome: {
-          paiPackDir,
+          paiPackDir: inputs.paiPackDir,
           outcome: "refused-substrate-specific",
           skillName: slug,
           reason: `substrate-specific file(s): ${error.files.join(", ")}`,
@@ -550,13 +592,108 @@ async function importOnePackWithOutcome(
     }
     return {
       outcome: {
-        paiPackDir,
+        paiPackDir: inputs.paiPackDir,
         outcome: "refused-other",
         skillName: slug,
         reason: errorMessage(error),
       },
     };
   }
+}
+
+/**
+ * Apply-side wrapper: runs `importPaiPack` per pack and classifies
+ * the outcome. Returns the same shape `importPacksWithOutcomes`
+ * already expects.
+ *
+ * `overwrite: true` on the inner `importPaiPack` mirrors the pre-#97
+ * behavior — migration is a "move my whole PAI install into Soma"
+ * operation and must not blow up because a previous run already
+ * imported the pack. The pack importer's per-pack rollback contract
+ * still protects on-disk safety.
+ */
+async function importOnePackWithOutcome(
+  inputs: BulkImportInputs,
+  paiPackDir: string,
+): Promise<{ pack?: PaiPackImportResult; outcome: PaiPackOutcome }> {
+  const { payload, outcome } = await runOnePackWithOutcome<PaiPackImportResult>(
+    {
+      paiPackDir,
+      homeDir: inputs.homeDir,
+      somaHome: inputs.somaHome,
+      overwriteReserved: inputs.overwriteReserved,
+      includeSubstrateSpecific: inputs.includeSubstrateSpecific,
+    },
+    (opts) =>
+      importPaiPack({
+        homeDir: opts.homeDir,
+        paiPackDir: opts.paiPackDir,
+        somaHome: opts.somaHome,
+        overwrite: true,
+        includeSubstrateSpecific: opts.includeSubstrateSpecific,
+      }),
+  );
+  return { pack: payload, outcome };
+}
+
+/**
+ * #102 — plan-side wrapper: runs `planPaiPackImport` per pack and
+ * classifies the outcome with the SAME refusal taxonomy as the apply
+ * path. Without this, plan-mode aborts on the first
+ * `PaiPackSubstrateSpecificRefusal` (the user-visible bug). Plan path
+ * doesn't write anything to disk, so `payload` is the
+ * `PaiPackImportPlan` (not a result); callers surface it on
+ * `PaiMigrationPlan.packs` for the principal to inspect.
+ */
+async function planOnePackWithOutcome(
+  inputs: BulkImportInputs,
+  paiPackDir: string,
+): Promise<{ pack?: PaiPackImportPlan; outcome: PaiPackOutcome }> {
+  const { payload, outcome } = await runOnePackWithOutcome<PaiPackImportPlan>(
+    {
+      paiPackDir,
+      homeDir: inputs.homeDir,
+      somaHome: inputs.somaHome,
+      overwriteReserved: inputs.overwriteReserved,
+      includeSubstrateSpecific: inputs.includeSubstrateSpecific,
+    },
+    (opts) =>
+      planPaiPackImport({
+        homeDir: opts.homeDir,
+        paiPackDir: opts.paiPackDir,
+        somaHome: opts.somaHome,
+        includeSubstrateSpecific: opts.includeSubstrateSpecific,
+      }),
+  );
+  return { pack: payload, outcome };
+}
+
+/**
+ * #102 — plan-side counterpart to `importPacksWithOutcomes`. Runs
+ * `planOnePackWithOutcome` per pack under the same bounded
+ * concurrency model. Each pack's outcome is classified independently;
+ * the plan phase never aborts on a per-pack failure, mirroring the
+ * apply phase's contract.
+ */
+interface BulkPlanResult {
+  packs: PaiPackImportPlan[];
+  outcomes: PaiPackOutcome[];
+}
+
+async function planPacksWithOutcomes(inputs: BulkImportInputs): Promise<BulkPlanResult> {
+  const results = await runBoundedConcurrent(
+    [...inputs.packPaths],
+    (paiPackDir) => planOnePackWithOutcome(inputs, paiPackDir),
+    4,
+  );
+
+  const packs: PaiPackImportPlan[] = [];
+  const outcomes: PaiPackOutcome[] = [];
+  for (const { pack, outcome } of results) {
+    if (pack) packs.push(pack);
+    outcomes.push(outcome);
+  }
+  return { packs, outcomes };
 }
 
 function errorMessage(error: unknown): string {
@@ -644,17 +781,24 @@ export async function planPaiMigration(options: PaiMigrationOptions = {}): Promi
   const algorithm = algorithmDir === null
     ? null
     : planAlgorithmImport({ homeDir: options.homeDir, paiAlgorithmDir: algorithmDir, somaHome });
-  const packs = options.skipSkills === true
-    ? []
-    // Sage r5 #95 Performance: bound the per-pack plan reads to 4
-    // workers (matches the apply path's import fan-out). The previous
-    // Promise.all opened one async pack-plan per discovered pack
-    // regardless of count.
-    : await runBoundedConcurrent(
+  // #102 — plan phase now uses `planPacksWithOutcomes` (mirrors the
+  // apply path's `importPacksWithOutcomes` shipped in #97). Without
+  // this wrapper, the first `PaiPackSubstrateSpecificRefusal` thrown
+  // by `planPaiPackImport` escaped `runBoundedConcurrent` and aborted
+  // the entire plan — the user-reported bug from `soma migrate pai
+  // --pai-repo ~/work/PAI` (no `--apply`). Each pack is now
+  // classified into one of four `PaiPackOutcome` buckets and the
+  // plan continues; refused packs do NOT appear in `packs` (matches
+  // apply-side semantics on `PaiMigrationResult.packs`).
+  const { packs, outcomes: packOutcomes } = options.skipSkills === true
+    ? { packs: [] as PaiPackImportPlan[], outcomes: [] as PaiPackOutcome[] }
+    : await planPacksWithOutcomes({
+        homeDir: options.homeDir,
+        somaHome,
         packPaths,
-        (paiPackDir) => planPaiPackImport({ homeDir: options.homeDir, paiPackDir, somaHome }),
-        4,
-      );
+        overwriteReserved: options.overwriteReserved === true,
+        includeSubstrateSpecific: options.includeSubstrateSpecific === true,
+      });
   const memory = options.skipMemory === true
     ? null
     : await planPaiMemoryMigration({ homeDir: options.homeDir, claudeHome, somaHome });
@@ -673,6 +817,7 @@ export async function planPaiMigration(options: PaiMigrationOptions = {}): Promi
     identity,
     algorithm,
     packs,
+    packOutcomes,
     memory,
     docs,
     manifestPath: manifestPathFor(somaHome),

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -49,6 +49,31 @@ export class PaiPackSubstrateSpecificRefusal extends Error {
   }
 }
 
+/**
+ * #102 (Sage r2 CodeQuality important) — typed refusal raised when a
+ * pack's normalized skill name is in the pack importer's own reserved
+ * set (`soma`, `the-algorithm`). The migration orchestrator runs its
+ * own broader reserved pre-check (`isa`, `the-algorithm`, `knowledge`,
+ * `telos`) BEFORE the inner call; that pre-check can be bypassed via
+ * `--overwrite-reserved`. The pack importer's reserved check cannot
+ * be bypassed — those names are structurally off-limits — and
+ * intersects the migration set at `the-algorithm`. Without this typed
+ * error subclass, the inner throw was a plain `Error`, so the
+ * migration orchestrator classified it as `refused-other` instead of
+ * `refused-reserved` whenever `--overwrite-reserved` was set and the
+ * inner throw fired. Carries the offending slug so the orchestrator
+ * can record `outcome.skillName` correctly.
+ */
+export class PaiPackReservedNameRefusal extends Error {
+  readonly kind = "reserved-name" as const;
+  readonly skillName: string;
+  constructor(skillName: string) {
+    super(`soma import pai-pack cannot overwrite reserved Soma skill '${skillName}'.`);
+    this.name = "PaiPackReservedNameRefusal";
+    this.skillName = skillName;
+  }
+}
+
 const SECRET_FILE_PATTERNS = [
   /(^|\/)\.env$/,
   /(^|\/)\.env\.(?!example$)[^/]+$/,
@@ -394,7 +419,13 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
     throw new Error(`soma import pai-pack produced invalid normalized skill name '${skillName}'.`);
   }
   if (RESERVED_SKILL_NAMES.has(skillName)) {
-    throw new Error(`soma import pai-pack cannot overwrite reserved Soma skill '${skillName}'.`);
+    // #102 — typed refusal so the migrate orchestrator classifies
+    // this as `refused-reserved` even when its outer pre-check is
+    // bypassed by `--overwrite-reserved` (the inner set is narrower
+    // and structurally enforced; the slug is preserved in the error).
+    // The standalone `soma import pai-pack` verb still surfaces the
+    // same human-readable message via `Error.message`.
+    throw new PaiPackReservedNameRefusal(skillName);
   }
   if (!options.overwrite) {
     await access(join(homes.somaHome, "skills", skillName))

--- a/test/pai-migration-issue-102.test.ts
+++ b/test/pai-migration-issue-102.test.ts
@@ -1,0 +1,306 @@
+/**
+ * #102 — `soma migrate pai` plan-mode log-and-continue (apply-only
+ * blindspot of #97).
+ *
+ * #97 (PR #99) shipped log-and-continue for the apply path:
+ * `migratePai` no longer aborts when a pack has substrate-specific
+ * files / collides with a reserved skill name / fails for genuine
+ * reasons. Each pack is classified into one of four `PaiPackOutcome`
+ * buckets and the migration continues.
+ *
+ * Plan path was not wrapped. `planPaiMigration` calls `planPaiPackImport`
+ * raw through `runBoundedConcurrent`; the first refusal escapes and
+ * aborts the entire plan — exactly the symptom the user hit while
+ * running `soma migrate pai --pai-repo ~/work/PAI` (no `--apply`).
+ *
+ * Six scenarios mirror the apply-mode tests in
+ * `test/pai-migration-issue-97.test.ts` but exercise `planPaiMigration`
+ * (and the CLI plan-mode surface) instead of `migratePai`:
+ *
+ *   1. All packs clean → every entry planned, every outcome `imported`.
+ *   2. Mixed substrate-specific without flag → refused entries recorded,
+ *      others planned, no throw, exit 0.
+ *   3. Mixed substrate-specific WITH `--include-substrate-specific` →
+ *      all entries planned (matches apply path semantics).
+ *   4. Mixed reserved-collision without `--overwrite-reserved` →
+ *      refused-reserved recorded, others planned, exit 0.
+ *   5. Single pack genuine failure (malformed) → refused-other recorded,
+ *      other packs still planned, CLI exit non-zero AFTER rest of
+ *      plan completes.
+ *   6. Plan output includes the per-pack outcome table — same shape
+ *      as apply (AC-5).
+ *
+ * Plus a real-world repro scenario that mimics the user's
+ * `~/work/PAI/Packs/{SystemsThinking,RootCauseAnalysis}` shape (packs
+ * with `src/Foundation.md` + `src/MethodSelection.md`) and confirms
+ * the plan completes without the raw throw the user originally saw.
+ */
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { planPaiMigration } from "../src/pai-migration";
+import { runSomaCli, SomaCliError } from "../src/cli";
+import {
+  withTempHome as withSharedTempHome,
+  writePaiIdentityFixture as writeIdentityFixture,
+  writePaiPackFixture as writePackFixture,
+} from "./fixtures/pai-migration-fixtures";
+
+const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
+  withSharedTempHome(fn, "soma-102-");
+
+/**
+ * Plant a substrate-specific file inside an existing pack fixture.
+ * `src/Foundation.md` is not under `src/Workflows/` or `src/Tools/`,
+ * so the pack-router classifies it `substrate-specific`. Mirrors the
+ * user-reported repro on SystemsThinking + RootCauseAnalysis.
+ */
+async function plantSubstrateSpecificFile(packDir: string, filename = "Foundation.md"): Promise<void> {
+  await writeFile(
+    join(packDir, "src", filename),
+    `# ${filename.replace(".md", "")}\n\nSubstrate-specific doc.\n`,
+    "utf8",
+  );
+}
+
+async function makeMalformedPack(packsDir: string, packName: string): Promise<void> {
+  // Missing INSTALL.md → REQUIRED_PACK_FILES check fails → buildPaiPackImportPlan
+  // throws → planPaiPackImport surfaces it → orchestrator must catch it as
+  // refused-other (mirrors the apply path).
+  const packDir = join(packsDir, packName);
+  await mkdir(join(packDir, "src"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    `---\nname: ${packName}\ndescription: malformed\n---\n\n# ${packName}\n`,
+    "utf8",
+  );
+  // INSTALL.md intentionally omitted.
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    `---\nname: ${packName}\ndescription: malformed\n---\n\n# ${packName}\n`,
+    "utf8",
+  );
+}
+
+test("scenario 1 — plan all-packs-clean: every pack planned, every outcome `imported`", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await writePackFixture(packsDir, "Alpha");
+    await writePackFixture(packsDir, "Beta");
+    const plan = await planPaiMigration({ homeDir, paiPacksDir: packsDir });
+    expect(plan.apply).toBe(false);
+    expect(plan.packOutcomes.length).toBe(2);
+    expect(plan.packOutcomes.every((o) => o.outcome === "imported")).toBe(true);
+    expect(plan.packs.length).toBe(2);
+  });
+});
+
+test("scenario 2 — plan mixed substrate-specific without flag: refused-substrate-specific, others plan, no throw", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    const subPack = await writePackFixture(packsDir, "SubA");
+    await plantSubstrateSpecificFile(subPack);
+    await writePackFixture(packsDir, "Clean");
+    // The critical assertion: this must NOT throw. Pre-#102 it did.
+    const plan = await planPaiMigration({ homeDir, paiPacksDir: packsDir });
+    expect(plan.packOutcomes.length).toBe(2);
+    const subOutcome = plan.packOutcomes.find((o) =>
+      /sub-a|suba/i.test(o.skillName ?? o.paiPackDir),
+    );
+    const cleanOutcome = plan.packOutcomes.find((o) =>
+      /clean/i.test(o.skillName ?? o.paiPackDir),
+    );
+    expect(subOutcome?.outcome).toBe("refused-substrate-specific");
+    expect(cleanOutcome?.outcome).toBe("imported");
+    // Only the clean pack appears in the planned-packs list.
+    expect(plan.packs.length).toBe(1);
+    expect(plan.packs[0].skillName).toBe("clean");
+  });
+});
+
+test("scenario 3 — plan mixed substrate-specific WITH includeSubstrateSpecific: all planned", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    const subPack = await writePackFixture(packsDir, "SubA");
+    await plantSubstrateSpecificFile(subPack);
+    await writePackFixture(packsDir, "Clean");
+    const plan = await planPaiMigration({
+      homeDir,
+      paiPacksDir: packsDir,
+      includeSubstrateSpecific: true,
+    });
+    expect(plan.packOutcomes.every((o) => o.outcome === "imported")).toBe(true);
+    expect(plan.packs.length).toBe(2);
+  });
+});
+
+test("scenario 4 — plan mixed reserved-collision without overwriteReserved: refused-reserved, others plan, no throw", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await writePackFixture(packsDir, "ISA", { skillName: "ISA" });
+    await writePackFixture(packsDir, "Clean");
+    const plan = await planPaiMigration({ homeDir, paiPacksDir: packsDir });
+    expect(plan.packOutcomes.length).toBe(2);
+    const isaOutcome = plan.packOutcomes.find((o) => /isa/i.test(o.skillName ?? ""));
+    const cleanOutcome = plan.packOutcomes.find((o) => /clean/i.test(o.skillName ?? ""));
+    expect(isaOutcome?.outcome).toBe("refused-reserved");
+    expect(cleanOutcome?.outcome).toBe("imported");
+    expect(plan.packs.length).toBe(1);
+    expect(plan.packs[0].skillName).toBe("clean");
+  });
+});
+
+test("scenario 5 — plan single pack genuine failure (malformed): refused-other recorded; other packs still planned", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await makeMalformedPack(packsDir, "Broken");
+    await writePackFixture(packsDir, "Healthy");
+    const plan = await planPaiMigration({ homeDir, paiPacksDir: packsDir });
+    expect(plan.packOutcomes.length).toBe(2);
+    const broken = plan.packOutcomes.find((o) => /broken/i.test(o.paiPackDir));
+    const healthy = plan.packOutcomes.find((o) => /healthy/i.test(o.skillName ?? ""));
+    expect(broken?.outcome).toBe("refused-other");
+    expect(broken?.reason).toMatch(/INSTALL\.md|required/i);
+    expect(healthy?.outcome).toBe("imported");
+    expect(plan.packs.length).toBe(1);
+    expect(plan.packs[0].skillName).toBe("healthy");
+  });
+});
+
+test("scenario 6 (AC-5) — plan output includes per-pack outcome table; CLI plan does not throw on substrate-specific", async () => {
+  // CLI plan surface: NOT `--apply`, NOT `--status`. The default plan
+  // mode must include the per-pack outcome table and must not throw on
+  // substrate-specific packs.
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    const sub = await writePackFixture(packsDir, "SubA");
+    await plantSubstrateSpecificFile(sub);
+    await writePackFixture(packsDir, "ISA", { skillName: "ISA" });
+    await writePackFixture(packsDir, "Healthy");
+    const out = await runSomaCli([
+      "migrate",
+      "pai",
+      "--home-dir",
+      homeDir,
+      "--pai-packs-dir",
+      packsDir,
+    ]);
+    expect(out).toContain("Pack outcomes");
+    expect(out).toContain("refused-substrate-specific");
+    expect(out).toContain("refused-reserved");
+    expect(out).toContain("imported");
+    // No skill landed on disk (plan path, not apply).
+    await expect(stat(join(homeDir, ".soma/skills/healthy"))).rejects.toThrow();
+  });
+});
+
+test("AC-1 — CLI parses --include-substrate-specific for `migrate pai` plan-mode (passthrough)", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    const sub = await writePackFixture(packsDir, "SubA");
+    await plantSubstrateSpecificFile(sub);
+    const out = await runSomaCli([
+      "migrate",
+      "pai",
+      "--include-substrate-specific",
+      "--home-dir",
+      homeDir,
+      "--pai-packs-dir",
+      packsDir,
+    ]);
+    // No --apply → plan output. Pack is included in the plan (imported).
+    expect(out).toContain("Pack outcomes");
+    expect(out).toContain("imported");
+    expect(out).not.toContain("refused-substrate-specific");
+  });
+});
+
+test("AC-4 — plan-mode CLI exit non-zero when a pack outcome is refused-other (after rest of plan completes)", async () => {
+  // Substrate-specific only → exit zero.
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    const sub = await writePackFixture(packsDir, "SubA");
+    await plantSubstrateSpecificFile(sub);
+    await writePackFixture(packsDir, "Healthy");
+    const out = await runSomaCli([
+      "migrate",
+      "pai",
+      "--home-dir",
+      homeDir,
+      "--pai-packs-dir",
+      packsDir,
+    ]);
+    expect(out).toContain("refused-substrate-specific");
+    expect(out).toContain("imported");
+  });
+  // Malformed pack → SomaCliError exitCode 1; output still includes
+  // the full plan body for the other packs.
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await makeMalformedPack(packsDir, "Broken");
+    await writePackFixture(packsDir, "Healthy");
+    let caught: unknown = null;
+    try {
+      await runSomaCli([
+        "migrate",
+        "pai",
+        "--home-dir",
+        homeDir,
+        "--pai-packs-dir",
+        packsDir,
+      ]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SomaCliError);
+    expect((caught as SomaCliError).exitCode).toBe(1);
+    // The full plan body — including the outcome table — must be in
+    // the error message so the principal sees what happened.
+    const msg = (caught as SomaCliError).message;
+    expect(msg).toContain("Pack outcomes");
+    expect(msg).toContain("refused-other");
+    expect(msg).toContain("imported");
+  });
+});
+
+test("real-world repro — SystemsThinking + RootCauseAnalysis shape: plan completes without raw throw", async () => {
+  // Mimics the user's exact repro: `~/work/PAI/Packs/SystemsThinking`
+  // has `src/Foundation.md`, `~/work/PAI/Packs/RootCauseAnalysis` has
+  // `src/MethodSelection.md`. Before #102 the first one encountered
+  // would throw `PaiPackSubstrateSpecificRefusal` out of
+  // `planPaiPackImport` and abort the whole plan.
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    const st = await writePackFixture(packsDir, "SystemsThinking");
+    await plantSubstrateSpecificFile(st, "Foundation.md");
+    const rca = await writePackFixture(packsDir, "RootCauseAnalysis");
+    await plantSubstrateSpecificFile(rca, "MethodSelection.md");
+    await writePackFixture(packsDir, "Council");
+    await writePackFixture(packsDir, "RedTeam");
+    // No throw. Plan returns with two refused + two imported.
+    const plan = await planPaiMigration({ homeDir, paiPacksDir: packsDir });
+    expect(plan.packOutcomes.length).toBe(4);
+    const refused = plan.packOutcomes.filter(
+      (o) => o.outcome === "refused-substrate-specific",
+    );
+    const imported = plan.packOutcomes.filter((o) => o.outcome === "imported");
+    expect(refused.length).toBe(2);
+    expect(imported.length).toBe(2);
+    expect(refused.map((o) => o.skillName).sort()).toEqual([
+      "root-cause-analysis",
+      "systems-thinking",
+    ]);
+    expect(imported.map((o) => o.skillName).sort()).toEqual(["council", "red-team"]);
+  });
+});

--- a/test/pai-migration-issue-102.test.ts
+++ b/test/pai-migration-issue-102.test.ts
@@ -271,6 +271,29 @@ test("AC-4 — plan-mode CLI exit non-zero when a pack outcome is refused-other 
   });
 });
 
+test("Sage r2 #103 CodeQuality — inner pack-importer reserved-name throw classifies as refused-reserved (overwriteReserved bypass)", async () => {
+  // Regression for Sage's r2 important finding: when --overwrite-reserved
+  // is set, the outer migrate-level pre-check is skipped. The pack
+  // importer's own narrower reserved set (`soma`, `the-algorithm`)
+  // still throws — that throw must classify as `refused-reserved`
+  // (not `refused-other`) so the outcome taxonomy stays correct and
+  // the CLI exit code stays zero on a structurally-reserved name.
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
+    await writePackFixture(packsDir, "the-algorithm", { skillName: "the-algorithm" });
+    await writePackFixture(packsDir, "Clean");
+    const plan = await planPaiMigration({
+      homeDir,
+      paiPacksDir: packsDir,
+      overwriteReserved: true,
+    });
+    const algo = plan.packOutcomes.find((o) => /the-algorithm/.test(o.skillName ?? ""));
+    const clean = plan.packOutcomes.find((o) => /clean/i.test(o.skillName ?? ""));
+    expect(algo?.outcome).toBe("refused-reserved");
+    expect(algo?.skillName).toBe("the-algorithm");
+    expect(clean?.outcome).toBe("imported");
+  });
+});
+
 test("real-world repro — SystemsThinking + RootCauseAnalysis shape: plan completes without raw throw", async () => {
   // Mimics the user's exact repro: `~/work/PAI/Packs/SystemsThinking`
   // has `src/Foundation.md`, `~/work/PAI/Packs/RootCauseAnalysis` has

--- a/test/pai-migration-issue-102.test.ts
+++ b/test/pai-migration-issue-102.test.ts
@@ -50,6 +50,22 @@ const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
   withSharedTempHome(fn, "soma-102-");
 
 /**
+ * Sage r1 #103 Maintainability — single-source the per-scenario
+ * setup. Every test in this file writes the identity fixture and
+ * derives `<homeDir>/Packs` as the packs root, so a helper keeps
+ * future fixture changes one-edit-away from propagating everywhere.
+ */
+async function withMigrationHome<T>(
+  fn: (ctx: { homeDir: string; packsDir: string }) => Promise<T>,
+): Promise<T> {
+  return withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    return fn({ homeDir, packsDir });
+  });
+}
+
+/**
  * Plant a substrate-specific file inside an existing pack fixture.
  * `src/Foundation.md` is not under `src/Workflows/` or `src/Tools/`,
  * so the pack-router classifies it `substrate-specific`. Mirrors the
@@ -84,9 +100,7 @@ async function makeMalformedPack(packsDir: string, packName: string): Promise<vo
 }
 
 test("scenario 1 — plan all-packs-clean: every pack planned, every outcome `imported`", async () => {
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     await writePackFixture(packsDir, "Alpha");
     await writePackFixture(packsDir, "Beta");
     const plan = await planPaiMigration({ homeDir, paiPacksDir: packsDir });
@@ -98,9 +112,7 @@ test("scenario 1 — plan all-packs-clean: every pack planned, every outcome `im
 });
 
 test("scenario 2 — plan mixed substrate-specific without flag: refused-substrate-specific, others plan, no throw", async () => {
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     const subPack = await writePackFixture(packsDir, "SubA");
     await plantSubstrateSpecificFile(subPack);
     await writePackFixture(packsDir, "Clean");
@@ -122,9 +134,7 @@ test("scenario 2 — plan mixed substrate-specific without flag: refused-substra
 });
 
 test("scenario 3 — plan mixed substrate-specific WITH includeSubstrateSpecific: all planned", async () => {
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     const subPack = await writePackFixture(packsDir, "SubA");
     await plantSubstrateSpecificFile(subPack);
     await writePackFixture(packsDir, "Clean");
@@ -139,9 +149,7 @@ test("scenario 3 — plan mixed substrate-specific WITH includeSubstrateSpecific
 });
 
 test("scenario 4 — plan mixed reserved-collision without overwriteReserved: refused-reserved, others plan, no throw", async () => {
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     await writePackFixture(packsDir, "ISA", { skillName: "ISA" });
     await writePackFixture(packsDir, "Clean");
     const plan = await planPaiMigration({ homeDir, paiPacksDir: packsDir });
@@ -156,9 +164,7 @@ test("scenario 4 — plan mixed reserved-collision without overwriteReserved: re
 });
 
 test("scenario 5 — plan single pack genuine failure (malformed): refused-other recorded; other packs still planned", async () => {
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     await makeMalformedPack(packsDir, "Broken");
     await writePackFixture(packsDir, "Healthy");
     const plan = await planPaiMigration({ homeDir, paiPacksDir: packsDir });
@@ -177,9 +183,7 @@ test("scenario 6 (AC-5) — plan output includes per-pack outcome table; CLI pla
   // CLI plan surface: NOT `--apply`, NOT `--status`. The default plan
   // mode must include the per-pack outcome table and must not throw on
   // substrate-specific packs.
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     const sub = await writePackFixture(packsDir, "SubA");
     await plantSubstrateSpecificFile(sub);
     await writePackFixture(packsDir, "ISA", { skillName: "ISA" });
@@ -202,9 +206,7 @@ test("scenario 6 (AC-5) — plan output includes per-pack outcome table; CLI pla
 });
 
 test("AC-1 — CLI parses --include-substrate-specific for `migrate pai` plan-mode (passthrough)", async () => {
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     const sub = await writePackFixture(packsDir, "SubA");
     await plantSubstrateSpecificFile(sub);
     const out = await runSomaCli([
@@ -225,9 +227,7 @@ test("AC-1 — CLI parses --include-substrate-specific for `migrate pai` plan-mo
 
 test("AC-4 — plan-mode CLI exit non-zero when a pack outcome is refused-other (after rest of plan completes)", async () => {
   // Substrate-specific only → exit zero.
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     const sub = await writePackFixture(packsDir, "SubA");
     await plantSubstrateSpecificFile(sub);
     await writePackFixture(packsDir, "Healthy");
@@ -244,9 +244,7 @@ test("AC-4 — plan-mode CLI exit non-zero when a pack outcome is refused-other 
   });
   // Malformed pack → SomaCliError exitCode 1; output still includes
   // the full plan body for the other packs.
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     await makeMalformedPack(packsDir, "Broken");
     await writePackFixture(packsDir, "Healthy");
     let caught: unknown = null;
@@ -279,9 +277,7 @@ test("real-world repro — SystemsThinking + RootCauseAnalysis shape: plan compl
   // `src/MethodSelection.md`. Before #102 the first one encountered
   // would throw `PaiPackSubstrateSpecificRefusal` out of
   // `planPaiPackImport` and abort the whole plan.
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     const st = await writePackFixture(packsDir, "SystemsThinking");
     await plantSubstrateSpecificFile(st, "Foundation.md");
     const rca = await writePackFixture(packsDir, "RootCauseAnalysis");


### PR DESCRIPTION
## Summary

`soma migrate pai` (plan mode, no `--apply`) was still aborting on substrate-specific packs after #97 (PR #99) landed log-and-continue semantics for the apply path. The plan path called `planPaiPackImport` raw through `runBoundedConcurrent` — the first `PaiPackSubstrateSpecificRefusal` escaped and aborted the entire plan. The user hit this on `soma migrate pai --pai-repo ~/work/PAI`.

The fix mirrors the apply-side `importOnePackWithOutcome` wrapper for plan mode, single-sourcing the catch ladder via a shared generic `runOnePackWithOutcome<TPayload>` helper. The refusal taxonomy (`refused-substrate-specific` / `refused-reserved` / `refused-other`) is now identical across both surfaces. Plan-mode CLI also applies the same exit-code policy as apply-mode.

## Acceptance criteria

- [x] **AC-1**: `soma migrate pai --pai-repo <root>` (no `--apply`) does NOT abort on substrate-specific packs. Other packs continue to plan; refused packs show up in the outcome table.
- [x] **AC-2**: `--include-substrate-specific` honored in plan mode (matches apply semantics).
- [x] **AC-3**: Reserved-name collisions in plan mode are caught (no abort) and surfaced as `refused-reserved`.
- [x] **AC-4**: Genuine errors (malformed pack, IO failure) surface as `refused-other` and cause non-zero CLI exit AFTER the rest of the plan completes.
- [x] **AC-5**: Plan output includes the per-pack outcome table — same shape as apply (via `formatPackOutcomeLines`).
- [x] **AC-6**: Tests for plan-mode log-and-continue mirror the apply-mode tests added in #97.

## Implementation notes

- **DRY**: `importOnePackWithOutcome` and `planOnePackWithOutcome` both delegate to a generic `runOnePackWithOutcome<TPayload>` helper. Adding a new refusal kind touches one function on both surfaces.
- **Reserved-name pre-check** happens BEFORE the inner call on both paths (clearer semantics, faster fail; doesn't depend on the inner importer happening to throw).
- `PaiMigrationPlan.packs` now reflects "successfully planned" only; refused packs live in `packOutcomes` (mirrors `PaiMigrationResult.packs` contract from #97).
- Plan-mode CLI exit-code policy mirrors apply-mode: zero on policy-respected refusals (`refused-substrate-specific`, `refused-reserved`), non-zero on `refused-other` after the full plan body prints.

## Test evidence

`test/pai-migration-issue-102.test.ts` (9 new tests):

1. All-clean plan → all `imported`.
2. Mixed substrate-specific without flag → refused recorded, others plan, no throw.
3. Mixed substrate-specific WITH `--include-substrate-specific` → all plan.
4. Mixed reserved-collision → `refused-reserved` recorded, others plan.
5. Single malformed pack → `refused-other` recorded, healthy pack still planned.
6. (AC-5) CLI plan output includes the per-pack outcome table.
7. (AC-1) `--include-substrate-specific` passthrough in plan mode.
8. (AC-4) CLI plan-mode exit non-zero on `refused-other` only.
9. Real-world repro: SystemsThinking + RootCauseAnalysis shape (user's exact reproduction) → plan completes without raw throw.

Test delta: **641 → 650 (+9)**. Typecheck clean. Smoke test against `~/work/PAI` shows `systems-thinking` and `root-cause-analysis` correctly classified `refused-substrate-specific`, exit 0.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 650/650 pass
- [x] Smoke: `bun src/cli.ts migrate pai --pai-repo ~/work/PAI` → plan completes, outcome table renders, exit 0

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)