### PR TITLE
fix(importer): skip IDE/editor config symlinks (.cursor/.vscode/.idea/.fleet/.zed) instead of refusing pack (#104)

### DIFF
--- a/docs/pai-pack-importer.md
+++ b/docs/pai-pack-importer.md
@@ -137,6 +137,19 @@ returns zero — that is the integration-level invariant tested in
 | --- | --- | --- |
 | `compacted-skill-description` | Skill description longer than the 1024-character Soma portable metadata limit. | Sentence-boundary-aware truncation; falls back to hard truncation on a non-sentence input. |
 
+### Editor-config symlink skip
+
+| Action kind | Trigger | Replacement |
+| --- | --- | --- |
+| `skipped-editor-config-symlink` | A symbolic link whose pack-relative path falls inside the IDE/editor-config denylist directories (`.cursor/`, `.vscode/`, `.idea/`, `.fleet/`, `.zed/`). | File is dropped from the import set; an audit entry is recorded with the matched denylist directory name. The pack is NOT refused. |
+
+The denylist is intentionally narrow — only well-known editor-config
+directories whose contents are noise rather than portable skill
+content. Every other symlink still aborts the pack as a security
+refusal (PAI pack import refused symlink path). The `art` and
+`prompting` PAI packs ship `.cursor/rules/*.mdc` symlinks; before this
+rule the importer refused the entire pack on first encounter.
+
 ### Advisory warnings (no rewrite)
 
 | Warning kind | Trigger |

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -15,6 +15,7 @@ import type {
   PaiPackImportPlan,
   PaiPackImportResult,
   PaiPackManifest,
+  PaiPackNormalizationAction,
   PaiPackNormalizationReport,
   PaiPackSourceImportFile,
   SomaSkillManifest,
@@ -72,6 +73,36 @@ export class PaiPackReservedNameRefusal extends Error {
     this.name = "PaiPackReservedNameRefusal";
     this.skillName = skillName;
   }
+}
+
+/**
+ * #104 — narrow denylist of IDE/editor config directory prefixes whose
+ * symlinked contents are silently skipped during pack enumeration
+ * instead of aborting the pack. Match is on POSIX-style pack-relative
+ * paths and triggers only when the file IS a symbolic link. Non-symlink
+ * editor-config files take the normal classification path; non-editor
+ * symlinks still abort the pack as `refused-other`. Keep this list
+ * narrow — every entry widens the security envelope.
+ *
+ * Each pattern is anchored at either the pack root or a directory
+ * boundary so a stray substring (e.g., `my.cursor.thing/`) does not
+ * trigger the skip.
+ */
+const EDITOR_CONFIG_SYMLINK_PATTERNS: { pattern: RegExp; dir: string }[] = [
+  { pattern: /(?:^|\/)\.cursor\//, dir: ".cursor" },
+  { pattern: /(?:^|\/)\.vscode\//, dir: ".vscode" },
+  { pattern: /(?:^|\/)\.idea\//, dir: ".idea" },
+  { pattern: /(?:^|\/)\.fleet\//, dir: ".fleet" },
+  { pattern: /(?:^|\/)\.zed\//, dir: ".zed" },
+];
+
+function matchEditorConfigSymlinkDir(relativePosixPath: string): string | null {
+  for (const { pattern, dir } of EDITOR_CONFIG_SYMLINK_PATTERNS) {
+    if (pattern.test(relativePosixPath)) {
+      return dir;
+    }
+  }
+  return null;
 }
 
 const SECRET_FILE_PATTERNS = [
@@ -185,8 +216,20 @@ export async function readPackMetadata(paiPackDir: string): Promise<PackMetadata
   };
 }
 
-async function collectFiles(root: string): Promise<string[]> {
+interface CollectFilesResult {
+  files: string[];
+  /**
+   * #104 — IDE/editor config symlinks dropped during enumeration. The
+   * pack importer surfaces these as `skipped-editor-config-symlink`
+   * audit actions on the normalization report so reviewers can see what
+   * the pack carried without the symlinks aborting the import.
+   */
+  skippedEditorSymlinks: { path: string; dir: string }[];
+}
+
+async function collectFiles(root: string): Promise<CollectFilesResult> {
   const files: string[] = [];
+  const skippedEditorSymlinks: { path: string; dir: string }[] = [];
   const realRoot = await realpath(root);
 
   async function visit(dir: string): Promise<void> {
@@ -199,7 +242,18 @@ async function collectFiles(root: string): Promise<string[]> {
       }
 
       if (entry.isSymbolicLink()) {
-        throw new Error(`PAI pack import refused symlink path: ${relative(root, fullPath).split(sep).join("/")}`);
+        const relPosix = relative(root, fullPath).split(sep).join("/");
+        // #104 — IDE/editor config symlinks (`.cursor/`, `.vscode/`,
+        // `.idea/`, `.fleet/`, `.zed/`) are dropped from the import set
+        // instead of aborting the pack. Audit entry is emitted upstream
+        // in `buildPaiPackImportPlan` once the normalization report is
+        // being assembled. Every other symlink still refuses the pack.
+        const editorDir = matchEditorConfigSymlinkDir(relPosix);
+        if (editorDir) {
+          skippedEditorSymlinks.push({ path: relPosix, dir: editorDir });
+          continue;
+        }
+        throw new Error(`PAI pack import refused symlink path: ${relPosix}`);
       }
 
       if (entry.isDirectory()) {
@@ -224,7 +278,7 @@ async function collectFiles(root: string): Promise<string[]> {
   }
 
   await visit(root);
-  return files.sort();
+  return { files: files.sort(), skippedEditorSymlinks };
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -406,7 +460,7 @@ function rewriteSkillFrontmatter(content: string, skillName: string, description
 
 async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promise<InternalPaiPackImportPlan> {
   const homes = resolvePackHomes(options);
-  const sourceFiles = await collectFiles(homes.paiPackDir);
+  const { files: sourceFiles, skippedEditorSymlinks } = await collectFiles(homes.paiPackDir);
   assertSafePackPaths(sourceFiles);
   assertRequiredPackFiles(sourceFiles);
 
@@ -496,9 +550,20 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
     file: "README.md",
     fallback: `Imported PAI pack: ${metadata.name}`,
   });
+  // #104 — surface IDE/editor config symlink skips alongside existing
+  // normalization actions in the per-pack `soma-pack.json` audit. The
+  // skips happen during file enumeration (before normalization runs),
+  // but the audit shape is the same: `{ file, kind, detail }`. Reviewers
+  // see exactly which editor files the pack carried that we dropped.
+  const editorSymlinkSkipActions: PaiPackNormalizationAction[] = skippedEditorSymlinks.map(({ path, dir }) => ({
+    file: path,
+    kind: "skipped-editor-config-symlink",
+    detail: `editor-config denylist dir: ${dir}`,
+  }));
   const normalization = mergeNormalizationReports([
     reportFromNormalizedFiles(normalizedSkillFiles.values()),
     { actions: normalizedDescription.action ? [normalizedDescription.action] : [], warnings: [] },
+    { actions: editorSymlinkSkipActions, warnings: [] },
   ]);
 
   routedFiles.push({

--- a/src/types.ts
+++ b/src/types.ts
@@ -449,7 +449,19 @@ export interface PaiPackNormalizationAction {
     | "rewrote-unmapped-claude-path"
     | "stripped-mandatory-runtime-block"
     | "stripped-pai-customization-block"
-    | "compacted-skill-description";
+    | "compacted-skill-description"
+    /**
+     * #104 — emitted during pack file enumeration (not normalization)
+     * when a symlink falls inside a well-known IDE/editor config
+     * directory denylist (`.cursor/`, `.vscode/`, `.idea/`, `.fleet/`,
+     * `.zed/`). The file is dropped from the import set instead of
+     * aborting the pack as `refused-other`. Every other symlink still
+     * refuses the pack. The audit entry surfaces in the per-pack
+     * `soma-pack.json` so reviewers can see which editor-config files
+     * the pack carried. `file` is the POSIX-style path relative to the
+     * pack root. `detail` names the matched denylist directory segment.
+     */
+    | "skipped-editor-config-symlink";
   detail: string;
 }
 

--- a/test/pai-pack-importer-issue-104.test.ts
+++ b/test/pai-pack-importer-issue-104.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Issue 104 — pai-pack-importer: skip IDE/editor config symlinks
+ * (`.cursor/`, `.vscode/`, `.idea/`, `.fleet/`, `.zed/`) instead of
+ * refusing the pack outright.
+ *
+ * The previous symlink-refusal rule aborted otherwise-valid packs the
+ * moment any symlink — including IDE editor noise like
+ * `.cursor/rules/use-bun-instead-of-node-vite-npm-pnpm.mdc` — was
+ * encountered. PAI's `art` and `prompting` packs were the trigger.
+ * The denylist is intentionally narrow: only well-known editor-config
+ * directories are skipped. Every other symlink still aborts the pack
+ * as `refused-other` so the security envelope is preserved.
+ *
+ * ACs:
+ * - AC-1: `art` / `prompting`-style packs with `.cursor/rules/*.mdc`
+ *         symlinks import successfully (no `refused-other`).
+ * - AC-2: New audit action `skipped-editor-config-symlink` recorded
+ *         per skipped file in the per-pack `soma-pack.json` audit.
+ * - AC-3: A non-editor symlink (e.g., `src/Workflows/payload.md`
+ *         symlinked to `/etc/passwd`) still aborts the pack.
+ * - AC-4: Fixture-based coverage for both paths.
+ */
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { importPaiPack, planPaiPackImport } from "../src/index";
+import type { PaiPackManifest } from "../src/types";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-issue-104-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function writeMinimalPack(packDir: string, packName = "Demo"): Promise<void> {
+  await mkdir(join(packDir, "src/Workflows"), { recursive: true });
+  await mkdir(join(packDir, "src/Tools"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    [
+      "---",
+      `name: ${packName}`,
+      "description: Editor-symlink fixture",
+      "---",
+      "",
+      `# ${packName}`,
+      "",
+      "Pack docs.",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    [
+      "---",
+      `name: ${packName}`,
+      "description: Original PAI skill",
+      "---",
+      "",
+      `# ${packName}`,
+      "",
+      "## Triggers",
+      "",
+      "- demo",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+// ─── AC-1 + AC-2: .cursor/rules/*.mdc symlink skipped + audit entry ────
+
+test("AC-1+AC-2: `.cursor/rules/*.mdc` symlink is skipped, pack imports, audit records skip", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Demo");
+    await writeMinimalPack(packDir);
+
+    // Plant a realistic editor-config symlink — Cursor rule file pointing
+    // outside the pack root (the same shape PAI's `art` + `prompting`
+    // packs have that triggered the original refusal).
+    const externalRule = join(homeDir, "shared-rules/use-bun.mdc");
+    await mkdir(join(homeDir, "shared-rules"), { recursive: true });
+    await writeFile(externalRule, "# Use Bun\n", "utf8");
+    await mkdir(join(packDir, "src/Tools/.cursor/rules"), { recursive: true });
+    await symlink(externalRule, join(packDir, "src/Tools/.cursor/rules/use-bun.mdc"));
+
+    // Plan must succeed — no `refused symlink` throw.
+    const plan = await planPaiPackImport({ homeDir, paiPackDir: packDir });
+    expect(plan.skillName).toBe("demo");
+
+    // The cursor symlink must NOT appear in the routed file set.
+    expect(plan.files.every((file) => !file.target.includes(".cursor/"))).toBe(true);
+
+    // AC-2: audit records `skipped-editor-config-symlink` for the cursor file.
+    const skipActions = plan.normalization.actions.filter(
+      (action) => action.kind === "skipped-editor-config-symlink",
+    );
+    expect(skipActions).toHaveLength(1);
+    expect(skipActions[0]?.file).toBe("src/Tools/.cursor/rules/use-bun.mdc");
+
+    // AC-1: apply path also succeeds end-to-end.
+    const result = await importPaiPack({ homeDir, paiPackDir: packDir });
+    expect(result.skillName).toBe("demo");
+    expect(result.normalization.actions.some((a) => a.kind === "skipped-editor-config-symlink")).toBe(true);
+
+    // The per-pack `soma-pack.json` audit surfaces the skip alongside
+    // existing normalization actions (AC-2: "audit alongside existing
+    // actions").
+    const manifestRaw = await readFile(join(homeDir, ".soma/skills/demo/soma-pack.json"), "utf8");
+    const manifest = JSON.parse(manifestRaw) as PaiPackManifest;
+    expect(manifest.normalization?.actions.some((a) => a.kind === "skipped-editor-config-symlink")).toBe(true);
+  });
+});
+
+test("AC-2: `.vscode/settings.json` symlink is skipped, pack imports, audit records skip", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Demo");
+    await writeMinimalPack(packDir);
+
+    const externalSettings = join(homeDir, "shared-vscode/settings.json");
+    await mkdir(join(homeDir, "shared-vscode"), { recursive: true });
+    await writeFile(externalSettings, '{ "editor.tabSize": 2 }\n', "utf8");
+    await mkdir(join(packDir, ".vscode"), { recursive: true });
+    await symlink(externalSettings, join(packDir, ".vscode/settings.json"));
+
+    const plan = await planPaiPackImport({ homeDir, paiPackDir: packDir });
+    expect(plan.files.every((file) => !file.target.includes(".vscode/"))).toBe(true);
+    const skipActions = plan.normalization.actions.filter(
+      (action) => action.kind === "skipped-editor-config-symlink",
+    );
+    expect(skipActions).toHaveLength(1);
+    expect(skipActions[0]?.file).toBe(".vscode/settings.json");
+
+    const result = await importPaiPack({ homeDir, paiPackDir: packDir });
+    expect(result.skillName).toBe("demo");
+  });
+});
+
+// ─── AC-3: non-editor symlink still REFUSES the pack ──────────────────
+
+test("AC-3: non-editor symlink (`src/Workflows/payload.md` → /etc/passwd) still refuses pack", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Demo");
+    await writeMinimalPack(packDir);
+
+    // The classic escape attempt the narrow denylist must NOT enable.
+    await symlink("/etc/passwd", join(packDir, "src/Workflows/payload.md"));
+
+    await expect(planPaiPackImport({ homeDir, paiPackDir: packDir })).rejects.toThrow(
+      /refused symlink path: src\/Workflows\/payload\.md/,
+    );
+  });
+});
+
+test("AC-3: non-editor symlink elsewhere (`src/Tools/leak.ts`) still refuses pack", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Demo");
+    await writeMinimalPack(packDir);
+
+    const outside = join(homeDir, "outside.ts");
+    await writeFile(outside, "// outside\n", "utf8");
+    await symlink(outside, join(packDir, "src/Tools/leak.ts"));
+
+    await expect(planPaiPackImport({ homeDir, paiPackDir: packDir })).rejects.toThrow(/refused symlink/);
+  });
+});
+
+// ─── AC-4: mixed pack — 2 editor-config symlinks + 3 normal files ─────
+
+test("AC-4: mixed pack with editor symlinks AND normal files imports cleanly with audit entries", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Demo");
+    await writeMinimalPack(packDir);
+
+    // Three normal portable files (Workflows + Tools regular content).
+    await writeFile(join(packDir, "src/Workflows/Update.md"), "# Update\n", "utf8");
+    await writeFile(join(packDir, "src/Workflows/Verify.md"), "# Verify\n", "utf8");
+    await writeFile(join(packDir, "src/Tools/Helper.ts"), "export const helper = true;\n", "utf8");
+
+    // Two editor-config symlinks.
+    const externalRule = join(homeDir, "shared-rules/use-bun.mdc");
+    await mkdir(join(homeDir, "shared-rules"), { recursive: true });
+    await writeFile(externalRule, "# Use Bun\n", "utf8");
+    await mkdir(join(packDir, "src/Tools/.cursor/rules"), { recursive: true });
+    await symlink(externalRule, join(packDir, "src/Tools/.cursor/rules/use-bun.mdc"));
+
+    const externalIdea = join(homeDir, "shared-idea/workspace.xml");
+    await mkdir(join(homeDir, "shared-idea"), { recursive: true });
+    await writeFile(externalIdea, "<project />\n", "utf8");
+    await mkdir(join(packDir, ".idea"), { recursive: true });
+    await symlink(externalIdea, join(packDir, ".idea/workspace.xml"));
+
+    const plan = await planPaiPackImport({ homeDir, paiPackDir: packDir });
+
+    // Audit has exactly 2 skip entries.
+    const skipActions = plan.normalization.actions.filter(
+      (action) => action.kind === "skipped-editor-config-symlink",
+    );
+    expect(skipActions).toHaveLength(2);
+    const skippedPaths = skipActions.map((a) => a.file).sort();
+    expect(skippedPaths).toEqual([".idea/workspace.xml", "src/Tools/.cursor/rules/use-bun.mdc"]);
+
+    // Normal files still get classified + imported.
+    expect(plan.files.some((file) => file.target.endsWith("Workflows/Update.md"))).toBe(true);
+    expect(plan.files.some((file) => file.target.endsWith("Workflows/Verify.md"))).toBe(true);
+    expect(plan.files.some((file) => file.target.endsWith("Tools/Helper.ts"))).toBe(true);
+
+    // No `.cursor` or `.idea` paths leak into the routed file set.
+    expect(plan.files.every((file) => !file.target.includes(".cursor/") && !file.target.includes(".idea/"))).toBe(true);
+
+    // Apply succeeds; no refusal.
+    const result = await importPaiPack({ homeDir, paiPackDir: packDir });
+    expect(result.skillName).toBe("demo");
+  });
+});
+
+test("AC-4: `.fleet/` and `.zed/` symlinks are also skipped (full denylist coverage)", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Demo");
+    await writeMinimalPack(packDir);
+
+    const fleetExt = join(homeDir, "fleet-settings.json");
+    const zedExt = join(homeDir, "zed-settings.json");
+    await writeFile(fleetExt, "{}\n", "utf8");
+    await writeFile(zedExt, "{}\n", "utf8");
+    await mkdir(join(packDir, ".fleet"), { recursive: true });
+    await mkdir(join(packDir, ".zed"), { recursive: true });
+    await symlink(fleetExt, join(packDir, ".fleet/settings.json"));
+    await symlink(zedExt, join(packDir, ".zed/settings.json"));
+
+    const plan = await planPaiPackImport({ homeDir, paiPackDir: packDir });
+    const skipActions = plan.normalization.actions.filter(
+      (action) => action.kind === "skipped-editor-config-symlink",
+    );
+    expect(skipActions.map((a) => a.file).sort()).toEqual([".fleet/settings.json", ".zed/settings.json"]);
+  });
+});


### PR DESCRIPTION
## Summary

PAI's `art` and `prompting` packs ship `.cursor/rules/*.mdc` symlinks that pointed outside the pack root. The pack importer's blanket symlink refusal aborted the entire pack on first encounter (`refused-other` during `soma migrate pai`). This PR introduces a narrow IDE/editor-config denylist so those packs no longer refuse on symlinks. Every other symlink still aborts the pack as before — the denylist does NOT open a hole for `src/Workflows/payload.md → /etc/passwd` escapes.

## Acceptance criteria

- [x] AC-1: `art` and `prompting` packs no longer abort on `.cursor/rules/*.mdc` symlinks. Verified locally via `bun src/cli.ts migrate pai --pai-repo ~/work/PAI` — both packs now land as `refused-substrate-specific` (nested-bundle territory of #105), NOT `refused-other` on the symlinks.
- [x] AC-2: New `PaiPackNormalizationAction.kind` value `skipped-editor-config-symlink` records `file` (pack-relative POSIX path) + `detail` (matched denylist dir). Audit entry surfaces in per-pack `soma-pack.json` alongside existing actions (verified via `JSON.parse` assertion in `AC-1+AC-2` test).
- [x] AC-3: Non-editor symlink (`src/Workflows/payload.md → /etc/passwd`, `src/Tools/leak.ts → outside`) still refuses pack via the original `PAI pack import refused symlink path:` throw.
- [x] AC-4: Fixture tests cover both paths — 6 new tests in `test/pai-pack-importer-issue-104.test.ts`: `.cursor` skip + audit + apply, `.vscode` skip + audit, two refusal scenarios, mixed pack (2 editor symlinks + 3 normal portable files = exact issue-prompt scenario), and full denylist coverage (`.fleet` + `.zed`).
- [x] AC-5: `docs/pai-pack-importer.md` classification table extended with `Editor-config symlink skip` section naming all five denylist directories.

## Implementation

1. `src/types.ts` — extend `PaiPackNormalizationAction.kind` union with `"skipped-editor-config-symlink"`, JSDoc explains the editor-config narrowness and the security envelope.
2. `src/pai-pack-importer.ts` — narrow `EDITOR_CONFIG_SYMLINK_PATTERNS` denylist; `collectFiles` returns `{ files, skippedEditorSymlinks }` (was just `files`); enumeration emits skip entries instead of throwing for matched paths; `buildPaiPackImportPlan` merges editor-symlink skip actions into the normalization report via `mergeNormalizationReports`.
3. `docs/pai-pack-importer.md` — new section under Normalization Actions.

## Test evidence

```
bun test → 657 pass / 0 fail / 2088 expect() calls (baseline 651, +6)
bun run typecheck → clean
```

Smoke test (post-build, not yet merged):
```
$ bun src/cli.ts migrate pai --pai-repo ~/work/PAI 2>&1 | grep -E "^  - (art|prompting):"
  - art: refused-substrate-specific — substrate-specific file(s): src/Examples/human-linear-form.png, ...
  - prompting: refused-substrate-specific — substrate-specific file(s): src/Standards.md, ...
```

Both packs now refuse on substrate-specific content (the nested-bundle issue #105 will address), not on `.cursor/rules/*.mdc` symlinks. AC-1 confirmed end-to-end.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)