### PR TITLE
feat(importer): support nested skill bundles — N nested skills → N Soma skills (#105)

### DIFF
--- a/docs/pai-pack-importer.md
+++ b/docs/pai-pack-importer.md
@@ -81,6 +81,72 @@ When substrate-specific files are explicitly included, Soma stores them outside
 the skill payload under `~/.soma/imports/pai-packs/<skill>/source/`. They are
 kept as migration source material, not projected skill content.
 
+## Nested skill bundles (#105)
+
+Many PAI packs ship multiple skills under one pack root. The importer
+recognizes a nested bundle pattern alongside the FLAT layout: a `<Name>`
+directly under `src/` is treated as a nested skill iff `src/<Name>/SKILL.md`
+exists in the pack file set. A pack with N nested skills (plus an
+optional top-level FLAT skill) imports as 1 + N independent Soma
+skills, each at `~/.soma/skills/<kebab-name>/`.
+
+### Nested classification table
+
+| Path | Classification | Lands as |
+| --- | --- | --- |
+| `src/<Name>/SKILL.md` | `portable` (nested entry) | `~/.soma/skills/<kebab-name>/SKILL.md` |
+| `src/<Name>/Workflows/<rest>` | `portable` | `~/.soma/skills/<kebab-name>/Workflows/<rest>` |
+| `src/<Name>/Tools/<rest>` | `portable` | `~/.soma/skills/<kebab-name>/Tools/<rest>` |
+| `src/<Name>/References/<rest>` | `portable` | `~/.soma/skills/<kebab-name>/References/<rest>` |
+| `src/<Name>/Examples/<rest>` | `portable` | `~/.soma/skills/<kebab-name>/Examples/<rest>` |
+| `src/<Name>/<other>` | `substrate-specific` | archive only (e.g., `src/Art/Lib/midjourney.ts` stays under the pack archive) |
+
+The detection rule is structural: a `<Name>` is nested **only** when
+`src/<Name>/SKILL.md` is present. A directory without `SKILL.md` is not
+a skill — its files fall through to substrate-specific.
+
+### Kebab-casing
+
+`<Name>` is kebab-cased to produce the Soma skill slug. The transform
+handles both standard CamelCase (`ExtractWisdom` → `extract-wisdom`)
+and ALL-CAPS prefixes (`PAIUpgrade` → `pai-upgrade`,
+`WorldThreatModelHarness` → `world-threat-model-harness`).
+
+### Pack-level docs land on every derived skill
+
+Pack-level `README.md` / `INSTALL.md` / `VERIFY.md` attach to **each**
+derived skill as `references/PAI-PACK-{README,INSTALL,VERIFY}.md` so
+any nested skill can be invoked standalone with full pack-level
+context. The pack-level archive at
+`~/.soma/imports/pai-packs/<pack-slug>/` records the original pack
+layout for auditability and `soma-pack-archive.json` lists every
+`derivedSkills` slug.
+
+### Name collisions
+
+Two flavors of collision are surfaced:
+
+1. **Within one pack** — two `src/<Name>/SKILL.md` paths kebab to the
+   same slug (e.g., `src/ExtractWisdom/SKILL.md` +
+   `src/extract-wisdom/SKILL.md`). The importer throws
+   `PaiPackNameCollisionRefusal`; the migration orchestrator records
+   `refused-name-collision` for the entire pack and continues.
+2. **Across packs** — Pack A's `browser` slug already landed; Pack B's
+   nested `src/Browser/SKILL.md` would also produce `browser`. The
+   second pack's nested skill records `refused-name-collision` unless
+   `--overwrite-reserved` is set. Other derived skills from the same
+   pack still land.
+
+### Breaking change: array return shape
+
+`importPaiPack` / `planPaiPackImport` now return arrays
+(`PaiPackImportResult[]` / `PaiPackImportPlan[]`) — one entry per
+derived skill. Single-skill (FLAT) packs return a one-element array;
+multi-skill nested packs return N entries. Callers that previously
+destructured a single result must adopt the array shape (typically
+`const [r] = await importPaiPack(...)` for the single-skill case, or
+iteration for the multi-skill case).
+
 ## Normalization Actions
 
 `normalizeSkillContent` applies a fixed pipeline of deterministic

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1738,10 +1738,12 @@ function formatPaiMigrationPlan(plan: PaiMigrationPlan): string {
   const outcomeLines = formatPackOutcomeLines(plan.packOutcomes, {
     labelKind: "path",
   });
-  // `packs.length` now reflects "successfully planned" only (refused
-  // packs live in `packOutcomes`); use `packOutcomes.length` for the
-  // discovery count so the principal sees the same "N discovered"
-  // total they got pre-#102 + the per-outcome breakdown.
+  // `packs.length` now reflects "successfully planned" derived skills,
+  // not source packs (#105 — a pack with N nested skills emits N
+  // entries here, plus 1 row per outcome). The discovered count is
+  // unique pack directories from outcomes; the to-import count is the
+  // derived-skill cardinality.
+  const uniquePackDirs = new Set(plan.packOutcomes.map((o) => o.paiPackDir)).size;
   return [
     "soma migrate pai — plan (dry-run; pass --apply to execute)",
     "",
@@ -1754,7 +1756,7 @@ function formatPaiMigrationPlan(plan: PaiMigrationPlan): string {
     algorithmLine,
     memoryLine,
     docsLine,
-    `  - packs:    ${plan.packOutcomes.length} discovered, ${plan.packs.length} to import`,
+    `  - packs:    ${uniquePackDirs} discovered, ${plan.packs.length} skill(s) to import`,
     "",
     "Pack outcomes:",
     ...outcomeLines,
@@ -1780,6 +1782,13 @@ function formatPaiMigrationResult(result: PaiMigrationResult): string {
   const outcomeLines = formatPackOutcomeLines(result.packOutcomes, {
     labelKind: "path",
   });
+  // #105 — `result.packs` is now one-entry-per-derived-skill (a pack
+  // with N nested skills produces N entries). The summary line counts
+  // unique pack directories so the principal-facing count matches the
+  // source-of-truth `~/work/PAI/Packs/` cardinality, not the derived
+  // skill cardinality (which lives in the outcomes table immediately
+  // below).
+  const uniquePackDirs = new Set(result.packs.map((p) => p.paiPackDir)).size;
   return [
     "soma migrate pai — applied",
     "",
@@ -1792,7 +1801,7 @@ function formatPaiMigrationResult(result: PaiMigrationResult): string {
     result.algorithm ? `  - algorithm: ${result.algorithm.files.length} file(s)` : "  - algorithm: skipped (not present)",
     memoryLine,
     docsLine,
-    `  - packs:    ${result.packs.length} pack(s), ${result.packs.reduce((sum, p) => sum + p.files.length, 0)} file(s)`,
+    `  - packs:    ${uniquePackDirs} pack(s) → ${result.packs.length} skill(s), ${result.packs.reduce((sum, p) => sum + p.files.length, 0)} file(s)`,
     "",
     "Pack outcomes:",
     ...outcomeLines,
@@ -1894,7 +1903,7 @@ function formatAlgorithmImportResult(result: AlgorithmImportResult): string {
   ].join("\n");
 }
 
-function formatPaiPackImportPlan(plan: PaiPackImportPlan): string {
+function formatOnePaiPackImportPlan(plan: PaiPackImportPlan): string {
   const counts = plan.files.reduce<Partial<Record<string, number>>>((acc, file) => {
     acc[file.classification] = (acc[file.classification] ?? 0) + 1;
     return acc;
@@ -1944,7 +1953,20 @@ function formatPaiPackImportPlan(plan: PaiPackImportPlan): string {
   ].join("\n");
 }
 
-function formatPaiPackImportResult(result: PaiPackImportResult): string {
+/**
+ * #105 — `importPaiPack` / `planPaiPackImport` now return an array
+ * (one entry per derived skill). The CLI prints each plan/result in
+ * turn separated by a blank line so multi-skill packs surface every
+ * derived skill to the principal.
+ */
+function formatPaiPackImportPlan(plans: PaiPackImportPlan[]): string {
+  if (plans.length === 0) return "Soma PAI Pack import plan: no derived skills.";
+  if (plans.length === 1) return formatOnePaiPackImportPlan(plans[0]);
+  const header = `Soma PAI Pack import plan: ${plans.length} derived skill(s) — ${plans.map((p) => p.skillName).join(", ")}`;
+  return [header, "", ...plans.map(formatOnePaiPackImportPlan)].join("\n\n");
+}
+
+function formatOnePaiPackImportResult(result: PaiPackImportResult): string {
   const quotedSomaHome = quoteShellArg(result.somaHome);
 
   const normalizationLines: string[] = [];
@@ -1968,6 +1990,13 @@ function formatPaiPackImportResult(result: PaiPackImportResult): string {
     "Files:",
     ...result.files.map((path) => `- ${path}`),
   ].join("\n");
+}
+
+function formatPaiPackImportResult(results: PaiPackImportResult[]): string {
+  if (results.length === 0) return "Soma PAI Pack import applied: no derived skills.";
+  if (results.length === 1) return formatOnePaiPackImportResult(results[0]);
+  const header = `Soma PAI Pack import applied: ${results.length} derived skill(s) — ${results.map((r) => r.skillName).join(", ")}`;
+  return [header, "", ...results.map(formatOnePaiPackImportResult)].join("\n\n");
 }
 
 function formatPaiDocsImportPlan(plan: PaiDocsImportPlan): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,13 +211,20 @@ export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
 export {
   importPaiPack,
-  importPaiPackFromPlan,
   PaiPackNameCollisionRefusal,
   PaiPackSubstrateSpecificRefusal,
   planPaiPackImport,
-  planPaiPackImportHandle,
-  type PaiPackImportPlanHandle,
 } from "./pai-pack-importer";
+// Sage r3 #108 Security (blocker) + Architecture (important):
+// `planPaiPackImportHandle`, `importPaiPackFromPlan`, and
+// `PaiPackImportPlanHandle` are migration-orchestrator plumbing and
+// MUST NOT appear on the public package barrel. Exposing them turns
+// an internal plan cache into irreversible SDK surface AND opens a
+// trust-boundary bypass — a JS caller could forge a handle whose
+// `routedFiles` escape `somaHome` and the cached plan would write
+// them without re-validating. The migration orchestrator imports the
+// trio directly from `./pai-pack-importer`; that module's
+// `castHandle` is unforgeable from outside the module file.
 // Sage r3 #103 Architecture: `PaiPackReservedNameRefusal` is an
 // internal migration-classification detail. The migration orchestrator
 // imports it directly from `./pai-pack-importer`; no demonstrated

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,6 +211,7 @@ export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
 export {
   importPaiPack,
+  PaiPackNameCollisionRefusal,
   PaiPackSubstrateSpecificRefusal,
   planPaiPackImport,
 } from "./pai-pack-importer";

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,9 +211,12 @@ export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
 export {
   importPaiPack,
+  importPaiPackFromPlan,
   PaiPackNameCollisionRefusal,
   PaiPackSubstrateSpecificRefusal,
   planPaiPackImport,
+  planPaiPackImportHandle,
+  type PaiPackImportPlanHandle,
 } from "./pai-pack-importer";
 // Sage r3 #103 Architecture: `PaiPackReservedNameRefusal` is an
 // internal migration-classification detail. The migration orchestrator

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -539,6 +539,39 @@ interface ResolvedPlanRow {
 }
 
 /**
+ * Sage r6 #108 (Maintainability, suggestion) — single source for
+ * partitioning a pack's plans into `collided` (slug already landed)
+ * and `survivors`. Both the apply path (which builds `landedSlugs`
+ * sequentially as packs successfully apply) and the plan-only path
+ * (which builds it optimistically inside `walkPlanRowsForCollisions`)
+ * consume this helper, so the rule "a slug collides iff it is in
+ * landedSlugs AND overwriteReserved is false" lives in exactly one
+ * place.
+ *
+ * NOTE: this helper does NOT mutate `landedSlugs` — the caller is
+ * responsible for adding slugs when the partition's contract for
+ * "successfully landed" is satisfied (apply path: only after a
+ * successful `importPaiPackFromPlan`; plan-only path: at partition
+ * time, since plan can't fail mid-apply).
+ */
+function partitionPlansByCollision(
+  plans: readonly PaiPackImportPlan[],
+  landedSlugs: ReadonlySet<string>,
+  overwriteReserved: boolean,
+): { collided: string[]; survivors: string[] } {
+  const collided: string[] = [];
+  const survivors: string[] = [];
+  for (const plan of plans) {
+    if (landedSlugs.has(plan.skillName) && !overwriteReserved) {
+      collided.push(plan.skillName);
+    } else {
+      survivors.push(plan.skillName);
+    }
+  }
+  return { collided, survivors };
+}
+
+/**
  * Sage r3 #108 (Maintainability suggestion) — single source for the
  * cross-pack `refused-name-collision` outcome shape. Both bulk paths
  * (apply + plan-only) emit identical rows; centralizing the
@@ -586,20 +619,11 @@ function walkPlanRowsForCollisions(
 
   for (const row of planRows) {
     if (row.kind === "refused") continue;
-    const collided: string[] = [];
-    const survivors: string[] = [];
-    for (const plan of row.plans) {
-      const willCollide = landedSlugs.has(plan.skillName);
-      if (willCollide && !overwriteReserved) {
-        collided.push(plan.skillName);
-      } else {
-        // Reserve the slug for cross-pack collision tracking. The
-        // caller's per-pack outcome emission confirms the actual
-        // "imported" row.
-        landedSlugs.add(plan.skillName);
-        survivors.push(plan.skillName);
-      }
-    }
+    const { collided, survivors } = partitionPlansByCollision(row.plans, landedSlugs, overwriteReserved);
+    // Plan-only mode: reserve every survivor up front. Plan can't
+    // fail mid-apply, so the optimistic-landing partition is correct.
+    // Apply path manages its own `landedSlugs` (Sage r4 #108).
+    for (const slug of survivors) landedSlugs.add(slug);
     resolved.push({
       paiPackDir: row.paiPackDir,
       plans: row.plans,
@@ -644,17 +668,9 @@ async function importPacksWithOutcomes(
     // Partition this pack's derived skills against the current
     // landed-slug set. `landedSlugs` reflects PRIOR SUCCESSFUL packs
     // only — a pack ahead of us that failed apply is not in the set,
-    // so its slug is available to us.
-    const collided: string[] = [];
-    const survivors: string[] = [];
-    for (const plan of row.plans) {
-      const willCollide = landedSlugs.has(plan.skillName);
-      if (willCollide && !inputs.overwriteReserved) {
-        collided.push(plan.skillName);
-      } else {
-        survivors.push(plan.skillName);
-      }
-    }
+    // so its slug is available to us. Sage r6 #108: same partitioning
+    // logic as the plan-only walker, via the shared helper.
+    const { collided, survivors } = partitionPlansByCollision(row.plans, landedSlugs, inputs.overwriteReserved);
 
     for (const slug of collided) {
       outcomes.push(crossPackCollisionOutcome(row.paiPackDir, slug));

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -34,6 +34,7 @@ import { importPaiIdentity, planPaiImport } from "./pai-importer";
 import { migratePaiMemory, planPaiMemoryMigration } from "./pai-memory-migrator";
 import {
   importPaiPack,
+  PaiPackNameCollisionRefusal,
   PaiPackReservedNameRefusal,
   PaiPackSubstrateSpecificRefusal,
   planPaiPackImport,
@@ -475,29 +476,36 @@ interface BulkImportResult {
   outcomes: PaiPackOutcome[];
 }
 
+/**
+ * #105 — bulk apply path. Packs are processed in **sorted-by-path**
+ * order (serial) so cross-pack name collisions resolve
+ * deterministically: the first pack lexically wins; later collisions
+ * surface as `refused-name-collision`. Previously packs ran 4-wide
+ * concurrent — that's still correct for substrate-specific / reserved
+ * outcomes but breaks deterministic collision resolution when two
+ * packs derive the same slug.
+ *
+ * Per-pack work is small I/O on ≤30 packs in a typical install; serial
+ * latency is well under one second on a modern disk. If that becomes
+ * a bottleneck, collision tracking can be promoted to a queue + worker
+ * pool design.
+ */
 async function importPacksWithOutcomes(
   inputs: BulkImportInputs,
 ): Promise<BulkImportResult> {
-  // Sage r2 #99 Performance: per-pack work is mostly I/O (small file
-  // reads + a directory copy); bounded concurrency mirrors the
-  // pre-#97 4-wide fan-out and the planner / fingerprint passes.
-  // `importOnePackWithOutcome` swallows its own per-pack errors into
-  // `outcome.outcome === "refused-other"`, so the helper is
-  // guaranteed to settle — `runBoundedConcurrent`'s "first error
-  // wins" abort contract never fires for legitimate pack failures.
-  const results = await runBoundedConcurrent(
-    [...inputs.packPaths],
-    (paiPackDir) => importOnePackWithOutcome(inputs, paiPackDir),
-    4,
-  );
-
+  const landedSlugs = new Set<string>();
   const packs: PaiPackImportResult[] = [];
   const outcomes: PaiPackOutcome[] = [];
-  for (const { pack, outcome } of results) {
-    if (pack) packs.push(pack);
-    outcomes.push(outcome);
+  const sortedPaths = [...inputs.packPaths].sort();
+  for (const paiPackDir of sortedPaths) {
+    const { items, outcomes: packOutcomes } = await importOnePackWithOutcome(
+      inputs,
+      paiPackDir,
+      landedSlugs,
+    );
+    packs.push(...items);
+    outcomes.push(...packOutcomes);
   }
-
   return { packs, outcomes };
 }
 
@@ -529,6 +537,27 @@ interface OnePackInputs {
   includeSubstrateSpecific: boolean;
 }
 
+/**
+ * #105 — generic per-pack runner. The `operation` callback now returns
+ * an array of payloads (one per derived skill) instead of a single
+ * payload. Outcomes are emitted one-per-payload on success; on refusal
+ * a single outcome is emitted for the whole pack.
+ *
+ * Cross-pack collision check: `landedSlugs` records every slug that
+ * has successfully landed in this run. The runner inspects it BEFORE
+ * invoking the operation (peeks at the pack's derived-skill set via a
+ * plan-mode call). When `overwriteReserved` is false, any colliding
+ * slug surfaces as `refused-name-collision` and the operation never
+ * runs. When `overwriteReserved` is true, collisions are permitted
+ * and the operation runs with `overwrite: true` semantics.
+ *
+ * The peek IS a duplicate plan call (the apply path then re-plans
+ * inside `importPaiPack`). That's a deliberate trade-off for clarity:
+ * the alternative is to expose collision-detection state across the
+ * importer boundary, which leaks the orchestrator's bookkeeping into
+ * a lower layer. Pack metadata reads are cheap (~ms) and only one
+ * extra read per pack happens this way.
+ */
 async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
   inputs: OnePackInputs,
   operation: (opts: {
@@ -536,8 +565,9 @@ async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
     paiPackDir: string;
     somaHome: string;
     includeSubstrateSpecific: boolean;
-  }) => Promise<TPayload>,
-): Promise<{ payload?: TPayload; outcome: PaiPackOutcome }> {
+  }) => Promise<TPayload[]>,
+  landedSlugs?: Set<string>,
+): Promise<{ items: TPayload[]; outcomes: PaiPackOutcome[] }> {
   // Sage r2 #103 Performance — defer the slug read to the only paths
   // that actually need it: the migrate-level reserved pre-check
   // (when `overwriteReserved` is false) and the refusal-classification
@@ -560,7 +590,8 @@ async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
       // verbatim; the principal needs the original reason in the
       // summary table. No `skillName` because metadata read failed.
       return {
-        outcome: { paiPackDir: inputs.paiPackDir, outcome: "refused-other", reason: errorMessage(error) },
+        items: [],
+        outcomes: [{ paiPackDir: inputs.paiPackDir, outcome: "refused-other", reason: errorMessage(error) }],
       };
     }
 
@@ -573,36 +604,77 @@ async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
     // surfaces).
     if (MIGRATE_RESERVED_SKILL_NAMES.has(upfrontSlug)) {
       return {
-        outcome: {
-          paiPackDir: inputs.paiPackDir,
-          outcome: "refused-reserved",
-          skillName: upfrontSlug,
-          reason: `reserved Soma skill '${upfrontSlug}' — re-run with --overwrite-reserved to permit.`,
-        },
+        items: [],
+        outcomes: [
+          {
+            paiPackDir: inputs.paiPackDir,
+            outcome: "refused-reserved",
+            skillName: upfrontSlug,
+            reason: `reserved Soma skill '${upfrontSlug}' — re-run with --overwrite-reserved to permit.`,
+          },
+        ],
       };
     }
   }
 
   try {
-    const payload = await operation({
+    const items = await operation({
       homeDir: inputs.homeDir,
       paiPackDir: inputs.paiPackDir,
       somaHome: inputs.somaHome,
       includeSubstrateSpecific: inputs.includeSubstrateSpecific,
     });
-    return {
-      payload,
-      outcome: { paiPackDir: inputs.paiPackDir, outcome: "imported", skillName: payload.skillName },
-    };
+
+    // #105 — cross-pack collision check. After the operation returns
+    // its derived-skill list, separate items into (kept, collided)
+    // based on whether their slug already lives in `landedSlugs`. On
+    // collision: when `overwriteReserved` is set the caller has opted
+    // in to clobbering — keep the item and mark it imported (it
+    // already wrote to disk via the inner `overwrite: true`). When
+    // `overwriteReserved` is unset, emit `refused-name-collision`.
+    //
+    // For the apply path, the inner `importPaiPack` already wrote
+    // EVERY derived skill (it doesn't know about collisions). When
+    // we refuse-after-the-fact we can't unwrite — but the practical
+    // effect on disk is: the second pack's content overwrote any
+    // pre-existing surface from earlier in the same run. That mirrors
+    // the historical behavior of `overwrite: true` on the inner call,
+    // and the outcome table makes the collision visible to the
+    // principal. Plan-mode (no writes) makes this cleanly advisory.
+    const outcomes: PaiPackOutcome[] = [];
+    const keptItems: TPayload[] = [];
+    for (const item of items) {
+      const collides = landedSlugs?.has(item.skillName) ?? false;
+      if (collides && !inputs.overwriteReserved) {
+        outcomes.push({
+          paiPackDir: inputs.paiPackDir,
+          outcome: "refused-name-collision",
+          skillName: item.skillName,
+          reason: `Soma skill '${item.skillName}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
+        });
+        continue;
+      }
+      keptItems.push(item);
+      landedSlugs?.add(item.skillName);
+      outcomes.push({
+        paiPackDir: inputs.paiPackDir,
+        outcome: "imported",
+        skillName: item.skillName,
+      });
+    }
+    return { items: keptItems, outcomes };
   } catch (error) {
     if (error instanceof PaiPackSubstrateSpecificRefusal) {
       return {
-        outcome: {
-          paiPackDir: inputs.paiPackDir,
-          outcome: "refused-substrate-specific",
-          skillName: upfrontSlug ?? (await safeReadSkillSlug(inputs.paiPackDir)),
-          reason: `substrate-specific file(s): ${error.files.join(", ")}`,
-        },
+        items: [],
+        outcomes: [
+          {
+            paiPackDir: inputs.paiPackDir,
+            outcome: "refused-substrate-specific",
+            skillName: upfrontSlug ?? (await safeReadSkillSlug(inputs.paiPackDir)),
+            reason: `substrate-specific file(s): ${error.files.join(", ")}`,
+          },
+        ],
       };
     }
     // Sage r2 #103 CodeQuality important — the pack importer's own
@@ -615,21 +687,44 @@ async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
     // don't need a second metadata read for `outcome.skillName`.
     if (error instanceof PaiPackReservedNameRefusal) {
       return {
-        outcome: {
-          paiPackDir: inputs.paiPackDir,
-          outcome: "refused-reserved",
-          skillName: error.skillName,
-          reason: `reserved by pack importer: '${error.skillName}'`,
-        },
+        items: [],
+        outcomes: [
+          {
+            paiPackDir: inputs.paiPackDir,
+            outcome: "refused-reserved",
+            skillName: error.skillName,
+            reason: `reserved by pack importer: '${error.skillName}'`,
+          },
+        ],
+      };
+    }
+    // #105 — within-pack name collision (two src/<Name>/SKILL.md files
+    // kebab to the same slug). The pack importer throws the typed
+    // refusal so we classify it before falling through to
+    // `refused-other`.
+    if (error instanceof PaiPackNameCollisionRefusal) {
+      return {
+        items: [],
+        outcomes: [
+          {
+            paiPackDir: inputs.paiPackDir,
+            outcome: "refused-name-collision",
+            skillName: error.skillName,
+            reason: `within-pack collision: ${error.sources.join(", ")} kebab to '${error.skillName}'`,
+          },
+        ],
       };
     }
     return {
-      outcome: {
-        paiPackDir: inputs.paiPackDir,
-        outcome: "refused-other",
-        skillName: upfrontSlug ?? (await safeReadSkillSlug(inputs.paiPackDir)),
-        reason: errorMessage(error),
-      },
+      items: [],
+      outcomes: [
+        {
+          paiPackDir: inputs.paiPackDir,
+          outcome: "refused-other",
+          skillName: upfrontSlug ?? (await safeReadSkillSlug(inputs.paiPackDir)),
+          reason: errorMessage(error),
+        },
+      ],
     };
   }
 }
@@ -665,8 +760,9 @@ async function safeReadSkillSlug(paiPackDir: string): Promise<string | undefined
 async function importOnePackWithOutcome(
   inputs: BulkImportInputs,
   paiPackDir: string,
-): Promise<{ pack?: PaiPackImportResult; outcome: PaiPackOutcome }> {
-  const { payload, outcome } = await runOnePackWithOutcome<PaiPackImportResult>(
+  landedSlugs: Set<string>,
+): Promise<{ items: PaiPackImportResult[]; outcomes: PaiPackOutcome[] }> {
+  return runOnePackWithOutcome<PaiPackImportResult>(
     {
       paiPackDir,
       homeDir: inputs.homeDir,
@@ -682,8 +778,8 @@ async function importOnePackWithOutcome(
         overwrite: true,
         includeSubstrateSpecific: opts.includeSubstrateSpecific,
       }),
+    landedSlugs,
   );
-  return { pack: payload, outcome };
 }
 
 /**
@@ -694,12 +790,18 @@ async function importOnePackWithOutcome(
  * doesn't write anything to disk, so `payload` is the
  * `PaiPackImportPlan` (not a result); callers surface it on
  * `PaiMigrationPlan.packs` for the principal to inspect.
+ *
+ * #105 — the operation now returns an array of plans (one per derived
+ * skill in the pack). Cross-pack collision tracking mirrors the
+ * apply-side serial loop: plan-mode iterates packs sorted by path so
+ * collision detection is deterministic.
  */
 async function planOnePackWithOutcome(
   inputs: BulkImportInputs,
   paiPackDir: string,
-): Promise<{ pack?: PaiPackImportPlan; outcome: PaiPackOutcome }> {
-  const { payload, outcome } = await runOnePackWithOutcome<PaiPackImportPlan>(
+  landedSlugs: Set<string>,
+): Promise<{ items: PaiPackImportPlan[]; outcomes: PaiPackOutcome[] }> {
+  return runOnePackWithOutcome<PaiPackImportPlan>(
     {
       paiPackDir,
       homeDir: inputs.homeDir,
@@ -714,16 +816,15 @@ async function planOnePackWithOutcome(
         somaHome: opts.somaHome,
         includeSubstrateSpecific: opts.includeSubstrateSpecific,
       }),
+    landedSlugs,
   );
-  return { pack: payload, outcome };
 }
 
 /**
- * #102 — plan-side counterpart to `importPacksWithOutcomes`. Runs
- * `planOnePackWithOutcome` per pack under the same bounded
- * concurrency model. Each pack's outcome is classified independently;
- * the plan phase never aborts on a per-pack failure, mirroring the
- * apply phase's contract.
+ * #102 — plan-side counterpart to `importPacksWithOutcomes`.
+ *
+ * #105 — serial iteration (sorted-by-path) for deterministic cross-pack
+ * collision detection. See `importPacksWithOutcomes` for rationale.
  */
 interface BulkPlanResult {
   packs: PaiPackImportPlan[];
@@ -731,17 +832,18 @@ interface BulkPlanResult {
 }
 
 async function planPacksWithOutcomes(inputs: BulkImportInputs): Promise<BulkPlanResult> {
-  const results = await runBoundedConcurrent(
-    [...inputs.packPaths],
-    (paiPackDir) => planOnePackWithOutcome(inputs, paiPackDir),
-    4,
-  );
-
+  const landedSlugs = new Set<string>();
   const packs: PaiPackImportPlan[] = [];
   const outcomes: PaiPackOutcome[] = [];
-  for (const { pack, outcome } of results) {
-    if (pack) packs.push(pack);
-    outcomes.push(outcome);
+  const sortedPaths = [...inputs.packPaths].sort();
+  for (const paiPackDir of sortedPaths) {
+    const { items, outcomes: packOutcomes } = await planOnePackWithOutcome(
+      inputs,
+      paiPackDir,
+      landedSlugs,
+    );
+    packs.push(...items);
+    outcomes.push(...packOutcomes);
   }
   return { packs, outcomes };
 }

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -33,14 +33,15 @@ import { importPaiDocs, planPaiDocsImport } from "./pai-docs-importer";
 import { importPaiIdentity, planPaiImport } from "./pai-importer";
 import { migratePaiMemory, planPaiMemoryMigration } from "./pai-memory-migrator";
 import {
-  importPaiPack,
+  importPaiPackFromPlan,
   PaiPackAllSkillsExcludedRefusal,
   PaiPackNameCollisionRefusal,
   PaiPackReservedNameRefusal,
   PaiPackSubstrateSpecificRefusal,
-  planPaiPackImport,
+  planPaiPackImportHandle,
   readPackMetadata,
   slugifySkillName,
+  type PaiPackImportPlanHandle,
 } from "./pai-pack-importer";
 import type {
   AlgorithmImportPlan,
@@ -507,75 +508,138 @@ interface BulkImportResult {
  * 4-wide bounded so the principal-facing latency on a 45-pack
  * install matches the pre-#105 throughput.
  */
-async function importPacksWithOutcomes(
-  inputs: BulkImportInputs,
-): Promise<BulkImportResult> {
-  const sortedPaths = [...inputs.packPaths].sort();
+/**
+ * #105 / Sage r2 #108 (Maintainability) — single source for the
+ * plan-then-collision-walk that both the apply path and the plan-only
+ * path share. Phase 1 produces one `PlanRow` per pack (bounded
+ * concurrent); Phase 2 walks the rows sequentially in sorted order and
+ * partitions per-skill slugs into "collided" (already landed from an
+ * earlier pack) vs "survivors" — the partition is exactly the input
+ * both bulk paths need. Apply consumes survivors+handle to write;
+ * plan-only consumes survivors+plans to record advisory outcomes.
+ *
+ * Sage r1 #108 contract preserved: no excluded slug ever touches disk
+ * because the handle path filters routedFiles in-memory before stage.
+ */
+type SharedPlanRow =
+  | {
+      kind: "planned";
+      paiPackDir: string;
+      plans: PaiPackImportPlan[];
+      handle: PaiPackImportPlanHandle;
+    }
+  | { kind: "refused"; outcomes: PaiPackOutcome[] };
 
-  // Phase 1: plan every pack (bounded concurrent). The plan classifies
-  // every refusal that does not depend on cross-pack state.
-  type PlanRow =
-    | { kind: "planned"; paiPackDir: string; plans: PaiPackImportPlan[] }
-    | { kind: "refused"; outcomes: PaiPackOutcome[] };
-  const planRows = await runBoundedConcurrent<string, PlanRow>(
+interface ResolvedPlanRow {
+  paiPackDir: string;
+  plans: PaiPackImportPlan[];
+  handle: PaiPackImportPlanHandle;
+  collided: string[];
+  survivors: string[];
+}
+
+async function planAllPacksWithHandles(
+  inputs: BulkImportInputs,
+): Promise<SharedPlanRow[]> {
+  const sortedPaths = [...inputs.packPaths].sort();
+  return runBoundedConcurrent<string, SharedPlanRow>(
     [...sortedPaths],
     async (paiPackDir) => {
-      const { items, outcomes } = await planOnePackForApply(inputs, paiPackDir);
-      if (items.length === 0) return { kind: "refused", outcomes };
-      return { kind: "planned", paiPackDir, plans: items };
+      const { items, handle, outcomes } = await planOnePackForApply(inputs, paiPackDir);
+      if (items.length === 0 || !handle) return { kind: "refused", outcomes };
+      return { kind: "planned", paiPackDir, plans: items, handle };
     },
     4,
   );
+}
 
-  // Phase 2: walk sorted-by-path, apply each surviving pack with
-  // per-skill collision filtering. The set is updated as packs land.
-  const packs: PaiPackImportResult[] = [];
-  const outcomes: PaiPackOutcome[] = [];
+/**
+ * Sage r2 #108 (Maintainability) — shared cross-pack collision walk.
+ * Walks `planRows` in sorted order; for each `planned` row, partitions
+ * its per-skill slugs into `collided` (already landed) and `survivors`.
+ * Pure function — no file writes, no apply calls. Callers walk
+ * `resolved` in their own order to emit outcomes (preserving the
+ * per-pack-interleaved ordering both bulk paths previously hand-coded).
+ */
+function walkPlanRowsForCollisions(
+  planRows: readonly SharedPlanRow[],
+  overwriteReserved: boolean,
+): { resolved: ResolvedPlanRow[] } {
+  const resolved: ResolvedPlanRow[] = [];
   const landedSlugs = new Set<string>();
 
   for (const row of planRows) {
-    if (row.kind === "refused") {
-      outcomes.push(...row.outcomes);
-      continue;
-    }
+    if (row.kind === "refused") continue;
     const collided: string[] = [];
     const survivors: string[] = [];
     for (const plan of row.plans) {
       const willCollide = landedSlugs.has(plan.skillName);
-      if (willCollide && !inputs.overwriteReserved) {
+      if (willCollide && !overwriteReserved) {
         collided.push(plan.skillName);
       } else {
+        // Reserve the slug for cross-pack collision tracking. The
+        // caller's per-pack outcome emission confirms the actual
+        // "imported" row.
+        landedSlugs.add(plan.skillName);
         survivors.push(plan.skillName);
       }
     }
-    // Record collision outcomes first so the per-pack outcome ordering
-    // surfaces every per-skill row.
-    for (const slug of collided) {
+    resolved.push({
+      paiPackDir: row.paiPackDir,
+      plans: row.plans,
+      handle: row.handle,
+      collided,
+      survivors,
+    });
+  }
+  return { resolved };
+}
+
+async function importPacksWithOutcomes(
+  inputs: BulkImportInputs,
+): Promise<BulkImportResult> {
+  // Phase 1: plan every pack (bounded concurrent). Each plan returns
+  // both the public per-skill plan view AND an opaque handle so Phase 2
+  // can apply WITHOUT a second buildPaiPackImportPlan pass (Sage r2
+  // #108 Performance).
+  const planRows = await planAllPacksWithHandles(inputs);
+  // Phase 2a: shared cross-pack collision walk (Sage r2 #108
+  // Maintainability — single source for collision logic across the
+  // apply and plan-only paths).
+  const { resolved } = walkPlanRowsForCollisions(planRows, inputs.overwriteReserved);
+
+  // Phase 2b: emit per-pack outcomes and apply survivors via the
+  // cached internal plan handle. Per-pack outcome ordering follows
+  // the pre-refactor contract: refused plan rows first (in sort
+  // order), then per-resolved-pack collision rows interleaved with
+  // surviving "imported" rows.
+  const packs: PaiPackImportResult[] = [];
+  const outcomes: PaiPackOutcome[] = [];
+
+  for (const row of planRows) {
+    if (row.kind === "refused") outcomes.push(...row.outcomes);
+  }
+
+  for (const resolvedRow of resolved) {
+    for (const slug of resolvedRow.collided) {
       outcomes.push({
-        paiPackDir: row.paiPackDir,
+        paiPackDir: resolvedRow.paiPackDir,
         outcome: "refused-name-collision",
         skillName: slug,
         reason: `Soma skill '${slug}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
       });
     }
-    if (survivors.length === 0) {
-      // Every derived skill was excluded — no apply.
-      continue;
-    }
+    if (resolvedRow.survivors.length === 0) continue;
+
     try {
-      const items = await importPaiPack({
-        homeDir: inputs.homeDir,
-        paiPackDir: row.paiPackDir,
-        somaHome: inputs.somaHome,
+      const items = await importPaiPackFromPlan(resolvedRow.handle, {
+        excludeSkills: new Set(resolvedRow.collided),
         overwrite: true,
-        includeSubstrateSpecific: inputs.includeSubstrateSpecific,
-        excludeSkills: new Set(collided),
       });
       for (const item of items) {
         packs.push(item);
-        landedSlugs.add(item.skillName);
         outcomes.push({
-          paiPackDir: row.paiPackDir,
+          paiPackDir: resolvedRow.paiPackDir,
           outcome: "imported",
           skillName: item.skillName,
         });
@@ -584,7 +648,7 @@ async function importPacksWithOutcomes(
       // Phase 2 errors are genuine — surface as refused-other and
       // continue (no abort).
       outcomes.push({
-        paiPackDir: row.paiPackDir,
+        paiPackDir: resolvedRow.paiPackDir,
         outcome: "refused-other",
         reason: errorMessage(error),
       });
@@ -634,15 +698,15 @@ interface OnePackInputs {
  * other refusal kind (substrate-specific, reserved, within-pack
  * collision, malformed metadata, genuine errors).
  */
-async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
+async function runOnePackWithOutcome<TPayload extends { skillName: string }, TExtras = undefined>(
   inputs: OnePackInputs,
   operation: (opts: {
     homeDir: string | undefined;
     paiPackDir: string;
     somaHome: string;
     includeSubstrateSpecific: boolean;
-  }) => Promise<TPayload[]>,
-): Promise<{ items: TPayload[]; outcomes: PaiPackOutcome[] }> {
+  }) => Promise<{ items: TPayload[]; extras?: TExtras }>,
+): Promise<{ items: TPayload[]; extras?: TExtras; outcomes: PaiPackOutcome[] }> {
   // Sage r2 #103 Performance — defer the slug read to the only paths
   // that actually need it: the migrate-level reserved pre-check
   // (when `overwriteReserved` is false) and the refusal-classification
@@ -693,7 +757,7 @@ async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
   }
 
   try {
-    const items = await operation({
+    const result = await operation({
       homeDir: inputs.homeDir,
       paiPackDir: inputs.paiPackDir,
       somaHome: inputs.somaHome,
@@ -702,12 +766,12 @@ async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
 
     // Per-payload outcome rows — one `imported` per derived skill.
     // Cross-pack collision tracking happens in the bulk-phase caller.
-    const outcomes: PaiPackOutcome[] = items.map((item) => ({
+    const outcomes: PaiPackOutcome[] = result.items.map((item) => ({
       paiPackDir: inputs.paiPackDir,
       outcome: "imported",
       skillName: item.skillName,
     }));
-    return { items, outcomes };
+    return { items: result.items, extras: result.extras, outcomes };
   } catch (error) {
     if (error instanceof PaiPackSubstrateSpecificRefusal) {
       return {
@@ -819,8 +883,8 @@ async function safeReadSkillSlug(paiPackDir: string): Promise<string | undefined
 async function planOnePackForApply(
   inputs: BulkImportInputs,
   paiPackDir: string,
-): Promise<{ items: PaiPackImportPlan[]; outcomes: PaiPackOutcome[] }> {
-  return runOnePackWithOutcome<PaiPackImportPlan>(
+): Promise<{ items: PaiPackImportPlan[]; handle?: PaiPackImportPlanHandle; outcomes: PaiPackOutcome[] }> {
+  const result = await runOnePackWithOutcome<PaiPackImportPlan, PaiPackImportPlanHandle>(
     {
       paiPackDir,
       homeDir: inputs.homeDir,
@@ -828,8 +892,8 @@ async function planOnePackForApply(
       overwriteReserved: inputs.overwriteReserved,
       includeSubstrateSpecific: inputs.includeSubstrateSpecific,
     },
-    (opts) =>
-      planPaiPackImport({
+    async (opts) => {
+      const { plans, handle } = await planPaiPackImportHandle({
         homeDir: opts.homeDir,
         paiPackDir: opts.paiPackDir,
         somaHome: opts.somaHome,
@@ -839,8 +903,11 @@ async function planOnePackForApply(
         // a rerun against an already-populated Soma home throws on the
         // "already exists" precheck during Phase 1.
         overwrite: true,
-      }),
+      });
+      return { items: plans, extras: handle };
+    },
   );
+  return { items: result.items, handle: result.extras, outcomes: result.outcomes };
 }
 
 /**
@@ -857,43 +924,39 @@ interface BulkPlanResult {
 }
 
 async function planPacksWithOutcomes(inputs: BulkImportInputs): Promise<BulkPlanResult> {
-  const sortedPaths = [...inputs.packPaths].sort();
-  type PlanRow =
-    | { kind: "planned"; paiPackDir: string; plans: PaiPackImportPlan[] }
-    | { kind: "refused"; outcomes: PaiPackOutcome[] };
-  const planRows = await runBoundedConcurrent<string, PlanRow>(
-    [...sortedPaths],
-    async (paiPackDir) => {
-      const { items, outcomes } = await planOnePackForApply(inputs, paiPackDir);
-      if (items.length === 0) return { kind: "refused", outcomes };
-      return { kind: "planned", paiPackDir, plans: items };
-    },
-    4,
-  );
+  // Sage r2 #108 (Maintainability) — share Phase 1 and the cross-pack
+  // collision walk with the apply path. Plan-only mode never touches
+  // disk; it just emits advisory `imported` rows for every survivor
+  // plus the same collision outcomes the apply path would produce.
+  const planRows = await planAllPacksWithHandles(inputs);
+  const { resolved } = walkPlanRowsForCollisions(planRows, inputs.overwriteReserved);
 
   const packs: PaiPackImportPlan[] = [];
   const outcomes: PaiPackOutcome[] = [];
-  const landedSlugs = new Set<string>();
+
+  // Refused plan rows come first in the original sort order.
   for (const row of planRows) {
-    if (row.kind === "refused") {
-      outcomes.push(...row.outcomes);
-      continue;
+    if (row.kind === "refused") outcomes.push(...row.outcomes);
+  }
+
+  // Per-pack: emit pack-scoped collision outcomes interleaved with
+  // surviving "imported" rows so the principal-facing summary table
+  // groups by pack identically to the apply path.
+  for (const resolvedRow of resolved) {
+    for (const slug of resolvedRow.collided) {
+      outcomes.push({
+        paiPackDir: resolvedRow.paiPackDir,
+        outcome: "refused-name-collision",
+        skillName: slug,
+        reason: `Soma skill '${slug}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
+      });
     }
-    for (const plan of row.plans) {
-      const collides = landedSlugs.has(plan.skillName);
-      if (collides && !inputs.overwriteReserved) {
-        outcomes.push({
-          paiPackDir: row.paiPackDir,
-          outcome: "refused-name-collision",
-          skillName: plan.skillName,
-          reason: `Soma skill '${plan.skillName}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
-        });
-        continue;
-      }
-      landedSlugs.add(plan.skillName);
+    const survivorSet = new Set(resolvedRow.survivors);
+    for (const plan of resolvedRow.plans) {
+      if (!survivorSet.has(plan.skillName)) continue;
       packs.push(plan);
       outcomes.push({
-        paiPackDir: row.paiPackDir,
+        paiPackDir: resolvedRow.paiPackDir,
         outcome: "imported",
         skillName: plan.skillName,
       });

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -34,6 +34,7 @@ import { importPaiIdentity, planPaiImport } from "./pai-importer";
 import { migratePaiMemory, planPaiMemoryMigration } from "./pai-memory-migrator";
 import {
   importPaiPack,
+  PaiPackAllSkillsExcludedRefusal,
   PaiPackNameCollisionRefusal,
   PaiPackReservedNameRefusal,
   PaiPackSubstrateSpecificRefusal,
@@ -477,35 +478,119 @@ interface BulkImportResult {
 }
 
 /**
- * #105 — bulk apply path. Packs are processed in **sorted-by-path**
- * order (serial) so cross-pack name collisions resolve
- * deterministically: the first pack lexically wins; later collisions
- * surface as `refused-name-collision`. Previously packs ran 4-wide
- * concurrent — that's still correct for substrate-specific / reserved
- * outcomes but breaks deterministic collision resolution when two
- * packs derive the same slug.
+ * #105 — bulk apply path. Two phases.
  *
- * Per-pack work is small I/O on ≤30 packs in a typical install; serial
- * latency is well under one second on a modern disk. If that becomes
- * a bottleneck, collision tracking can be promoted to a queue + worker
- * pool design.
+ *   Phase 1 (PLAN, bounded 4-wide concurrent over sorted paths):
+ *     Plan every pack. Surfaces refusals that don't depend on
+ *     cross-pack state (substrate-specific, reserved, malformed,
+ *     within-pack collision) without writing anything. Each plan
+ *     yields a list of derived skill slugs.
+ *
+ *   Phase 2 (APPLY, sequential over sorted paths):
+ *     Walk planned packs in sorted order. For each, intersect its
+ *     derived skill slugs with `landedSlugs`. Slugs already landed
+ *     by an earlier pack record `refused-name-collision` and are
+ *     passed to the inner `importPaiPack` via `excludeSkills` so
+ *     they NEVER touch disk. Surviving slugs apply, record
+ *     `imported`, and are added to `landedSlugs`. If `overwriteReserved`
+ *     is set, the collision filter is a no-op — earlier surfaces are
+ *     clobbered (matches pre-#105 contract).
+ *
+ * Sage r1 #108 (blocker) drove the two-phase split: previously the
+ * collision check happened AFTER the inner apply wrote every derived
+ * skill, which let a later pack clobber an earlier skill while the
+ * outcome reported a refusal. Now writes never happen for collided
+ * slugs.
+ *
+ * Performance: per-pack apply still serial in Phase 2 to preserve
+ * deterministic collision ordering. Phase 1's plan fan-out is
+ * 4-wide bounded so the principal-facing latency on a 45-pack
+ * install matches the pre-#105 throughput.
  */
 async function importPacksWithOutcomes(
   inputs: BulkImportInputs,
 ): Promise<BulkImportResult> {
-  const landedSlugs = new Set<string>();
+  const sortedPaths = [...inputs.packPaths].sort();
+
+  // Phase 1: plan every pack (bounded concurrent). The plan classifies
+  // every refusal that does not depend on cross-pack state.
+  type PlanRow =
+    | { kind: "planned"; paiPackDir: string; plans: PaiPackImportPlan[] }
+    | { kind: "refused"; outcomes: PaiPackOutcome[] };
+  const planRows = await runBoundedConcurrent<string, PlanRow>(
+    [...sortedPaths],
+    async (paiPackDir) => {
+      const { items, outcomes } = await planOnePackForApply(inputs, paiPackDir);
+      if (items.length === 0) return { kind: "refused", outcomes };
+      return { kind: "planned", paiPackDir, plans: items };
+    },
+    4,
+  );
+
+  // Phase 2: walk sorted-by-path, apply each surviving pack with
+  // per-skill collision filtering. The set is updated as packs land.
   const packs: PaiPackImportResult[] = [];
   const outcomes: PaiPackOutcome[] = [];
-  const sortedPaths = [...inputs.packPaths].sort();
-  for (const paiPackDir of sortedPaths) {
-    const { items, outcomes: packOutcomes } = await importOnePackWithOutcome(
-      inputs,
-      paiPackDir,
-      landedSlugs,
-    );
-    packs.push(...items);
-    outcomes.push(...packOutcomes);
+  const landedSlugs = new Set<string>();
+
+  for (const row of planRows) {
+    if (row.kind === "refused") {
+      outcomes.push(...row.outcomes);
+      continue;
+    }
+    const collided: string[] = [];
+    const survivors: string[] = [];
+    for (const plan of row.plans) {
+      const willCollide = landedSlugs.has(plan.skillName);
+      if (willCollide && !inputs.overwriteReserved) {
+        collided.push(plan.skillName);
+      } else {
+        survivors.push(plan.skillName);
+      }
+    }
+    // Record collision outcomes first so the per-pack outcome ordering
+    // surfaces every per-skill row.
+    for (const slug of collided) {
+      outcomes.push({
+        paiPackDir: row.paiPackDir,
+        outcome: "refused-name-collision",
+        skillName: slug,
+        reason: `Soma skill '${slug}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
+      });
+    }
+    if (survivors.length === 0) {
+      // Every derived skill was excluded — no apply.
+      continue;
+    }
+    try {
+      const items = await importPaiPack({
+        homeDir: inputs.homeDir,
+        paiPackDir: row.paiPackDir,
+        somaHome: inputs.somaHome,
+        overwrite: true,
+        includeSubstrateSpecific: inputs.includeSubstrateSpecific,
+        excludeSkills: new Set(collided),
+      });
+      for (const item of items) {
+        packs.push(item);
+        landedSlugs.add(item.skillName);
+        outcomes.push({
+          paiPackDir: row.paiPackDir,
+          outcome: "imported",
+          skillName: item.skillName,
+        });
+      }
+    } catch (error) {
+      // Phase 2 errors are genuine — surface as refused-other and
+      // continue (no abort).
+      outcomes.push({
+        paiPackDir: row.paiPackDir,
+        outcome: "refused-other",
+        reason: errorMessage(error),
+      });
+    }
   }
+
   return { packs, outcomes };
 }
 
@@ -538,25 +623,16 @@ interface OnePackInputs {
 }
 
 /**
- * #105 — generic per-pack runner. The `operation` callback now returns
- * an array of payloads (one per derived skill) instead of a single
- * payload. Outcomes are emitted one-per-payload on success; on refusal
- * a single outcome is emitted for the whole pack.
+ * #105 — generic per-pack runner. The `operation` callback returns an
+ * array of payloads (one per derived skill). Outcomes are emitted one-
+ * per-payload on success; on refusal a single outcome is emitted for
+ * the whole pack.
  *
- * Cross-pack collision check: `landedSlugs` records every slug that
- * has successfully landed in this run. The runner inspects it BEFORE
- * invoking the operation (peeks at the pack's derived-skill set via a
- * plan-mode call). When `overwriteReserved` is false, any colliding
- * slug surfaces as `refused-name-collision` and the operation never
- * runs. When `overwriteReserved` is true, collisions are permitted
- * and the operation runs with `overwrite: true` semantics.
- *
- * The peek IS a duplicate plan call (the apply path then re-plans
- * inside `importPaiPack`). That's a deliberate trade-off for clarity:
- * the alternative is to expose collision-detection state across the
- * importer boundary, which leaks the orchestrator's bookkeeping into
- * a lower layer. Pack metadata reads are cheap (~ms) and only one
- * extra read per pack happens this way.
+ * Cross-pack collision tracking lives at the bulk-phase level (Sage
+ * r1 #108): the apply path now plans first, applies second, with
+ * per-skill exclusion via `excludeSkills`. This helper handles every
+ * other refusal kind (substrate-specific, reserved, within-pack
+ * collision, malformed metadata, genuine errors).
  */
 async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
   inputs: OnePackInputs,
@@ -566,7 +642,6 @@ async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
     somaHome: string;
     includeSubstrateSpecific: boolean;
   }) => Promise<TPayload[]>,
-  landedSlugs?: Set<string>,
 ): Promise<{ items: TPayload[]; outcomes: PaiPackOutcome[] }> {
   // Sage r2 #103 Performance — defer the slug read to the only paths
   // that actually need it: the migrate-level reserved pre-check
@@ -625,44 +700,14 @@ async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
       includeSubstrateSpecific: inputs.includeSubstrateSpecific,
     });
 
-    // #105 — cross-pack collision check. After the operation returns
-    // its derived-skill list, separate items into (kept, collided)
-    // based on whether their slug already lives in `landedSlugs`. On
-    // collision: when `overwriteReserved` is set the caller has opted
-    // in to clobbering — keep the item and mark it imported (it
-    // already wrote to disk via the inner `overwrite: true`). When
-    // `overwriteReserved` is unset, emit `refused-name-collision`.
-    //
-    // For the apply path, the inner `importPaiPack` already wrote
-    // EVERY derived skill (it doesn't know about collisions). When
-    // we refuse-after-the-fact we can't unwrite — but the practical
-    // effect on disk is: the second pack's content overwrote any
-    // pre-existing surface from earlier in the same run. That mirrors
-    // the historical behavior of `overwrite: true` on the inner call,
-    // and the outcome table makes the collision visible to the
-    // principal. Plan-mode (no writes) makes this cleanly advisory.
-    const outcomes: PaiPackOutcome[] = [];
-    const keptItems: TPayload[] = [];
-    for (const item of items) {
-      const collides = landedSlugs?.has(item.skillName) ?? false;
-      if (collides && !inputs.overwriteReserved) {
-        outcomes.push({
-          paiPackDir: inputs.paiPackDir,
-          outcome: "refused-name-collision",
-          skillName: item.skillName,
-          reason: `Soma skill '${item.skillName}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
-        });
-        continue;
-      }
-      keptItems.push(item);
-      landedSlugs?.add(item.skillName);
-      outcomes.push({
-        paiPackDir: inputs.paiPackDir,
-        outcome: "imported",
-        skillName: item.skillName,
-      });
-    }
-    return { items: keptItems, outcomes };
+    // Per-payload outcome rows — one `imported` per derived skill.
+    // Cross-pack collision tracking happens in the bulk-phase caller.
+    const outcomes: PaiPackOutcome[] = items.map((item) => ({
+      paiPackDir: inputs.paiPackDir,
+      outcome: "imported",
+      skillName: item.skillName,
+    }));
+    return { items, outcomes };
   } catch (error) {
     if (error instanceof PaiPackSubstrateSpecificRefusal) {
       return {
@@ -715,6 +760,14 @@ async function runOnePackWithOutcome<TPayload extends { skillName: string }>(
         ],
       };
     }
+    // #105 (Sage r1 #108) — every derived skill in the pack was
+    // excluded by the caller (orchestrator's collision filter). The
+    // pack itself produces no `imported` rows; per-slug collisions
+    // were already recorded by the caller. Empty outcome list keeps
+    // the orchestrator's accounting consistent.
+    if (error instanceof PaiPackAllSkillsExcludedRefusal) {
+      return { items: [], outcomes: [] };
+    }
     return {
       items: [],
       outcomes: [
@@ -757,49 +810,15 @@ async function safeReadSkillSlug(paiPackDir: string): Promise<string | undefined
  * imported the pack. The pack importer's per-pack rollback contract
  * still protects on-disk safety.
  */
-async function importOnePackWithOutcome(
-  inputs: BulkImportInputs,
-  paiPackDir: string,
-  landedSlugs: Set<string>,
-): Promise<{ items: PaiPackImportResult[]; outcomes: PaiPackOutcome[] }> {
-  return runOnePackWithOutcome<PaiPackImportResult>(
-    {
-      paiPackDir,
-      homeDir: inputs.homeDir,
-      somaHome: inputs.somaHome,
-      overwriteReserved: inputs.overwriteReserved,
-      includeSubstrateSpecific: inputs.includeSubstrateSpecific,
-    },
-    (opts) =>
-      importPaiPack({
-        homeDir: opts.homeDir,
-        paiPackDir: opts.paiPackDir,
-        somaHome: opts.somaHome,
-        overwrite: true,
-        includeSubstrateSpecific: opts.includeSubstrateSpecific,
-      }),
-    landedSlugs,
-  );
-}
-
 /**
- * #102 — plan-side wrapper: runs `planPaiPackImport` per pack and
- * classifies the outcome with the SAME refusal taxonomy as the apply
- * path. Without this, plan-mode aborts on the first
- * `PaiPackSubstrateSpecificRefusal` (the user-visible bug). Plan path
- * doesn't write anything to disk, so `payload` is the
- * `PaiPackImportPlan` (not a result); callers surface it on
- * `PaiMigrationPlan.packs` for the principal to inspect.
- *
- * #105 — the operation now returns an array of plans (one per derived
- * skill in the pack). Cross-pack collision tracking mirrors the
- * apply-side serial loop: plan-mode iterates packs sorted by path so
- * collision detection is deterministic.
+ * #105 (Sage r1 #108) — Phase 1 of the two-phase apply path. Runs
+ * `planPaiPackImport` and classifies non-cross-pack refusals. Returns
+ * the plan array on success so Phase 2 can compute per-skill
+ * collisions before any write.
  */
-async function planOnePackWithOutcome(
+async function planOnePackForApply(
   inputs: BulkImportInputs,
   paiPackDir: string,
-  landedSlugs: Set<string>,
 ): Promise<{ items: PaiPackImportPlan[]; outcomes: PaiPackOutcome[] }> {
   return runOnePackWithOutcome<PaiPackImportPlan>(
     {
@@ -815,16 +834,22 @@ async function planOnePackWithOutcome(
         paiPackDir: opts.paiPackDir,
         somaHome: opts.somaHome,
         includeSubstrateSpecific: opts.includeSubstrateSpecific,
+        // Migration runs always pass `overwrite: true` to the apply path
+        // (mirrors pre-#105 behavior). Plan-phase must mirror that or
+        // a rerun against an already-populated Soma home throws on the
+        // "already exists" precheck during Phase 1.
+        overwrite: true,
       }),
-    landedSlugs,
   );
 }
 
 /**
- * #102 — plan-side counterpart to `importPacksWithOutcomes`.
- *
- * #105 — serial iteration (sorted-by-path) for deterministic cross-pack
- * collision detection. See `importPacksWithOutcomes` for rationale.
+ * #102 / #105 — plan-side counterpart to `importPacksWithOutcomes`.
+ * Same two-phase shape: plan every pack (4-wide bounded), then walk
+ * sorted-by-path to compute cross-pack collisions. Plan mode never
+ * writes anything, so the "would have written" semantics are pure
+ * advisory — but the per-skill outcome rows match the apply path
+ * exactly so the principal sees the same future.
  */
 interface BulkPlanResult {
   packs: PaiPackImportPlan[];
@@ -832,18 +857,47 @@ interface BulkPlanResult {
 }
 
 async function planPacksWithOutcomes(inputs: BulkImportInputs): Promise<BulkPlanResult> {
-  const landedSlugs = new Set<string>();
+  const sortedPaths = [...inputs.packPaths].sort();
+  type PlanRow =
+    | { kind: "planned"; paiPackDir: string; plans: PaiPackImportPlan[] }
+    | { kind: "refused"; outcomes: PaiPackOutcome[] };
+  const planRows = await runBoundedConcurrent<string, PlanRow>(
+    [...sortedPaths],
+    async (paiPackDir) => {
+      const { items, outcomes } = await planOnePackForApply(inputs, paiPackDir);
+      if (items.length === 0) return { kind: "refused", outcomes };
+      return { kind: "planned", paiPackDir, plans: items };
+    },
+    4,
+  );
+
   const packs: PaiPackImportPlan[] = [];
   const outcomes: PaiPackOutcome[] = [];
-  const sortedPaths = [...inputs.packPaths].sort();
-  for (const paiPackDir of sortedPaths) {
-    const { items, outcomes: packOutcomes } = await planOnePackWithOutcome(
-      inputs,
-      paiPackDir,
-      landedSlugs,
-    );
-    packs.push(...items);
-    outcomes.push(...packOutcomes);
+  const landedSlugs = new Set<string>();
+  for (const row of planRows) {
+    if (row.kind === "refused") {
+      outcomes.push(...row.outcomes);
+      continue;
+    }
+    for (const plan of row.plans) {
+      const collides = landedSlugs.has(plan.skillName);
+      if (collides && !inputs.overwriteReserved) {
+        outcomes.push({
+          paiPackDir: row.paiPackDir,
+          outcome: "refused-name-collision",
+          skillName: plan.skillName,
+          reason: `Soma skill '${plan.skillName}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
+        });
+        continue;
+      }
+      landedSlugs.add(plan.skillName);
+      packs.push(plan);
+      outcomes.push({
+        paiPackDir: row.paiPackDir,
+        outcome: "imported",
+        skillName: plan.skillName,
+      });
+    }
   }
   return { packs, outcomes };
 }

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -509,17 +509,17 @@ interface BulkImportResult {
  * install matches the pre-#105 throughput.
  */
 /**
- * #105 / Sage r2 #108 (Maintainability) — single source for the
- * plan-then-collision-walk that both the apply path and the plan-only
- * path share. Phase 1 produces one `PlanRow` per pack (bounded
- * concurrent); Phase 2 walks the rows sequentially in sorted order and
- * partitions per-skill slugs into "collided" (already landed from an
- * earlier pack) vs "survivors" — the partition is exactly the input
- * both bulk paths need. Apply consumes survivors+handle to write;
- * plan-only consumes survivors+plans to record advisory outcomes.
+ * Single source for the plan-then-collision-walk that both the
+ * apply path and the plan-only path share. Phase 1 produces one
+ * `PlanRow` per pack (bounded concurrent); Phase 2 walks the rows
+ * sequentially in sorted order and partitions per-skill slugs into
+ * "collided" (already landed from an earlier pack) vs "survivors" —
+ * the partition is exactly the input both bulk paths need. Apply
+ * consumes survivors+handle to write; plan-only consumes
+ * survivors+plans to record advisory outcomes.
  *
- * Sage r1 #108 contract preserved: no excluded slug ever touches disk
- * because the handle path filters routedFiles in-memory before stage.
+ * Invariant: no excluded slug ever touches disk because the handle
+ * path filters `routedFiles` in-memory before stage.
  */
 type SharedPlanRow =
   | {
@@ -539,8 +539,8 @@ interface ResolvedPlanRow {
 }
 
 /**
- * Sage r6 #108 (Maintainability, suggestion) — single source for
- * partitioning a pack's plans into `collided` (slug already landed)
+ * Single source for partitioning a pack's plans into `collided`
+ * (slug already landed)
  * and `survivors`. Both the apply path (which builds `landedSlugs`
  * sequentially as packs successfully apply) and the plan-only path
  * (which builds it optimistically inside `walkPlanRowsForCollisions`)
@@ -572,8 +572,8 @@ function partitionPlansByCollision(
 }
 
 /**
- * Sage r3 #108 (Maintainability suggestion) — single source for the
- * cross-pack `refused-name-collision` outcome shape. Both bulk paths
+ * Single source for the cross-pack `refused-name-collision` outcome
+ * shape. Both bulk paths
  * (apply + plan-only) emit identical rows; centralizing the
  * construction prevents the reason text + outcome kind from drifting
  * across the two surfaces.
@@ -603,7 +603,7 @@ async function planAllPacksWithHandles(
 }
 
 /**
- * Sage r2 #108 (Maintainability) — shared cross-pack collision walk.
+ * Shared cross-pack collision walk.
  * Walks `planRows` in sorted order; for each `planned` row, partitions
  * its per-skill slugs into `collided` (already landed) and `survivors`.
  * Pure function — no file writes, no apply calls. Callers walk
@@ -622,7 +622,8 @@ function walkPlanRowsForCollisions(
     const { collided, survivors } = partitionPlansByCollision(row.plans, landedSlugs, overwriteReserved);
     // Plan-only mode: reserve every survivor up front. Plan can't
     // fail mid-apply, so the optimistic-landing partition is correct.
-    // Apply path manages its own `landedSlugs` (Sage r4 #108).
+    // The apply path manages its own `landedSlugs` to track only
+    // packs whose write actually succeeded.
     for (const slug of survivors) landedSlugs.add(slug);
     resolved.push({
       paiPackDir: row.paiPackDir,
@@ -640,20 +641,17 @@ async function importPacksWithOutcomes(
 ): Promise<BulkImportResult> {
   // Phase 1: plan every pack (bounded concurrent). Each plan returns
   // both the public per-skill plan view AND an opaque handle so Phase 2
-  // can apply WITHOUT a second buildPaiPackImportPlan pass (Sage r2
-  // #108 Performance).
+  // can apply WITHOUT a second `buildPaiPackImportPlan` pass.
   const planRows = await planAllPacksWithHandles(inputs);
 
-  // Phase 2: sequential apply with collision tracking. Sage r3 #108
-  // CodeQuality (important): the cross-pack collision set grows ONLY
-  // after a pack's apply actually succeeds. A pack that plans cleanly
-  // but fails inside apply must NOT block a later pack with the same
+  // Phase 2: sequential apply with collision tracking.
+  // Invariant: the cross-pack collision set grows ONLY after a
+  // pack's apply actually succeeds. A pack that plans cleanly but
+  // fails inside apply does NOT block a later pack with the same
   // slug — the earlier pack never wrote anything, so the slug is
-  // still free. The R2 walker pre-reserved on plan and got this
-  // wrong; the apply path now manages its own `landedSlugs`.
-  //
-  // Plan-only mode is unaffected (it can't fail mid-apply) and still
-  // uses `walkPlanRowsForCollisions` for its advisory partition.
+  // still free. Plan-only mode is unaffected (it can't fail mid-
+  // apply) and uses `walkPlanRowsForCollisions` for its optimistic
+  // advisory partition.
   const packs: PaiPackImportResult[] = [];
   const outcomes: PaiPackOutcome[] = [];
   const landedSlugs = new Set<string>();
@@ -668,8 +666,9 @@ async function importPacksWithOutcomes(
     // Partition this pack's derived skills against the current
     // landed-slug set. `landedSlugs` reflects PRIOR SUCCESSFUL packs
     // only — a pack ahead of us that failed apply is not in the set,
-    // so its slug is available to us. Sage r6 #108: same partitioning
-    // logic as the plan-only walker, via the shared helper.
+    // so its slug is available to us. Same partitioning logic as the
+    // plan-only walker, via the shared `partitionPlansByCollision`
+    // helper.
     const { collided, survivors } = partitionPlansByCollision(row.plans, landedSlugs, inputs.overwriteReserved);
 
     for (const slug of collided) {
@@ -682,6 +681,25 @@ async function importPacksWithOutcomes(
         excludeSkills: new Set(collided),
         overwrite: true,
       });
+      // Survivor-completeness check: the contract for
+      // `importPaiPackFromPlan(handle, {excludeSkills})` is that
+      // every survivor (i.e. every plan.skillName NOT in excludeSkills)
+      // lands and appears in the returned items. Any mismatch means
+      // a derived skill was silently dropped — either a contract bug
+      // in the importer or a future filter change drifted. Surface
+      // any silently-dropped survivor as `refused-other` so the
+      // principal sees a row instead of a missing outcome.
+      const itemsBySlug = new Set(items.map((item) => item.skillName));
+      for (const survivor of survivors) {
+        if (!itemsBySlug.has(survivor)) {
+          outcomes.push({
+            paiPackDir: row.paiPackDir,
+            outcome: "refused-other",
+            skillName: survivor,
+            reason: `Pack importer returned no result row for derived skill '${survivor}' — this is a contract violation; please file an issue with the pack name attached.`,
+          });
+        }
+      }
       for (const item of items) {
         packs.push(item);
         // Reserve only after a real, successful write. Future packs

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -538,6 +538,22 @@ interface ResolvedPlanRow {
   survivors: string[];
 }
 
+/**
+ * Sage r3 #108 (Maintainability suggestion) — single source for the
+ * cross-pack `refused-name-collision` outcome shape. Both bulk paths
+ * (apply + plan-only) emit identical rows; centralizing the
+ * construction prevents the reason text + outcome kind from drifting
+ * across the two surfaces.
+ */
+function crossPackCollisionOutcome(paiPackDir: string, slug: string): PaiPackOutcome {
+  return {
+    paiPackDir,
+    outcome: "refused-name-collision",
+    skillName: slug,
+    reason: `Soma skill '${slug}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
+  };
+}
+
 async function planAllPacksWithHandles(
   inputs: BulkImportInputs,
 ): Promise<SharedPlanRow[]> {
@@ -622,12 +638,7 @@ async function importPacksWithOutcomes(
 
   for (const resolvedRow of resolved) {
     for (const slug of resolvedRow.collided) {
-      outcomes.push({
-        paiPackDir: resolvedRow.paiPackDir,
-        outcome: "refused-name-collision",
-        skillName: slug,
-        reason: `Soma skill '${slug}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
-      });
+      outcomes.push(crossPackCollisionOutcome(resolvedRow.paiPackDir, slug));
     }
     if (resolvedRow.survivors.length === 0) continue;
 
@@ -944,12 +955,7 @@ async function planPacksWithOutcomes(inputs: BulkImportInputs): Promise<BulkPlan
   // groups by pack identically to the apply path.
   for (const resolvedRow of resolved) {
     for (const slug of resolvedRow.collided) {
-      outcomes.push({
-        paiPackDir: resolvedRow.paiPackDir,
-        outcome: "refused-name-collision",
-        skillName: slug,
-        reason: `Soma skill '${slug}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
-      });
+      outcomes.push(crossPackCollisionOutcome(resolvedRow.paiPackDir, slug));
     }
     const survivorSet = new Set(resolvedRow.survivors);
     for (const plan of resolvedRow.plans) {

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -619,47 +619,71 @@ async function importPacksWithOutcomes(
   // can apply WITHOUT a second buildPaiPackImportPlan pass (Sage r2
   // #108 Performance).
   const planRows = await planAllPacksWithHandles(inputs);
-  // Phase 2a: shared cross-pack collision walk (Sage r2 #108
-  // Maintainability — single source for collision logic across the
-  // apply and plan-only paths).
-  const { resolved } = walkPlanRowsForCollisions(planRows, inputs.overwriteReserved);
 
-  // Phase 2b: emit per-pack outcomes and apply survivors via the
-  // cached internal plan handle. Per-pack outcome ordering follows
-  // the pre-refactor contract: refused plan rows first (in sort
-  // order), then per-resolved-pack collision rows interleaved with
-  // surviving "imported" rows.
+  // Phase 2: sequential apply with collision tracking. Sage r3 #108
+  // CodeQuality (important): the cross-pack collision set grows ONLY
+  // after a pack's apply actually succeeds. A pack that plans cleanly
+  // but fails inside apply must NOT block a later pack with the same
+  // slug — the earlier pack never wrote anything, so the slug is
+  // still free. The R2 walker pre-reserved on plan and got this
+  // wrong; the apply path now manages its own `landedSlugs`.
+  //
+  // Plan-only mode is unaffected (it can't fail mid-apply) and still
+  // uses `walkPlanRowsForCollisions` for its advisory partition.
   const packs: PaiPackImportResult[] = [];
   const outcomes: PaiPackOutcome[] = [];
+  const landedSlugs = new Set<string>();
 
   for (const row of planRows) {
     if (row.kind === "refused") outcomes.push(...row.outcomes);
   }
 
-  for (const resolvedRow of resolved) {
-    for (const slug of resolvedRow.collided) {
-      outcomes.push(crossPackCollisionOutcome(resolvedRow.paiPackDir, slug));
+  for (const row of planRows) {
+    if (row.kind !== "planned") continue;
+
+    // Partition this pack's derived skills against the current
+    // landed-slug set. `landedSlugs` reflects PRIOR SUCCESSFUL packs
+    // only — a pack ahead of us that failed apply is not in the set,
+    // so its slug is available to us.
+    const collided: string[] = [];
+    const survivors: string[] = [];
+    for (const plan of row.plans) {
+      const willCollide = landedSlugs.has(plan.skillName);
+      if (willCollide && !inputs.overwriteReserved) {
+        collided.push(plan.skillName);
+      } else {
+        survivors.push(plan.skillName);
+      }
     }
-    if (resolvedRow.survivors.length === 0) continue;
+
+    for (const slug of collided) {
+      outcomes.push(crossPackCollisionOutcome(row.paiPackDir, slug));
+    }
+    if (survivors.length === 0) continue;
 
     try {
-      const items = await importPaiPackFromPlan(resolvedRow.handle, {
-        excludeSkills: new Set(resolvedRow.collided),
+      const items = await importPaiPackFromPlan(row.handle, {
+        excludeSkills: new Set(collided),
         overwrite: true,
       });
       for (const item of items) {
         packs.push(item);
+        // Reserve only after a real, successful write. Future packs
+        // checking this slug will now collide; the pack-on-disk owns
+        // the surface.
+        landedSlugs.add(item.skillName);
         outcomes.push({
-          paiPackDir: resolvedRow.paiPackDir,
+          paiPackDir: row.paiPackDir,
           outcome: "imported",
           skillName: item.skillName,
         });
       }
     } catch (error) {
-      // Phase 2 errors are genuine — surface as refused-other and
-      // continue (no abort).
+      // Phase 2 apply errors are genuine — surface as refused-other.
+      // No slug from this pack joins `landedSlugs`; a later pack with
+      // the same slug correctly gets a chance to land.
       outcomes.push({
-        paiPackDir: resolvedRow.paiPackDir,
+        paiPackDir: row.paiPackDir,
         outcome: "refused-other",
         reason: errorMessage(error),
       });

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -1153,6 +1153,31 @@ export async function planPaiPackImportHandle(
 }
 
 /**
+ * Single source for the "archive attaches to the first derived skill"
+ * bucketing rule. Both `splitInternalPlanByDerivedSkill` (the plan
+ * surface) and `applyInternalPlan` (the result surface) use this so
+ * the policy can't drift between dry-run and applied views: if it
+ * ever changes (e.g., to attach the archive to a synthetic "_pack"
+ * surface or to skip attachment entirely), one helper updates both
+ * paths in lockstep.
+ *
+ * `fileDerivedSkill` is the routed file's own derived-skill slug;
+ * empty string means "archive / pack-level file." Returns:
+ *   - the file's own slug when it has one (normal per-skill files);
+ *   - the first derived skill when the file is archive-only AND the
+ *     pack derived at least one skill;
+ *   - `null` when there are no derived skills (defensive — the
+ *     caller should skip the file).
+ */
+function attachArchiveToFirstSkill(
+  fileDerivedSkill: string,
+  derivedSkills: readonly string[],
+): string | null {
+  if (fileDerivedSkill) return fileDerivedSkill;
+  return derivedSkills[0] ?? null;
+}
+
+/**
  * #105 — split the single internal plan (which holds every routed
  * file in one bag) into one externally-visible `PaiPackImportPlan`
  * per derived skill. The archive surface (under
@@ -1179,13 +1204,12 @@ function splitInternalPlanByDerivedSkill(
   // Group every routed source file + every generated per-skill manifest
   // under its derived-skill bucket. Archive-only files (derivedSkill ==
   // "") attach to the first skill so they don't disappear from the
-  // public plan surface.
+  // public plan surface (see `attachArchiveToFirstSkill`).
   const buckets = new Map<string, PaiPackImportFile[]>();
   for (const slug of internal.derivedSkills) buckets.set(slug, []);
-  const firstSlug = internal.derivedSkills[0];
 
   for (const file of internal.routedFiles) {
-    const slug = file.derivedSkill || firstSlug;
+    const slug = attachArchiveToFirstSkill(file.derivedSkill, internal.derivedSkills);
     if (!slug) continue;
     if (!buckets.has(slug)) buckets.set(slug, []);
     const { renderMode: _r, derivedSkill: _d, ...stripped } = file;
@@ -1532,7 +1556,6 @@ async function applyInternalPlan(
   // the migration orchestrator can record N outcome rows.
   const filesBySlug = new Map<string, string[]>();
   for (const slug of plan.derivedSkills) filesBySlug.set(slug, []);
-  const firstSlug = plan.derivedSkills[0];
   const skillRoots = new Map(
     plan.derivedSkills.map((slug) => [slug, join(plan.somaHome, "skills", slug)]),
   );
@@ -1546,9 +1569,10 @@ async function applyInternalPlan(
       }
     }
     if (!placed) {
-      // Archive / pack-level file — attach to first slug so it doesn't
-      // disappear from the result surface.
-      if (firstSlug) filesBySlug.get(firstSlug)!.push(target);
+      // Archive / pack-level file — bucket to the first derived
+      // skill via the shared `attachArchiveToFirstSkill` rule.
+      const slug = attachArchiveToFirstSkill("", plan.derivedSkills);
+      if (slug) filesBySlug.get(slug)!.push(target);
     }
   }
 

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -217,8 +217,7 @@ interface InternalPaiPackImportPlan extends PaiPackImportPlan {
   /** #105 — every derived skill slug produced by this plan (sorted). */
   derivedSkills: string[];
   /**
-   * Sage r5 #108 (CodeQuality, important): each nested skill's own
-   * frontmatter description, normalized via
+   * Each nested skill's own frontmatter description, normalized via
    * `normalizeSkillDescription`. Keyed by derived skill slug. Used by
    * the staging step to populate the rewritten SKILL.md frontmatter
    * AND by the SomaSkill manifest renderer — both surfaces previously
@@ -689,8 +688,8 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptionsInternal = {}
   // skills depend on it.
   const hasFlatEntry = sourceFiles.includes("src/SKILL.md");
 
-  // Sage r7 #108 (CodeQuality, important): the pack-slug reserved
-  // refusal applies ONLY when the pack has a FLAT entry. For a pure-
+  // The pack-slug reserved refusal applies ONLY when the pack has a
+  // FLAT entry. For a pure-
   // nested pack with a reserved pack name (e.g. README `name: soma`
   // with only `src/Foo/SKILL.md` + `src/Bar/SKILL.md`), `packSlug`
   // is just the archive root identifier under `~/.soma/imports/pai-
@@ -735,8 +734,8 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptionsInternal = {}
   // nested src/Foo/SKILL.md) is a collision — both would target the
   // same skill root. Refuse with the typed error.
   //
-  // Sage r3 #108 CodeQuality (suggestion): use the RAW nested dir name
-  // when building the source path. Previously this template used
+  // Use the RAW nested dir name when building the source path.
+  // Previously this template used
   // `packSlug`, which is kebab-cased — for a `src/PAIUpgrade/SKILL.md`
   // colliding with pack slug `pai-upgrade`, the refusal would report
   // `src/pai-upgrade/SKILL.md` (a path that does not exist on disk),
@@ -934,11 +933,11 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptionsInternal = {}
 
   const files = routedFiles.map(({ renderMode: _renderMode, derivedSkill: _derivedSkill, ...file }) => file);
 
-  // Sage r5 #108 (CodeQuality, important): capture each nested
-  // skill's own frontmatter `description` so the staging step and
-  // SomaSkill manifest renderer can preserve it instead of
-  // clobbering with `nestedSkillDescription(slug)`. We parse the
-  // already-normalized SKILL.md content (no second file read).
+  // Capture each nested skill's own frontmatter `description` so the
+  // staging step and SomaSkill manifest renderer can preserve it
+  // instead of clobbering with `nestedSkillDescription(slug)`. We
+  // parse the already-normalized SKILL.md content (no second file
+  // read).
   const nestedSkillDescriptions = new Map<string, string>();
   for (const file of routedFiles) {
     if (
@@ -985,10 +984,10 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptionsInternal = {}
 }
 
 /**
- * Sage r5 #108 helper: find the raw nested dir name for a given kebab
- * slug. Used by the description-normalization step so per-file audit
- * paths name the actual on-disk path (matches the R3 fix in the
- * flat-vs-nested collision message).
+ * Find the raw nested dir name for a given kebab slug. Used by the
+ * description-normalization step so per-file audit paths name the
+ * actual on-disk path (consistent with the flat-vs-nested collision
+ * message).
  */
 function findNestedRawForSlug(
   nestedIndex: readonly NestedSkillRecord[],
@@ -1071,30 +1070,27 @@ export async function planPaiPackImport(
 }
 
 /**
- * #105 / Sage r2 #108 (Performance) — opaque handle for plan-once,
- * apply-later. The migration orchestrator's two-phase apply path
- * uses this to plan once (Phase 1, bounded-concurrent) and apply
- * later (Phase 2, sequential with cross-pack collision filtering)
- * WITHOUT a second full plan rebuild.
+ * Opaque handle for plan-once, apply-later imports. The migration
+ * orchestrator's two-phase apply path uses this to plan once
+ * (Phase 1, bounded-concurrent) and apply later (Phase 2, sequential
+ * with cross-pack collision filtering) WITHOUT a second full plan
+ * rebuild.
  *
- * Sage r6 #108 (Security, blocker): the plan data is stored OFF the
- * handle, in a module-private `WeakMap<handle, planData>`. The
- * handle itself is a frozen empty object — it carries no addressable
- * plan state. A caller who legitimately receives a handle cannot
- * mutate `handle.plan.routedFiles` to bypass containment validation
- * because there is no `.plan` field to mutate. The WeakMap lookup
- * is the only path from a handle to its plan, and the WeakMap has
- * no external accessor.
+ * Security invariant: plan data is stored OFF the handle, in a
+ * module-private `WeakMap<handle, planData>`. The handle itself is
+ * a frozen empty object — it carries no addressable plan state, so
+ * a caller with a legitimate handle cannot mutate
+ * `handle.plan.routedFiles` to bypass containment validation. The
+ * same WeakMap doubles as the trusted-handle set: forged handles
+ * (objects fitting the structural interface but never registered)
+ * have no entry and `castHandle` rejects them with a `TypeError`.
  *
- * Sage r5 #108 (Security, blocker): the same WeakMap doubles as the
- * trusted-handle set — forged handles (objects fitting the
- * structural interface but never registered) have no entry and
- * `castHandle` rejects them with a clear `TypeError`.
- *
- * The trio (`PaiPackImportPlanHandle`, `planPaiPackImportHandle`,
- * `importPaiPackFromPlan`) is module-internal — NOT re-exported on
- * the package barrel. The only legitimate consumer is the migration
- * orchestrator, which deep-imports from this module.
+ * @internal The handle trio (`PaiPackImportPlanHandle`,
+ * `planPaiPackImportHandle`, `importPaiPackFromPlan`) is
+ * orchestration-only plumbing. NOT re-exported from `src/index.ts`;
+ * the only legitimate consumer is the migration orchestrator, which
+ * deep-imports from this module. The WeakMap design is free to
+ * change; do not depend on the export.
  */
 export interface PaiPackImportPlanHandle {
   readonly __brand: "PaiPackImportPlanHandle";
@@ -1105,11 +1101,11 @@ interface TrustedPlanData {
   readonly options: PaiPackImportOptionsInternal;
 }
 
-// Sage r6 #108 (Security, blocker): module-private WeakMap from
-// frozen handle → plan data. The handle object never holds the plan
-// directly, so an external caller with a legitimate handle cannot
-// mutate the cached plan in any way. The WeakMap has no external
-// accessor and lookup is the only path from handle to plan.
+// Module-private WeakMap from frozen handle → plan data. The handle
+// object never holds the plan directly, so an external caller with
+// a legitimate handle cannot mutate the cached plan in any way. The
+// WeakMap has no external accessor and lookup is the only path from
+// handle to plan.
 const TRUSTED_PLAN_BY_HANDLE = new WeakMap<object, TrustedPlanData>();
 
 function castHandle(handle: PaiPackImportPlanHandle): TrustedPlanData {
@@ -1127,28 +1123,30 @@ function castHandle(handle: PaiPackImportPlanHandle): TrustedPlanData {
 }
 
 /**
- * #105 / Sage r2 #108 (Performance) — plan-once API for the migration
- * orchestrator. Returns the public per-skill plan view (for outcome
- * reporting) alongside an opaque handle that `importPaiPackFromPlan`
- * consumes to apply WITHOUT a second plan rebuild.
+ * Plan-once API for the migration orchestrator. Returns the public
+ * per-skill plan view (for outcome reporting) alongside an opaque
+ * handle that `importPaiPackFromPlan` consumes to apply WITHOUT a
+ * second plan rebuild.
  *
  * Standalone CLI consumers (`soma import pai-pack`) keep using
- * `planPaiPackImport` + `importPaiPack` — the handle path is an SDK
- * optimization for callers that already planned and want to apply
- * the same plan.
+ * `planPaiPackImport` + `importPaiPack` — the handle path is an
+ * orchestration-level optimization for callers that already planned
+ * and want to apply the same plan.
+ *
+ * @internal Orchestration plumbing for the migration apply path.
+ * Not part of the public SDK surface; do not depend on the export.
  */
 export async function planPaiPackImportHandle(
   options: PaiPackImportOptionsInternal = {},
 ): Promise<{ plans: PaiPackImportPlan[]; handle: PaiPackImportPlanHandle }> {
   const internal = await buildPaiPackImportPlan(options);
   const plans = splitInternalPlanByDerivedSkill(internal);
-  // Sage r6 #108 (Security, blocker): the handle is a frozen empty
-  // object — it carries NO addressable plan state. The plan lives
-  // in the module-private WeakMap, keyed by the handle. A caller
-  // with a legitimate handle cannot mutate `handle.plan` because
-  // there is no `.plan` field; the only path from handle to plan
-  // is the WeakMap lookup in `castHandle`, which lives in this
-  // module file.
+  // The handle is a frozen empty object — it carries NO addressable
+  // plan state. The plan lives in the module-private WeakMap, keyed
+  // by the handle. A caller with a legitimate handle cannot mutate
+  // `handle.plan` because there is no `.plan` field; the only path
+  // from handle to plan is the WeakMap lookup in `castHandle`, which
+  // lives in this module file.
   const handle = Object.freeze({ __brand: "PaiPackImportPlanHandle" } as const);
   TRUSTED_PLAN_BY_HANDLE.set(handle, { plan: internal, options });
   return { plans, handle };
@@ -1238,12 +1236,12 @@ async function stagePaiPackFiles(plan: InternalPaiPackImportPlan, stageRoot: str
       // Workflows/Tools markdown keeps its original frontmatter intact —
       // Sage round-3 important: their identity isn't the root skill's.
       //
-      // Sage r5 #108 (CodeQuality, important): nested skills now use
-      // their OWN SKILL.md description (captured in the plan's
-      // `nestedSkillDescriptions` map). Fallback to the generic
-      // `nestedSkillDescription(slug)` only when the nested skill
-      // shipped no description at all. Pack-level (FLAT) slug keeps
-      // using `plan.description` (the README-derived pack description).
+      // Nested skills use their OWN SKILL.md description (captured
+      // in the plan's `nestedSkillDescriptions` map). Fallback to
+      // the generic `nestedSkillDescription(slug)` only when the
+      // nested skill shipped no description. Pack-level (FLAT) slug
+      // keeps using `plan.description` (the README-derived pack
+      // description).
       const finalContent = file.renderMode === "skill"
         ? `${rewriteSkillFrontmatter(
             normalizedContent,
@@ -1275,9 +1273,9 @@ function renderSomaSkillManifest(plan: InternalPaiPackImportPlan, skillSlug: str
     .map((file) => skillRelPath(file.target));
   const manifest: SomaSkillManifest = generateSomaSkillManifest({
     skillName: skillSlug,
-    // Sage r5 #108: preserve each nested skill's own SKILL.md
-    // description in its soma-skill.json manifest (same source-of-
-    // truth fix as the SKILL.md frontmatter rewrite above).
+    // Preserve each nested skill's own SKILL.md description in its
+    // soma-skill.json manifest (same source-of-truth as the SKILL.md
+    // frontmatter rewrite above).
     description: resolveDerivedSkillDescription(plan, skillSlug),
     packName: plan.packName,
     entrypoint: skillMd ? skillRelPath(skillMd.target) : "SKILL.md",
@@ -1288,8 +1286,8 @@ function renderSomaSkillManifest(plan: InternalPaiPackImportPlan, skillSlug: str
 }
 
 /**
- * Sage r5 #108 (CodeQuality, important) — single source for resolving
- * the description that a derived skill gets in BOTH its rewritten
+ * Single source for resolving the description that a derived skill
+ * gets in BOTH its rewritten
  * SKILL.md frontmatter AND its soma-skill.json manifest. Order:
  *   1. Pack-level (FLAT) slug always uses the pack's normalized
  *      README-derived description.
@@ -1419,21 +1417,24 @@ export async function importPaiPack(
 }
 
 /**
- * #105 / Sage r2 #108 (Performance) — apply a previously-built plan
- * WITHOUT a second `buildPaiPackImportPlan` pass. `excludeSkills`
- * filters the cached internal plan in-memory; the routed-file list is
- * already grouped by `derivedSkill`, so the filter is O(files) with no
- * I/O. The stage + promote pipeline is shared with `importPaiPack`.
+ * Apply a previously-built plan WITHOUT a second
+ * `buildPaiPackImportPlan` pass. `excludeSkills` filters the cached
+ * internal plan in-memory; the routed-file list is already grouped
+ * by `derivedSkill`, so the filter is O(files) with no I/O. The
+ * stage + promote pipeline is shared with `importPaiPack`.
  *
- * Sage r1 #108 collision-filter contract preserved: every excluded
- * slug is dropped from `routedFiles` BEFORE staging — no excluded
- * skill ever touches disk. The pack-level archive surface (renderMode
- * `archive-manifest`, derivedSkill `""`) is unaffected; its
- * `derivedSkills` field is regenerated from the filtered set.
+ * Collision-filter contract: every excluded slug is dropped from
+ * `routedFiles` BEFORE staging — no excluded skill ever touches
+ * disk. The pack-level archive surface (renderMode `archive-manifest`,
+ * derivedSkill `""`) is unaffected; its `derivedSkills` field is
+ * regenerated from the filtered set.
  *
  * Throws `PaiPackAllSkillsExcludedRefusal` if every derived skill is
  * excluded — matches `importPaiPack`'s contract so the migration
  * orchestrator's typed-catch path stays identical.
+ *
+ * @internal Orchestration plumbing for the migration apply path.
+ * Not part of the public SDK surface; do not depend on the export.
  */
 export async function importPaiPackFromPlan(
   handle: PaiPackImportPlanHandle,

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -676,13 +676,6 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptionsInternal = {}
   if (!NORMALIZED_SKILL_NAME_PATTERN.test(packSlug)) {
     throw new Error(`soma import pai-pack produced invalid normalized skill name '${packSlug}'.`);
   }
-  if (RESERVED_SKILL_NAMES.has(packSlug)) {
-    // #102 — typed refusal so the migrate orchestrator classifies
-    // this as `refused-reserved` even when its outer pre-check is
-    // bypassed by `--overwrite-reserved` (the inner set is narrower
-    // and structurally enforced; the slug is preserved in the error).
-    throw new PaiPackReservedNameRefusal(packSlug);
-  }
 
   // #105 — enumerate every Soma skill this pack will derive. The
   // FLAT top-level surface (pack slug) exists iff `src/SKILL.md` is
@@ -695,6 +688,24 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptionsInternal = {}
   // surface (archive / docs) still lands because surviving derived
   // skills depend on it.
   const hasFlatEntry = sourceFiles.includes("src/SKILL.md");
+
+  // Sage r7 #108 (CodeQuality, important): the pack-slug reserved
+  // refusal applies ONLY when the pack has a FLAT entry. For a pure-
+  // nested pack with a reserved pack name (e.g. README `name: soma`
+  // with only `src/Foo/SKILL.md` + `src/Bar/SKILL.md`), `packSlug`
+  // is just the archive root identifier under `~/.soma/imports/pai-
+  // packs/`. It is NOT an imported skill name, so refusing on it
+  // would reject otherwise-valid derived skills. The per-derived-
+  // skill reserved check below still fires when a NESTED slug is in
+  // the reserved set, so genuinely-reserved skill names are still
+  // refused on both layouts.
+  if (hasFlatEntry && RESERVED_SKILL_NAMES.has(packSlug)) {
+    // #102 — typed refusal so the migrate orchestrator classifies
+    // this as `refused-reserved` even when its outer pre-check is
+    // bypassed by `--overwrite-reserved` (the inner set is narrower
+    // and structurally enforced; the slug is preserved in the error).
+    throw new PaiPackReservedNameRefusal(packSlug);
+  }
   const excludeSkills = options.excludeSkills ?? new Set<string>();
   const derivedSkillSet = new Set<string>();
   if (hasFlatEntry && !excludeSkills.has(packSlug)) derivedSkillSet.add(packSlug);

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -92,7 +92,7 @@ export class PaiPackReservedNameRefusal extends Error {
  * present in the pack are silently ignored. Empty/undefined means no
  * exclusion.
  */
-export interface PaiPackImportOptionsInternal extends PaiPackImportOptions {
+interface PaiPackImportOptionsInternal extends PaiPackImportOptions {
   excludeSkills?: ReadonlySet<string>;
 }
 

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -216,6 +216,20 @@ interface InternalPaiPackImportPlan extends PaiPackImportPlan {
   packSlug: string;
   /** #105 — every derived skill slug produced by this plan (sorted). */
   derivedSkills: string[];
+  /**
+   * Sage r5 #108 (CodeQuality, important): each nested skill's own
+   * frontmatter description, normalized via
+   * `normalizeSkillDescription`. Keyed by derived skill slug. Used by
+   * the staging step to populate the rewritten SKILL.md frontmatter
+   * AND by the SomaSkill manifest renderer — both surfaces previously
+   * overwrote the nested skill's authentic description with the
+   * generic `Imported PAI nested skill: <Name>` string. Pack-level
+   * (FLAT) slug is NOT in this map; it uses `plan.description`
+   * (the pack-level README-derived description) the same way it
+   * always has. A nested skill missing its own description falls
+   * back to the generic string at lookup time.
+   */
+  nestedSkillDescriptions: Map<string, string>;
 }
 
 function isRoutedSourceFile(file: RoutedPaiPackImportFile): file is Extract<RoutedPaiPackImportFile, { origin: "source" }> {
@@ -909,6 +923,36 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptionsInternal = {}
 
   const files = routedFiles.map(({ renderMode: _renderMode, derivedSkill: _derivedSkill, ...file }) => file);
 
+  // Sage r5 #108 (CodeQuality, important): capture each nested
+  // skill's own frontmatter `description` so the staging step and
+  // SomaSkill manifest renderer can preserve it instead of
+  // clobbering with `nestedSkillDescription(slug)`. We parse the
+  // already-normalized SKILL.md content (no second file read).
+  const nestedSkillDescriptions = new Map<string, string>();
+  for (const file of routedFiles) {
+    if (
+      file.renderMode !== "skill" ||
+      !isRoutedSourceFile(file) ||
+      file.derivedSkill === packSlug ||
+      file.derivedSkill === ""
+    ) {
+      continue;
+    }
+    const normalized = normalizedSkillFiles.get(file.source);
+    if (!normalized) continue;
+    const fm = parseFrontmatter(normalized.normalized);
+    const rawDescription = fm.description;
+    if (!rawDescription) continue;
+    // Normalize the same way the pack-level description is normalized
+    // so trailing punctuation, blank entries, and "your" → "the" type
+    // adjustments stay consistent across surfaces.
+    const normalizedDesc = normalizeSkillDescription(rawDescription, {
+      file: `src/${findNestedRawForSlug(nestedIndex, file.derivedSkill) ?? file.derivedSkill}/SKILL.md`,
+      fallback: nestedSkillDescription(file.derivedSkill),
+    });
+    nestedSkillDescriptions.set(file.derivedSkill, normalizedDesc.description);
+  }
+
   return {
     apply: false,
     paiPackDir: homes.paiPackDir,
@@ -925,7 +969,24 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptionsInternal = {}
     normalizedSkillFiles,
     packSlug,
     derivedSkills,
+    nestedSkillDescriptions,
   };
+}
+
+/**
+ * Sage r5 #108 helper: find the raw nested dir name for a given kebab
+ * slug. Used by the description-normalization step so per-file audit
+ * paths name the actual on-disk path (matches the R3 fix in the
+ * flat-vs-nested collision message).
+ */
+function findNestedRawForSlug(
+  nestedIndex: readonly NestedSkillRecord[],
+  slug: string,
+): string | null {
+  for (const record of nestedIndex) {
+    if (record.slug === slug) return record.raw;
+  }
+  return null;
 }
 
 interface NormalizedSkillFile {
@@ -1004,16 +1065,23 @@ export async function planPaiPackImport(
  * migration orchestrator's two-phase apply path uses this to plan
  * once (Phase 1, bounded-concurrent) and apply later (Phase 2,
  * sequential with cross-pack collision filtering) WITHOUT a second
- * full plan rebuild. On 45 packs that saves a full pass of:
- *   - directory walk (`collectFiles`)
- *   - `readPackMetadata`
- *   - route classification (every source path)
- *   - normalization (read + normalize every SKILL.md / Workflow .md)
+ * full plan rebuild.
  *
- * The handle is opaque to external consumers — the wrapped types are
- * intentionally module-private so the orchestration contract can
- * evolve without an SDK break. Built only via
- * `planPaiPackImportHandle`; consumed only by `importPaiPackFromPlan`.
+ * Sage r5 #108 (Security, blocker): handles are validated at apply
+ * time against a module-private `WeakSet` so forgeries (any object
+ * implementing the structural `PaiPackImportPlanHandle` interface)
+ * are rejected by `importPaiPackFromPlan`. A caller cannot fabricate
+ * a handle that bypasses `buildPaiPackImportPlan`'s `escapedTargets`
+ * validation — the only path that adds to the WeakSet is
+ * `planPaiPackImportHandle` itself, after the plan was produced by
+ * the validated builder. The handle interface is intentionally empty
+ * (no addressable fields) so any external attempt to construct one
+ * must produce a fresh object that won't be in the WeakSet.
+ *
+ * The trio (`PaiPackImportPlanHandle`, `planPaiPackImportHandle`,
+ * `importPaiPackFromPlan`) is module-internal — NOT re-exported on
+ * the package barrel. The only legitimate consumer is the migration
+ * orchestrator, which deep-imports from this module.
  */
 export interface PaiPackImportPlanHandle {
   readonly __brand: "PaiPackImportPlanHandle";
@@ -1024,7 +1092,22 @@ interface InternalPlanHandle extends PaiPackImportPlanHandle {
   readonly options: PaiPackImportOptionsInternal;
 }
 
+// Sage r5 #108 (Security, blocker): module-private WeakSet of handles
+// known to have been produced by the trusted builder. The WeakSet
+// has no public access, so a forged handle (any object matching the
+// structural interface) will not be in it and `castHandle` rejects.
+const TRUSTED_HANDLES = new WeakSet<object>();
+
 function castHandle(handle: PaiPackImportPlanHandle): InternalPlanHandle {
+  if (handle === null || typeof handle !== "object") {
+    throw new TypeError("importPaiPackFromPlan: handle must be a PaiPackImportPlanHandle object.");
+  }
+  if (!TRUSTED_HANDLES.has(handle)) {
+    throw new TypeError(
+      "importPaiPackFromPlan: handle was not produced by planPaiPackImportHandle. " +
+        "Refusing to apply a potentially-forged plan that has not been validated by the builder.",
+    );
+  }
   return handle as InternalPlanHandle;
 }
 
@@ -1045,6 +1128,11 @@ export async function planPaiPackImportHandle(
   const internal = await buildPaiPackImportPlan(options);
   const plans = splitInternalPlanByDerivedSkill(internal);
   const handle: InternalPlanHandle = { __brand: "PaiPackImportPlanHandle", plan: internal, options };
+  // Sage r5 #108 (Security, blocker): register the handle in the
+  // module-private trusted set. `castHandle` rejects any object not
+  // in this set, so forged handles cannot bypass the builder's
+  // validation (escapedTargets, secret-file refusal, etc.).
+  TRUSTED_HANDLES.add(handle);
   return { plans, handle };
 }
 
@@ -1131,13 +1219,18 @@ async function stagePaiPackFiles(plan: InternalPaiPackImportPlan, stageRoot: str
       // Only the entry SKILL.md gets the skill identity frontmatter rewrite.
       // Workflows/Tools markdown keeps its original frontmatter intact —
       // Sage round-3 important: their identity isn't the root skill's.
+      //
+      // Sage r5 #108 (CodeQuality, important): nested skills now use
+      // their OWN SKILL.md description (captured in the plan's
+      // `nestedSkillDescriptions` map). Fallback to the generic
+      // `nestedSkillDescription(slug)` only when the nested skill
+      // shipped no description at all. Pack-level (FLAT) slug keeps
+      // using `plan.description` (the README-derived pack description).
       const finalContent = file.renderMode === "skill"
         ? `${rewriteSkillFrontmatter(
             normalizedContent,
             file.derivedSkill,
-            file.derivedSkill === plan.packSlug
-              ? plan.description
-              : nestedSkillDescription(file.derivedSkill),
+            resolveDerivedSkillDescription(plan, file.derivedSkill),
           ).trimEnd()}\n`
         : `${normalizedContent.trimEnd()}\n`;
       await writeFile(stagedTarget, finalContent, "utf8");
@@ -1164,16 +1257,38 @@ function renderSomaSkillManifest(plan: InternalPaiPackImportPlan, skillSlug: str
     .map((file) => skillRelPath(file.target));
   const manifest: SomaSkillManifest = generateSomaSkillManifest({
     skillName: skillSlug,
-    description:
-      skillSlug === plan.packSlug
-        ? plan.description
-        : nestedSkillDescription(skillSlug),
+    // Sage r5 #108: preserve each nested skill's own SKILL.md
+    // description in its soma-skill.json manifest (same source-of-
+    // truth fix as the SKILL.md frontmatter rewrite above).
+    description: resolveDerivedSkillDescription(plan, skillSlug),
     packName: plan.packName,
     entrypoint: skillMd ? skillRelPath(skillMd.target) : "SKILL.md",
     references,
     workflowFiles,
   });
   return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+/**
+ * Sage r5 #108 (CodeQuality, important) — single source for resolving
+ * the description that a derived skill gets in BOTH its rewritten
+ * SKILL.md frontmatter AND its soma-skill.json manifest. Order:
+ *   1. Pack-level (FLAT) slug always uses the pack's normalized
+ *      README-derived description.
+ *   2. Nested skills use their OWN normalized SKILL.md frontmatter
+ *      description (captured in `plan.nestedSkillDescriptions`).
+ *   3. Nested skills missing a description fall back to the generic
+ *      `Imported PAI nested skill: <Name>` string so the manifest is
+ *      never empty.
+ */
+function resolveDerivedSkillDescription(
+  plan: InternalPaiPackImportPlan,
+  derivedSlug: string,
+): string {
+  if (derivedSlug === plan.packSlug) return plan.description;
+  const own = plan.nestedSkillDescriptions.get(derivedSlug);
+  if (own) return own;
+  return nestedSkillDescription(derivedSlug);
 }
 
 interface PromotionContext {

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -1,7 +1,7 @@
 import { access, copyFile, lstat, mkdir, readdir, readFile, realpath, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
-import { routePaiPackSourceFile, type PaiPackRenderMode } from "./pai-pack-routing";
+import { kebabNestedName, routePaiPackSourceFile, type PaiPackRenderMode } from "./pai-pack-routing";
 import {
   generateSomaSkillManifest,
   mergeNormalizationReports,
@@ -27,7 +27,7 @@ interface PackMetadata {
 }
 
 const RESERVED_SKILL_NAMES = new Set(["soma", "the-algorithm"]);
-const REQUIRED_PACK_FILES = ["README.md", "INSTALL.md", "VERIFY.md", "src/SKILL.md"];
+const REQUIRED_PACK_DOC_FILES = ["README.md", "INSTALL.md", "VERIFY.md"];
 const NORMALIZED_SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 /**
@@ -72,6 +72,34 @@ export class PaiPackReservedNameRefusal extends Error {
     super(`soma import pai-pack cannot overwrite reserved Soma skill '${skillName}'.`);
     this.name = "PaiPackReservedNameRefusal";
     this.skillName = skillName;
+  }
+}
+
+/**
+ * #105 — typed refusal raised when a pack's nested-skill set contains
+ * two `src/<Name>/SKILL.md` paths whose kebab-cased names collapse to
+ * the same slug (e.g., `src/Foo/SKILL.md` + `src/foo/SKILL.md`, or
+ * `src/extract-wisdom/SKILL.md` + `src/ExtractWisdom/SKILL.md`). The
+ * migration orchestrator classifies these as `refused-name-collision`
+ * for the entire pack. Carries the colliding slug + the raw source
+ * names so the principal can fix the upstream pack.
+ *
+ * Note: cross-pack collisions (Pack A landed `browser`, Pack B's
+ * `src/Browser/SKILL.md` would clobber it) are handled at the
+ * migration-orchestrator level, NOT here — the pack importer alone
+ * cannot see what other packs have landed.
+ */
+export class PaiPackNameCollisionRefusal extends Error {
+  readonly kind = "name-collision" as const;
+  readonly skillName: string;
+  readonly sources: readonly string[];
+  constructor(skillName: string, sources: readonly string[]) {
+    super(
+      `PAI pack import refused name collision on '${skillName}': ${sources.join(", ")} collapse to the same Soma skill slug.`,
+    );
+    this.name = "PaiPackNameCollisionRefusal";
+    this.skillName = skillName;
+    this.sources = sources;
   }
 }
 
@@ -125,15 +153,28 @@ const SECRET_FILE_PATTERNS = [
 ];
 
 type RoutedPaiPackImportFile =
-  | (PaiPackSourceImportFile & { renderMode: Extract<PaiPackRenderMode, "copy" | "skill" | "skill-body"> })
+  | (PaiPackSourceImportFile & {
+      renderMode: Extract<PaiPackRenderMode, "copy" | "skill" | "skill-body">;
+      /**
+       * #105 — derived skill slug this file belongs to. Empty string
+       * for archive-only files (route.root === "archive") since they
+       * live under the pack-level archive root, not any skill root.
+       */
+      derivedSkill: string;
+    })
   | (PaiPackGeneratedImportFile & {
       renderMode: Extract<PaiPackRenderMode, "manifest" | "archive-manifest"> | "soma-skill-manifest";
+      derivedSkill: string;
     });
 
 interface InternalPaiPackImportPlan extends PaiPackImportPlan {
   routedFiles: RoutedPaiPackImportFile[];
   normalization: PaiPackNormalizationReport;
   normalizedSkillFiles: Map<string, NormalizedSkillFile>;
+  /** #105 — pack-level slug for archive routing. */
+  packSlug: string;
+  /** #105 — every derived skill slug produced by this plan (sorted). */
+  derivedSkills: string[];
 }
 
 function isRoutedSourceFile(file: RoutedPaiPackImportFile): file is Extract<RoutedPaiPackImportFile, { origin: "source" }> {
@@ -161,10 +202,22 @@ function resolvePackHomes(options: PaiPackImportOptions = {}): { paiPackDir: str
  * function — Sage #95 Maintainability finding (avoid drift between
  * the importer's reserved check and the orchestrator's reserved
  * check).
+ *
+ * Two transformations split CamelCase boundaries before lowercasing:
+ *   1. `([A-Z]+)([A-Z][a-z])` → `$1-$2`  — splits ALL-CAPS prefix from
+ *      a following Capital+lowercase (e.g., `PAIUpgrade` →
+ *      `PAI-Upgrade`, `HTMLParser` → `HTML-Parser`).
+ *   2. `([a-z0-9])([A-Z])` → `$1-$2`     — standard CamelCase split
+ *      (e.g., `ExtractWisdom` → `Extract-Wisdom`).
+ *
+ * Order matters: rule 1 runs first so it can fire on `PAI` before
+ * rule 2 sees `IU` (no lower-upper boundary there). Then lowercasing
+ * and final non-alnum-to-hyphen normalization runs.
  */
 export function slugifySkillName(value: string): string {
   return value
     .trim()
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
     .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
@@ -308,11 +361,55 @@ function isLikelySecretPath(path: string): boolean {
   return SECRET_FILE_PATTERNS.some((pattern) => pattern.test(normalizedPath.toLowerCase()));
 }
 
-function assertRequiredPackFiles(sourceFiles: string[]): void {
+/**
+ * #105 — scan the file list and return the raw `<Name>` portion of
+ * every `src/<Name>/SKILL.md`. Order is the sorted file order from
+ * `collectFiles`. Duplicates are impossible from a single fs scan, so
+ * the result is a unique set keyed by raw `<Name>`.
+ *
+ * The orchestrator must compute the kebab projection separately —
+ * within-pack collision detection lives on top of this.
+ */
+function findNestedSkillNames(sourceFiles: readonly string[]): Set<string> {
+  const result = new Set<string>();
+  for (const path of sourceFiles) {
+    if (!path.startsWith("src/")) continue;
+    const tail = path.slice("src/".length);
+    const idx = tail.indexOf("/");
+    if (idx === -1) continue;
+    const name = tail.slice(0, idx);
+    const rest = tail.slice(idx + 1);
+    if (rest === "SKILL.md") {
+      result.add(name);
+    }
+  }
+  return result;
+}
+
+function assertRequiredPackDocs(sourceFiles: readonly string[]): void {
   const sourceFileSet = new Set(sourceFiles);
-  const missing = REQUIRED_PACK_FILES.filter((path) => !sourceFileSet.has(path));
+  const missing = REQUIRED_PACK_DOC_FILES.filter((path) => !sourceFileSet.has(path));
   if (missing.length > 0) {
     throw new Error(`PAI pack import requires V0 pack file(s): ${missing.join(", ")}`);
+  }
+}
+
+/**
+ * #105 — require at least one skill entrypoint, either FLAT
+ * (`src/SKILL.md`) or nested (any `src/<Name>/SKILL.md`). Before this
+ * issue the importer required `src/SKILL.md` unconditionally, which
+ * forced pure-nested packs (like Thinking/) to fail validation before
+ * the new router got a chance to recognize the bundles.
+ */
+function assertHasSkillEntrypoint(
+  sourceFiles: readonly string[],
+  nestedSkills: ReadonlySet<string>,
+): void {
+  const hasFlat = sourceFiles.includes("src/SKILL.md");
+  if (!hasFlat && nestedSkills.size === 0) {
+    throw new Error(
+      `PAI pack import requires V0 pack file(s): src/SKILL.md (or at least one nested src/<Name>/SKILL.md)`,
+    );
   }
 }
 
@@ -399,19 +496,35 @@ async function mapWithConcurrency<T, R>(items: T[], concurrency: number, worker:
   return results;
 }
 
-function renderManifest(plan: PaiPackImportPlan): string {
-  const skillRoot = join(plan.somaHome, "skills", plan.skillName);
+function renderManifestForSkill(plan: InternalPaiPackImportPlan, skillSlug: string): string {
+  const skillRoot = join(plan.somaHome, "skills", skillSlug);
   const skillFiles = plan.files.filter((file) => isWithinPath(skillRoot, file.target));
-  return renderManifestForRoot(plan, skillRoot, skillFiles);
+  return renderManifestForRoot(
+    { ...plan, skillName: skillSlug },
+    skillRoot,
+    skillFiles,
+  );
 }
 
-function renderArchiveManifest(plan: PaiPackImportPlan): string {
-  const archiveRoot = join(plan.somaHome, "imports", "pai-packs", plan.skillName);
-  const archiveFiles = plan.files.filter((file) => isWithinPath(archiveRoot, file.target) && file.origin === "source");
-  return renderManifestForRoot(plan, archiveRoot, archiveFiles);
+function renderArchiveManifest(plan: InternalPaiPackImportPlan): string {
+  const archiveRoot = join(plan.somaHome, "imports", "pai-packs", plan.packSlug);
+  const archiveFiles = plan.files.filter(
+    (file) => isWithinPath(archiveRoot, file.target) && file.origin === "source",
+  );
+  return renderManifestForRoot(
+    { ...plan, skillName: plan.packSlug },
+    archiveRoot,
+    archiveFiles,
+    { derivedSkills: plan.derivedSkills },
+  );
 }
 
-function renderManifestForRoot(plan: PaiPackImportPlan, root: string, files: PaiPackImportFile[]): string {
+function renderManifestForRoot(
+  plan: { paiPackDir: string; somaHome: string; skillName: string; packName: string; description: string; normalization: PaiPackNormalizationReport },
+  root: string,
+  files: PaiPackImportFile[],
+  extras: { derivedSkills?: string[] } = {},
+): string {
   const manifest: PaiPackManifest = {
     schema: "soma.pai-pack-import.v1",
     skillName: plan.skillName,
@@ -440,6 +553,9 @@ function renderManifestForRoot(plan: PaiPackImportPlan, root: string, files: Pai
       };
     }),
   };
+  if (extras.derivedSkills) {
+    manifest.derivedSkills = [...extras.derivedSkills].sort();
+  }
 
   return `${JSON.stringify(manifest, null, 2)}\n`;
 }
@@ -458,41 +574,120 @@ function rewriteSkillFrontmatter(content: string, skillName: string, description
   return ["---", `name: ${JSON.stringify(skillName)}`, `description: ${JSON.stringify(description || `Imported PAI pack: ${skillName}`)}`, "metadata:", "  source: pai-pack", "---", body.trimStart()].join("\n");
 }
 
+/**
+ * #105 — pack-level frontmatter for a nested skill's own SKILL.md. The
+ * nested skill's frontmatter (e.g. `name: ExtractWisdom`) is preserved
+ * via the standard rewrite — only its `name` is replaced with the
+ * kebab-cased slug. Nested skills get the pack-level description as a
+ * fallback when their own frontmatter lacks one.
+ */
+function nestedSkillDescription(nestedRawName: string): string {
+  return `Imported PAI nested skill: ${nestedRawName}`;
+}
+
+/**
+ * #105 — resolve the kebab projection of a nested skill name and
+ * detect within-pack collisions before any plan work runs. Returns the
+ * full set of `{ raw, slug }` pairs sorted by raw name for
+ * deterministic downstream iteration. Throws
+ * `PaiPackNameCollisionRefusal` on collision so the migration
+ * orchestrator can classify it via `instanceof`.
+ */
+interface NestedSkillRecord {
+  raw: string;
+  slug: string;
+}
+
+function buildNestedSkillIndex(nestedRawNames: ReadonlySet<string>): NestedSkillRecord[] {
+  const bySlug = new Map<string, string[]>();
+  for (const raw of nestedRawNames) {
+    const slug = kebabNestedName(raw);
+    const list = bySlug.get(slug) ?? [];
+    list.push(raw);
+    bySlug.set(slug, list);
+  }
+  for (const [slug, raws] of bySlug) {
+    if (raws.length > 1) {
+      throw new PaiPackNameCollisionRefusal(slug, raws.sort());
+    }
+  }
+  return Array.from(nestedRawNames, (raw) => ({ raw, slug: kebabNestedName(raw) }))
+    .sort((a, b) => a.raw.localeCompare(b.raw));
+}
+
 async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promise<InternalPaiPackImportPlan> {
   const homes = resolvePackHomes(options);
   const { files: sourceFiles, skippedEditorSymlinks } = await collectFiles(homes.paiPackDir);
   assertSafePackPaths(sourceFiles);
-  assertRequiredPackFiles(sourceFiles);
+  assertRequiredPackDocs(sourceFiles);
+  // #105 — detect nested skill bundles BEFORE the skill-entrypoint
+  // check, then accept the pack iff it has either FLAT or ≥1 nested
+  // entrypoint. The previous unconditional `src/SKILL.md` requirement
+  // would have rejected pure-nested packs (Thinking/, Utilities/) that
+  // ship with only nested SKILL.md files.
+  const nestedRawNames = findNestedSkillNames(sourceFiles);
+  // Build index BEFORE entrypoint check so within-pack name collisions
+  // (e.g. Foo/ vs foo/) refuse with the typed error instead of falling
+  // through to a downstream duplicate-target failure.
+  const nestedIndex = buildNestedSkillIndex(nestedRawNames);
+  assertHasSkillEntrypoint(sourceFiles, nestedRawNames);
 
   const metadata = await readPackMetadata(homes.paiPackDir);
-  const skillName = options.skillName ? slugifySkillName(options.skillName) : slugifySkillName(metadata.name);
-  if (!skillName) {
+  const packSlug = options.skillName ? slugifySkillName(options.skillName) : slugifySkillName(metadata.name);
+  if (!packSlug) {
     throw new Error("soma import pai-pack requires a non-empty skill name after normalization.");
   }
-  if (!NORMALIZED_SKILL_NAME_PATTERN.test(skillName)) {
-    throw new Error(`soma import pai-pack produced invalid normalized skill name '${skillName}'.`);
+  if (!NORMALIZED_SKILL_NAME_PATTERN.test(packSlug)) {
+    throw new Error(`soma import pai-pack produced invalid normalized skill name '${packSlug}'.`);
   }
-  if (RESERVED_SKILL_NAMES.has(skillName)) {
+  if (RESERVED_SKILL_NAMES.has(packSlug)) {
     // #102 — typed refusal so the migrate orchestrator classifies
     // this as `refused-reserved` even when its outer pre-check is
     // bypassed by `--overwrite-reserved` (the inner set is narrower
     // and structurally enforced; the slug is preserved in the error).
-    // The standalone `soma import pai-pack` verb still surfaces the
-    // same human-readable message via `Error.message`.
-    throw new PaiPackReservedNameRefusal(skillName);
+    throw new PaiPackReservedNameRefusal(packSlug);
   }
+
+  // #105 — enumerate every Soma skill this pack will derive. The
+  // FLAT top-level surface (pack slug) exists iff `src/SKILL.md` is
+  // present in the file list; nested skills are the kebab projection
+  // of every `src/<Name>/SKILL.md`.
+  const hasFlatEntry = sourceFiles.includes("src/SKILL.md");
+  const derivedSkillSet = new Set<string>();
+  if (hasFlatEntry) derivedSkillSet.add(packSlug);
+  for (const { slug } of nestedIndex) derivedSkillSet.add(slug);
+
+  // Each derived skill is also subject to the pack importer's reserved
+  // name set; structurally off-limits even for nested bundles.
+  for (const slug of derivedSkillSet) {
+    if (RESERVED_SKILL_NAMES.has(slug)) {
+      throw new PaiPackReservedNameRefusal(slug);
+    }
+    if (!NORMALIZED_SKILL_NAME_PATTERN.test(slug)) {
+      throw new Error(`soma import pai-pack produced invalid normalized skill name '${slug}'.`);
+    }
+  }
+  // FLAT slug colliding with a nested slug (e.g., pack name "Foo" with
+  // nested src/Foo/SKILL.md) is a collision — both would target the
+  // same skill root. Refuse with the typed error.
+  if (hasFlatEntry && nestedIndex.some(({ slug }) => slug === packSlug)) {
+    throw new PaiPackNameCollisionRefusal(packSlug, ["src/SKILL.md", `src/${packSlug}/SKILL.md`]);
+  }
+
   if (!options.overwrite) {
-    await access(join(homes.somaHome, "skills", skillName))
+    for (const slug of derivedSkillSet) {
+      await access(join(homes.somaHome, "skills", slug))
+        .then(() => {
+          throw new Error(`Soma skill '${slug}' already exists. Re-run with --overwrite to replace it.`);
+        })
+        .catch((error: unknown) => {
+          if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+          throw error;
+        });
+    }
+    await access(join(homes.somaHome, "imports", "pai-packs", packSlug))
       .then(() => {
-        throw new Error(`Soma skill '${skillName}' already exists. Re-run with --overwrite to replace it.`);
-      })
-      .catch((error: unknown) => {
-        if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
-        throw error;
-      });
-    await access(join(homes.somaHome, "imports", "pai-packs", skillName))
-      .then(() => {
-        throw new Error(`Soma PAI pack archive '${skillName}' already exists. Re-run with --overwrite to replace it.`);
+        throw new Error(`Soma PAI pack archive '${packSlug}' already exists. Re-run with --overwrite to replace it.`);
       })
       .catch((error: unknown) => {
         if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
@@ -505,7 +700,10 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
     throw new Error(`PAI pack import refused likely secret file(s): ${secretFiles.join(", ")}`);
   }
 
-  const routes = sourceFiles.map((path) => ({ path, route: routePaiPackSourceFile(path) }));
+  const routes = sourceFiles.map((path) => ({
+    path,
+    route: routePaiPackSourceFile(path, nestedRawNames),
+  }));
   const substrateSpecific = routes.filter(({ route }) => route.classification === "substrate-specific");
   if (substrateSpecific.length > 0 && !options.includeSubstrateSpecific) {
     // #97 — typed refusal so callers (the migrate orchestrator in
@@ -516,16 +714,55 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
     throw new PaiPackSubstrateSpecificRefusal(substrateSpecific.map(({ path }) => path));
   }
 
-  const routedFiles: RoutedPaiPackImportFile[] = routes.map(({ path, route }) => ({
-    source: join(homes.paiPackDir, path),
-    target: join(homes.somaHome, route.root === "skill" ? "skills" : "imports/pai-packs", skillName, route.relativePath),
-    classification: route.classification,
-    renderMode: route.renderMode,
-    origin: "source",
-  }));
+  const routedFiles: RoutedPaiPackImportFile[] = [];
+  for (const { path, route } of routes) {
+    // Resolve the destination skill slug for portable routes:
+    //   - route.skillName === null → pack-level (FLAT) slug
+    //   - route.skillName !== null → nested skill slug
+    const destSkill = route.skillName ?? packSlug;
+    const destRoot =
+      route.root === "skill"
+        ? join(homes.somaHome, "skills", destSkill)
+        : join(homes.somaHome, "imports/pai-packs", packSlug);
+    routedFiles.push({
+      source: join(homes.paiPackDir, path),
+      target: join(destRoot, route.relativePath),
+      classification: route.classification,
+      renderMode: route.renderMode,
+      origin: "source",
+      derivedSkill: route.root === "skill" ? destSkill : "",
+    });
+  }
+
+  // #105 — pack-level README/INSTALL/VERIFY land under EACH derived
+  // skill so each nested skill is independently invocable with the
+  // pack's context attached. The base routing only emits one copy
+  // (to the pack-level surface); we replicate it per nested skill.
+  for (const docName of REQUIRED_PACK_DOC_FILES) {
+    if (!sourceFiles.includes(docName)) continue;
+    const targetBasename = {
+      "README.md": "PAI-PACK-README.md",
+      "INSTALL.md": "PAI-PACK-INSTALL.md",
+      "VERIFY.md": "PAI-PACK-VERIFY.md",
+    }[docName];
+    if (!targetBasename) continue;
+    for (const { slug } of nestedIndex) {
+      // Skip if FLAT pack already has this slug — the route already
+      // landed it.
+      if (hasFlatEntry && slug === packSlug) continue;
+      routedFiles.push({
+        source: join(homes.paiPackDir, docName),
+        target: join(homes.somaHome, "skills", slug, "references", targetBasename),
+        classification: "source-doc",
+        renderMode: "copy",
+        origin: "source",
+        derivedSkill: slug,
+      });
+    }
+  }
 
   // AC-4 — preserve every normalized file's original under
-  // imports/pai-packs/<skill>/source/<original-path> so the un-normalized
+  // imports/pai-packs/<pack-slug>/source/<original-path> so the un-normalized
   // PAI source remains auditable. Copy mode; never normalized.
   // Both "skill" (entry SKILL.md) and "skill-body" (Workflows/Tools .md)
   // get archived — round-3 split introduced skill-body and the archive
@@ -534,10 +771,11 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
     if (route.renderMode === "skill" || route.renderMode === "skill-body") {
       routedFiles.push({
         source: join(homes.paiPackDir, path),
-        target: join(homes.somaHome, "imports", "pai-packs", skillName, "source", path),
+        target: join(homes.somaHome, "imports", "pai-packs", packSlug, "source", path),
         classification: "source-doc",
         renderMode: "copy",
         origin: "source",
+        derivedSkill: "",
       });
     }
   }
@@ -566,31 +804,39 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
     { actions: editorSymlinkSkipActions, warnings: [] },
   ]);
 
-  routedFiles.push({
-    target: join(homes.somaHome, `skills/${skillName}/soma-pack.json`),
-    classification: "portable",
-    renderMode: "manifest",
-    origin: "generated",
-    generator: "pai-pack-importer",
-  });
-  // Always emit a runtime skill manifest (soma-skill.json) alongside the
-  // pack provenance manifest.
-  routedFiles.push({
-    target: join(homes.somaHome, `skills/${skillName}/soma-skill.json`),
-    classification: "portable",
-    renderMode: "soma-skill-manifest",
-    origin: "generated",
-    generator: "pai-pack-importer",
-  });
-  if (substrateSpecific.length > 0) {
+  // Per-derived-skill manifests: each skill gets its own soma-pack.json
+  // (per-skill audit) and soma-skill.json (runtime manifest).
+  const derivedSkills = Array.from(derivedSkillSet).sort();
+  for (const slug of derivedSkills) {
     routedFiles.push({
-      target: join(homes.somaHome, `imports/pai-packs/${skillName}/soma-pack-archive.json`),
-      classification: "substrate-specific",
-      renderMode: "archive-manifest",
+      target: join(homes.somaHome, `skills/${slug}/soma-pack.json`),
+      classification: "portable",
+      renderMode: "manifest",
       origin: "generated",
       generator: "pai-pack-importer",
+      derivedSkill: slug,
+    });
+    routedFiles.push({
+      target: join(homes.somaHome, `skills/${slug}/soma-skill.json`),
+      classification: "portable",
+      renderMode: "soma-skill-manifest",
+      origin: "generated",
+      generator: "pai-pack-importer",
+      derivedSkill: slug,
     });
   }
+  // Pack-level archive manifest is always emitted when there are
+  // archive-bound files (substrate-specific OR every imported pack
+  // gets one as part of #105's auditability contract — the archive's
+  // `derivedSkills` list is principal-facing).
+  routedFiles.push({
+    target: join(homes.somaHome, `imports/pai-packs/${packSlug}/soma-pack-archive.json`),
+    classification: substrateSpecific.length > 0 ? "substrate-specific" : "portable",
+    renderMode: "archive-manifest",
+    origin: "generated",
+    generator: "pai-pack-importer",
+    derivedSkill: "",
+  });
 
   const escapedTargets = routedFiles.filter((file) => !isWithinPath(homes.somaHome, file.target));
   if (escapedTargets.length > 0) {
@@ -598,19 +844,24 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
   }
   assertUniqueTargets(routedFiles);
 
-  const files = routedFiles.map(({ renderMode: _renderMode, ...file }) => file);
+  const files = routedFiles.map(({ renderMode: _renderMode, derivedSkill: _derivedSkill, ...file }) => file);
 
   return {
     apply: false,
     paiPackDir: homes.paiPackDir,
     somaHome: homes.somaHome,
-    skillName,
+    // For the single-plan view, `skillName` is the pack slug — kept
+    // for back-compat with manifest renderers. Callers consume
+    // `derivedSkills` to enumerate per-skill landing pads.
+    skillName: packSlug,
     packName: metadata.name,
     description: normalizedDescription.description,
     files,
     routedFiles,
     normalization,
     normalizedSkillFiles,
+    packSlug,
+    derivedSkills,
   };
 }
 
@@ -638,10 +889,17 @@ async function normalizeSkillFiles(
   routedFiles: RoutedPaiPackImportFile[],
 ): Promise<Map<string, NormalizedSkillFile>> {
   const realPackRoot = await realpath(paiPackDir);
-  const skillFiles: PaiPackSourceImportFile[] = [];
+  const skillFiles: { source: string }[] = [];
+  const seen = new Set<string>();
   for (const file of routedFiles) {
-    if (file.renderMode === "skill" || file.renderMode === "skill-body") {
-      skillFiles.push(file);
+    if ((file.renderMode === "skill" || file.renderMode === "skill-body") && isRoutedSourceFile(file)) {
+      // Each unique source path normalizes once (multiple derived
+      // skills can reference the same source through different
+      // routings; we only run the normalizer once per source).
+      if (!seen.has(file.source)) {
+        seen.add(file.source);
+        skillFiles.push({ source: file.source });
+      }
     }
   }
   const results = await mapWithConcurrency(skillFiles, 8, (file) =>
@@ -660,9 +918,68 @@ function reportFromNormalizedFiles(files: Iterable<NormalizedSkillFile>): PaiPac
   );
 }
 
-export async function planPaiPackImport(options: PaiPackImportOptions = {}): Promise<PaiPackImportPlan> {
-  const { routedFiles: _routedFiles, ...plan } = await buildPaiPackImportPlan(options);
-  return plan;
+/**
+ * #105 — public-facing plan function. Returns one
+ * `PaiPackImportPlan` per derived skill in the pack (≥ 1 always).
+ *
+ * BREAKING CHANGE: previously returned a single `PaiPackImportPlan`.
+ * Callers that expected a scalar must adapt — the migration
+ * orchestrator (the primary consumer) handles the array shape
+ * natively. The standalone `soma import pai-pack` CLI verb prints
+ * each plan in turn.
+ */
+export async function planPaiPackImport(
+  options: PaiPackImportOptions = {},
+): Promise<PaiPackImportPlan[]> {
+  const internal = await buildPaiPackImportPlan(options);
+  return splitInternalPlanByDerivedSkill(internal);
+}
+
+/**
+ * #105 — split the single internal plan (which holds every routed
+ * file in one bag) into one externally-visible `PaiPackImportPlan`
+ * per derived skill. The archive surface (under
+ * `<somaHome>/imports/pai-packs/<pack-slug>/`) is attached to the
+ * first (sorted) derived skill so its files don't vanish — callers
+ * that want the archive listing can find it on `plans[0].files`.
+ *
+ * Each plan reports the same `paiPackDir`, `somaHome`, `packName`,
+ * `description`, `normalization` — those are pack-level properties
+ * shared by every derived skill.
+ */
+function splitInternalPlanByDerivedSkill(
+  internal: InternalPaiPackImportPlan,
+): PaiPackImportPlan[] {
+  const sharedFields = {
+    apply: internal.apply,
+    paiPackDir: internal.paiPackDir,
+    somaHome: internal.somaHome,
+    packName: internal.packName,
+    description: internal.description,
+    normalization: internal.normalization,
+  };
+
+  // Group every routed source file + every generated per-skill manifest
+  // under its derived-skill bucket. Archive-only files (derivedSkill ==
+  // "") attach to the first skill so they don't disappear from the
+  // public plan surface.
+  const buckets = new Map<string, PaiPackImportFile[]>();
+  for (const slug of internal.derivedSkills) buckets.set(slug, []);
+  const firstSlug = internal.derivedSkills[0];
+
+  for (const file of internal.routedFiles) {
+    const slug = file.derivedSkill || firstSlug;
+    if (!slug) continue;
+    if (!buckets.has(slug)) buckets.set(slug, []);
+    const { renderMode: _r, derivedSkill: _d, ...stripped } = file;
+    buckets.get(slug)!.push(stripped);
+  }
+
+  return internal.derivedSkills.map((slug) => ({
+    ...sharedFields,
+    skillName: slug,
+    files: buckets.get(slug) ?? [],
+  }));
 }
 
 async function stagePaiPackFiles(plan: InternalPaiPackImportPlan, stageRoot: string): Promise<void> {
@@ -678,15 +995,19 @@ async function stagePaiPackFiles(plan: InternalPaiPackImportPlan, stageRoot: str
     await mkdir(dirname(stagedTarget), { recursive: true });
 
     if (file.renderMode === "manifest") {
-      await writeFile(stagedTarget, renderManifest(plan), "utf8");
+      // Per-skill soma-pack.json (one per derived skill).
+      await writeFile(stagedTarget, renderManifestForSkill(plan, file.derivedSkill), "utf8");
     } else if (file.renderMode === "archive-manifest") {
       await writeFile(stagedTarget, renderArchiveManifest(plan), "utf8");
     } else if (file.renderMode === "soma-skill-manifest") {
-      await writeFile(stagedTarget, renderSomaSkillManifest(plan), "utf8");
+      await writeFile(stagedTarget, renderSomaSkillManifest(plan, file.derivedSkill), "utf8");
     } else if (file.renderMode === "skill" || file.renderMode === "skill-body") {
       // Reuse the cached normalization computed during plan construction
       // so we don't re-read or re-normalize the same source per Sage's
       // double-pass finding. Fallback: re-read if cache miss.
+      if (!isRoutedSourceFile(file)) {
+        throw new Error(`PAI pack import cannot normalize generated file: ${target}`);
+      }
       const cached = plan.normalizedSkillFiles.get(file.source);
       const normalizedContent = cached
         ? cached.normalized
@@ -698,7 +1019,13 @@ async function stagePaiPackFiles(plan: InternalPaiPackImportPlan, stageRoot: str
       // Workflows/Tools markdown keeps its original frontmatter intact —
       // Sage round-3 important: their identity isn't the root skill's.
       const finalContent = file.renderMode === "skill"
-        ? `${rewriteSkillFrontmatter(normalizedContent, plan.skillName, plan.description).trimEnd()}\n`
+        ? `${rewriteSkillFrontmatter(
+            normalizedContent,
+            file.derivedSkill,
+            file.derivedSkill === plan.packSlug
+              ? plan.description
+              : nestedSkillDescription(file.derivedSkill),
+          ).trimEnd()}\n`
         : `${normalizedContent.trimEnd()}\n`;
       await writeFile(stagedTarget, finalContent, "utf8");
     } else {
@@ -711,8 +1038,8 @@ async function stagePaiPackFiles(plan: InternalPaiPackImportPlan, stageRoot: str
   });
 }
 
-function renderSomaSkillManifest(plan: InternalPaiPackImportPlan): string {
-  const skillRoot = join(plan.somaHome, "skills", plan.skillName);
+function renderSomaSkillManifest(plan: InternalPaiPackImportPlan, skillSlug: string): string {
+  const skillRoot = join(plan.somaHome, "skills", skillSlug);
   const skillRelPath = (target: string): string => relative(skillRoot, target).split(sep).join("/");
   const skillFiles = plan.files.filter((file) => isWithinPath(skillRoot, file.target));
   const skillMd = skillFiles.find((file) => skillRelPath(file.target) === "SKILL.md");
@@ -723,8 +1050,11 @@ function renderSomaSkillManifest(plan: InternalPaiPackImportPlan): string {
     .filter((file) => skillRelPath(file.target).startsWith("Workflows/"))
     .map((file) => skillRelPath(file.target));
   const manifest: SomaSkillManifest = generateSomaSkillManifest({
-    skillName: plan.skillName,
-    description: plan.description,
+    skillName: skillSlug,
+    description:
+      skillSlug === plan.packSlug
+        ? plan.description
+        : nestedSkillDescription(skillSlug),
     packName: plan.packName,
     entrypoint: skillMd ? skillRelPath(skillMd.target) : "SKILL.md",
     references,
@@ -737,62 +1067,79 @@ interface PromotionContext {
   plan: InternalPaiPackImportPlan;
   stageRoot: string;
   backupRoot: string;
-  skillRoot: string;
-  sourceArchiveRoot: string;
   overwrite: boolean;
   cleanupRoots: Set<string>;
 }
 
 async function promoteStagedImportWithRollback(context: PromotionContext): Promise<void> {
-  const { plan, stageRoot, backupRoot, skillRoot, sourceArchiveRoot, overwrite, cleanupRoots } = context;
-  const backupSkillRoot = join(backupRoot, "skills", plan.skillName);
-  const backupArchiveRoot = join(backupRoot, "imports", "pai-packs", plan.skillName);
-  const hadSkillRoot = await pathExists(skillRoot);
-  const hadArchiveRoot = await pathExists(sourceArchiveRoot);
+  const { plan, stageRoot, backupRoot, overwrite, cleanupRoots } = context;
+  const archiveRoot = join(plan.somaHome, "imports", "pai-packs", plan.packSlug);
+  const backupArchiveRoot = join(backupRoot, "imports", "pai-packs", plan.packSlug);
+  const hadArchiveRoot = await pathExists(archiveRoot);
 
-  const stagedSkillRoot = join(stageRoot, "skills", plan.skillName);
-  const stagedArchiveRoot = join(stageRoot, "imports", "pai-packs", plan.skillName);
-  let promotedSkillRoot = false;
+  // Track every skill root that needs to be promoted + backed up.
+  const skillEntries = plan.derivedSkills.map((slug) => {
+    const dest = join(plan.somaHome, "skills", slug);
+    const backup = join(backupRoot, "skills", slug);
+    const staged = join(stageRoot, "skills", slug);
+    return { slug, dest, backup, staged };
+  });
+  const stagedArchiveRoot = join(stageRoot, "imports", "pai-packs", plan.packSlug);
+
+  const hadDest: Record<string, boolean> = {};
+  for (const entry of skillEntries) {
+    hadDest[entry.slug] = await pathExists(entry.dest);
+  }
+
+  const promotedDest = new Set<string>();
   let promotedArchiveRoot = false;
 
   try {
     if (overwrite) {
-      if (hadSkillRoot) {
-        await mkdir(dirname(backupSkillRoot), { recursive: true });
-        await rename(skillRoot, backupSkillRoot);
+      for (const entry of skillEntries) {
+        if (hadDest[entry.slug]) {
+          await mkdir(dirname(entry.backup), { recursive: true });
+          await rename(entry.dest, entry.backup);
+        }
       }
       if (hadArchiveRoot) {
         await mkdir(dirname(backupArchiveRoot), { recursive: true });
-        await rename(sourceArchiveRoot, backupArchiveRoot);
+        await rename(archiveRoot, backupArchiveRoot);
       }
     }
 
-    if (await pathExists(stagedSkillRoot)) {
-      await mkdir(dirname(skillRoot), { recursive: true });
-      await rename(stagedSkillRoot, skillRoot);
-      promotedSkillRoot = true;
+    for (const entry of skillEntries) {
+      if (await pathExists(entry.staged)) {
+        await mkdir(dirname(entry.dest), { recursive: true });
+        await rename(entry.staged, entry.dest);
+        promotedDest.add(entry.slug);
+      }
     }
 
     if (await pathExists(stagedArchiveRoot)) {
-      await mkdir(dirname(sourceArchiveRoot), { recursive: true });
-      await rename(stagedArchiveRoot, sourceArchiveRoot);
+      await mkdir(dirname(archiveRoot), { recursive: true });
+      await rename(stagedArchiveRoot, archiveRoot);
       promotedArchiveRoot = true;
     }
   } catch (error) {
     try {
-      if (promotedSkillRoot) {
-        await rm(skillRoot, { recursive: true, force: true });
+      for (const entry of skillEntries) {
+        if (promotedDest.has(entry.slug)) {
+          await rm(entry.dest, { recursive: true, force: true });
+        }
       }
       if (promotedArchiveRoot) {
-        await rm(sourceArchiveRoot, { recursive: true, force: true });
+        await rm(archiveRoot, { recursive: true, force: true });
       }
-      if (hadSkillRoot && (await pathExists(backupSkillRoot))) {
-        await mkdir(dirname(skillRoot), { recursive: true });
-        await rename(backupSkillRoot, skillRoot);
+      for (const entry of skillEntries) {
+        if (hadDest[entry.slug] && (await pathExists(entry.backup))) {
+          await mkdir(dirname(entry.dest), { recursive: true });
+          await rename(entry.backup, entry.dest);
+        }
       }
       if (hadArchiveRoot && (await pathExists(backupArchiveRoot))) {
-        await mkdir(dirname(sourceArchiveRoot), { recursive: true });
-        await rename(backupArchiveRoot, sourceArchiveRoot);
+        await mkdir(dirname(archiveRoot), { recursive: true });
+        await rename(backupArchiveRoot, archiveRoot);
       }
       await rm(backupRoot, { recursive: true, force: true }).catch(() => undefined);
       cleanupRoots.delete(backupRoot);
@@ -808,28 +1155,39 @@ async function promoteStagedImportWithRollback(context: PromotionContext): Promi
   }
 }
 
-export async function importPaiPack(options: PaiPackImportOptions = {}): Promise<PaiPackImportResult> {
+/**
+ * #105 — public-facing apply function. Returns one
+ * `PaiPackImportResult` per derived skill in the pack (≥ 1 always).
+ *
+ * BREAKING CHANGE: previously returned a single `PaiPackImportResult`.
+ * Callers must adapt to the array shape. The migration orchestrator
+ * is the primary consumer and handles N-per-pack natively. The
+ * standalone `soma import pai-pack` CLI verb iterates over the result
+ * array when rendering its summary.
+ */
+export async function importPaiPack(
+  options: PaiPackImportOptions = {},
+): Promise<PaiPackImportResult[]> {
   const plan = { ...(await buildPaiPackImportPlan(options)), apply: true };
   const written: string[] = [];
-  const skillRoot = join(plan.somaHome, "skills", plan.skillName);
-  const sourceArchiveRoot = join(plan.somaHome, "imports", "pai-packs", plan.skillName);
-  const stageRoot = join(plan.somaHome, ".tmp", `pai-pack-${plan.skillName}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-  const backupRoot = join(plan.somaHome, ".tmp", `pai-pack-backup-${plan.skillName}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const archiveRoot = join(plan.somaHome, "imports", "pai-packs", plan.packSlug);
+  const stageRoot = join(plan.somaHome, ".tmp", `pai-pack-${plan.packSlug}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const backupRoot = join(plan.somaHome, ".tmp", `pai-pack-backup-${plan.packSlug}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   const cleanupRoots = new Set([stageRoot, backupRoot]);
 
   try {
     await mkdir(plan.somaHome, { recursive: true });
     await assertParentWithinRealRoot(plan.somaHome, stageRoot);
-    await assertParentWithinRealRoot(plan.somaHome, skillRoot);
-    await assertParentWithinRealRoot(plan.somaHome, sourceArchiveRoot);
+    for (const slug of plan.derivedSkills) {
+      await assertParentWithinRealRoot(plan.somaHome, join(plan.somaHome, "skills", slug));
+    }
+    await assertParentWithinRealRoot(plan.somaHome, archiveRoot);
 
     await stagePaiPackFiles(plan, stageRoot);
     await promoteStagedImportWithRollback({
       plan,
       stageRoot,
       backupRoot,
-      skillRoot,
-      sourceArchiveRoot,
       overwrite: options.overwrite === true,
       cleanupRoots,
     });
@@ -839,11 +1197,35 @@ export async function importPaiPack(options: PaiPackImportOptions = {}): Promise
     await Promise.allSettled(Array.from(cleanupRoots, (path) => rm(path, { recursive: true, force: true })));
   }
 
-  return {
+  // Per-skill result split. Each skill carries its own files subset so
+  // the migration orchestrator can record N outcome rows.
+  const filesBySlug = new Map<string, string[]>();
+  for (const slug of plan.derivedSkills) filesBySlug.set(slug, []);
+  const firstSlug = plan.derivedSkills[0];
+  const skillRoots = new Map(
+    plan.derivedSkills.map((slug) => [slug, join(plan.somaHome, "skills", slug)]),
+  );
+  for (const target of written) {
+    let placed = false;
+    for (const [slug, root] of skillRoots) {
+      if (isWithinPath(root, target)) {
+        filesBySlug.get(slug)!.push(target);
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      // Archive / pack-level file — attach to first slug so it doesn't
+      // disappear from the result surface.
+      if (firstSlug) filesBySlug.get(firstSlug)!.push(target);
+    }
+  }
+
+  return plan.derivedSkills.map((slug) => ({
     paiPackDir: plan.paiPackDir,
     somaHome: plan.somaHome,
-    skillName: plan.skillName,
-    files: written,
+    skillName: slug,
+    files: filesBySlug.get(slug) ?? [],
     normalization: plan.normalization,
-  };
+  }));
 }

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -709,8 +709,22 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptionsInternal = {}
   // FLAT slug colliding with a nested slug (e.g., pack name "Foo" with
   // nested src/Foo/SKILL.md) is a collision — both would target the
   // same skill root. Refuse with the typed error.
-  if (hasFlatEntry && nestedIndex.some(({ slug }) => slug === packSlug)) {
-    throw new PaiPackNameCollisionRefusal(packSlug, ["src/SKILL.md", `src/${packSlug}/SKILL.md`]);
+  //
+  // Sage r3 #108 CodeQuality (suggestion): use the RAW nested dir name
+  // when building the source path. Previously this template used
+  // `packSlug`, which is kebab-cased — for a `src/PAIUpgrade/SKILL.md`
+  // colliding with pack slug `pai-upgrade`, the refusal would report
+  // `src/pai-upgrade/SKILL.md` (a path that does not exist on disk),
+  // making the error misleading. Resolving via `nestedIndex.raw`
+  // pins the actual filesystem path the principal can inspect.
+  const flatCollidingNested = hasFlatEntry
+    ? nestedIndex.find(({ slug }) => slug === packSlug)
+    : undefined;
+  if (flatCollidingNested) {
+    throw new PaiPackNameCollisionRefusal(packSlug, [
+      "src/SKILL.md",
+      `src/${flatCollidingNested.raw}/SKILL.md`,
+    ]);
   }
 
   if (!options.overwrite) {

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -1060,23 +1060,25 @@ export async function planPaiPackImport(
 }
 
 /**
- * #105 / Sage r2 #108 (Performance) — opaque handle wrapping the
- * internal plan + the resolved option set used to produce it. The
- * migration orchestrator's two-phase apply path uses this to plan
- * once (Phase 1, bounded-concurrent) and apply later (Phase 2,
- * sequential with cross-pack collision filtering) WITHOUT a second
- * full plan rebuild.
+ * #105 / Sage r2 #108 (Performance) — opaque handle for plan-once,
+ * apply-later. The migration orchestrator's two-phase apply path
+ * uses this to plan once (Phase 1, bounded-concurrent) and apply
+ * later (Phase 2, sequential with cross-pack collision filtering)
+ * WITHOUT a second full plan rebuild.
  *
- * Sage r5 #108 (Security, blocker): handles are validated at apply
- * time against a module-private `WeakSet` so forgeries (any object
- * implementing the structural `PaiPackImportPlanHandle` interface)
- * are rejected by `importPaiPackFromPlan`. A caller cannot fabricate
- * a handle that bypasses `buildPaiPackImportPlan`'s `escapedTargets`
- * validation — the only path that adds to the WeakSet is
- * `planPaiPackImportHandle` itself, after the plan was produced by
- * the validated builder. The handle interface is intentionally empty
- * (no addressable fields) so any external attempt to construct one
- * must produce a fresh object that won't be in the WeakSet.
+ * Sage r6 #108 (Security, blocker): the plan data is stored OFF the
+ * handle, in a module-private `WeakMap<handle, planData>`. The
+ * handle itself is a frozen empty object — it carries no addressable
+ * plan state. A caller who legitimately receives a handle cannot
+ * mutate `handle.plan.routedFiles` to bypass containment validation
+ * because there is no `.plan` field to mutate. The WeakMap lookup
+ * is the only path from a handle to its plan, and the WeakMap has
+ * no external accessor.
+ *
+ * Sage r5 #108 (Security, blocker): the same WeakMap doubles as the
+ * trusted-handle set — forged handles (objects fitting the
+ * structural interface but never registered) have no entry and
+ * `castHandle` rejects them with a clear `TypeError`.
  *
  * The trio (`PaiPackImportPlanHandle`, `planPaiPackImportHandle`,
  * `importPaiPackFromPlan`) is module-internal — NOT re-exported on
@@ -1087,28 +1089,30 @@ export interface PaiPackImportPlanHandle {
   readonly __brand: "PaiPackImportPlanHandle";
 }
 
-interface InternalPlanHandle extends PaiPackImportPlanHandle {
+interface TrustedPlanData {
   readonly plan: InternalPaiPackImportPlan;
   readonly options: PaiPackImportOptionsInternal;
 }
 
-// Sage r5 #108 (Security, blocker): module-private WeakSet of handles
-// known to have been produced by the trusted builder. The WeakSet
-// has no public access, so a forged handle (any object matching the
-// structural interface) will not be in it and `castHandle` rejects.
-const TRUSTED_HANDLES = new WeakSet<object>();
+// Sage r6 #108 (Security, blocker): module-private WeakMap from
+// frozen handle → plan data. The handle object never holds the plan
+// directly, so an external caller with a legitimate handle cannot
+// mutate the cached plan in any way. The WeakMap has no external
+// accessor and lookup is the only path from handle to plan.
+const TRUSTED_PLAN_BY_HANDLE = new WeakMap<object, TrustedPlanData>();
 
-function castHandle(handle: PaiPackImportPlanHandle): InternalPlanHandle {
+function castHandle(handle: PaiPackImportPlanHandle): TrustedPlanData {
   if (handle === null || typeof handle !== "object") {
     throw new TypeError("importPaiPackFromPlan: handle must be a PaiPackImportPlanHandle object.");
   }
-  if (!TRUSTED_HANDLES.has(handle)) {
+  const data = TRUSTED_PLAN_BY_HANDLE.get(handle);
+  if (!data) {
     throw new TypeError(
       "importPaiPackFromPlan: handle was not produced by planPaiPackImportHandle. " +
         "Refusing to apply a potentially-forged plan that has not been validated by the builder.",
     );
   }
-  return handle as InternalPlanHandle;
+  return data;
 }
 
 /**
@@ -1127,12 +1131,15 @@ export async function planPaiPackImportHandle(
 ): Promise<{ plans: PaiPackImportPlan[]; handle: PaiPackImportPlanHandle }> {
   const internal = await buildPaiPackImportPlan(options);
   const plans = splitInternalPlanByDerivedSkill(internal);
-  const handle: InternalPlanHandle = { __brand: "PaiPackImportPlanHandle", plan: internal, options };
-  // Sage r5 #108 (Security, blocker): register the handle in the
-  // module-private trusted set. `castHandle` rejects any object not
-  // in this set, so forged handles cannot bypass the builder's
-  // validation (escapedTargets, secret-file refusal, etc.).
-  TRUSTED_HANDLES.add(handle);
+  // Sage r6 #108 (Security, blocker): the handle is a frozen empty
+  // object — it carries NO addressable plan state. The plan lives
+  // in the module-private WeakMap, keyed by the handle. A caller
+  // with a legitimate handle cannot mutate `handle.plan` because
+  // there is no `.plan` field; the only path from handle to plan
+  // is the WeakMap lookup in `castHandle`, which lives in this
+  // module file.
+  const handle = Object.freeze({ __brand: "PaiPackImportPlanHandle" } as const);
+  TRUSTED_PLAN_BY_HANDLE.set(handle, { plan: internal, options });
   return { plans, handle };
 }
 
@@ -1421,12 +1428,12 @@ export async function importPaiPackFromPlan(
   handle: PaiPackImportPlanHandle,
   options: { excludeSkills?: ReadonlySet<string>; overwrite?: boolean } = {},
 ): Promise<PaiPackImportResult[]> {
-  const { plan: cached, options: planOptions } = castHandle(handle);
+  const data = castHandle(handle);
   const excludeSkills = options.excludeSkills ?? new Set<string>();
-  const filtered = filterInternalPlanByExcludes(cached, excludeSkills);
+  const filtered = filterInternalPlanByExcludes(data.plan, excludeSkills);
   // `overwrite` follows the apply-time option; if the caller omits it,
   // fall back to the original plan options.
-  const overwrite = options.overwrite ?? planOptions.overwrite === true;
+  const overwrite = options.overwrite ?? data.options.overwrite === true;
   return applyInternalPlan(filtered, overwrite);
 }
 

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -2,6 +2,7 @@ import { access, copyFile, lstat, mkdir, readdir, readFile, realpath, rename, rm
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { kebabNestedName, routePaiPackSourceFile, type PaiPackRenderMode } from "./pai-pack-routing";
+import { kebabSlug } from "./pai-pack-slug";
 import {
   generateSomaSkillManifest,
   mergeNormalizationReports,
@@ -72,6 +73,26 @@ export class PaiPackReservedNameRefusal extends Error {
     super(`soma import pai-pack cannot overwrite reserved Soma skill '${skillName}'.`);
     this.name = "PaiPackReservedNameRefusal";
     this.skillName = skillName;
+  }
+}
+
+/**
+ * #105 — typed refusal raised when caller's `excludeSkills` filters
+ * out every derived skill in the pack (Sage r1 #108 finding). The
+ * orchestrator catches this and treats it as a successful "no-op"
+ * pack — every excluded slug already has its own
+ * `refused-name-collision` outcome from the pre-check, so the pack
+ * itself doesn't need an additional outcome row.
+ */
+export class PaiPackAllSkillsExcludedRefusal extends Error {
+  readonly kind = "all-skills-excluded" as const;
+  readonly excluded: readonly string[];
+  constructor(excluded: readonly string[]) {
+    super(
+      `PAI pack import: all derived skills excluded (${excluded.join(", ")}). Nothing to import.`,
+    );
+    this.name = "PaiPackAllSkillsExcludedRefusal";
+    this.excluded = excluded;
   }
 }
 
@@ -196,32 +217,13 @@ function resolvePackHomes(options: PaiPackImportOptions = {}): { paiPackDir: str
 
 /**
  * Slugify a pack name into the canonical Soma skill folder name.
- *
- * Exported so the migrate orchestrator (and any future reserved-name
- * preflight) can derive the same slug without duplicating the
- * function — Sage #95 Maintainability finding (avoid drift between
- * the importer's reserved check and the orchestrator's reserved
- * check).
- *
- * Two transformations split CamelCase boundaries before lowercasing:
- *   1. `([A-Z]+)([A-Z][a-z])` → `$1-$2`  — splits ALL-CAPS prefix from
- *      a following Capital+lowercase (e.g., `PAIUpgrade` →
- *      `PAI-Upgrade`, `HTMLParser` → `HTML-Parser`).
- *   2. `([a-z0-9])([A-Z])` → `$1-$2`     — standard CamelCase split
- *      (e.g., `ExtractWisdom` → `Extract-Wisdom`).
- *
- * Order matters: rule 1 runs first so it can fire on `PAI` before
- * rule 2 sees `IU` (no lower-upper boundary there). Then lowercasing
- * and final non-alnum-to-hyphen normalization runs.
+ * Single-source kebab pipeline lives in `src/pai-pack-slug.ts`; this
+ * re-export keeps the migrate orchestrator's existing import path
+ * (`from "./pai-pack-importer"`) stable so callers don't move during
+ * the Sage r1 #108 maintainability fix.
  */
 export function slugifySkillName(value: string): string {
-  return value
-    .trim()
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
-    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+  return kebabSlug(value);
 }
 
 function parseFrontmatter(content: string): Partial<Record<string, string>> {
@@ -652,10 +654,27 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
   // FLAT top-level surface (pack slug) exists iff `src/SKILL.md` is
   // present in the file list; nested skills are the kebab projection
   // of every `src/<Name>/SKILL.md`.
+  //
+  // `options.excludeSkills` (Sage r1 #108) drops slugs the caller has
+  // determined would collide cross-pack. Excluded skills never enter
+  // the plan; their files are never staged or written. The pack-level
+  // surface (archive / docs) still lands because surviving derived
+  // skills depend on it.
   const hasFlatEntry = sourceFiles.includes("src/SKILL.md");
+  const excludeSkills = options.excludeSkills ?? new Set<string>();
   const derivedSkillSet = new Set<string>();
-  if (hasFlatEntry) derivedSkillSet.add(packSlug);
-  for (const { slug } of nestedIndex) derivedSkillSet.add(slug);
+  if (hasFlatEntry && !excludeSkills.has(packSlug)) derivedSkillSet.add(packSlug);
+  for (const { slug } of nestedIndex) {
+    if (!excludeSkills.has(slug)) derivedSkillSet.add(slug);
+  }
+  if (derivedSkillSet.size === 0) {
+    // All derived skills excluded — nothing to import. The orchestrator
+    // emits per-slug `refused-name-collision` outcomes; the pack just
+    // shouldn't run its inner apply.
+    throw new PaiPackAllSkillsExcludedRefusal(
+      Array.from(excludeSkills).sort(),
+    );
+  }
 
   // Each derived skill is also subject to the pack importer's reserved
   // name set; structurally off-limits even for nested bundles.
@@ -720,6 +739,14 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
     //   - route.skillName === null → pack-level (FLAT) slug
     //   - route.skillName !== null → nested skill slug
     const destSkill = route.skillName ?? packSlug;
+    // Sage r1 #108 BLOCKER: skip routed files for any skill that the
+    // caller excluded. The pack-level archive surface (route.root ===
+    // "archive") is unaffected — it lives under the pack slug, not a
+    // skill slug — so substrate-specific files still archive even
+    // when their associated skill is excluded.
+    if (route.root === "skill" && !derivedSkillSet.has(destSkill)) {
+      continue;
+    }
     const destRoot =
       route.root === "skill"
         ? join(homes.somaHome, "skills", destSkill)
@@ -737,7 +764,8 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
   // #105 — pack-level README/INSTALL/VERIFY land under EACH derived
   // skill so each nested skill is independently invocable with the
   // pack's context attached. The base routing only emits one copy
-  // (to the pack-level surface); we replicate it per nested skill.
+  // (to the pack-level surface); we replicate it per nested skill
+  // that survived the exclusion filter.
   for (const docName of REQUIRED_PACK_DOC_FILES) {
     if (!sourceFiles.includes(docName)) continue;
     const targetBasename = {
@@ -748,8 +776,9 @@ async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promi
     if (!targetBasename) continue;
     for (const { slug } of nestedIndex) {
       // Skip if FLAT pack already has this slug — the route already
-      // landed it.
+      // landed it. Skip if the slug was excluded by the caller.
       if (hasFlatEntry && slug === packSlug) continue;
+      if (!derivedSkillSet.has(slug)) continue;
       routedFiles.push({
         source: join(homes.paiPackDir, docName),
         target: join(homes.somaHome, "skills", slug, "references", targetBasename),

--- a/src/pai-pack-importer.ts
+++ b/src/pai-pack-importer.ts
@@ -77,6 +77,26 @@ export class PaiPackReservedNameRefusal extends Error {
 }
 
 /**
+ * #105 — internal extension of `PaiPackImportOptions` for the migration
+ * orchestrator. Adds `excludeSkills`, the cross-pack collision filter.
+ *
+ * Sage r2 #108 Architecture (suggestion): kept OFF the public
+ * `PaiPackImportOptions` surface — the standalone `soma import pai-pack`
+ * CLI never sets it, the inner SDK consumer (migration orchestrator)
+ * imports it from this module directly. Leaks of orchestration-only
+ * options on the public type let downstream callers depend on a contract
+ * we don't intend to support; keeping it module-internal preserves
+ * freedom to revise the collision-filter shape without an SDK break.
+ *
+ * `excludeSkills`: kebab-cased derived skill slugs to omit. Slugs not
+ * present in the pack are silently ignored. Empty/undefined means no
+ * exclusion.
+ */
+export interface PaiPackImportOptionsInternal extends PaiPackImportOptions {
+  excludeSkills?: ReadonlySet<string>;
+}
+
+/**
  * #105 — typed refusal raised when caller's `excludeSkills` filters
  * out every derived skill in the pack (Sage r1 #108 finding). The
  * orchestrator catches this and treats it as a successful "no-op"
@@ -617,7 +637,7 @@ function buildNestedSkillIndex(nestedRawNames: ReadonlySet<string>): NestedSkill
     .sort((a, b) => a.raw.localeCompare(b.raw));
 }
 
-async function buildPaiPackImportPlan(options: PaiPackImportOptions = {}): Promise<InternalPaiPackImportPlan> {
+async function buildPaiPackImportPlan(options: PaiPackImportOptionsInternal = {}): Promise<InternalPaiPackImportPlan> {
   const homes = resolvePackHomes(options);
   const { files: sourceFiles, skippedEditorSymlinks } = await collectFiles(homes.paiPackDir);
   assertSafePackPaths(sourceFiles);
@@ -965,6 +985,56 @@ export async function planPaiPackImport(
 }
 
 /**
+ * #105 / Sage r2 #108 (Performance) — opaque handle wrapping the
+ * internal plan + the resolved option set used to produce it. The
+ * migration orchestrator's two-phase apply path uses this to plan
+ * once (Phase 1, bounded-concurrent) and apply later (Phase 2,
+ * sequential with cross-pack collision filtering) WITHOUT a second
+ * full plan rebuild. On 45 packs that saves a full pass of:
+ *   - directory walk (`collectFiles`)
+ *   - `readPackMetadata`
+ *   - route classification (every source path)
+ *   - normalization (read + normalize every SKILL.md / Workflow .md)
+ *
+ * The handle is opaque to external consumers — the wrapped types are
+ * intentionally module-private so the orchestration contract can
+ * evolve without an SDK break. Built only via
+ * `planPaiPackImportHandle`; consumed only by `importPaiPackFromPlan`.
+ */
+export interface PaiPackImportPlanHandle {
+  readonly __brand: "PaiPackImportPlanHandle";
+}
+
+interface InternalPlanHandle extends PaiPackImportPlanHandle {
+  readonly plan: InternalPaiPackImportPlan;
+  readonly options: PaiPackImportOptionsInternal;
+}
+
+function castHandle(handle: PaiPackImportPlanHandle): InternalPlanHandle {
+  return handle as InternalPlanHandle;
+}
+
+/**
+ * #105 / Sage r2 #108 (Performance) — plan-once API for the migration
+ * orchestrator. Returns the public per-skill plan view (for outcome
+ * reporting) alongside an opaque handle that `importPaiPackFromPlan`
+ * consumes to apply WITHOUT a second plan rebuild.
+ *
+ * Standalone CLI consumers (`soma import pai-pack`) keep using
+ * `planPaiPackImport` + `importPaiPack` — the handle path is an SDK
+ * optimization for callers that already planned and want to apply
+ * the same plan.
+ */
+export async function planPaiPackImportHandle(
+  options: PaiPackImportOptionsInternal = {},
+): Promise<{ plans: PaiPackImportPlan[]; handle: PaiPackImportPlanHandle }> {
+  const internal = await buildPaiPackImportPlan(options);
+  const plans = splitInternalPlanByDerivedSkill(internal);
+  const handle: InternalPlanHandle = { __brand: "PaiPackImportPlanHandle", plan: internal, options };
+  return { plans, handle };
+}
+
+/**
  * #105 — split the single internal plan (which holds every routed
  * file in one bag) into one externally-visible `PaiPackImportPlan`
  * per derived skill. The archive surface (under
@@ -1198,6 +1268,90 @@ export async function importPaiPack(
   options: PaiPackImportOptions = {},
 ): Promise<PaiPackImportResult[]> {
   const plan = { ...(await buildPaiPackImportPlan(options)), apply: true };
+  return applyInternalPlan(plan, options.overwrite === true);
+}
+
+/**
+ * #105 / Sage r2 #108 (Performance) — apply a previously-built plan
+ * WITHOUT a second `buildPaiPackImportPlan` pass. `excludeSkills`
+ * filters the cached internal plan in-memory; the routed-file list is
+ * already grouped by `derivedSkill`, so the filter is O(files) with no
+ * I/O. The stage + promote pipeline is shared with `importPaiPack`.
+ *
+ * Sage r1 #108 collision-filter contract preserved: every excluded
+ * slug is dropped from `routedFiles` BEFORE staging — no excluded
+ * skill ever touches disk. The pack-level archive surface (renderMode
+ * `archive-manifest`, derivedSkill `""`) is unaffected; its
+ * `derivedSkills` field is regenerated from the filtered set.
+ *
+ * Throws `PaiPackAllSkillsExcludedRefusal` if every derived skill is
+ * excluded — matches `importPaiPack`'s contract so the migration
+ * orchestrator's typed-catch path stays identical.
+ */
+export async function importPaiPackFromPlan(
+  handle: PaiPackImportPlanHandle,
+  options: { excludeSkills?: ReadonlySet<string>; overwrite?: boolean } = {},
+): Promise<PaiPackImportResult[]> {
+  const { plan: cached, options: planOptions } = castHandle(handle);
+  const excludeSkills = options.excludeSkills ?? new Set<string>();
+  const filtered = filterInternalPlanByExcludes(cached, excludeSkills);
+  // `overwrite` follows the apply-time option; if the caller omits it,
+  // fall back to the original plan options.
+  const overwrite = options.overwrite ?? planOptions.overwrite === true;
+  return applyInternalPlan(filtered, overwrite);
+}
+
+/**
+ * #105 / Sage r2 #108 — in-memory filter that drops every routed file
+ * whose `derivedSkill` is in `excludeSkills`, prunes the `derivedSkills`
+ * list, and regenerates the per-skill manifest rows so the apply path
+ * sees a coherent plan. Throws `PaiPackAllSkillsExcludedRefusal` when
+ * the filter empties the derived-skill set.
+ *
+ * Archive files (`derivedSkill === ""`) and the pack-level
+ * archive-manifest survive — they aren't tied to any derived skill.
+ * Per-skill manifest rows (`manifest`, `soma-skill-manifest`) are
+ * REGENERATED here because the manifest renderer reads
+ * `plan.derivedSkills` to enumerate sibling skills; filtering it
+ * without regenerating would point a surviving skill's manifest at a
+ * stale list.
+ */
+function filterInternalPlanByExcludes(
+  plan: InternalPaiPackImportPlan,
+  excludeSkills: ReadonlySet<string>,
+): InternalPaiPackImportPlan {
+  if (excludeSkills.size === 0) {
+    return { ...plan, apply: true };
+  }
+  const survivingDerived = plan.derivedSkills.filter((slug) => !excludeSkills.has(slug));
+  if (survivingDerived.length === 0) {
+    throw new PaiPackAllSkillsExcludedRefusal(Array.from(excludeSkills).sort());
+  }
+  const survivingSet = new Set(survivingDerived);
+  const routedFiles: RoutedPaiPackImportFile[] = plan.routedFiles.filter((file) => {
+    if (file.derivedSkill === "") return true; // archive / pack-level
+    return survivingSet.has(file.derivedSkill);
+  });
+  const files = routedFiles.map(({ renderMode: _renderMode, derivedSkill: _derivedSkill, ...rest }) => rest);
+  return {
+    ...plan,
+    apply: true,
+    derivedSkills: survivingDerived,
+    routedFiles,
+    files,
+  };
+}
+
+/**
+ * Shared apply core extracted from `importPaiPack` so the planning-
+ * cache path (`importPaiPackFromPlan`) and the single-shot path share
+ * one stage + promote + result-mapping pipeline. Sage r2 #108
+ * Maintainability — single-source the apply contract.
+ */
+async function applyInternalPlan(
+  plan: InternalPaiPackImportPlan,
+  overwrite: boolean,
+): Promise<PaiPackImportResult[]> {
   const written: string[] = [];
   const archiveRoot = join(plan.somaHome, "imports", "pai-packs", plan.packSlug);
   const stageRoot = join(plan.somaHome, ".tmp", `pai-pack-${plan.packSlug}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -1217,7 +1371,7 @@ export async function importPaiPack(
       plan,
       stageRoot,
       backupRoot,
-      overwrite: options.overwrite === true,
+      overwrite,
       cleanupRoots,
     });
 

--- a/src/pai-pack-routing.ts
+++ b/src/pai-pack-routing.ts
@@ -1,3 +1,4 @@
+import { kebabSlug } from "./pai-pack-slug";
 import type { PaiPackImportFile } from "./types";
 
 export type PaiPackRenderMode = "copy" | "skill" | "skill-body" | "manifest" | "archive-manifest";
@@ -61,28 +62,13 @@ function stripSrcPrefix(path: string): string {
 }
 
 /**
- * Lower-case kebab transform for nested skill folder names. Mirrors
- * `slugifySkillName` in `pai-pack-importer.ts` so a `src/ExtractWisdom/`
- * dir lands at `~/.soma/skills/extract-wisdom/`. Two-step CamelCase
- * split handles both standard boundaries (`ExtractWisdom`) and
- * ALL-CAPS prefix transitions (`PAIUpgrade` → `pai-upgrade`).
- *
- * NOTE: This duplicates `slugifySkillName` rather than importing it
- * because the routing module is a leaf dependency of the importer —
- * importing back from the importer would create a circular import.
- * Any change to either function MUST land in both. Tests in
- * `test/pai-pack-importer-issue-105.test.ts` pin the contract for the
- * routing-level kebab; tests in `test/pai-pack-importer.test.ts` pin
- * the importer-level slug.
+ * Lower-case kebab transform for nested skill folder names. Delegates
+ * to `kebabSlug` so a `src/ExtractWisdom/` dir lands at
+ * `~/.soma/skills/extract-wisdom/`. Single-source — see
+ * `src/pai-pack-slug.ts` for the pipeline + Sage r1 #108 rationale.
  */
 export function kebabNestedName(name: string): string {
-  return name
-    .trim()
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
-    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+  return kebabSlug(name);
 }
 
 /**

--- a/src/pai-pack-routing.ts
+++ b/src/pai-pack-routing.ts
@@ -122,32 +122,28 @@ export function routePaiPackSourceFile(
     };
   }
 
-  if (path === "src/SKILL.md" || PORTABLE_PREFIXES.some((prefix) => path.startsWith(prefix))) {
-    let renderMode: Extract<PaiPackRenderMode, "copy" | "skill" | "skill-body">;
-    if (path === "src/SKILL.md") {
-      // Entry file: normalize body AND rewrite frontmatter to Soma skill identity.
-      renderMode = "skill";
-    } else if (path.endsWith(".md")) {
-      // Workflows/Tools markdown: normalize body ONLY. Preserve original
-      // frontmatter — it isn't the skill entrypoint so it shouldn't
-      // receive the root skill's name/description.
-      renderMode = "skill-body";
-    } else {
-      renderMode = "copy";
-    }
+  // #105 — `src/SKILL.md` is the FLAT entry; always route to the
+  // pack-level skill (no nested override possible — `nestedDirName`
+  // returns null for bare files under src/).
+  if (path === "src/SKILL.md") {
     return {
       classification: "portable",
       root: "skill",
-      relativePath: stripSrcPrefix(path),
-      renderMode,
+      relativePath: "SKILL.md",
+      renderMode: "skill",
       skillName: null,
     };
   }
 
-  // #105 — nested skill bundle detection. The `<Name>` directly under
-  // `src/` is treated as a nested skill iff the caller's nested-skill
-  // set contains it (i.e., `src/<Name>/SKILL.md` exists in the file
-  // list). Without that, the file falls through to substrate-specific.
+  // #105 (Sage r2 #108 CodeQuality important) — nested-skill detection
+  // MUST run before the FLAT `PORTABLE_PREFIXES` check; otherwise a
+  // pack with `src/Tools/SKILL.md` (or `src/Workflows/SKILL.md`) is
+  // misrouted as a flat portable file with `skillName: null` instead
+  // of a nested `tools` (or `workflows`) skill. The detection rule
+  // (nested iff `src/<Name>/SKILL.md` exists in the file set) is
+  // structural — `nestedSkills` already encodes that fact, so we can
+  // safely intercept here without breaking standard FLAT packs whose
+  // nested set is empty.
   const nestedName = nestedDirName(path);
   if (nestedName !== null && nestedSkills.has(nestedName)) {
     const tail = path.slice(`src/${nestedName}/`.length);
@@ -178,6 +174,29 @@ export function routePaiPackSourceFile(
     }
     // src/<Name>/<other> — known nested skill but not a recognized subdir.
     // Fall through to substrate-specific (archive).
+    return {
+      classification: "substrate-specific",
+      root: "archive",
+      relativePath: `source/${path}`,
+      renderMode: "copy",
+      skillName: null,
+    };
+  }
+
+  // FLAT pack portable: `src/Workflows/*` and `src/Tools/*` at the
+  // pack root (no nested override). The nested branch above already
+  // intercepted any case where `Workflows` / `Tools` was the name of
+  // a nested skill, so this branch is unambiguously the FLAT one.
+  if (PORTABLE_PREFIXES.some((prefix) => path.startsWith(prefix))) {
+    const renderMode: Extract<PaiPackRenderMode, "copy" | "skill" | "skill-body"> =
+      path.endsWith(".md") ? "skill-body" : "copy";
+    return {
+      classification: "portable",
+      root: "skill",
+      relativePath: stripSrcPrefix(path),
+      renderMode,
+      skillName: null,
+    };
   }
 
   return {

--- a/src/pai-pack-routing.ts
+++ b/src/pai-pack-routing.ts
@@ -3,11 +3,35 @@ import type { PaiPackImportFile } from "./types";
 export type PaiPackRenderMode = "copy" | "skill" | "skill-body" | "manifest" | "archive-manifest";
 export type PaiPackRouteRoot = "skill" | "archive";
 
+/**
+ * Routing result for a single pack-relative source path.
+ *
+ * `skillName` (#105):
+ *   - `null` when the file belongs to the FLAT top-level skill (pack
+ *     name kebab-cased). The caller already knows the pack-level slug.
+ *   - A kebab-cased nested skill name (e.g. `"remotion"`) when the file
+ *     belongs to a nested bundle at `src/<Name>/...`. The caller routes
+ *     it under `<somaHome>/skills/<skillName>/<relativePath>`.
+ *
+ * `relativePath` is always relative to the eventual skill root —
+ * stripped of the `src/<Name>/` (or `src/`) prefix that lives upstream
+ * of the routed shape. The caller composes the absolute target by
+ * joining `<somaHome>` + `skills` + the resolved skill slug + this.
+ *
+ * Archive routes still carry `relativePath` rooted at the archive's
+ * source/ subtree so the original pack layout survives intact.
+ */
 export interface PaiPackRoute {
   classification: PaiPackImportFile["classification"];
   root: PaiPackRouteRoot;
   relativePath: string;
   renderMode: Extract<PaiPackRenderMode, "copy" | "skill" | "skill-body">;
+  /**
+   * Nested skill slug when the route belongs to a `src/<Name>/...`
+   * bundle (#105); `null` for top-level FLAT files and for archive
+   * routes. Always lower-case kebab.
+   */
+  skillName: string | null;
 }
 
 const SOURCE_DOC_TARGETS: Record<string, string> = {
@@ -19,11 +43,78 @@ const SOURCE_DOC_TARGETS: Record<string, string> = {
 const TEMPLATE_PREFIXES = ["src/DashboardTemplate/", "src/ReportTemplate/"];
 const PORTABLE_PREFIXES = ["src/Workflows/", "src/Tools/"];
 
+/**
+ * Recognized subdirectories under a nested skill bundle. Mirrors the
+ * issue-105 contract table.
+ *
+ *   src/<Name>/SKILL.md         → portable (skill entry)
+ *   src/<Name>/Workflows/<r>    → portable
+ *   src/<Name>/Tools/<r>        → portable
+ *   src/<Name>/References/<r>   → portable
+ *   src/<Name>/Examples/<r>     → portable
+ *   src/<Name>/<other>          → substrate-specific (archive)
+ */
+const NESTED_PORTABLE_SUBDIRS = ["Workflows", "Tools", "References", "Examples"] as const;
+
 function stripSrcPrefix(path: string): string {
   return path.slice("src/".length);
 }
 
-export function routePaiPackSourceFile(path: string): PaiPackRoute {
+/**
+ * Lower-case kebab transform for nested skill folder names. Mirrors
+ * `slugifySkillName` in `pai-pack-importer.ts` so a `src/ExtractWisdom/`
+ * dir lands at `~/.soma/skills/extract-wisdom/`. Two-step CamelCase
+ * split handles both standard boundaries (`ExtractWisdom`) and
+ * ALL-CAPS prefix transitions (`PAIUpgrade` → `pai-upgrade`).
+ *
+ * NOTE: This duplicates `slugifySkillName` rather than importing it
+ * because the routing module is a leaf dependency of the importer —
+ * importing back from the importer would create a circular import.
+ * Any change to either function MUST land in both. Tests in
+ * `test/pai-pack-importer-issue-105.test.ts` pin the contract for the
+ * routing-level kebab; tests in `test/pai-pack-importer.test.ts` pin
+ * the importer-level slug.
+ */
+export function kebabNestedName(name: string): string {
+  return name
+    .trim()
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Match `src/<Name>/<rest>` and return the `<Name>` segment (raw, not
+ * kebabed). `null` if the path doesn't have that shape.
+ */
+function nestedDirName(path: string): string | null {
+  if (!path.startsWith("src/")) return null;
+  const tail = path.slice("src/".length);
+  const slash = tail.indexOf("/");
+  if (slash === -1) return null; // bare file at src root
+  return tail.slice(0, slash);
+}
+
+/**
+ * Classify a pack-relative source path into a route.
+ *
+ * The `nestedSkills` set names the raw (pre-kebab) `<Name>` of every
+ * `src/<Name>/SKILL.md` found in the pack. The router uses it to
+ * distinguish a recognized nested bundle (`src/Remotion/Workflows/...`)
+ * from a generic sibling subdirectory that should stay substrate-
+ * specific (`src/Art/Lib/...`).
+ *
+ * The detection rule (issue 105): a `<Name>` is nested iff
+ * `src/<Name>/SKILL.md` exists in the pack file set. The caller MUST
+ * compute the set BEFORE invoking the router. Without `SKILL.md` the
+ * dir isn't a skill — its files stay substrate-specific.
+ */
+export function routePaiPackSourceFile(
+  path: string,
+  nestedSkills: ReadonlySet<string> = new Set(),
+): PaiPackRoute {
   const sourceDocTarget = SOURCE_DOC_TARGETS[path];
   if (sourceDocTarget) {
     return {
@@ -31,6 +122,7 @@ export function routePaiPackSourceFile(path: string): PaiPackRoute {
       root: "skill",
       relativePath: `references/${sourceDocTarget}`,
       renderMode: "copy",
+      skillName: null,
     };
   }
 
@@ -40,6 +132,7 @@ export function routePaiPackSourceFile(path: string): PaiPackRoute {
       root: "skill",
       relativePath: stripSrcPrefix(path),
       renderMode: "copy",
+      skillName: null,
     };
   }
 
@@ -61,7 +154,44 @@ export function routePaiPackSourceFile(path: string): PaiPackRoute {
       root: "skill",
       relativePath: stripSrcPrefix(path),
       renderMode,
+      skillName: null,
     };
+  }
+
+  // #105 — nested skill bundle detection. The `<Name>` directly under
+  // `src/` is treated as a nested skill iff the caller's nested-skill
+  // set contains it (i.e., `src/<Name>/SKILL.md` exists in the file
+  // list). Without that, the file falls through to substrate-specific.
+  const nestedName = nestedDirName(path);
+  if (nestedName !== null && nestedSkills.has(nestedName)) {
+    const tail = path.slice(`src/${nestedName}/`.length);
+    const slug = kebabNestedName(nestedName);
+    // src/<Name>/SKILL.md — nested skill entry.
+    if (tail === "SKILL.md") {
+      return {
+        classification: "portable",
+        root: "skill",
+        relativePath: "SKILL.md",
+        renderMode: "skill",
+        skillName: slug,
+      };
+    }
+    // src/<Name>/{Workflows,Tools,References,Examples}/<rest>
+    const firstSlash = tail.indexOf("/");
+    if (firstSlash !== -1) {
+      const subdir = tail.slice(0, firstSlash);
+      if ((NESTED_PORTABLE_SUBDIRS as readonly string[]).includes(subdir)) {
+        return {
+          classification: "portable",
+          root: "skill",
+          relativePath: tail,
+          renderMode: tail.endsWith(".md") ? "skill-body" : "copy",
+          skillName: slug,
+        };
+      }
+    }
+    // src/<Name>/<other> — known nested skill but not a recognized subdir.
+    // Fall through to substrate-specific (archive).
   }
 
   return {
@@ -69,5 +199,6 @@ export function routePaiPackSourceFile(path: string): PaiPackRoute {
     root: "archive",
     relativePath: `source/${path}`,
     renderMode: "copy",
+    skillName: null,
   };
 }

--- a/src/pai-pack-slug.ts
+++ b/src/pai-pack-slug.ts
@@ -1,0 +1,31 @@
+/**
+ * Single-source kebab transform for PAI pack / nested skill names.
+ *
+ * Sage r1 #108 Maintainability — previously the same regex pipeline
+ * lived in both `pai-pack-importer.ts:slugifySkillName` and
+ * `pai-pack-routing.ts:kebabNestedName`, with a comment warning that
+ * "Any change to either function MUST land in both." Extracting it
+ * to this leaf module removes the trap: both modules import from
+ * here, no duplication, no circular import.
+ *
+ * Pipeline:
+ *   1. `([A-Z]+)([A-Z][a-z])` → `$1-$2`  — splits ALL-CAPS prefix
+ *      from a following Capital+lowercase (`PAIUpgrade` → `PAI-Upgrade`,
+ *      `HTMLParser` → `HTML-Parser`).
+ *   2. `([a-z0-9])([A-Z])` → `$1-$2`     — standard CamelCase split
+ *      (`ExtractWisdom` → `Extract-Wisdom`).
+ *   3. lowercase → all-non-alnum to `-` → trim leading/trailing `-`.
+ *
+ * Order matters: rule 1 runs first so `PAIUpgrade` matches the
+ * ALL-CAPS prefix branch before rule 2 sees `IU` (no lower-upper
+ * boundary there).
+ */
+export function kebabSlug(value: string): string {
+  return value
+    .trim()
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -400,6 +400,20 @@ export interface PaiPackImportOptions {
   skillName?: string;
   overwrite?: boolean;
   includeSubstrateSpecific?: boolean;
+  /**
+   * #105 — kebab-cased derived skill slugs to omit from the import.
+   * Used by the migration orchestrator to skip cross-pack name
+   * collisions WITHOUT staging or writing the collided skill — the
+   * file-system surface is touched only for slugs that survived the
+   * orchestrator's collision check. Other derived skills in the same
+   * pack still land.
+   *
+   * Empty / undefined means no exclusion (import every derived skill
+   * the pack produces). Slugs not present in the pack are silently
+   * ignored — the migration orchestrator can pre-populate the set
+   * without re-checking pack membership.
+   */
+  excludeSkills?: ReadonlySet<string>;
 }
 
 export interface PaiPackImportFileBase {

--- a/src/types.ts
+++ b/src/types.ts
@@ -490,6 +490,16 @@ export interface PaiPackManifest {
   description: string;
   files: PaiPackManifestFile[];
   normalization?: PaiPackNormalizationReport;
+  /**
+   * #105 — when the pack archive manifest is rendered (the
+   * `<somaHome>/imports/pai-packs/<pack-slug>/soma-pack-archive.json`
+   * surface), every Soma skill derived from the pack is listed here in
+   * sorted order. For per-skill manifests (`<somaHome>/skills/<slug>/
+   * soma-pack.json`) the field is omitted. Single-skill packs still
+   * emit the field on the archive manifest (one-element array) so the
+   * archive shape is stable across FLAT and nested layouts.
+   */
+  derivedSkills?: string[];
 }
 
 export interface SomaSkillManifest {
@@ -550,6 +560,23 @@ export type PaiPackOutcomeKind =
   | "imported"
   | "refused-substrate-specific"
   | "refused-reserved"
+  /**
+   * #105 — emitted when a derived skill's kebab-cased name collides
+   * with an already-landed Soma skill. Two flavors:
+   *
+   *   1. **Within one pack** — two `src/<Name>/SKILL.md` files kebab to
+   *      the same slug. The pack importer throws
+   *      `PaiPackNameCollisionRefusal`; the migration orchestrator
+   *      classifies it `refused-name-collision`.
+   *   2. **Across packs** — Pack A landed `browser`, Pack B's nested
+   *      `Browser` would also kebab to `browser`. The second pack's
+   *      derived skill records `refused-name-collision` unless
+   *      `--overwrite-reserved` is set.
+   *
+   * `outcome.skillName` is the colliding slug; `outcome.reason`
+   * names which pack already owned the surface.
+   */
+  | "refused-name-collision"
   | "refused-other";
 
 export interface PaiPackOutcome {

--- a/src/types.ts
+++ b/src/types.ts
@@ -400,20 +400,6 @@ export interface PaiPackImportOptions {
   skillName?: string;
   overwrite?: boolean;
   includeSubstrateSpecific?: boolean;
-  /**
-   * #105 — kebab-cased derived skill slugs to omit from the import.
-   * Used by the migration orchestrator to skip cross-pack name
-   * collisions WITHOUT staging or writing the collided skill — the
-   * file-system surface is touched only for slugs that survived the
-   * orchestrator's collision check. Other derived skills in the same
-   * pack still land.
-   *
-   * Empty / undefined means no exclusion (import every derived skill
-   * the pack produces). Slugs not present in the pack are silently
-   * ignored — the migration orchestrator can pre-populate the set
-   * without re-checking pack membership.
-   */
-  excludeSkills?: ReadonlySet<string>;
 }
 
 export interface PaiPackImportFileBase {

--- a/test/fixtures/pai-pack-fixtures.ts
+++ b/test/fixtures/pai-pack-fixtures.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared PAI-pack fixture builders for issue 105 (+ R2/R3 follow-ups
+ * on PR #108).
+ *
+ * Sage r3 #108 (Maintainability suggestion): two test files previously
+ * defined `writeFlatPack` independently — drifted helpers raise the
+ * cost of evolving the canonical pack shape (e.g. the README/INSTALL/
+ * VERIFY contract or the SKILL.md frontmatter). Single-sourcing the
+ * builders here pins the shape and keeps the tests focused on what
+ * they're asserting, not how to set up a pack.
+ *
+ * Test-only helpers; not part of the public package surface.
+ */
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Minimal FLAT pack with `src/SKILL.md` + `src/Workflows/Run.md` + the
+ * three required pack-level docs. The pack's `name` (in README and
+ * SKILL.md frontmatter) defaults to "Flat"; callers override per test.
+ */
+export async function writeFlatPack(packDir: string, packName = "Flat"): Promise<void> {
+  await mkdir(join(packDir, "src/Workflows"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    ["---", `name: ${packName}`, `description: Flat pack`, "---", "", `# ${packName}`, "", "Pack docs.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    ["---", `name: ${packName}`, "description: flat", "---", "", `# ${packName}`, "", "Body.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "src/Workflows/Run.md"), "# Run\n", "utf8");
+}
+
+/**
+ * Pack with no FLAT entry — pure-nested layout, just the docs at the
+ * pack root. Pairs with `writeNestedSkill` to assemble multi-skill
+ * nested packs.
+ */
+export async function writeNestedPackShell(packDir: string, packName: string): Promise<void> {
+  await mkdir(join(packDir, "src"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    ["---", `name: ${packName}`, `description: Nested pack`, "---", "", `# ${packName}`, "", "Pack docs.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+}
+
+/**
+ * A nested skill bundle under `<packDir>/src/<nestedName>/` with its
+ * own `SKILL.md` + `Workflows/Default.md`. The optional `extras`
+ * list adds sibling subdirs (each gets a `demo.txt`) so tests can
+ * pin substrate-specific vs portable routing for `src/<Name>/<other>`
+ * cases.
+ */
+export async function writeNestedSkill(
+  packDir: string,
+  nestedName: string,
+  options: { extras?: string[] } = {},
+): Promise<void> {
+  const base = join(packDir, "src", nestedName);
+  await mkdir(join(base, "Workflows"), { recursive: true });
+  await writeFile(
+    join(base, "SKILL.md"),
+    [
+      "---",
+      `name: ${nestedName}`,
+      `description: Nested ${nestedName} skill`,
+      "---",
+      "",
+      `# ${nestedName}`,
+      "",
+      "Body.\n",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(base, "Workflows/Default.md"), `# ${nestedName} Default\n`, "utf8");
+  for (const extra of options.extras ?? []) {
+    await mkdir(join(base, extra), { recursive: true });
+    await writeFile(join(base, extra, "demo.txt"), "demo\n", "utf8");
+  }
+}
+
+/**
+ * Mixed pack — FLAT entry + two nested skills (one named to collide
+ * with the existing FLAT portable PORTABLE_PREFIXES set: "Tools").
+ * Used by R2 #1 regression tests to confirm nested detection runs
+ * BEFORE the flat-portable branch.
+ */
+export async function writeFlatNestedPack(packDir: string, packName = "Mixed"): Promise<void> {
+  await mkdir(join(packDir, "src/Workflows"), { recursive: true });
+  await mkdir(join(packDir, "src/Tools/Workflows"), { recursive: true });
+  await mkdir(join(packDir, "src/Remotion/Workflows"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    ["---", `name: ${packName}`, `description: Mixed pack`, "---", "", `# ${packName}`, "", "Pack docs.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    ["---", `name: ${packName}`, "description: flat", "---", "", `# ${packName}`, "", "Flat body.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "src/Workflows/Run.md"), "# Run\n", "utf8");
+  // Nested "Tools" — must NOT flatten as FLAT portable.
+  await writeFile(
+    join(packDir, "src/Tools/SKILL.md"),
+    ["---", `name: Tools`, "description: nested tools skill", "---", "", `# Tools`, "", "Tools body.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "src/Tools/Workflows/Helper.md"), "# Helper\n", "utf8");
+  // Plain nested skill (sanity baseline)
+  await writeFile(
+    join(packDir, "src/Remotion/SKILL.md"),
+    ["---", `name: Remotion`, "description: nested remotion", "---", "", `# Remotion`, "", "Remotion body.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "src/Remotion/Workflows/Render.md"), "# Render\n", "utf8");
+}

--- a/test/pai-migration-issue-105.test.ts
+++ b/test/pai-migration-issue-105.test.ts
@@ -212,6 +212,68 @@ test("AC-3: FLAT pack still imports as one outcome row (backwards compat)", asyn
 // plan mode mirrors apply mode
 // ───────────────────────────────────────────────────────────────────────
 
+// ───────────────────────────────────────────────────────────────────────
+// Sage R1 #108 BLOCKER regression — collided skill NEVER touches disk
+// ───────────────────────────────────────────────────────────────────────
+
+test("Sage r1 #108: cross-pack collision: refused skill's bytes never overwrite the winner", async () => {
+  // The previous implementation called `importPaiPack` for the
+  // colliding pack BEFORE checking collisions, so the second pack's
+  // bytes overwrote the first pack's `browser` skill on disk while
+  // the outcome reported `refused-name-collision`. The fix is the
+  // two-phase plan-then-apply with `excludeSkills` filtering: the
+  // colliding pack runs `importPaiPack` with `excludeSkills: {browser}`,
+  // so no file under `~/.soma/skills/browser/` is staged or written.
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
+    // Pack A — flat `Browser` skill with distinctive body content.
+    const packA = join(packsDir, "Browser");
+    await mkdir(join(packA, "src/Workflows"), { recursive: true });
+    await writeFile(
+      join(packA, "README.md"),
+      "---\nname: Browser\ndescription: A\n---\n\n# Browser\n",
+      "utf8",
+    );
+    await writeFile(join(packA, "INSTALL.md"), "# Install A\n", "utf8");
+    await writeFile(join(packA, "VERIFY.md"), "# Verify A\n", "utf8");
+    await writeFile(
+      join(packA, "src/SKILL.md"),
+      "---\nname: Browser\ndescription: A\n---\n\n# Browser pack A — DISTINCT_A\n",
+      "utf8",
+    );
+
+    // Pack B — nested Browser inside Utilities with different bytes.
+    const packB = join(packsDir, "Utilities");
+    await mkdir(join(packB, "src/Browser/Workflows"), { recursive: true });
+    await writeFile(
+      join(packB, "README.md"),
+      "---\nname: Utilities\ndescription: B\n---\n\n# Utilities\n",
+      "utf8",
+    );
+    await writeFile(join(packB, "INSTALL.md"), "# Install B\n", "utf8");
+    await writeFile(join(packB, "VERIFY.md"), "# Verify B\n", "utf8");
+    await writeFile(
+      join(packB, "src/Browser/SKILL.md"),
+      "---\nname: Browser\ndescription: B\n---\n\n# Utilities/Browser — DISTINCT_B\n",
+      "utf8",
+    );
+    await writeFile(join(packB, "src/Browser/Workflows/Default.md"), "# Utilities/Browser Default\n", "utf8");
+
+    const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true });
+
+    // Pack A's `Browser` won — its bytes are on disk untouched.
+    const browserSkillMd = await readFile(
+      join(homeDir, ".soma/skills/browser/SKILL.md"),
+      "utf8",
+    );
+    expect(browserSkillMd).toContain("DISTINCT_A");
+    expect(browserSkillMd).not.toContain("DISTINCT_B");
+
+    // The refusal is recorded for pack B's nested browser.
+    const collisions = result.packOutcomes.filter((o) => o.outcome === "refused-name-collision");
+    expect(collisions.some((o) => o.skillName === "browser")).toBe(true);
+  });
+});
+
 test("plan mode produces same per-skill outcome rows for nested packs", async () => {
   await withMigrationHome(async ({ homeDir, packsDir }) => {
     await writeNestedPack(packsDir, "Media", ["Art", "Remotion"]);

--- a/test/pai-migration-issue-105.test.ts
+++ b/test/pai-migration-issue-105.test.ts
@@ -27,10 +27,19 @@ import {
   withTempHome as withSharedTempHome,
   writePaiIdentityFixture as writeIdentityFixture,
 } from "./fixtures/pai-migration-fixtures";
+import { writeNestedPackShell, writeNestedSkill } from "./fixtures/pai-pack-fixtures";
 
 const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
   withSharedTempHome(fn, "soma-105-");
 
+/**
+ * Sage r4 #108 (Maintainability suggestion): compose this multi-skill
+ * nested pack from the shared `writeNestedPackShell` +
+ * `writeNestedSkill` builders so the canonical pack shape is single-
+ * sourced in `test/fixtures/pai-pack-fixtures.ts`. The function still
+ * lives here because the (pack, [skills]) signature is migration-test
+ * specific.
+ */
 async function writeNestedPack(
   packsDir: string,
   packName: string,
@@ -38,22 +47,9 @@ async function writeNestedPack(
 ): Promise<string> {
   const packDir = join(packsDir, packName);
   await mkdir(packDir, { recursive: true });
-  await writeFile(
-    join(packDir, "README.md"),
-    `---\nname: ${packName}\ndescription: ${packName} pack\n---\n\n# ${packName}\n\nFixture.\n`,
-    "utf8",
-  );
-  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
-  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
-  await mkdir(join(packDir, "src"), { recursive: true });
+  await writeNestedPackShell(packDir, packName);
   for (const skill of skills) {
-    await mkdir(join(packDir, "src", skill, "Workflows"), { recursive: true });
-    await writeFile(
-      join(packDir, "src", skill, "SKILL.md"),
-      `---\nname: ${skill}\ndescription: nested ${skill}\n---\n\n# ${skill}\n\nBody.\n`,
-      "utf8",
-    );
-    await writeFile(join(packDir, "src", skill, "Workflows/Default.md"), `# ${skill} Default\n`, "utf8");
+    await writeNestedSkill(packDir, skill);
   }
   return packDir;
 }

--- a/test/pai-migration-issue-105.test.ts
+++ b/test/pai-migration-issue-105.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Issue 105 — migration orchestrator: handle N-skills-per-pack from
+ * nested skill bundles, plus cross-pack name collisions.
+ *
+ * The pack importer (`importPaiPack`) now returns
+ * `PaiPackImportResult[]` (Option A breaking change shipped in this
+ * PR). The orchestrator must:
+ *
+ *  - Treat each derived skill in a pack as its own outcome row in
+ *    `packOutcomes`. A pack with N derived skills produces ≥ N
+ *    outcome rows (N successes, or fewer + refusals).
+ *  - Detect cross-pack name collisions: if Pack A landed `browser`
+ *    and Pack B's nested `Browser` would also kebab to `browser`, the
+ *    second pack's `browser` derived skill records
+ *    `refused-name-collision` unless `--overwrite-reserved`-style
+ *    flow permits it. (Per issue body: `--overwrite` flag on the
+ *    pack-import call permits, mirrored at migrate level.)
+ *  - Handle the within-pack collision (two derived skills kebab to
+ *    the same name) by passing the typed refusal up — the orchestrator
+ *    records `refused-name-collision` for the whole pack and continues.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { migratePai, planPaiMigration } from "../src/pai-migration";
+import {
+  withTempHome as withSharedTempHome,
+  writePaiIdentityFixture as writeIdentityFixture,
+} from "./fixtures/pai-migration-fixtures";
+
+const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
+  withSharedTempHome(fn, "soma-105-");
+
+async function writeNestedPack(
+  packsDir: string,
+  packName: string,
+  skills: string[],
+): Promise<string> {
+  const packDir = join(packsDir, packName);
+  await mkdir(packDir, { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    `---\nname: ${packName}\ndescription: ${packName} pack\n---\n\n# ${packName}\n\nFixture.\n`,
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  await mkdir(join(packDir, "src"), { recursive: true });
+  for (const skill of skills) {
+    await mkdir(join(packDir, "src", skill, "Workflows"), { recursive: true });
+    await writeFile(
+      join(packDir, "src", skill, "SKILL.md"),
+      `---\nname: ${skill}\ndescription: nested ${skill}\n---\n\n# ${skill}\n\nBody.\n`,
+      "utf8",
+    );
+    await writeFile(join(packDir, "src", skill, "Workflows/Default.md"), `# ${skill} Default\n`, "utf8");
+  }
+  return packDir;
+}
+
+async function withMigrationHome<T>(
+  fn: (ctx: { homeDir: string; packsDir: string }) => Promise<T>,
+): Promise<T> {
+  return withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    return fn({ homeDir, packsDir });
+  });
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-2 / AC-4: N-per-pack lands as N skills in the migration outcome
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-2: nested pack with 2 skills produces 2 imported outcome rows", async () => {
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
+    await writeNestedPack(packsDir, "Media", ["Art", "Remotion"]);
+
+    const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true });
+
+    // Two outcome rows — one per derived skill.
+    const skillNames = result.packOutcomes
+      .filter((o) => o.outcome === "imported")
+      .map((o) => o.skillName)
+      .sort();
+    expect(skillNames).toEqual(["art", "remotion"]);
+
+    // Two pack-import-result objects (one per derived skill).
+    const importedNames = result.packs.map((p) => p.skillName).sort();
+    expect(importedNames).toEqual(["art", "remotion"]);
+
+    // The two skills landed in the Soma home.
+    for (const name of ["art", "remotion"]) {
+      const path = join(homeDir, ".soma/skills", name, "SKILL.md");
+      const bytes = await readFile(path, "utf8");
+      expect(bytes.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-5: Cross-pack name collision
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-5: cross-pack name collision records refused-name-collision for the second pack", async () => {
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
+    // Pack A: flat pack named "Browser".
+    const packA = join(packsDir, "Browser");
+    await mkdir(join(packA, "src/Workflows"), { recursive: true });
+    await writeFile(
+      join(packA, "README.md"),
+      "---\nname: Browser\ndescription: A\n---\n\n# Browser\n",
+      "utf8",
+    );
+    await writeFile(join(packA, "INSTALL.md"), "# Install\n", "utf8");
+    await writeFile(join(packA, "VERIFY.md"), "# Verify\n", "utf8");
+    await writeFile(
+      join(packA, "src/SKILL.md"),
+      "---\nname: Browser\ndescription: A\n---\n\n# Browser\n",
+      "utf8",
+    );
+
+    // Pack B: nested pack containing src/Browser/SKILL.md.
+    await writeNestedPack(packsDir, "Utilities", ["Browser"]);
+
+    const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true });
+
+    const importedNames = result.packOutcomes
+      .filter((o) => o.outcome === "imported")
+      .map((o) => o.skillName)
+      .sort();
+
+    // First pack's `browser` wins; second pack's nested `browser` collides.
+    expect(importedNames).toContain("browser");
+
+    const refusedCollisions = result.packOutcomes.filter(
+      (o) => o.outcome === "refused-name-collision",
+    );
+    expect(refusedCollisions.length).toBeGreaterThanOrEqual(1);
+    expect(refusedCollisions.some((o) => o.skillName === "browser")).toBe(true);
+  });
+});
+
+test("AC-5: cross-pack collision with --overwrite-reserved-equivalent flag — second wins", async () => {
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
+    const packA = join(packsDir, "Browser");
+    await mkdir(join(packA, "src/Workflows"), { recursive: true });
+    await writeFile(
+      join(packA, "README.md"),
+      "---\nname: Browser\ndescription: A\n---\n\n# Browser\n",
+      "utf8",
+    );
+    await writeFile(join(packA, "INSTALL.md"), "# Install A\n", "utf8");
+    await writeFile(join(packA, "VERIFY.md"), "# Verify A\n", "utf8");
+    await writeFile(
+      join(packA, "src/SKILL.md"),
+      "---\nname: Browser\ndescription: A\n---\n\n# Browser pack A\n",
+      "utf8",
+    );
+
+    await writeNestedPack(packsDir, "Utilities", ["Browser"]);
+
+    // Note: `overwriteReserved` repurposed at migrate level to permit name
+    // collisions across packs as well. (Simpler than adding a fresh flag;
+    // the principal already opted in to overwriting canonical surfaces.)
+    const result = await migratePai({
+      homeDir,
+      paiPacksDir: packsDir,
+      skipMemory: true,
+      overwriteReserved: true,
+    });
+
+    // Both packs' browsers should appear in outcomes; one wins on disk.
+    const imported = result.packOutcomes
+      .filter((o) => o.outcome === "imported")
+      .map((o) => o.skillName);
+    expect(imported.filter((n) => n === "browser").length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-3 backwards compat: FLAT packs still produce single outcome
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-3: FLAT pack still imports as one outcome row (backwards compat)", async () => {
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
+    const packDir = join(packsDir, "Single");
+    await mkdir(join(packDir, "src/Workflows"), { recursive: true });
+    await writeFile(
+      join(packDir, "README.md"),
+      "---\nname: Single\ndescription: flat\n---\n\n# Single\n",
+      "utf8",
+    );
+    await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+    await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+    await writeFile(
+      join(packDir, "src/SKILL.md"),
+      "---\nname: Single\ndescription: flat\n---\n\n# Single\n",
+      "utf8",
+    );
+    await writeFile(join(packDir, "src/Workflows/Run.md"), "# Run\n", "utf8");
+
+    const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true });
+
+    expect(result.packs).toHaveLength(1);
+    expect(result.packs[0].skillName).toBe("single");
+    expect(result.packOutcomes.filter((o) => o.outcome === "imported")).toHaveLength(1);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// plan mode mirrors apply mode
+// ───────────────────────────────────────────────────────────────────────
+
+test("plan mode produces same per-skill outcome rows for nested packs", async () => {
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
+    await writeNestedPack(packsDir, "Media", ["Art", "Remotion"]);
+
+    const plan = await planPaiMigration({ homeDir, paiPacksDir: packsDir, skipMemory: true });
+
+    const planned = plan.packOutcomes
+      .filter((o) => o.outcome === "imported")
+      .map((o) => o.skillName)
+      .sort();
+    expect(planned).toEqual(["art", "remotion"]);
+    expect(plan.packs).toHaveLength(2);
+  });
+});

--- a/test/pai-migration-issue-105.test.ts
+++ b/test/pai-migration-issue-105.test.ts
@@ -27,7 +27,7 @@ import {
   withTempHome as withSharedTempHome,
   writePaiIdentityFixture as writeIdentityFixture,
 } from "./fixtures/pai-migration-fixtures";
-import { writeNestedPackShell, writeNestedSkill } from "./fixtures/pai-pack-fixtures";
+import { writeFlatPack, writeNestedPackShell, writeNestedSkill } from "./fixtures/pai-pack-fixtures";
 
 const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
   withSharedTempHome(fn, "soma-105-");
@@ -101,20 +101,7 @@ test("AC-2: nested pack with 2 skills produces 2 imported outcome rows", async (
 test("AC-5: cross-pack name collision records refused-name-collision for the second pack", async () => {
   await withMigrationHome(async ({ homeDir, packsDir }) => {
     // Pack A: flat pack named "Browser".
-    const packA = join(packsDir, "Browser");
-    await mkdir(join(packA, "src/Workflows"), { recursive: true });
-    await writeFile(
-      join(packA, "README.md"),
-      "---\nname: Browser\ndescription: A\n---\n\n# Browser\n",
-      "utf8",
-    );
-    await writeFile(join(packA, "INSTALL.md"), "# Install\n", "utf8");
-    await writeFile(join(packA, "VERIFY.md"), "# Verify\n", "utf8");
-    await writeFile(
-      join(packA, "src/SKILL.md"),
-      "---\nname: Browser\ndescription: A\n---\n\n# Browser\n",
-      "utf8",
-    );
+    await writeFlatPack(join(packsDir, "Browser"), "Browser");
 
     // Pack B: nested pack containing src/Browser/SKILL.md.
     await writeNestedPack(packsDir, "Utilities", ["Browser"]);
@@ -139,21 +126,7 @@ test("AC-5: cross-pack name collision records refused-name-collision for the sec
 
 test("AC-5: cross-pack collision with --overwrite-reserved-equivalent flag — second wins", async () => {
   await withMigrationHome(async ({ homeDir, packsDir }) => {
-    const packA = join(packsDir, "Browser");
-    await mkdir(join(packA, "src/Workflows"), { recursive: true });
-    await writeFile(
-      join(packA, "README.md"),
-      "---\nname: Browser\ndescription: A\n---\n\n# Browser\n",
-      "utf8",
-    );
-    await writeFile(join(packA, "INSTALL.md"), "# Install A\n", "utf8");
-    await writeFile(join(packA, "VERIFY.md"), "# Verify A\n", "utf8");
-    await writeFile(
-      join(packA, "src/SKILL.md"),
-      "---\nname: Browser\ndescription: A\n---\n\n# Browser pack A\n",
-      "utf8",
-    );
-
+    await writeFlatPack(join(packsDir, "Browser"), "Browser");
     await writeNestedPack(packsDir, "Utilities", ["Browser"]);
 
     // Note: `overwriteReserved` repurposed at migrate level to permit name
@@ -180,21 +153,7 @@ test("AC-5: cross-pack collision with --overwrite-reserved-equivalent flag — s
 
 test("AC-3: FLAT pack still imports as one outcome row (backwards compat)", async () => {
   await withMigrationHome(async ({ homeDir, packsDir }) => {
-    const packDir = join(packsDir, "Single");
-    await mkdir(join(packDir, "src/Workflows"), { recursive: true });
-    await writeFile(
-      join(packDir, "README.md"),
-      "---\nname: Single\ndescription: flat\n---\n\n# Single\n",
-      "utf8",
-    );
-    await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
-    await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
-    await writeFile(
-      join(packDir, "src/SKILL.md"),
-      "---\nname: Single\ndescription: flat\n---\n\n# Single\n",
-      "utf8",
-    );
-    await writeFile(join(packDir, "src/Workflows/Run.md"), "# Run\n", "utf8");
+    await writeFlatPack(join(packsDir, "Single"), "Single");
 
     const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true });
 
@@ -221,32 +180,27 @@ test("Sage r1 #108: cross-pack collision: refused skill's bytes never overwrite 
   // colliding pack runs `importPaiPack` with `excludeSkills: {browser}`,
   // so no file under `~/.soma/skills/browser/` is staged or written.
   await withMigrationHome(async ({ homeDir, packsDir }) => {
-    // Pack A — flat `Browser` skill with distinctive body content.
+    // Pack A — flat `Browser` skill with distinctive body content
+    // (DISTINCT_A). Built from the shared fixture; the SKILL.md body
+    // is overridden so the test can assert pack-A's bytes are on
+    // disk after the collision is recorded.
     const packA = join(packsDir, "Browser");
-    await mkdir(join(packA, "src/Workflows"), { recursive: true });
-    await writeFile(
-      join(packA, "README.md"),
-      "---\nname: Browser\ndescription: A\n---\n\n# Browser\n",
-      "utf8",
-    );
-    await writeFile(join(packA, "INSTALL.md"), "# Install A\n", "utf8");
-    await writeFile(join(packA, "VERIFY.md"), "# Verify A\n", "utf8");
+    await writeFlatPack(packA, "Browser");
     await writeFile(
       join(packA, "src/SKILL.md"),
       "---\nname: Browser\ndescription: A\n---\n\n# Browser pack A — DISTINCT_A\n",
       "utf8",
     );
 
-    // Pack B — nested Browser inside Utilities with different bytes.
+    // Pack B — nested Browser inside Utilities with DISTINCT_B body.
+    // Composed from the shared nested-pack-shell + nested-skill
+    // builders so the canonical pack shape is single-sourced; the
+    // SKILL.md body and Workflow default are overridden for the
+    // collision assertion.
     const packB = join(packsDir, "Utilities");
-    await mkdir(join(packB, "src/Browser/Workflows"), { recursive: true });
-    await writeFile(
-      join(packB, "README.md"),
-      "---\nname: Utilities\ndescription: B\n---\n\n# Utilities\n",
-      "utf8",
-    );
-    await writeFile(join(packB, "INSTALL.md"), "# Install B\n", "utf8");
-    await writeFile(join(packB, "VERIFY.md"), "# Verify B\n", "utf8");
+    await mkdir(packB, { recursive: true });
+    await writeNestedPackShell(packB, "Utilities");
+    await writeNestedSkill(packB, "Browser");
     await writeFile(
       join(packB, "src/Browser/SKILL.md"),
       "---\nname: Browser\ndescription: B\n---\n\n# Utilities/Browser — DISTINCT_B\n",

--- a/test/pai-pack-importer-issue-104.test.ts
+++ b/test/pai-pack-importer-issue-104.test.ts
@@ -90,7 +90,9 @@ test("AC-1+AC-2: `.cursor/rules/*.mdc` symlink is skipped, pack imports, audit r
     await symlink(externalRule, join(packDir, "src/Tools/.cursor/rules/use-bun.mdc"));
 
     // Plan must succeed — no `refused symlink` throw.
-    const plan = await planPaiPackImport({ homeDir, paiPackDir: packDir });
+    // #105 — `planPaiPackImport` returns one plan per derived skill.
+    // Single-skill packs (no nested SKILL.md) produce a one-element array.
+    const [plan] = await planPaiPackImport({ homeDir, paiPackDir: packDir });
     expect(plan.skillName).toBe("demo");
 
     // The cursor symlink must NOT appear in the routed file set.
@@ -104,7 +106,7 @@ test("AC-1+AC-2: `.cursor/rules/*.mdc` symlink is skipped, pack imports, audit r
     expect(skipActions[0]?.file).toBe("src/Tools/.cursor/rules/use-bun.mdc");
 
     // AC-1: apply path also succeeds end-to-end.
-    const result = await importPaiPack({ homeDir, paiPackDir: packDir });
+    const [result] = await importPaiPack({ homeDir, paiPackDir: packDir });
     expect(result.skillName).toBe("demo");
     expect(result.normalization.actions.some((a) => a.kind === "skipped-editor-config-symlink")).toBe(true);
 
@@ -128,7 +130,7 @@ test("AC-2: `.vscode/settings.json` symlink is skipped, pack imports, audit reco
     await mkdir(join(packDir, ".vscode"), { recursive: true });
     await symlink(externalSettings, join(packDir, ".vscode/settings.json"));
 
-    const plan = await planPaiPackImport({ homeDir, paiPackDir: packDir });
+    const [plan] = await planPaiPackImport({ homeDir, paiPackDir: packDir });
     expect(plan.files.every((file) => !file.target.includes(".vscode/"))).toBe(true);
     const skipActions = plan.normalization.actions.filter(
       (action) => action.kind === "skipped-editor-config-symlink",
@@ -136,7 +138,7 @@ test("AC-2: `.vscode/settings.json` symlink is skipped, pack imports, audit reco
     expect(skipActions).toHaveLength(1);
     expect(skipActions[0]?.file).toBe(".vscode/settings.json");
 
-    const result = await importPaiPack({ homeDir, paiPackDir: packDir });
+    const [result] = await importPaiPack({ homeDir, paiPackDir: packDir });
     expect(result.skillName).toBe("demo");
   });
 });
@@ -195,7 +197,7 @@ test("AC-4: mixed pack with editor symlinks AND normal files imports cleanly wit
     await mkdir(join(packDir, ".idea"), { recursive: true });
     await symlink(externalIdea, join(packDir, ".idea/workspace.xml"));
 
-    const plan = await planPaiPackImport({ homeDir, paiPackDir: packDir });
+    const [plan] = await planPaiPackImport({ homeDir, paiPackDir: packDir });
 
     // Audit has exactly 2 skip entries.
     const skipActions = plan.normalization.actions.filter(
@@ -214,7 +216,7 @@ test("AC-4: mixed pack with editor symlinks AND normal files imports cleanly wit
     expect(plan.files.every((file) => !file.target.includes(".cursor/") && !file.target.includes(".idea/"))).toBe(true);
 
     // Apply succeeds; no refusal.
-    const result = await importPaiPack({ homeDir, paiPackDir: packDir });
+    const [result] = await importPaiPack({ homeDir, paiPackDir: packDir });
     expect(result.skillName).toBe("demo");
   });
 });
@@ -233,7 +235,7 @@ test("AC-4: `.fleet/` and `.zed/` symlinks are also skipped (full denylist cover
     await symlink(fleetExt, join(packDir, ".fleet/settings.json"));
     await symlink(zedExt, join(packDir, ".zed/settings.json"));
 
-    const plan = await planPaiPackImport({ homeDir, paiPackDir: packDir });
+    const [plan] = await planPaiPackImport({ homeDir, paiPackDir: packDir });
     const skipActions = plan.normalization.actions.filter(
       (action) => action.kind === "skipped-editor-config-symlink",
     );

--- a/test/pai-pack-importer-issue-105.test.ts
+++ b/test/pai-pack-importer-issue-105.test.ts
@@ -35,13 +35,13 @@
  *          breaking change). Single-skill packs return a one-element
  *          array.
  */
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { importPaiPack, planPaiPackImport } from "../src/index";
 import { routePaiPackSourceFile } from "../src/pai-pack-routing";
 import type { PaiPackManifest } from "../src/types";
+import { withTempHome as withSharedTempHome } from "./fixtures/pai-migration-fixtures";
 import {
   writeFlatPack,
   writeNestedPackShell,
@@ -52,14 +52,11 @@ import {
 // Helpers
 // ───────────────────────────────────────────────────────────────────────
 
-async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
-  const homeDir = await mkdtemp(join(tmpdir(), "soma-issue-105-"));
-  try {
-    return await fn(homeDir);
-  } finally {
-    await rm(homeDir, { recursive: true, force: true });
-  }
-}
+// Sage r8 #108 (Maintainability suggestion): mkdtemp/rm wrapper lives
+// in `test/fixtures/pai-migration-fixtures.ts` so cleanup behavior
+// stays single-sourced across the importer test suites.
+const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
+  withSharedTempHome(fn, "soma-issue-105-");
 
 // Sage r3 #108 (Maintainability): pack-writer fixtures live in
 // `test/fixtures/pai-pack-fixtures.ts`. Imported below so test files

--- a/test/pai-pack-importer-issue-105.test.ts
+++ b/test/pai-pack-importer-issue-105.test.ts
@@ -42,6 +42,11 @@ import { expect, test } from "bun:test";
 import { importPaiPack, planPaiPackImport } from "../src/index";
 import { routePaiPackSourceFile } from "../src/pai-pack-routing";
 import type { PaiPackManifest } from "../src/types";
+import {
+  writeFlatPack,
+  writeNestedPackShell,
+  writeNestedSkill,
+} from "./fixtures/pai-pack-fixtures";
 
 // ───────────────────────────────────────────────────────────────────────
 // Helpers
@@ -56,61 +61,9 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
   }
 }
 
-async function writeFlatPack(packDir: string, packName = "Flat"): Promise<void> {
-  await mkdir(join(packDir, "src/Workflows"), { recursive: true });
-  await writeFile(
-    join(packDir, "README.md"),
-    ["---", `name: ${packName}`, `description: Flat pack`, "---", "", `# ${packName}`, "", "Pack docs.\n"].join("\n"),
-    "utf8",
-  );
-  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
-  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
-  await writeFile(
-    join(packDir, "src/SKILL.md"),
-    ["---", `name: ${packName}`, "description: flat", "---", "", `# ${packName}`, "", "Body.\n"].join("\n"),
-    "utf8",
-  );
-  await writeFile(join(packDir, "src/Workflows/Run.md"), "# Run\n", "utf8");
-}
-
-async function writeNestedSkill(
-  packDir: string,
-  nestedName: string,
-  options: { extras?: string[] } = {},
-): Promise<void> {
-  const base = join(packDir, "src", nestedName);
-  await mkdir(join(base, "Workflows"), { recursive: true });
-  await writeFile(
-    join(base, "SKILL.md"),
-    [
-      "---",
-      `name: ${nestedName}`,
-      `description: Nested ${nestedName} skill`,
-      "---",
-      "",
-      `# ${nestedName}`,
-      "",
-      "Body.\n",
-    ].join("\n"),
-    "utf8",
-  );
-  await writeFile(join(base, "Workflows/Default.md"), `# ${nestedName} Default\n`, "utf8");
-  for (const extra of options.extras ?? []) {
-    await mkdir(join(base, extra), { recursive: true });
-    await writeFile(join(base, extra, "demo.txt"), "demo\n", "utf8");
-  }
-}
-
-async function writeNestedPackShell(packDir: string, packName: string): Promise<void> {
-  await mkdir(join(packDir, "src"), { recursive: true });
-  await writeFile(
-    join(packDir, "README.md"),
-    ["---", `name: ${packName}`, `description: Nested pack`, "---", "", `# ${packName}`, "", "Pack docs.\n"].join("\n"),
-    "utf8",
-  );
-  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
-  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
-}
+// Sage r3 #108 (Maintainability): pack-writer fixtures live in
+// `test/fixtures/pai-pack-fixtures.ts`. Imported below so test files
+// stay focused on assertions.
 
 // ───────────────────────────────────────────────────────────────────────
 // AC-1: Router classification

--- a/test/pai-pack-importer-issue-105.test.ts
+++ b/test/pai-pack-importer-issue-105.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Issue 105 — pai-pack-importer: support nested skill bundles.
+ *
+ * PAI packs often ship multiple skills under one pack root, each at
+ * `src/<Name>/SKILL.md` with its own `Workflows/`, `Tools/`, etc. Before
+ * this issue the router only recognized a FLAT layout (`src/SKILL.md` +
+ * `src/Workflows/` at the pack root); every nested bundle dropped into
+ * the catch-all substrate-specific bucket.
+ *
+ * Implementation contract (the test file pins what ships):
+ *
+ *  - AC-1: Router recognizes `src/<Name>/{SKILL.md,Workflows/,Tools/,
+ *          References/,Examples/}` as portable. `src/<Name>/<other>` is
+ *          still substrate-specific.
+ *  - AC-2: A pack with N nested skills (where N skills means N
+ *          `src/<Name>/SKILL.md` files) imports as N independent Soma
+ *          skills at `~/.soma/skills/<kebab-name>/`.
+ *  - AC-3: A FLAT pack (existing behaviour — `src/SKILL.md` at root with
+ *          no nested skills) still imports as exactly ONE Soma skill.
+ *  - AC-4: A mixed pack (top-level `src/SKILL.md` PLUS nested
+ *          `src/<Name>/SKILL.md`) imports as 1 + N skills.
+ *  - AC-5: Two `src/<Name>/SKILL.md` paths that collapse to the same
+ *          kebab-name within one pack refuse with a typed
+ *          `PaiPackNameCollisionRefusal`. Across packs, the second pack
+ *          surfaces as `refused-name-collision` unless `--overwrite` is
+ *          set.
+ *  - AC-6: Pack-level `README.md` / `INSTALL.md` / `VERIFY.md` attach to
+ *          EACH derived skill as `References/PAI-PACK-{README,INSTALL,
+ *          VERIFY}.md` so any nested skill is independently invocable.
+ *  - AC-7: The pack-level archive at
+ *          `~/.soma/imports/pai-packs/<pack-slug>/` records the original
+ *          pack layout for auditability and `soma-pack.json` lists every
+ *          `derived-skills`.
+ *  - AC-8: `importPaiPack` now returns `PaiPackImportResult[]` (Option A
+ *          breaking change). Single-skill packs return a one-element
+ *          array.
+ */
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { importPaiPack, planPaiPackImport } from "../src/index";
+import { routePaiPackSourceFile } from "../src/pai-pack-routing";
+import type { PaiPackManifest } from "../src/types";
+
+// ───────────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────────
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-issue-105-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function writeFlatPack(packDir: string, packName = "Flat"): Promise<void> {
+  await mkdir(join(packDir, "src/Workflows"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    ["---", `name: ${packName}`, `description: Flat pack`, "---", "", `# ${packName}`, "", "Pack docs.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    ["---", `name: ${packName}`, "description: flat", "---", "", `# ${packName}`, "", "Body.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "src/Workflows/Run.md"), "# Run\n", "utf8");
+}
+
+async function writeNestedSkill(
+  packDir: string,
+  nestedName: string,
+  options: { extras?: string[] } = {},
+): Promise<void> {
+  const base = join(packDir, "src", nestedName);
+  await mkdir(join(base, "Workflows"), { recursive: true });
+  await writeFile(
+    join(base, "SKILL.md"),
+    [
+      "---",
+      `name: ${nestedName}`,
+      `description: Nested ${nestedName} skill`,
+      "---",
+      "",
+      `# ${nestedName}`,
+      "",
+      "Body.\n",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(base, "Workflows/Default.md"), `# ${nestedName} Default\n`, "utf8");
+  for (const extra of options.extras ?? []) {
+    await mkdir(join(base, extra), { recursive: true });
+    await writeFile(join(base, extra, "demo.txt"), "demo\n", "utf8");
+  }
+}
+
+async function writeNestedPackShell(packDir: string, packName: string): Promise<void> {
+  await mkdir(join(packDir, "src"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    ["---", `name: ${packName}`, `description: Nested pack`, "---", "", `# ${packName}`, "", "Pack docs.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-1: Router classification
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-1: router classifies nested SKILL.md as portable with nested-skill set", () => {
+  const nested = new Set(["Art", "Remotion"]);
+  const route = routePaiPackSourceFile("src/Art/SKILL.md", nested);
+  expect(route.classification).toBe("portable");
+  expect(route.root).toBe("skill");
+  expect(route.renderMode).toBe("skill");
+  // Target should land under the nested skill's own kebab name, not the pack root.
+  expect(route.relativePath).toBe("SKILL.md");
+  expect(route.skillName).toBe("art");
+});
+
+test("AC-1: router classifies nested Workflows/Tools/References/Examples as portable under nested skill", () => {
+  const nested = new Set(["Remotion"]);
+  for (const subdir of ["Workflows", "Tools", "References", "Examples"]) {
+    const route = routePaiPackSourceFile(`src/Remotion/${subdir}/file.md`, nested);
+    expect(route.classification).toBe("portable");
+    expect(route.root).toBe("skill");
+    expect(route.skillName).toBe("remotion");
+    expect(route.relativePath).toBe(`${subdir}/file.md`);
+  }
+});
+
+test("AC-1: router still classifies src/<Name>/<other> as substrate-specific", () => {
+  // `src/Art/Lib/` and `src/Art/Assets/` are not portable subdirs — they
+  // stay archive-only. The nested skill set HAS Art, so the rule is on
+  // the subdir name not on whether the parent is a known nested skill.
+  const nested = new Set(["Art"]);
+  const route = routePaiPackSourceFile("src/Art/Assets/icon.png", nested);
+  expect(route.classification).toBe("substrate-specific");
+  expect(route.root).toBe("archive");
+});
+
+test("AC-1: when nested skill set is empty, src/<Name>/SKILL.md stays substrate-specific", () => {
+  // The detection rule: a Name is treated as nested iff src/<Name>/SKILL.md
+  // exists in the pack file set. Without that, nested dirs stay archive.
+  const empty = new Set<string>();
+  const route = routePaiPackSourceFile("src/Foo/SKILL.md", empty);
+  expect(route.classification).toBe("substrate-specific");
+});
+
+test("AC-1: FLAT routing (src/SKILL.md, src/Workflows/, src/Tools/) unchanged", () => {
+  const nested = new Set<string>();
+  expect(routePaiPackSourceFile("src/SKILL.md", nested)).toMatchObject({
+    classification: "portable",
+    root: "skill",
+    relativePath: "SKILL.md",
+    renderMode: "skill",
+    skillName: null,
+  });
+  expect(routePaiPackSourceFile("src/Workflows/Run.md", nested)).toMatchObject({
+    classification: "portable",
+    root: "skill",
+    skillName: null,
+  });
+  expect(routePaiPackSourceFile("src/Tools/run.ts", nested)).toMatchObject({
+    classification: "portable",
+    root: "skill",
+    skillName: null,
+  });
+});
+
+test("AC-1: source-doc and template classifications still win over nested detection", () => {
+  const nested = new Set(["Tools"]); // adversarial — shouldn't pollute root routing
+  expect(routePaiPackSourceFile("README.md", nested).classification).toBe("source-doc");
+  expect(routePaiPackSourceFile("src/DashboardTemplate/foo.tsx", nested).classification).toBe("template");
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-3: FLAT pack still imports as ONE skill
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-3: FLAT pack imports as exactly one Soma skill", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Flat");
+    await writeFlatPack(packDir, "Flat");
+    const results = await importPaiPack({ homeDir, paiPackDir: packDir });
+    expect(results).toHaveLength(1);
+    expect(results[0].skillName).toBe("flat");
+    expect(results[0].files.some((p) => p.endsWith(".soma/skills/flat/SKILL.md"))).toBe(true);
+    expect(results[0].files.some((p) => p.endsWith(".soma/skills/flat/Workflows/Run.md"))).toBe(true);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-2: 2-skill nested pack
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-2: 2-skill nested pack imports as 2 Soma skills", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Media");
+    await writeNestedPackShell(packDir, "Media");
+    await writeNestedSkill(packDir, "Art");
+    await writeNestedSkill(packDir, "Remotion");
+
+    const results = await importPaiPack({ homeDir, paiPackDir: packDir });
+    const skillNames = results.map((r) => r.skillName).sort();
+    expect(skillNames).toEqual(["art", "remotion"]);
+
+    for (const name of ["art", "remotion"]) {
+      const skillMd = join(homeDir, ".soma", "skills", name, "SKILL.md");
+      const wf = join(homeDir, ".soma", "skills", name, "Workflows/Default.md");
+      expect((await readFile(skillMd, "utf8")).length).toBeGreaterThan(0);
+      expect((await readFile(wf, "utf8")).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-2 / scale: 5+ skill nested pack
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-2: 5-skill nested pack imports as 5 Soma skills (Thinking-style)", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Thinking");
+    await writeNestedPackShell(packDir, "Thinking");
+    const names = ["BeCreative", "Council", "FirstPrinciples", "IterativeDepth", "RedTeam"];
+    for (const n of names) {
+      await writeNestedSkill(packDir, n);
+    }
+
+    const results = await importPaiPack({ homeDir, paiPackDir: packDir });
+    const skillNames = results.map((r) => r.skillName).sort();
+    expect(skillNames).toEqual(["be-creative", "council", "first-principles", "iterative-depth", "red-team"]);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-4: Mixed (top-level + nested)
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-4: mixed pack (top-level SKILL.md + nested) imports as 1 + N skills", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Utilities");
+    await writeNestedPackShell(packDir, "Utilities");
+    // Top-level SKILL.md
+    await writeFile(
+      join(packDir, "src/SKILL.md"),
+      ["---", "name: Utilities", "description: top", "---", "", "# Utilities\n"].join("\n"),
+      "utf8",
+    );
+    await mkdir(join(packDir, "src/Workflows"), { recursive: true });
+    await writeFile(join(packDir, "src/Workflows/Top.md"), "# Top\n", "utf8");
+    // Plus 2 nested
+    await writeNestedSkill(packDir, "Browser");
+    await writeNestedSkill(packDir, "Documents");
+
+    const results = await importPaiPack({ homeDir, paiPackDir: packDir });
+    const skillNames = results.map((r) => r.skillName).sort();
+    expect(skillNames).toEqual(["browser", "documents", "utilities"]);
+
+    // Top-level skill gets its workflow under utilities/Workflows/Top.md
+    const topWf = join(homeDir, ".soma/skills/utilities/Workflows/Top.md");
+    expect((await readFile(topWf, "utf8")).length).toBeGreaterThan(0);
+    // Browser gets its workflow under browser/Workflows/Default.md
+    const browserWf = join(homeDir, ".soma/skills/browser/Workflows/Default.md");
+    expect((await readFile(browserWf, "utf8")).length).toBeGreaterThan(0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-1 / AC-3 again: substrate-specific siblings under a nested skill
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-1+3: nested skill with non-recognized sibling (Assets/) still archives sibling", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/MediaWithAssets");
+    await writeNestedPackShell(packDir, "MediaWithAssets");
+    await writeNestedSkill(packDir, "Art", { extras: ["Assets"] });
+
+    // Without --include-substrate-specific the import should refuse the pack
+    // because src/Art/Assets/demo.txt classifies as substrate-specific.
+    await expect(importPaiPack({ homeDir, paiPackDir: packDir })).rejects.toThrow("substrate-specific");
+
+    // With include-substrate-specific the pack imports — but the asset lands
+    // in the pack-level archive, not in the nested Art skill.
+    const results = await importPaiPack({
+      homeDir,
+      paiPackDir: packDir,
+      includeSubstrateSpecific: true,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].skillName).toBe("art");
+    // The asset is NOT under skills/art/Assets — it's under the pack archive.
+    const skillFiles = results[0].files;
+    expect(skillFiles.some((p) => p.includes("/skills/art/Assets/demo.txt"))).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-5: Within-pack collision
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-5: within-pack collision (ExtractWisdom + extract-wisdom) refuses pack with name-collision", async () => {
+  // Two distinct nested-skill dirs that kebab to the same slug. Using
+  // `ExtractWisdom` (CamelCase → `extract-wisdom`) plus literal
+  // `extract-wisdom` exercises the within-pack collision path while
+  // staying portable on case-insensitive filesystems (APFS on macOS
+  // treats `Foo/` and `foo/` as the same path so that pair can't even
+  // be expressed by the fixture).
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Collision");
+    await writeNestedPackShell(packDir, "Collision");
+    await writeNestedSkill(packDir, "ExtractWisdom");
+    await writeNestedSkill(packDir, "extract-wisdom");
+
+    await expect(importPaiPack({ homeDir, paiPackDir: packDir })).rejects.toThrow(/name collision|name-collision/i);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-6: Pack-level docs attach to EACH derived skill
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-6: pack-level README/INSTALL/VERIFY attach to each derived skill", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Media");
+    await writeNestedPackShell(packDir, "Media");
+    await writeNestedSkill(packDir, "Art");
+    await writeNestedSkill(packDir, "Remotion");
+
+    const results = await importPaiPack({ homeDir, paiPackDir: packDir });
+    for (const r of results) {
+      const refDir = join(homeDir, ".soma/skills", r.skillName, "references");
+      const readme = join(refDir, "PAI-PACK-README.md");
+      const install = join(refDir, "PAI-PACK-INSTALL.md");
+      const verify = join(refDir, "PAI-PACK-VERIFY.md");
+      expect((await readFile(readme, "utf8")).length).toBeGreaterThan(0);
+      expect((await readFile(install, "utf8")).length).toBeGreaterThan(0);
+      expect((await readFile(verify, "utf8")).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-7: archive records derived-skills
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-7: pack archive records derived-skills list", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Media");
+    await writeNestedPackShell(packDir, "Media");
+    await writeNestedSkill(packDir, "Art");
+    await writeNestedSkill(packDir, "Remotion");
+
+    await importPaiPack({ homeDir, paiPackDir: packDir });
+
+    const archiveManifestPath = join(homeDir, ".soma/imports/pai-packs/media/soma-pack-archive.json");
+    const raw = await readFile(archiveManifestPath, "utf8");
+    const manifest = JSON.parse(raw) as PaiPackManifest & { derivedSkills?: string[] };
+    expect(manifest.derivedSkills?.sort()).toEqual(["art", "remotion"]);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// AC-8: planPaiPackImport returns plan-array
+// ───────────────────────────────────────────────────────────────────────
+
+test("AC-8: planPaiPackImport returns array of plans, one per derived skill", async () => {
+  await withTempHome(async (homeDir) => {
+    const packDir = join(homeDir, "PAI/Packs/Media");
+    await writeNestedPackShell(packDir, "Media");
+    await writeNestedSkill(packDir, "Art");
+    await writeNestedSkill(packDir, "Remotion");
+
+    const plans = await planPaiPackImport({ homeDir, paiPackDir: packDir });
+    expect(plans).toHaveLength(2);
+    const names = plans.map((p) => p.skillName).sort();
+    expect(names).toEqual(["art", "remotion"]);
+    for (const plan of plans) {
+      expect(plan.apply).toBe(false);
+    }
+  });
+});

--- a/test/pai-pack-importer-issue-108-r2.test.ts
+++ b/test/pai-pack-importer-issue-108-r2.test.ts
@@ -335,6 +335,69 @@ test("R7 #1: pure-nested pack with reserved pack name is permitted (only archive
   });
 });
 
+// ───────────────────────────────────────────────────────────────────────
+// R9 #1 (CodeQuality, important): survivor completeness in apply path
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Contract: when the migrate apply path calls
+ * `importPaiPackFromPlan(handle, {excludeSkills})`, every survivor
+ * (plan.skillName not in excludeSkills) must appear in the returned
+ * items. If the importer silently drops one, the orchestrator must
+ * emit a `refused-other` row for it so the principal sees a missing
+ * outcome instead of a silent gap. The standard happy path (no
+ * collisions, every survivor lands) is exercised by every other
+ * importer test; this test exercises the contract guard.
+ */
+test("R9 #1: every imported pack's survivor set matches its returned item set", async () => {
+  await withTempHome(async (home) => {
+    const packsDir = join(home, "PAI/Packs");
+    await mkdir(packsDir, { recursive: true });
+    await writePaiIdentityFixture(home);
+    // Multi-skill nested pack — three derived skills, none excluded.
+    const packDir = join(packsDir, "MultiPack");
+    await mkdir(packDir, { recursive: true });
+    await writeFile(
+      join(packDir, "README.md"),
+      "---\nname: MultiPack\ndescription: Multi-skill pack.\n---\n\n# MultiPack\n",
+      "utf8",
+    );
+    await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+    await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+    for (const skill of ["Alpha", "Beta", "Gamma"]) {
+      await mkdir(join(packDir, "src", skill, "Workflows"), { recursive: true });
+      await writeFile(
+        join(packDir, "src", skill, "SKILL.md"),
+        `---\nname: ${skill}\ndescription: ${skill} desc.\n---\n\n# ${skill}\n`,
+        "utf8",
+      );
+      await writeFile(join(packDir, "src", skill, "Workflows/Default.md"), `# ${skill}\n`, "utf8");
+    }
+
+    const result = await migratePai({
+      homeDir: home,
+      claudeHome: join(home, ".claude"),
+      somaHome: join(home, ".soma"),
+      paiPacksDir: packsDir,
+      skipMemory: true,
+      skipDocs: true,
+    });
+
+    // All three nested skills appear as `imported` outcomes; none
+    // silently dropped. (Contract violations would record an extra
+    // `refused-other` row with a clear "contract violation" reason.)
+    const imported = result.packOutcomes
+      .filter((o) => o.outcome === "imported")
+      .map((o) => o.skillName)
+      .sort();
+    expect(imported).toEqual(["alpha", "beta", "gamma"]);
+    const contractViolations = result.packOutcomes.filter(
+      (o) => o.outcome === "refused-other" && o.reason?.includes("contract violation"),
+    );
+    expect(contractViolations).toEqual([]);
+  });
+});
+
 test("R7 #1: nested skill itself in reserved set is still refused (per-derived-skill check fires)", async () => {
   await withTempHome(async (home) => {
     const packDir = join(home, "pack");

--- a/test/pai-pack-importer-issue-108-r2.test.ts
+++ b/test/pai-pack-importer-issue-108-r2.test.ts
@@ -294,6 +294,79 @@ test("R2 #4: planPaiMigration and migratePai produce matching per-pack outcomes 
 });
 
 // ───────────────────────────────────────────────────────────────────────
+// R7 #1 (CodeQuality, important): pure-nested pack with reserved pack name
+// ───────────────────────────────────────────────────────────────────────
+
+test("R7 #1: pure-nested pack with reserved pack name is permitted (only archive uses packSlug)", async () => {
+  await withTempHome(async (home) => {
+    const packDir = join(home, "pack");
+    await mkdir(packDir, { recursive: true });
+    // Pack README declares a reserved name (`soma`), but the pack
+    // ships ONLY nested skills — no `src/SKILL.md`. The `packSlug`
+    // value here is just the archive root identifier under
+    // `~/.soma/imports/pai-packs/soma/`, NOT an imported skill name.
+    // The pre-R7 implementation refused this loud; the R7 fix only
+    // applies the packSlug-reserved refusal when a FLAT entry exists.
+    await writeFile(
+      join(packDir, "README.md"),
+      "---\nname: soma\ndescription: Pure nested pack happens to be named soma.\n---\n\n# soma\n",
+      "utf8",
+    );
+    await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+    await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+    await mkdir(join(packDir, "src/Foo/Workflows"), { recursive: true });
+    await writeFile(
+      join(packDir, "src/Foo/SKILL.md"),
+      "---\nname: Foo\ndescription: Foo nested skill.\n---\n\n# Foo\n",
+      "utf8",
+    );
+    await writeFile(join(packDir, "src/Foo/Workflows/Default.md"), "# Default\n", "utf8");
+    const somaHome = join(home, ".soma");
+
+    const result = await importPaiPack({ homeDir: home, paiPackDir: packDir, somaHome });
+    expect(result.length).toBe(1);
+    expect(result[0]!.skillName).toBe("foo");
+
+    // The archive landed under `imports/pai-packs/soma/` — the
+    // reserved pack name is only used as an archive identifier,
+    // not an imported skill name.
+    const archiveExists = await readFile(
+      join(somaHome, "imports/pai-packs/soma/soma-pack-archive.json"),
+      "utf8",
+    );
+    expect(archiveExists.length).toBeGreaterThan(0);
+  });
+});
+
+test("R7 #1: nested skill itself in reserved set is still refused (per-derived-skill check fires)", async () => {
+  await withTempHome(async (home) => {
+    const packDir = join(home, "pack");
+    await mkdir(packDir, { recursive: true });
+    await writeFile(
+      join(packDir, "README.md"),
+      "---\nname: ValidPack\ndescription: Valid pack with reserved nested.\n---\n\n# ValidPack\n",
+      "utf8",
+    );
+    await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+    await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+    // Nested skill named "soma" — genuinely reserved as an IMPORTED
+    // skill name. The per-derived-skill loop below must still refuse.
+    await mkdir(join(packDir, "src/soma/Workflows"), { recursive: true });
+    await writeFile(
+      join(packDir, "src/soma/SKILL.md"),
+      "---\nname: soma\ndescription: Tries to be soma.\n---\n\n# soma\n",
+      "utf8",
+    );
+    await writeFile(join(packDir, "src/soma/Workflows/Default.md"), "# Default\n", "utf8");
+    const somaHome = join(home, ".soma");
+
+    await expect(
+      importPaiPack({ homeDir: home, paiPackDir: packDir, somaHome }),
+    ).rejects.toThrow(/reserved Soma skill 'soma'/i);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
 // R5 #2 (Security, blocker): forged handles are rejected
 // ───────────────────────────────────────────────────────────────────────
 

--- a/test/pai-pack-importer-issue-108-r2.test.ts
+++ b/test/pai-pack-importer-issue-108-r2.test.ts
@@ -26,8 +26,7 @@
  * outside the module set it. The fact that `bun run typecheck` is
  * green proves the contract.
  */
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import { join, relative, sep } from "node:path";
 import { expect, test } from "bun:test";
 import { migratePai, planPaiMigration } from "../src/index";
@@ -37,24 +36,22 @@ import {
   planPaiPackImportHandle,
 } from "../src/pai-pack-importer";
 import { routePaiPackSourceFile } from "../src/pai-pack-routing";
-import { writePaiIdentityFixture } from "./fixtures/pai-migration-fixtures";
+import {
+  withTempHome as withSharedTempHome,
+  writePaiIdentityFixture,
+} from "./fixtures/pai-migration-fixtures";
 import { writeFlatNestedPack, writeFlatPack } from "./fixtures/pai-pack-fixtures";
 
 // ───────────────────────────────────────────────────────────────────────
 // Helpers
 // ───────────────────────────────────────────────────────────────────────
 
-async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
-  const homeDir = await mkdtemp(join(tmpdir(), "soma-issue-108-r2-"));
-  try {
-    return await fn(homeDir);
-  } finally {
-    await rm(homeDir, { recursive: true, force: true });
-  }
-}
+// Sage r8 #108 (Maintainability suggestion): single source for the
+// mkdtemp/rm temp-home lifecycle (in `pai-migration-fixtures.ts`).
+const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
+  withSharedTempHome(fn, "soma-issue-108-r2-");
 
-// Sage r3 #108 (Maintainability): pack-writer fixtures shared via
-// `test/fixtures/pai-pack-fixtures.ts`.
+// Pack-writer fixtures shared via `test/fixtures/pai-pack-fixtures.ts`.
 
 /**
  * Recursively list every file under `root`, returning POSIX-relative

--- a/test/pai-pack-importer-issue-108-r2.test.ts
+++ b/test/pai-pack-importer-issue-108-r2.test.ts
@@ -322,6 +322,38 @@ test("R5 #2: importPaiPackFromPlan rejects null and non-object handles", async (
   ).rejects.toThrow(/must be a PaiPackImportPlanHandle/i);
 });
 
+test("R6 #1: legitimate handle carries NO addressable plan state (immutable)", async () => {
+  await withTempHome(async (home) => {
+    const packDir = join(home, "pack");
+    await writeFlatPack(packDir, "Immutable");
+    const somaHome = join(home, ".soma");
+
+    const { handle } = await planPaiPackImportHandle({
+      homeDir: home,
+      paiPackDir: packDir,
+      somaHome,
+    });
+
+    // The handle must be frozen and carry no addressable plan/options
+    // a malicious caller could mutate. The plan lives in the
+    // module-private WeakMap, not on the handle.
+    expect(Object.isFrozen(handle)).toBe(true);
+    const keys = Object.keys(handle);
+    expect(keys).toEqual(["__brand"]);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((handle as any).plan).toBeUndefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((handle as any).options).toBeUndefined();
+    // Mutation attempts must NOT silently install a `.plan` either.
+    expect(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (handle as any).plan = { evil: true };
+    }).toThrow(); // frozen object → strict mode TypeError
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((handle as any).plan).toBeUndefined();
+  });
+});
+
 // ───────────────────────────────────────────────────────────────────────
 // R5 #1 (CodeQuality, important): nested SKILL.md descriptions are preserved
 // ───────────────────────────────────────────────────────────────────────

--- a/test/pai-pack-importer-issue-108-r2.test.ts
+++ b/test/pai-pack-importer-issue-108-r2.test.ts
@@ -26,7 +26,7 @@
  * outside the module set it. The fact that `bun run typecheck` is
  * green proves the contract.
  */
-import { mkdir, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative, sep } from "node:path";
 import { expect, test } from "bun:test";
@@ -290,5 +290,156 @@ test("R2 #4: planPaiMigration and migratePai produce matching per-pack outcomes 
       const applySlugs = applyResult.packs.map((r) => r.skillName).sort();
       expect(planSlugs).toEqual(applySlugs);
     });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// R3 #3 (CodeQuality): flat-vs-nested collision sources use RAW name
+// ───────────────────────────────────────────────────────────────────────
+
+test("R3 #3: FLAT-vs-nested collision refusal reports RAW nested dir name (not kebab slug)", async () => {
+  await withTempHome(async (home) => {
+    const packDir = join(home, "pack");
+    await mkdir(join(packDir, "src/PAIUpgrade"), { recursive: true });
+    await writeFile(
+      join(packDir, "README.md"),
+      "---\nname: PAIUpgrade\ndescription: collision\n---\n\n# PAIUpgrade\n",
+      "utf8",
+    );
+    await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+    await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+    // Pack-level slug is "pai-upgrade"; nested skill named "PAIUpgrade"
+    // ALSO kebabs to "pai-upgrade". The refusal must point at the
+    // real on-disk path `src/PAIUpgrade/SKILL.md`, not the kebab-cased
+    // `src/pai-upgrade/SKILL.md` (which does not exist).
+    await writeFile(
+      join(packDir, "src/SKILL.md"),
+      "---\nname: PAIUpgrade\ndescription: flat\n---\n\n# PAIUpgrade\n",
+      "utf8",
+    );
+    await writeFile(
+      join(packDir, "src/PAIUpgrade/SKILL.md"),
+      "---\nname: PAIUpgrade\ndescription: nested\n---\n\n# PAIUpgrade\n",
+      "utf8",
+    );
+    const somaHome = join(home, ".soma");
+
+    let caught: unknown = null;
+    try {
+      await importPaiPack({ homeDir: home, paiPackDir: packDir, somaHome });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeTruthy();
+    const message = (caught as Error).message;
+    expect(message).toContain("src/PAIUpgrade/SKILL.md");
+    expect(message).not.toContain("src/pai-upgrade/SKILL.md");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// R4 #1 (CodeQuality, important): failed apply does NOT reserve slug
+// ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Sage r4 #108 — a pack that plans cleanly but fails mid-apply must
+ * NOT block a later pack from importing the same derived skill slug.
+ * The cross-pack collision set may only grow after a real, completed
+ * apply. To force a deterministic apply-time failure for the first
+ * pack while keeping the second pack clean, we plant a non-empty FILE
+ * at the staging tmp root the importer would use, so `mkdir`-ing the
+ * stage path throws — surfacing as `refused-other` for pack-a; pack-b
+ * with the same slug should still land as `imported`.
+ *
+ * Note: the apply path uses `stageRoot = join(somaHome, '.tmp',
+ * 'pai-pack-<slug>-<ts>-<rand>')`, so a parent file at
+ * `<somaHome>/.tmp` itself blocks every pack's mkdir attempt. We need
+ * a more surgical failure for pack-a specifically. Easier: use a
+ * within-pack defect — e.g., a fragile constructed pack where some
+ * file path escapes containment — and pair it with a healthy pack-b.
+ * Simplest reliable construction: pack-a has a NESTED skill name that
+ * is structurally reserved by the pack importer (`soma`), which
+ * triggers `PaiPackReservedNameRefusal` AT THE INNER PACK LEVEL but
+ * does NOT raise `refused-other` — Sage's concern was specifically
+ * about apply-throw paths that hit the `catch (error)` block. We
+ * instead simulate the issue by:
+ *   - pack-a: VALID plan, INVALID apply (introduce a writable-conflict
+ *     by pre-creating the destination skill DIRECTORY as a FILE so
+ *     `rename` during promotion throws).
+ *   - pack-b: same slug, valid all the way through.
+ */
+test("R4 #1: failed apply does NOT reserve slug — later pack with same slug still lands", async () => {
+  await withTempHome(async (home) => {
+    const packsDir = join(home, "PAI/Packs");
+    await mkdir(packsDir, { recursive: true });
+    await writePaiIdentityFixture(home);
+
+    // Two packs with the same skill name. Pack-a will fail at apply
+    // time; pack-b should still land because pack-a wrote nothing.
+    const packA = join(packsDir, "pack-a");
+    const packB = join(packsDir, "pack-b");
+    await writeFlatPack(packA, "Shared");
+    await writeFlatPack(packB, "Shared");
+
+    // Force pack-a to fail at apply by pre-creating the target skill
+    // path as a FILE (not directory). The importer's promotion step
+    // refuses to overwrite a non-directory; `rename` over a file
+    // location either throws or leaves the pre-existing file. Either
+    // way pack-a's outcome lands as `refused-other`, while pack-b
+    // (sorted SECOND in the iteration: `pack-a` < `pack-b`) must
+    // still land.
+    //
+    // Sorted-by-path order is alphabetical, so pack-a is attempted
+    // first. We can't easily fail it without invasive setup; instead
+    // use a smaller, equivalent integration: pack-a has the SAME
+    // skill name as a Soma RESERVED slug (`isa`), so the migrate-level
+    // pre-check refuses it as `refused-reserved` — which has the same
+    // semantic shape as `refused-other` for collision-reservation
+    // purposes: pack-a never wrote anything.
+    //
+    // Actually `refused-reserved` is caught BEFORE the apply path is
+    // entered, so it never touches `landedSlugs` in either the pre-R4
+    // walker OR the new inline implementation. To genuinely exercise
+    // R4's contract we need a pack that plans + clears reserved but
+    // then fails on apply. The simplest way: pre-create a file at the
+    // archive target so the archive's `mkdir -p` fails — but the
+    // importer uses tmp-stage + rename, so it doesn't hit the
+    // archive until promotion. Cleanest reliable approach: pre-create
+    // a READ-ONLY directory at the skill target path; the promotion
+    // step's rename fails because it can't replace a non-empty
+    // readonly dir.
+    await mkdir(join(home, ".soma/skills/shared"), { recursive: true });
+    // Plant a file inside so rename refuses to overwrite a non-empty
+    // dir on macOS / Linux behaviour.
+    await writeFile(join(home, ".soma/skills/shared/blocker.txt"), "blocker\n", "utf8");
+
+    const result = await migratePai({
+      homeDir: home,
+      claudeHome: join(home, ".claude"),
+      somaHome: join(home, ".soma"),
+      paiPacksDir: packsDir,
+      skipMemory: true,
+      skipDocs: true,
+    });
+
+    // pack-a's outcome should NOT be `refused-name-collision` (pack-b
+    // is the second one sorted, but the test is about pack-b too).
+    const packAOutcomes = result.packOutcomes.filter((o) => o.paiPackDir === packA);
+    const packBOutcomes = result.packOutcomes.filter((o) => o.paiPackDir === packB);
+    // pack-a fails apply because the destination exists non-empty
+    // with `overwrite: true` from migration — actually overwrite IS
+    // set, so this might succeed. The test still pins the right
+    // contract: if BOTH packs land successfully, no collision is
+    // reported; if pack-a fails for some other reason, pack-b STILL
+    // gets a chance.
+    const hasCollisionForB = packBOutcomes.some((o) => o.outcome === "refused-name-collision");
+    const hasOtherFailureForA = packAOutcomes.some((o) => o.outcome === "refused-other");
+    if (hasOtherFailureForA) {
+      // Pre-R4: pack-b would record refused-name-collision spuriously
+      // because pack-a had already reserved the slug. Post-R4: pack-b
+      // is free to attempt and either imports or fails on its own
+      // merits — but NOT as a cross-pack collision.
+      expect(hasCollisionForB).toBe(false);
+    }
   });
 });

--- a/test/pai-pack-importer-issue-108-r2.test.ts
+++ b/test/pai-pack-importer-issue-108-r2.test.ts
@@ -26,7 +26,7 @@
  * outside the module set it. The fact that `bun run typecheck` is
  * green proves the contract.
  */
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative, sep } from "node:path";
 import { expect, test } from "bun:test";
@@ -38,6 +38,7 @@ import {
 } from "../src/pai-pack-importer";
 import { routePaiPackSourceFile } from "../src/pai-pack-routing";
 import { writePaiIdentityFixture } from "./fixtures/pai-migration-fixtures";
+import { writeFlatNestedPack, writeFlatPack } from "./fixtures/pai-pack-fixtures";
 
 // ───────────────────────────────────────────────────────────────────────
 // Helpers
@@ -52,56 +53,8 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
   }
 }
 
-async function writeFlatNestedPack(packDir: string, packName = "Mixed"): Promise<void> {
-  await mkdir(join(packDir, "src/Workflows"), { recursive: true });
-  await mkdir(join(packDir, "src/Tools/Workflows"), { recursive: true });
-  await mkdir(join(packDir, "src/Remotion/Workflows"), { recursive: true });
-  await writeFile(
-    join(packDir, "README.md"),
-    ["---", `name: ${packName}`, `description: Mixed pack`, "---", "", `# ${packName}`, "", "Pack docs.\n"].join("\n"),
-    "utf8",
-  );
-  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
-  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
-  // FLAT entry
-  await writeFile(
-    join(packDir, "src/SKILL.md"),
-    ["---", `name: ${packName}`, "description: flat", "---", "", `# ${packName}`, "", "Flat body.\n"].join("\n"),
-    "utf8",
-  );
-  await writeFile(join(packDir, "src/Workflows/Run.md"), "# Run\n", "utf8");
-  // Nested skill named "Tools" — must NOT flatten as FLAT portable.
-  await writeFile(
-    join(packDir, "src/Tools/SKILL.md"),
-    ["---", `name: Tools`, "description: nested tools skill", "---", "", `# Tools`, "", "Tools body.\n"].join("\n"),
-    "utf8",
-  );
-  await writeFile(join(packDir, "src/Tools/Workflows/Helper.md"), "# Helper\n", "utf8");
-  // Plain nested skill (sanity baseline)
-  await writeFile(
-    join(packDir, "src/Remotion/SKILL.md"),
-    ["---", `name: Remotion`, "description: nested remotion", "---", "", `# Remotion`, "", "Remotion body.\n"].join("\n"),
-    "utf8",
-  );
-  await writeFile(join(packDir, "src/Remotion/Workflows/Render.md"), "# Render\n", "utf8");
-}
-
-async function writeFlatPack(packDir: string, packName = "Flat"): Promise<void> {
-  await mkdir(join(packDir, "src/Workflows"), { recursive: true });
-  await writeFile(
-    join(packDir, "README.md"),
-    ["---", `name: ${packName}`, `description: Flat pack`, "---", "", `# ${packName}`, "", "Pack docs.\n"].join("\n"),
-    "utf8",
-  );
-  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
-  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
-  await writeFile(
-    join(packDir, "src/SKILL.md"),
-    ["---", `name: ${packName}`, "description: flat", "---", "", `# ${packName}`, "", "Body.\n"].join("\n"),
-    "utf8",
-  );
-  await writeFile(join(packDir, "src/Workflows/Run.md"), "# Run\n", "utf8");
-}
+// Sage r3 #108 (Maintainability): pack-writer fixtures shared via
+// `test/fixtures/pai-pack-fixtures.ts`.
 
 /**
  * Recursively list every file under `root`, returning POSIX-relative

--- a/test/pai-pack-importer-issue-108-r2.test.ts
+++ b/test/pai-pack-importer-issue-108-r2.test.ts
@@ -1,0 +1,341 @@
+/**
+ * PR #108 — Sage R2 follow-ups for issue 105.
+ *
+ * Tests pin the contract for the three remaining R2 findings:
+ *
+ *   - R2 #1 (CodeQuality, important) — `src/pai-pack-routing.ts`:
+ *     Nested-skill detection MUST run BEFORE the FLAT PORTABLE_PREFIXES
+ *     check. A pack with `src/Tools/SKILL.md` (i.e. "Tools" is the
+ *     name of a nested skill, not a flat-portable subdir) must route
+ *     to the `tools` skill, not flatten into the pack-level skill.
+ *
+ *   - R2 #2 (Performance, important) — `importPaiPackFromPlan` applies
+ *     a cached internal plan WITHOUT a second `buildPaiPackImportPlan`
+ *     pass. On-disk output must match `importPaiPack` exactly (byte-
+ *     stable; same skill set, same files, same content).
+ *
+ *   - R2 #4 (Maintainability, suggestion) — `walkPlanRowsForCollisions`
+ *     is the single source for cross-pack collision logic. Both the
+ *     apply and plan-only bulk paths consume it; their outputs (skill
+ *     set, outcome rows) must match the pre-refactor surfaces.
+ *
+ * R2 #3 (Architecture, suggestion — `excludeSkills` off public type)
+ * is verified at compile time: removing `excludeSkills` from
+ * `PaiPackImportOptions` and moving it to the module-internal
+ * `PaiPackImportOptionsInternal` would break the typecheck if anything
+ * outside the module set it. The fact that `bun run typecheck` is
+ * green proves the contract.
+ */
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, relative, sep } from "node:path";
+import { expect, test } from "bun:test";
+import { migratePai, planPaiMigration } from "../src/index";
+import {
+  importPaiPack,
+  importPaiPackFromPlan,
+  planPaiPackImportHandle,
+} from "../src/pai-pack-importer";
+import { routePaiPackSourceFile } from "../src/pai-pack-routing";
+import { writePaiIdentityFixture } from "./fixtures/pai-migration-fixtures";
+
+// ───────────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────────
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-issue-108-r2-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function writeFlatNestedPack(packDir: string, packName = "Mixed"): Promise<void> {
+  await mkdir(join(packDir, "src/Workflows"), { recursive: true });
+  await mkdir(join(packDir, "src/Tools/Workflows"), { recursive: true });
+  await mkdir(join(packDir, "src/Remotion/Workflows"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    ["---", `name: ${packName}`, `description: Mixed pack`, "---", "", `# ${packName}`, "", "Pack docs.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  // FLAT entry
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    ["---", `name: ${packName}`, "description: flat", "---", "", `# ${packName}`, "", "Flat body.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "src/Workflows/Run.md"), "# Run\n", "utf8");
+  // Nested skill named "Tools" — must NOT flatten as FLAT portable.
+  await writeFile(
+    join(packDir, "src/Tools/SKILL.md"),
+    ["---", `name: Tools`, "description: nested tools skill", "---", "", `# Tools`, "", "Tools body.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "src/Tools/Workflows/Helper.md"), "# Helper\n", "utf8");
+  // Plain nested skill (sanity baseline)
+  await writeFile(
+    join(packDir, "src/Remotion/SKILL.md"),
+    ["---", `name: Remotion`, "description: nested remotion", "---", "", `# Remotion`, "", "Remotion body.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "src/Remotion/Workflows/Render.md"), "# Render\n", "utf8");
+}
+
+async function writeFlatPack(packDir: string, packName = "Flat"): Promise<void> {
+  await mkdir(join(packDir, "src/Workflows"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    ["---", `name: ${packName}`, `description: Flat pack`, "---", "", `# ${packName}`, "", "Pack docs.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    ["---", `name: ${packName}`, "description: flat", "---", "", `# ${packName}`, "", "Body.\n"].join("\n"),
+    "utf8",
+  );
+  await writeFile(join(packDir, "src/Workflows/Run.md"), "# Run\n", "utf8");
+}
+
+/**
+ * Recursively list every file under `root`, returning POSIX-relative
+ * paths sorted for deterministic comparison. Used to assert equality
+ * between two on-disk outputs (apply via `importPaiPack` vs apply via
+ * `importPaiPackFromPlan`).
+ */
+async function listTree(root: string): Promise<string[]> {
+  const acc: string[] = [];
+  async function walk(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) await walk(full);
+      else acc.push(relative(root, full).split(sep).join("/"));
+    }
+  }
+  try {
+    await walk(root);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  return acc.sort();
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// R2 #1 (CodeQuality, important): nested routing before PORTABLE_PREFIXES
+// ───────────────────────────────────────────────────────────────────────
+
+test("R2 #1: nested-skill detection runs BEFORE PORTABLE_PREFIXES — src/Tools/SKILL.md routes as nested 'tools' skill", () => {
+  const nestedSet = new Set(["Tools"]);
+  const route = routePaiPackSourceFile("src/Tools/SKILL.md", nestedSet);
+  expect(route.classification).toBe("portable");
+  expect(route.root).toBe("skill");
+  expect(route.renderMode).toBe("skill");
+  expect(route.skillName).toBe("tools");
+  expect(route.relativePath).toBe("SKILL.md");
+});
+
+test("R2 #1: src/Tools/Workflows/x.md routes under nested 'tools' skill when Tools is nested", () => {
+  const nestedSet = new Set(["Tools"]);
+  const route = routePaiPackSourceFile("src/Tools/Workflows/x.md", nestedSet);
+  expect(route.skillName).toBe("tools");
+  expect(route.relativePath).toBe("Workflows/x.md");
+});
+
+test("R2 #1: FLAT pack — src/Tools/payload.ts still routes as flat portable (no nested override)", () => {
+  const route = routePaiPackSourceFile("src/Tools/payload.ts", new Set());
+  expect(route.classification).toBe("portable");
+  expect(route.skillName).toBe(null); // flat portable
+  expect(route.relativePath).toBe("Tools/payload.ts");
+});
+
+test("R2 #1: FLAT pack — src/SKILL.md routes as FLAT skill entry (no nested override possible)", () => {
+  const route = routePaiPackSourceFile("src/SKILL.md", new Set(["Anything"]));
+  expect(route.classification).toBe("portable");
+  expect(route.root).toBe("skill");
+  expect(route.skillName).toBe(null);
+  expect(route.relativePath).toBe("SKILL.md");
+  expect(route.renderMode).toBe("skill");
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// R2 #2 (Performance): importPaiPackFromPlan equivalence
+// ───────────────────────────────────────────────────────────────────────
+
+test("R2 #2: importPaiPackFromPlan produces the same on-disk output as importPaiPack (flat pack)", async () => {
+  await withTempHome(async (homeA) => {
+    await withTempHome(async (homeB) => {
+      const packA = join(homeA, "pack");
+      const packB = join(homeB, "pack");
+      await writeFlatPack(packA, "Demo");
+      await writeFlatPack(packB, "Demo");
+
+      const somaA = join(homeA, ".soma");
+      const somaB = join(homeB, ".soma");
+
+      // Path A: single-shot importPaiPack.
+      const resultA = await importPaiPack({
+        homeDir: homeA,
+        paiPackDir: packA,
+        somaHome: somaA,
+      });
+
+      // Path B: plan-then-apply-from-plan.
+      const { handle } = await planPaiPackImportHandle({
+        homeDir: homeB,
+        paiPackDir: packB,
+        somaHome: somaB,
+      });
+      const resultB = await importPaiPackFromPlan(handle, { overwrite: false });
+
+      // Same shape.
+      expect(resultB.length).toBe(resultA.length);
+      expect(resultB.map((r) => r.skillName).sort()).toEqual(resultA.map((r) => r.skillName).sort());
+
+      // Same file tree under skills/.
+      const treeA = await listTree(join(somaA, "skills"));
+      const treeB = await listTree(join(somaB, "skills"));
+      expect(treeB).toEqual(treeA);
+
+      // Same content for SKILL.md.
+      const slug = resultA[0]!.skillName;
+      const skillMdA = await readFile(join(somaA, "skills", slug, "SKILL.md"), "utf8");
+      const skillMdB = await readFile(join(somaB, "skills", slug, "SKILL.md"), "utf8");
+      expect(skillMdB).toBe(skillMdA);
+    });
+  });
+});
+
+test("R2 #2: importPaiPackFromPlan with excludeSkills drops collided skill and lands survivors (mixed pack)", async () => {
+  await withTempHome(async (home) => {
+    const packDir = join(home, "pack");
+    await writeFlatNestedPack(packDir, "Mixed");
+    const somaHome = join(home, ".soma");
+
+    const { plans, handle } = await planPaiPackImportHandle({
+      homeDir: home,
+      paiPackDir: packDir,
+      somaHome,
+    });
+
+    // Mixed pack derives 3 skills: pack-level "mixed", nested "remotion", nested "tools".
+    const slugs = plans.map((p) => p.skillName).sort();
+    expect(slugs).toEqual(["mixed", "remotion", "tools"]);
+
+    // Apply WITHOUT the "tools" skill. The flat pack-level "mixed" and
+    // nested "remotion" must still land; "tools" must NOT land.
+    const result = await importPaiPackFromPlan(handle, {
+      excludeSkills: new Set(["tools"]),
+      overwrite: false,
+    });
+    expect(result.map((r) => r.skillName).sort()).toEqual(["mixed", "remotion"]);
+
+    const tree = await listTree(join(somaHome, "skills"));
+    // "tools" must NOT appear in the tree at all.
+    expect(tree.some((p) => p.startsWith("tools/"))).toBe(false);
+    // The other two skills must be present with their SKILL.md.
+    expect(tree).toContain("mixed/SKILL.md");
+    expect(tree).toContain("remotion/SKILL.md");
+
+    // The pack-level archive still lists every original derived skill —
+    // it preserves the unfiltered pack identity for audit purposes.
+    const archiveManifestRaw = await readFile(
+      join(somaHome, "imports", "pai-packs", "mixed", "soma-pack-archive.json"),
+      "utf8",
+    );
+    const archiveManifest = JSON.parse(archiveManifestRaw) as { derivedSkills?: string[] };
+    // After exclusion the archive reflects the SURVIVING derived skills.
+    expect(archiveManifest.derivedSkills?.sort()).toEqual(["mixed", "remotion"]);
+  });
+});
+
+test("R2 #2: importPaiPackFromPlan throws PaiPackAllSkillsExcludedRefusal when every skill is excluded", async () => {
+  await withTempHome(async (home) => {
+    const packDir = join(home, "pack");
+    await writeFlatPack(packDir, "OnlyOne");
+    const somaHome = join(home, ".soma");
+
+    const { plans, handle } = await planPaiPackImportHandle({
+      homeDir: home,
+      paiPackDir: packDir,
+      somaHome,
+    });
+    const slug = plans[0]!.skillName;
+
+    await expect(
+      importPaiPackFromPlan(handle, {
+        excludeSkills: new Set([slug]),
+        overwrite: false,
+      }),
+    ).rejects.toThrow(/all derived skills excluded/i);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// R2 #4 (Maintainability): shared walker — plan vs apply outcome parity
+// ───────────────────────────────────────────────────────────────────────
+
+test("R2 #4: planPaiMigration and migratePai produce matching per-pack outcomes (skill set + outcome kinds)", async () => {
+  await withTempHome(async (homeApply) => {
+    await withTempHome(async (homePlan) => {
+      const packsApply = join(homeApply, "PAI/Packs");
+      const packsPlan = join(homePlan, "PAI/Packs");
+      await mkdir(packsApply, { recursive: true });
+      await mkdir(packsPlan, { recursive: true });
+      await writePaiIdentityFixture(homeApply);
+      await writePaiIdentityFixture(homePlan);
+
+      // Two packs that produce overlapping derived skills — the second
+      // pack's overlapping slug must surface as `refused-name-collision`
+      // in both plan and apply outputs.
+      const packAApply = join(packsApply, "pack-a");
+      const packBApply = join(packsApply, "pack-b");
+      const packAPlan = join(packsPlan, "pack-a");
+      const packBPlan = join(packsPlan, "pack-b");
+      for (const dir of [packAApply, packBApply, packAPlan, packBPlan]) {
+        await writeFlatPack(dir, "SharedName");
+      }
+
+      const somaApply = join(homeApply, ".soma");
+      const somaPlan = join(homePlan, ".soma");
+
+      const planResult = await planPaiMigration({
+        homeDir: homePlan,
+        claudeHome: join(homePlan, ".claude"),
+        somaHome: somaPlan,
+        paiPacksDir: packsPlan,
+        skipMemory: true,
+        skipDocs: true,
+      });
+
+      const applyResult = await migratePai({
+        homeDir: homeApply,
+        claudeHome: join(homeApply, ".claude"),
+        somaHome: somaApply,
+        paiPacksDir: packsApply,
+        skipMemory: true,
+        skipDocs: true,
+      });
+
+      // Outcome counts (per kind) match across plan and apply paths.
+      const tally = (outcomes: readonly { outcome: string }[]) => {
+        const t: Record<string, number> = {};
+        for (const o of outcomes) t[o.outcome] = (t[o.outcome] ?? 0) + 1;
+        return t;
+      };
+      expect(tally(planResult.packOutcomes)).toEqual(tally(applyResult.packOutcomes));
+
+      // Skill-name set (sorted) matches across plan and apply.
+      const planSlugs = planResult.packs.map((p) => p.skillName).sort();
+      const applySlugs = applyResult.packs.map((r) => r.skillName).sort();
+      expect(planSlugs).toEqual(applySlugs);
+    });
+  });
+});

--- a/test/pai-pack-importer-issue-108-r2.test.ts
+++ b/test/pai-pack-importer-issue-108-r2.test.ts
@@ -294,6 +294,108 @@ test("R2 #4: planPaiMigration and migratePai produce matching per-pack outcomes 
 });
 
 // ───────────────────────────────────────────────────────────────────────
+// R5 #2 (Security, blocker): forged handles are rejected
+// ───────────────────────────────────────────────────────────────────────
+
+test("R5 #2: importPaiPackFromPlan rejects a forged handle (not produced by planPaiPackImportHandle)", async () => {
+  await withTempHome(async (home) => {
+    const somaHome = join(home, ".soma");
+    await mkdir(somaHome, { recursive: true });
+    // Forge a handle that matches the structural interface but was
+    // NOT registered in the module-private trusted WeakSet.
+    const forged = { __brand: "PaiPackImportPlanHandle" as const };
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      importPaiPackFromPlan(forged as any, { overwrite: false }),
+    ).rejects.toThrow(/was not produced by planPaiPackImportHandle/i);
+  });
+});
+
+test("R5 #2: importPaiPackFromPlan rejects null and non-object handles", async () => {
+  await expect(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    importPaiPackFromPlan(null as any),
+  ).rejects.toThrow(/must be a PaiPackImportPlanHandle/i);
+  await expect(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    importPaiPackFromPlan("nope" as any),
+  ).rejects.toThrow(/must be a PaiPackImportPlanHandle/i);
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// R5 #1 (CodeQuality, important): nested SKILL.md descriptions are preserved
+// ───────────────────────────────────────────────────────────────────────
+
+test("R5 #1: nested skill's own SKILL.md description is preserved (not clobbered with generic string)", async () => {
+  await withTempHome(async (home) => {
+    const packDir = join(home, "pack");
+    await mkdir(join(packDir, "src/Remotion/Workflows"), { recursive: true });
+    await writeFile(
+      join(packDir, "README.md"),
+      "---\nname: MultiSkillPack\ndescription: Pack-level description.\n---\n\n# MultiSkillPack\n",
+      "utf8",
+    );
+    await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+    await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+    // Nested skill with its OWN, distinctive description.
+    const nestedDescription = "Render videos via Remotion from React components.";
+    await writeFile(
+      join(packDir, "src/Remotion/SKILL.md"),
+      `---\nname: Remotion\ndescription: ${nestedDescription}\n---\n\n# Remotion\n`,
+      "utf8",
+    );
+    await writeFile(
+      join(packDir, "src/Remotion/Workflows/Render.md"),
+      "# Render\n",
+      "utf8",
+    );
+    const somaHome = join(home, ".soma");
+    await importPaiPack({ homeDir: home, paiPackDir: packDir, somaHome });
+
+    // The nested skill's SKILL.md MUST carry its own description in
+    // the rewritten frontmatter — NOT the generic
+    // `Imported PAI nested skill: Remotion` string.
+    const remotionSkillMd = await readFile(join(somaHome, "skills/remotion/SKILL.md"), "utf8");
+    expect(remotionSkillMd).toContain(nestedDescription);
+    expect(remotionSkillMd).not.toContain("Imported PAI nested skill");
+
+    // Same in the soma-skill.json manifest.
+    const remotionManifestRaw = await readFile(join(somaHome, "skills/remotion/soma-skill.json"), "utf8");
+    const remotionManifest = JSON.parse(remotionManifestRaw) as { description?: string };
+    expect(remotionManifest.description).toBe(nestedDescription);
+  });
+});
+
+test("R5 #1: nested skill missing description falls back to generic", async () => {
+  await withTempHome(async (home) => {
+    const packDir = join(home, "pack");
+    await mkdir(join(packDir, "src/Bare/Workflows"), { recursive: true });
+    await writeFile(
+      join(packDir, "README.md"),
+      "---\nname: BarePack\ndescription: Bare pack.\n---\n\n# BarePack\n",
+      "utf8",
+    );
+    await writeFile(join(packDir, "INSTALL.md"), "# Install\n", "utf8");
+    await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+    // Nested SKILL.md without a description field at all.
+    await writeFile(
+      join(packDir, "src/Bare/SKILL.md"),
+      "---\nname: Bare\n---\n\n# Bare\n",
+      "utf8",
+    );
+    await writeFile(join(packDir, "src/Bare/Workflows/Default.md"), "# Default\n", "utf8");
+    const somaHome = join(home, ".soma");
+    await importPaiPack({ homeDir: home, paiPackDir: packDir, somaHome });
+
+    const manifestRaw = await readFile(join(somaHome, "skills/bare/soma-skill.json"), "utf8");
+    const manifest = JSON.parse(manifestRaw) as { description?: string };
+    // Fallback string is the generic one (this is the legacy behavior
+    // for a nested skill that genuinely has no description).
+    expect(manifest.description).toContain("Imported PAI nested skill");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
 // R3 #3 (CodeQuality): flat-vs-nested collision sources use RAW name
 // ───────────────────────────────────────────────────────────────────────
 
@@ -342,76 +444,34 @@ test("R3 #3: FLAT-vs-nested collision refusal reports RAW nested dir name (not k
 // ───────────────────────────────────────────────────────────────────────
 
 /**
- * Sage r4 #108 — a pack that plans cleanly but fails mid-apply must
- * NOT block a later pack from importing the same derived skill slug.
- * The cross-pack collision set may only grow after a real, completed
- * apply. To force a deterministic apply-time failure for the first
- * pack while keeping the second pack clean, we plant a non-empty FILE
- * at the staging tmp root the importer would use, so `mkdir`-ing the
- * stage path throws — surfacing as `refused-other` for pack-a; pack-b
- * with the same slug should still land as `imported`.
+ * Sage r4 #108 contract: a pack that fails mid-apply MUST NOT reserve
+ * its derived skill slug for cross-pack collision tracking. Pack-a
+ * fails as `refused-other`; pack-b with the same slug should still
+ * be attempted (and either land cleanly or fail on its own merits)
+ * rather than spuriously refused as `refused-name-collision`.
  *
- * Note: the apply path uses `stageRoot = join(somaHome, '.tmp',
- * 'pai-pack-<slug>-<ts>-<rand>')`, so a parent file at
- * `<somaHome>/.tmp` itself blocks every pack's mkdir attempt. We need
- * a more surgical failure for pack-a specifically. Easier: use a
- * within-pack defect — e.g., a fragile constructed pack where some
- * file path escapes containment — and pair it with a healthy pack-b.
- * Simplest reliable construction: pack-a has a NESTED skill name that
- * is structurally reserved by the pack importer (`soma`), which
- * triggers `PaiPackReservedNameRefusal` AT THE INNER PACK LEVEL but
- * does NOT raise `refused-other` — Sage's concern was specifically
- * about apply-throw paths that hit the `catch (error)` block. We
- * instead simulate the issue by:
- *   - pack-a: VALID plan, INVALID apply (introduce a writable-conflict
- *     by pre-creating the destination skill DIRECTORY as a FILE so
- *     `rename` during promotion throws).
- *   - pack-b: same slug, valid all the way through.
+ * To produce a deterministic apply-time `refused-other`, pack-a is
+ * built with a forbidden path the importer rejects during enumeration
+ * (`PAI pack import refused likely secret file(s):`). The migrate
+ * orchestrator catches this as `refused-other` (it's a plain Error,
+ * not a typed refusal). Pack-b is a clean pack with the same skill
+ * slug.
  */
-test("R4 #1: failed apply does NOT reserve slug — later pack with same slug still lands", async () => {
+test("R4 #1: pack-a failure does NOT reserve slug — pack-b with same slug still attempted", async () => {
   await withTempHome(async (home) => {
     const packsDir = join(home, "PAI/Packs");
     await mkdir(packsDir, { recursive: true });
     await writePaiIdentityFixture(home);
 
-    // Two packs with the same skill name. Pack-a will fail at apply
-    // time; pack-b should still land because pack-a wrote nothing.
+    // pack-a sorts before pack-b alphabetically. Build pack-a with a
+    // file the importer refuses to enumerate (a `.env`).
     const packA = join(packsDir, "pack-a");
-    const packB = join(packsDir, "pack-b");
     await writeFlatPack(packA, "Shared");
-    await writeFlatPack(packB, "Shared");
+    await writeFile(join(packA, ".env"), "SECRET=oops\n", "utf8");
 
-    // Force pack-a to fail at apply by pre-creating the target skill
-    // path as a FILE (not directory). The importer's promotion step
-    // refuses to overwrite a non-directory; `rename` over a file
-    // location either throws or leaves the pre-existing file. Either
-    // way pack-a's outcome lands as `refused-other`, while pack-b
-    // (sorted SECOND in the iteration: `pack-a` < `pack-b`) must
-    // still land.
-    //
-    // Sorted-by-path order is alphabetical, so pack-a is attempted
-    // first. We can't easily fail it without invasive setup; instead
-    // use a smaller, equivalent integration: pack-a has the SAME
-    // skill name as a Soma RESERVED slug (`isa`), so the migrate-level
-    // pre-check refuses it as `refused-reserved` — which has the same
-    // semantic shape as `refused-other` for collision-reservation
-    // purposes: pack-a never wrote anything.
-    //
-    // Actually `refused-reserved` is caught BEFORE the apply path is
-    // entered, so it never touches `landedSlugs` in either the pre-R4
-    // walker OR the new inline implementation. To genuinely exercise
-    // R4's contract we need a pack that plans + clears reserved but
-    // then fails on apply. The simplest way: pre-create a file at the
-    // archive target so the archive's `mkdir -p` fails — but the
-    // importer uses tmp-stage + rename, so it doesn't hit the
-    // archive until promotion. Cleanest reliable approach: pre-create
-    // a READ-ONLY directory at the skill target path; the promotion
-    // step's rename fails because it can't replace a non-empty
-    // readonly dir.
-    await mkdir(join(home, ".soma/skills/shared"), { recursive: true });
-    // Plant a file inside so rename refuses to overwrite a non-empty
-    // dir on macOS / Linux behaviour.
-    await writeFile(join(home, ".soma/skills/shared/blocker.txt"), "blocker\n", "utf8");
+    // pack-b is clean and produces the same derived skill slug.
+    const packB = join(packsDir, "pack-b");
+    await writeFlatPack(packB, "Shared");
 
     const result = await migratePai({
       homeDir: home,
@@ -422,24 +482,13 @@ test("R4 #1: failed apply does NOT reserve slug — later pack with same slug st
       skipDocs: true,
     });
 
-    // pack-a's outcome should NOT be `refused-name-collision` (pack-b
-    // is the second one sorted, but the test is about pack-b too).
-    const packAOutcomes = result.packOutcomes.filter((o) => o.paiPackDir === packA);
+    // pack-a fails (refused-other) — its slug "shared" was never
+    // reserved. pack-b is therefore free to land its own "shared".
     const packBOutcomes = result.packOutcomes.filter((o) => o.paiPackDir === packB);
-    // pack-a fails apply because the destination exists non-empty
-    // with `overwrite: true` from migration — actually overwrite IS
-    // set, so this might succeed. The test still pins the right
-    // contract: if BOTH packs land successfully, no collision is
-    // reported; if pack-a fails for some other reason, pack-b STILL
-    // gets a chance.
-    const hasCollisionForB = packBOutcomes.some((o) => o.outcome === "refused-name-collision");
-    const hasOtherFailureForA = packAOutcomes.some((o) => o.outcome === "refused-other");
-    if (hasOtherFailureForA) {
-      // Pre-R4: pack-b would record refused-name-collision spuriously
-      // because pack-a had already reserved the slug. Post-R4: pack-b
-      // is free to attempt and either imports or fails on its own
-      // merits — but NOT as a cross-pack collision.
-      expect(hasCollisionForB).toBe(false);
-    }
+    const packBCollision = packBOutcomes.find((o) => o.outcome === "refused-name-collision");
+    expect(packBCollision).toBeUndefined();
+    // Pack-b must have landed successfully — its "shared" skill is on disk.
+    const packBImported = packBOutcomes.find((o) => o.outcome === "imported" && o.skillName === "shared");
+    expect(packBImported).toBeDefined();
   });
 });

--- a/test/pai-pack-importer-issue-86.test.ts
+++ b/test/pai-pack-importer-issue-86.test.ts
@@ -290,7 +290,9 @@ test("AC-3: bare ~/.claude prose mentions rewrite to ~/.soma (zero-residue grep)
 
 test("AC-3 + AC-4: importing the issue-86 fixture leaves zero ~/.claude/ residue", async () => {
   await withTempHome(async (homeDir, somaHome) => {
-    const result = await importPaiPack({ homeDir, somaHome, paiPackDir: FIXTURE_PACK_DIR });
+    // #105 — `importPaiPack` returns one result per derived skill.
+    // The issue-86 fixture has no nested skills, so we expect a one-element array.
+    const [result] = await importPaiPack({ homeDir, somaHome, paiPackDir: FIXTURE_PACK_DIR });
     const skillRoot = join(somaHome, "skills", result.skillName);
     // Match the issue 86 reproduction scope: SKILL.md + Workflows/*.md only.
     // The `references/` directory under the skill root preserves original

--- a/test/pai-pack-importer.test.ts
+++ b/test/pai-pack-importer.test.ts
@@ -68,7 +68,8 @@ test("requires an explicit PAI Pack directory", async () => {
 test("plans a PAI Pack import without writing files", async () => {
   await withTempHome(async (homeDir) => {
     const packDir = await writePackFixture(homeDir);
-    const plan = await planPaiPackImport({ homeDir, paiPackDir: packDir });
+    // #105 — `planPaiPackImport` returns array. FLAT pack → one plan.
+    const [plan] = await planPaiPackImport({ homeDir, paiPackDir: packDir });
 
     expect(plan.apply).toBe(false);
     expect(plan.skillName).toBe("telos");
@@ -97,7 +98,10 @@ test("rejects invalid, reserved, colliding, secret, and substrate-specific pack 
 
     await mkdir(join(homeDir, ".soma/skills/telos"), { recursive: true });
     await expect(planPaiPackImport({ homeDir, paiPackDir: packDir })).rejects.toThrow("already exists");
-    await expect(planPaiPackImport({ homeDir, paiPackDir: packDir, overwrite: true })).resolves.toMatchObject({ skillName: "telos" });
+    // #105 — planPaiPackImport returns array; assert first plan matches.
+    await expect(planPaiPackImport({ homeDir, paiPackDir: packDir, overwrite: true })).resolves.toMatchObject([
+      { skillName: "telos" },
+    ]);
 
     const secretPackDir = await writePackFixture(join(homeDir, "secret"));
     await writeFile(join(secretPackDir, "src/DashboardTemplate/.env"), "TOKEN=secret\n", "utf8");
@@ -147,7 +151,7 @@ test("rejects invalid, reserved, colliding, secret, and substrate-specific pack 
     await mkdir(join(substratePackDir, "claude"), { recursive: true });
     await writeFile(join(substratePackDir, "claude/profile.md"), "# Claude profile\n", "utf8");
     await expect(planPaiPackImport({ homeDir, paiPackDir: substratePackDir, overwrite: true })).rejects.toThrow("substrate-specific");
-    const substratePlan = await planPaiPackImport({ homeDir, paiPackDir: substratePackDir, overwrite: true, includeSubstrateSpecific: true });
+    const [substratePlan] = await planPaiPackImport({ homeDir, paiPackDir: substratePackDir, overwrite: true, includeSubstrateSpecific: true });
     expect(substratePlan.files).toContainEqual(
       expect.objectContaining({
         target: join(homeDir, ".soma/imports/pai-packs/telos/source/claude/profile.md"),
@@ -185,7 +189,8 @@ test("imports a PAI Pack as a Soma skill", async () => {
   await withTempHome(async (homeDir) => {
     const packDir = await writePackFixture(homeDir);
     await bootstrapSomaHome({ homeDir });
-    const result = await importPaiPack({ homeDir, paiPackDir: packDir });
+    // #105 — `importPaiPack` returns array. FLAT pack → one result.
+    const [result] = await importPaiPack({ homeDir, paiPackDir: packDir });
     const context = await loadSomaHome(result.somaHome);
 
     expect(result.files).toContain(join(homeDir, ".soma/skills/telos/SKILL.md"));

--- a/test/pai-pack-normalizer.test.ts
+++ b/test/pai-pack-normalizer.test.ts
@@ -279,7 +279,8 @@ test("generateSomaSkillManifest keeps generated descriptions within portable lim
 
 test("AC-1: dry-run plan reports normalization actions + warnings", async () => {
   await withFakePack(async (paiPackDir, somaHome, homeDir) => {
-    const plan = await planPaiPackImport({ homeDir, somaHome, paiPackDir });
+    // #105 — planPaiPackImport returns array; FLAT pack → one plan.
+    const [plan] = await planPaiPackImport({ homeDir, somaHome, paiPackDir });
     expect(plan.normalization.actions.length).toBeGreaterThan(0);
     expect(plan.normalization.warnings.length).toBeGreaterThan(0);
     // No files written under somaHome
@@ -296,7 +297,8 @@ test("PAI pack import compacts oversized skill descriptions in frontmatter and m
       "utf8",
     );
 
-    const result = await importPaiPack({ homeDir, somaHome, paiPackDir });
+    // #105 — importPaiPack returns array; FLAT pack → one result.
+    const [result] = await importPaiPack({ homeDir, somaHome, paiPackDir });
     expect(result.normalization.actions.some((action) => action.kind === "compacted-skill-description")).toBe(true);
 
     const skillMd = await readFile(join(somaHome, "skills", "test-pack", "SKILL.md"), "utf8");
@@ -310,7 +312,8 @@ test("PAI pack import compacts oversized skill descriptions in frontmatter and m
 
 test("AC-2: apply writes normalized skill files + soma-skill.json", async () => {
   await withFakePack(async (paiPackDir, somaHome, homeDir) => {
-    const result = await importPaiPack({ homeDir, somaHome, paiPackDir });
+    // #105 — importPaiPack returns array; FLAT pack → one result.
+    const [result] = await importPaiPack({ homeDir, somaHome, paiPackDir });
     expect(result.normalization.actions.length).toBeGreaterThan(0);
 
     // AC-3: notification block removed from projected skill body


### PR DESCRIPTION
## Summary

PAI packs with N nested `src/<Name>/SKILL.md` files now import as N independent Soma skills. Routing layer recognises nested bundles; importer emits per-derived-skill plans/results; orchestrator tracks cross-pack name collisions and records them as a new `refused-name-collision` outcome.

**Smoke**: 45 source PAI packs → **59 landed Soma skills** (was 17 pre-#105). All 23 named-skill targets land: `art`, `remotion`, `extract-wisdom`, `be-creative`, `council`, `first-principles`, `iterative-depth`, `red-team`, `science`, `world-threat-model-harness`, `aphorisms`, `audio-editor`, `browser`, `cloudflare`, `create-cli`, `create-skill`, `delegation`, `documents`, `evals`, `fabric`, `pai-upgrade`, `parser`, `prompting`.

## Design decision: Option A (breaking change)

`importPaiPack` / `planPaiPackImport` now return arrays (`PaiPackImportResult[]` / `PaiPackImportPlan[]`) — one entry per derived skill. FLAT packs return one-element arrays. The migration orchestrator (primary consumer) handles arrays natively; the standalone `soma import pai-pack` CLI verb prints each plan/result in turn. Six pre-existing tests adjusted to `[0]`-destructure.

Rationale: forcing every caller to handle the multi-skill case prevents future drift.

## ACs

- [x] AC-1: Router recognizes nested `src/<Name>/{SKILL.md,Workflows/,Tools/,References/,Examples/}` as portable.
- [x] AC-2: PAI pack with N nested skills imports as N Soma skills under `~/.soma/skills/<kebab-name>/`.
- [x] AC-3: `src/<Name>/<other>` still classifies as substrate-specific.
- [x] AC-4: Name collisions surface as new outcome kind `refused-name-collision` (typed `PaiPackNameCollisionRefusal` for within-pack; bulk-phase tracking for across-pack).
- [x] AC-5: 19 new fixture tests in `test/pai-pack-importer-issue-105.test.ts` (14) + `test/pai-migration-issue-105.test.ts` (5) covering single-skill FLAT, 2-skill nested, 5-skill nested, mixed (top-level + nested), nested-skill non-recognized sibling, within-pack collision, across-pack collision, across-pack with override, plan-mode parity.
- [x] AC-6: Real `~/work/PAI/Packs/` smoke landed 59 skills cleanly with `--include-substrate-specific`. All 23 named skills present.
- [x] AC-7: `docs/pai-pack-importer.md` extended with a "Nested skill bundles (#105)" section — full classification table, kebab-casing rules, per-derived-skill doc attachment policy, name-collision policy, breaking-change note.

## Implementation notes

- **Routing** takes a `nestedSkills: Set<string>` parameter. A `<Name>` is nested iff `src/<Name>/SKILL.md` exists in the pack file set. Route result gains `skillName: string | null`.
- **Cross-pack collisions**: bulk-pack phase changed from 4-wide concurrent to serial-sorted iteration. `landedSlugs` set threads through apply + plan; first pack lexically wins; later collisions record `refused-name-collision`. Permitted via existing `--overwrite-reserved` flag.
- **Pack-level docs**: `README/INSTALL/VERIFY.md` now attach to each derived skill so nested skills are independently invocable with full pack context.
- **Archive** records sorted `derivedSkills` list in `soma-pack-archive.json`.
- **Slugifier fix**: handles ALL-CAPS prefixes (`PAIUpgrade` → `pai-upgrade`, `HTMLParser` → `html-parser`). Kept in sync between `slugifySkillName` and `kebabNestedName` — they duplicate the regex pair rather than risk a circular import.
- **REQUIRED_PACK_FILES** split: doc requirements still mandatory; `src/SKILL.md` now optional iff ≥1 nested SKILL.md exists.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 677 pass (was 657, +20)
- [x] Smoke: `bun src/cli.ts migrate pai --pai-repo ~/work/PAI --soma-home /tmp/soma-issue-105-smoke --apply --include-substrate-specific` lands 59 skills
- [x] Without `--include-substrate-specific`: 19 skills land (pure-portable nested packs only)
- [ ] Sage review loop
- [ ] Post-merge smoke on main

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)