### PR TITLE
fix(migrate): plan-mode exits 0 on refused-other; apply mode keeps exit 1 (#112)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2555,23 +2555,24 @@ export async function runSomaCli(args: string[]): Promise<string> {
     if (parsed.mode === "plan") {
       const plan = await planPaiMigration(parsed.options);
       const formatted = formatPaiMigrationPlan(plan, parsed.verbose);
-      // #102 — AC-4 mirror: plan mode honors the same exit-code policy
-      // as the apply path. Genuine errors (`refused-other`) cause a
-      // non-zero exit AFTER the rest of the plan completes, so the
-      // principal sees the full plan body including the outcome table
-      // before the error message. Policy-respected refusals
-      // (`refused-unrecognized-layout`, `refused-reserved`) stay zero
-      // exit — the principal asked for them by NOT passing the
-      // relevant override flag.
+      // #112 — split exit semantics by mode. Plan-mode (dry-run) is
+      // "show me what would happen"; a known-malformed upstream pack
+      // is informative, not a deploy blocker. The footer line stays —
+      // it's the principal signal regardless of exit code — but the
+      // CLI exits 0 so interactive use doesn't pair a non-zero exit
+      // with what is essentially a preview. Apply-mode keeps exit 1
+      // on `refused-other` per #97 AC-4 (write phase had a genuine
+      // error → CI must triage).
+      //
+      // Pre-#112 (per #102 AC-4 mirror): plan mode shared the apply
+      // policy and threw `SomaCliError(..., 1)` on any `refused-other`.
+      // That mirror is intentionally dropped here.
       const refusedOther = plan.packOutcomes.filter((o) => o.outcome === "refused-other");
       if (refusedOther.length > 0) {
         const detail = refusedOther
           .map((o) => `  - ${o.skillName ?? o.paiPackDir}: ${o.reason ?? "(no detail)"}`)
           .join("\n");
-        throw new SomaCliError(
-          `${formatted}\nsoma migrate pai — ${refusedOther.length} pack(s) failed with genuine errors:\n${detail}\n`,
-          1,
-        );
+        return `${formatted}\nsoma migrate pai — ${refusedOther.length} pack(s) failed with genuine errors:\n${detail}\n`;
       }
       return formatted;
     }

--- a/test/fixtures/pai-migration-fixtures.ts
+++ b/test/fixtures/pai-migration-fixtures.ts
@@ -109,6 +109,46 @@ export async function writePaiPackFixture(
 }
 
 /**
+ * Holly #113 nit — single-source the per-scenario migration setup. Every
+ * orchestrator-level test (#97, #102, #112) writes the identity fixture
+ * and derives `<homeDir>/Packs` as the packs root. Wraps `withTempHome`
+ * with the identity-fixture write + packs-dir derivation.
+ */
+export async function withMigrationHome<T>(
+  fn: (ctx: { homeDir: string; packsDir: string }) => Promise<T>,
+  prefix = "soma-migrate-",
+): Promise<T> {
+  return withTempHome(async (homeDir) => {
+    await writePaiIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    return fn({ homeDir, packsDir });
+  }, prefix);
+}
+
+/**
+ * Holly #113 nit — single-source the malformed-pack fixture. Used by
+ * the apply-side (#97), plan-side (#102), and exit-code (#112) tests
+ * to trigger `refused-other` outcomes. Missing INSTALL.md is the
+ * structural error the importer's REQUIRED_PACK_FILES check raises.
+ */
+export async function writeMalformedPaiPack(packsDir: string, packName: string): Promise<void> {
+  const packDir = join(packsDir, packName);
+  await mkdir(join(packDir, "src"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    `---\nname: ${packName}\ndescription: malformed\n---\n\n# ${packName}\n`,
+    "utf8",
+  );
+  // INSTALL.md intentionally omitted.
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    `---\nname: ${packName}\ndescription: malformed\n---\n\n# ${packName}\n`,
+    "utf8",
+  );
+}
+
+/**
  * Write a minimal PAI release tree under
  * `<homeDir>/PAI/Releases/v5.0.0/.claude/PAI` sufficient for
  * `importPaiDocs` to recognize via its `DOCUMENTATION/` guard.

--- a/test/pai-migration-issue-102.test.ts
+++ b/test/pai-migration-issue-102.test.ts
@@ -39,7 +39,7 @@ import { mkdir, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { planPaiMigration } from "../src/pai-migration";
-import { runSomaCli, SomaCliError } from "../src/cli";
+import { runSomaCli } from "../src/cli";
 import {
   withTempHome as withSharedTempHome,
   writePaiIdentityFixture as writeIdentityFixture,
@@ -223,7 +223,7 @@ test("AC-1 — CLI parses --include-unrecognized for `migrate pai` plan-mode (pa
   });
 });
 
-test("AC-4 — plan-mode CLI exit non-zero when a pack outcome is refused-other (after rest of plan completes)", async () => {
+test("AC-4 — plan-mode CLI exit ZERO on refused-other (per #112; full plan body still emitted with footer)", async () => {
   // #109 — unrecognized files no longer refuse the pack (partial-import).
   // The remaining `refused-other` branch is still exercised below.
   await withMigrationHome(async ({ homeDir, packsDir }) => {
@@ -240,32 +240,32 @@ test("AC-4 — plan-mode CLI exit non-zero when a pack outcome is refused-other 
     ]);
     expect(out).toContain("imported");
   });
-  // Malformed pack → SomaCliError exitCode 1; output still includes
-  // the full plan body for the other packs.
+  // #112 — plan-mode now exits 0 on `refused-other`. The full plan
+  // body — including the outcome table AND the "N pack(s) failed
+  // with genuine errors:" footer — is returned as the formatted
+  // output (not thrown). Apply-mode keeps exit 1 per #97 AC-4;
+  // that's covered in `pai-migration-issue-112.test.ts` AC-2.
+  //
+  // Pre-#112 this assertion was `toBeInstanceOf(SomaCliError) +
+  // exitCode === 1`. #112 intentionally inverts the contract for the
+  // plan path.
   await withMigrationHome(async ({ homeDir, packsDir }) => {
     await makeMalformedPack(packsDir, "Broken");
     await writePackFixture(packsDir, "Healthy");
-    let caught: unknown = null;
-    try {
-      await runSomaCli([
-        "migrate",
-        "pai",
-        "--home-dir",
-        homeDir,
-        "--pai-packs-dir",
-        packsDir,
-      ]);
-    } catch (err) {
-      caught = err;
-    }
-    expect(caught).toBeInstanceOf(SomaCliError);
-    expect((caught as SomaCliError).exitCode).toBe(1);
-    // The full plan body — including the outcome table — must be in
-    // the error message so the principal sees what happened.
-    const msg = (caught as SomaCliError).message;
-    expect(msg).toContain("Pack outcomes");
-    expect(msg).toContain("refused-other");
-    expect(msg).toContain("imported");
+    const out = await runSomaCli([
+      "migrate",
+      "pai",
+      "--home-dir",
+      homeDir,
+      "--pai-packs-dir",
+      packsDir,
+    ]);
+    // No throw → exit 0. Full plan body still emitted.
+    expect(out).toContain("Pack outcomes");
+    expect(out).toContain("refused-other");
+    expect(out).toContain("imported");
+    // Footer line — the principal signal — stays in plan mode.
+    expect(out).toMatch(/\d+ pack\(s\) failed with genuine errors:/);
   });
 });
 

--- a/test/pai-migration-issue-102.test.ts
+++ b/test/pai-migration-issue-102.test.ts
@@ -35,35 +35,20 @@
  * with `src/Foundation.md` + `src/MethodSelection.md`) and confirms
  * the plan completes without the raw throw the user originally saw.
  */
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { planPaiMigration } from "../src/pai-migration";
 import { runSomaCli } from "../src/cli";
 import {
-  withTempHome as withSharedTempHome,
-  writePaiIdentityFixture as writeIdentityFixture,
+  withMigrationHome as withSharedMigrationHome,
+  writeMalformedPaiPack as makeMalformedPack,
   writePaiPackFixture as writePackFixture,
 } from "./fixtures/pai-migration-fixtures";
 
-const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
-  withSharedTempHome(fn, "soma-102-");
-
-/**
- * Sage r1 #103 Maintainability — single-source the per-scenario
- * setup. Every test in this file writes the identity fixture and
- * derives `<homeDir>/Packs` as the packs root, so a helper keeps
- * future fixture changes one-edit-away from propagating everywhere.
- */
-async function withMigrationHome<T>(
+const withMigrationHome = <T>(
   fn: (ctx: { homeDir: string; packsDir: string }) => Promise<T>,
-): Promise<T> {
-  return withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
-    return fn({ homeDir, packsDir });
-  });
-}
+): Promise<T> => withSharedMigrationHome(fn, "soma-102-");
 
 /**
  * Plant a substrate-specific file inside an existing pack fixture.
@@ -75,26 +60,6 @@ async function plantSubstrateSpecificFile(packDir: string, filename = "Foundatio
   await writeFile(
     join(packDir, "src", filename),
     `# ${filename.replace(".md", "")}\n\nSubstrate-specific doc.\n`,
-    "utf8",
-  );
-}
-
-async function makeMalformedPack(packsDir: string, packName: string): Promise<void> {
-  // Missing INSTALL.md → REQUIRED_PACK_FILES check fails → buildPaiPackImportPlan
-  // throws → planPaiPackImport surfaces it → orchestrator must catch it as
-  // refused-other (mirrors the apply path).
-  const packDir = join(packsDir, packName);
-  await mkdir(join(packDir, "src"), { recursive: true });
-  await writeFile(
-    join(packDir, "README.md"),
-    `---\nname: ${packName}\ndescription: malformed\n---\n\n# ${packName}\n`,
-    "utf8",
-  );
-  // INSTALL.md intentionally omitted.
-  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
-  await writeFile(
-    join(packDir, "src/SKILL.md"),
-    `---\nname: ${packName}\ndescription: malformed\n---\n\n# ${packName}\n`,
     "utf8",
   );
 }

--- a/test/pai-migration-issue-112.test.ts
+++ b/test/pai-migration-issue-112.test.ts
@@ -24,47 +24,24 @@
  * AC-4 of #112: fixture tests cover all 4 cells of the
  * mode × refused-other matrix. This file is those tests.
  */
-import { mkdir, stat, writeFile } from "node:fs/promises";
+import { stat } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { runSomaCli, SomaCliError } from "../src/cli";
 import {
-  withTempHome as withSharedTempHome,
-  writePaiIdentityFixture as writeIdentityFixture,
+  withMigrationHome as withSharedMigrationHome,
+  writeMalformedPaiPack as makeMalformedPack,
   writePaiPackFixture as writePackFixture,
 } from "./fixtures/pai-migration-fixtures";
 
-const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
-  withSharedTempHome(fn, "soma-112-");
-
-/**
- * A pack missing INSTALL.md is "malformed" by the importer's
- * REQUIRED_PACK_FILES check — the issue's outcome enum classifies it
- * `refused-other`. Mirrors the helper in `pai-migration-issue-97.test.ts`.
- */
-async function makeMalformedPack(packsDir: string, packName: string): Promise<void> {
-  const packDir = join(packsDir, packName);
-  await mkdir(join(packDir, "src"), { recursive: true });
-  await writeFile(
-    join(packDir, "README.md"),
-    `---\nname: ${packName}\ndescription: malformed\n---\n\n# ${packName}\n`,
-    "utf8",
-  );
-  // INSTALL.md intentionally omitted.
-  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
-  await writeFile(
-    join(packDir, "src/SKILL.md"),
-    `---\nname: ${packName}\ndescription: malformed\n---\n\n# ${packName}\n`,
-    "utf8",
-  );
-}
+const withMigrationHome = <T>(
+  fn: (ctx: { homeDir: string; packsDir: string }) => Promise<T>,
+): Promise<T> => withSharedMigrationHome(fn, "soma-112-");
 
 const FOOTER_RE = /\d+ pack\(s\) failed with genuine errors:/;
 
 test("AC-1 — plan mode (no --apply) with refused-other exits 0 + footer line present", async () => {
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     await makeMalformedPack(packsDir, "Broken");
     await writePackFixture(packsDir, "Healthy");
     // Plan mode = no --apply.
@@ -83,9 +60,7 @@ test("AC-1 — plan mode (no --apply) with refused-other exits 0 + footer line p
 });
 
 test("AC-1 (matrix cell: plan + no refused-other) → exit 0 + no footer", async () => {
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     await writePackFixture(packsDir, "Alpha");
     await writePackFixture(packsDir, "Beta");
     const out = await runSomaCli([
@@ -101,9 +76,7 @@ test("AC-1 (matrix cell: plan + no refused-other) → exit 0 + no footer", async
 });
 
 test("AC-2 — apply mode with refused-other exits 1 + footer line present (unchanged from #97 AC-4)", async () => {
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     await makeMalformedPack(packsDir, "Broken");
     await writePackFixture(packsDir, "Healthy");
     let caught: unknown = null;
@@ -131,9 +104,7 @@ test("AC-2 — apply mode with refused-other exits 1 + footer line present (unch
 });
 
 test("AC-2 (matrix cell: apply + no refused-other) → exit 0 + no footer", async () => {
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     await writePackFixture(packsDir, "Alpha");
     await writePackFixture(packsDir, "Beta");
     const out = await runSomaCli([
@@ -156,9 +127,7 @@ test("AC-3 — footer line wording matches across both modes (plan + apply)", as
   // The footer line is the principal signal regardless of exit code.
   // The wording must be byte-identical across modes so downstream
   // stdout parsers don't need to branch on mode.
-  await withTempHome(async (homeDir) => {
-    await writeIdentityFixture(homeDir);
-    const packsDir = join(homeDir, "Packs");
+  await withMigrationHome(async ({ homeDir, packsDir }) => {
     await makeMalformedPack(packsDir, "Broken");
     await writePackFixture(packsDir, "Healthy");
     const planOut = await runSomaCli([

--- a/test/pai-migration-issue-112.test.ts
+++ b/test/pai-migration-issue-112.test.ts
@@ -1,0 +1,194 @@
+/**
+ * #112 — `soma migrate pai` plan-mode exit semantics.
+ *
+ * Pre-#112 (per #97 AC-4 mirror in #102): plan mode shared the apply
+ * mode's exit policy — any `refused-other` outcome caused a non-zero
+ * CLI exit AFTER printing the full plan body.
+ *
+ * #112 splits the policy by mode:
+ *
+ *   | Mode  | refused-other present | Exit |
+ *   | ----- | --------------------- | ---- |
+ *   | plan  | yes                   | 0    |  (NEW — was 1)
+ *   | plan  | no                    | 0    |
+ *   | apply | yes                   | 1    |  (unchanged)
+ *   | apply | no                    | 0    |
+ *
+ * Rationale: dry-run on a known-malformed upstream PAI pack adds
+ * friction without informing the human. CI scripts that need a hard
+ * signal pass `--apply`; that path keeps exit 1 on genuine errors per
+ * #97 AC-4. The footer "N pack(s) failed with genuine errors:" line
+ * STAYS in both modes — it's the principal signal regardless of exit
+ * code.
+ *
+ * AC-4 of #112: fixture tests cover all 4 cells of the
+ * mode × refused-other matrix. This file is those tests.
+ */
+import { mkdir, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { runSomaCli, SomaCliError } from "../src/cli";
+import {
+  withTempHome as withSharedTempHome,
+  writePaiIdentityFixture as writeIdentityFixture,
+  writePaiPackFixture as writePackFixture,
+} from "./fixtures/pai-migration-fixtures";
+
+const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
+  withSharedTempHome(fn, "soma-112-");
+
+/**
+ * A pack missing INSTALL.md is "malformed" by the importer's
+ * REQUIRED_PACK_FILES check — the issue's outcome enum classifies it
+ * `refused-other`. Mirrors the helper in `pai-migration-issue-97.test.ts`.
+ */
+async function makeMalformedPack(packsDir: string, packName: string): Promise<void> {
+  const packDir = join(packsDir, packName);
+  await mkdir(join(packDir, "src"), { recursive: true });
+  await writeFile(
+    join(packDir, "README.md"),
+    `---\nname: ${packName}\ndescription: malformed\n---\n\n# ${packName}\n`,
+    "utf8",
+  );
+  // INSTALL.md intentionally omitted.
+  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
+  await writeFile(
+    join(packDir, "src/SKILL.md"),
+    `---\nname: ${packName}\ndescription: malformed\n---\n\n# ${packName}\n`,
+    "utf8",
+  );
+}
+
+const FOOTER_RE = /\d+ pack\(s\) failed with genuine errors:/;
+
+test("AC-1 — plan mode (no --apply) with refused-other exits 0 + footer line present", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await makeMalformedPack(packsDir, "Broken");
+    await writePackFixture(packsDir, "Healthy");
+    // Plan mode = no --apply.
+    const out = await runSomaCli([
+      "migrate",
+      "pai",
+      "--home-dir",
+      homeDir,
+      "--pai-packs-dir",
+      packsDir,
+    ]);
+    // No throw → exit 0. Footer still present in the returned text.
+    expect(out).toMatch(FOOTER_RE);
+    expect(out).toMatch(/refused-other/);
+  });
+});
+
+test("AC-1 (matrix cell: plan + no refused-other) → exit 0 + no footer", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await writePackFixture(packsDir, "Alpha");
+    await writePackFixture(packsDir, "Beta");
+    const out = await runSomaCli([
+      "migrate",
+      "pai",
+      "--home-dir",
+      homeDir,
+      "--pai-packs-dir",
+      packsDir,
+    ]);
+    expect(out).not.toMatch(FOOTER_RE);
+  });
+});
+
+test("AC-2 — apply mode with refused-other exits 1 + footer line present (unchanged from #97 AC-4)", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await makeMalformedPack(packsDir, "Broken");
+    await writePackFixture(packsDir, "Healthy");
+    let caught: unknown = null;
+    try {
+      await runSomaCli([
+        "migrate",
+        "pai",
+        "--apply",
+        "--home-dir",
+        homeDir,
+        "--pai-packs-dir",
+        packsDir,
+      ]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(SomaCliError);
+    expect((caught as SomaCliError).exitCode).toBe(1);
+    // Footer line is in the error message.
+    expect((caught as SomaCliError).message).toMatch(FOOTER_RE);
+    // Healthy pack still imported despite Broken pack's refusal —
+    // log-and-continue from #97.
+    await stat(join(homeDir, ".soma/skills/healthy/SKILL.md"));
+  });
+});
+
+test("AC-2 (matrix cell: apply + no refused-other) → exit 0 + no footer", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await writePackFixture(packsDir, "Alpha");
+    await writePackFixture(packsDir, "Beta");
+    const out = await runSomaCli([
+      "migrate",
+      "pai",
+      "--apply",
+      "--home-dir",
+      homeDir,
+      "--pai-packs-dir",
+      packsDir,
+    ]);
+    expect(out).not.toMatch(FOOTER_RE);
+    // Both packs landed.
+    await stat(join(homeDir, ".soma/skills/alpha/SKILL.md"));
+    await stat(join(homeDir, ".soma/skills/beta/SKILL.md"));
+  });
+});
+
+test("AC-3 — footer line wording matches across both modes (plan + apply)", async () => {
+  // The footer line is the principal signal regardless of exit code.
+  // The wording must be byte-identical across modes so downstream
+  // stdout parsers don't need to branch on mode.
+  await withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    await makeMalformedPack(packsDir, "Broken");
+    await writePackFixture(packsDir, "Healthy");
+    const planOut = await runSomaCli([
+      "migrate",
+      "pai",
+      "--home-dir",
+      homeDir,
+      "--pai-packs-dir",
+      packsDir,
+    ]);
+    let applyErr: SomaCliError | null = null;
+    try {
+      await runSomaCli([
+        "migrate",
+        "pai",
+        "--apply",
+        "--home-dir",
+        homeDir,
+        "--pai-packs-dir",
+        packsDir,
+      ]);
+    } catch (err) {
+      applyErr = err as SomaCliError;
+    }
+    expect(applyErr).not.toBeNull();
+    // Same footer line in both outputs.
+    const planFooter = planOut.match(/\d+ pack\(s\) failed with genuine errors:.*?(?:\n|$)/);
+    const applyFooter = applyErr!.message.match(/\d+ pack\(s\) failed with genuine errors:.*?(?:\n|$)/);
+    expect(planFooter).not.toBeNull();
+    expect(applyFooter).not.toBeNull();
+    expect(planFooter![0]).toBe(applyFooter![0]);
+  });
+});

--- a/test/pai-migration-issue-97.test.ts
+++ b/test/pai-migration-issue-97.test.ts
@@ -17,7 +17,7 @@
  * them) is covered by a sixth test that asserts MIGRATION.md body
  * fingerprint contains the per-pack outcome lines.
  */
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { migratePai } from "../src/pai-migration";
@@ -25,6 +25,7 @@ import { runSomaCli, SomaCliError } from "../src/cli";
 import {
   withTempHome as withSharedTempHome,
   writePaiIdentityFixture as writeIdentityFixture,
+  writeMalformedPaiPack as makeMalformedPack,
   writePaiPackFixture as writePackFixture,
 } from "./fixtures/pai-migration-fixtures";
 
@@ -41,26 +42,6 @@ async function plantSubstrateSpecificFile(packDir: string): Promise<void> {
   await writeFile(
     join(packDir, "src/Foundation.md"),
     "# Foundation\n\nSubstrate-specific doc.\n",
-    "utf8",
-  );
-}
-
-async function makeMalformedPack(packsDir: string, packName: string): Promise<void> {
-  // A pack missing INSTALL.md is "malformed" by the importer's
-  // REQUIRED_PACK_FILES check — it raises a structural error that
-  // the issue's outcome enum classifies `refused-other`.
-  const packDir = join(packsDir, packName);
-  await mkdir(join(packDir, "src"), { recursive: true });
-  await writeFile(
-    join(packDir, "README.md"),
-    `---\nname: ${packName}\ndescription: malformed\n---\n\n# ${packName}\n`,
-    "utf8",
-  );
-  // INSTALL.md intentionally omitted.
-  await writeFile(join(packDir, "VERIFY.md"), "# Verify\n", "utf8");
-  await writeFile(
-    join(packDir, "src/SKILL.md"),
-    `---\nname: ${packName}\ndescription: malformed\n---\n\n# ${packName}\n`,
     "utf8",
   );
 }


### PR DESCRIPTION
## Summary

Splits `soma migrate pai` exit semantics by mode. Plan-mode (dry-run, no `--apply`) is a preview — a known-malformed upstream PAI pack (e.g. `~/work/PAI/Packs/ContextSearch` shipping `src/commands/` only, no `SKILL.md`) is informative, not a deploy blocker. The footer `N pack(s) failed with genuine errors:` line **stays in both modes** — it's the principal signal regardless of exit code. Apply-mode (`--apply`) keeps exit 1 on `refused-other` per #97 AC-4: CI scripts running the write phase need the hard signal.

## Before / after exit-code matrix

| Mode  | `refused-other` present | Before | After |
| ----- | ----------------------- | ------ | ----- |
| plan  | yes                     | 1      | **0** |
| plan  | no                      | 0      | 0     |
| apply | yes                     | 1      | 1     |
| apply | no                      | 0      | 0     |

Only the plan + refused-other cell changes.

## Acceptance criteria

- [x] **AC-1** — `soma migrate pai --pai-repo <root>` (no `--apply`) with refused-other packs exits 0.
- [x] **AC-2** — `soma migrate pai --pai-repo <root> --apply` with refused-other packs still exits 1.
- [x] **AC-3** — Footer `N pack(s) failed with genuine errors:` line still emitted in both modes.
- [x] **AC-4** — Fixture tests cover all 4 cells of the mode × refused-other matrix.

## Test evidence

- NEW `test/pai-migration-issue-112.test.ts` (5 tests):
  - AC-1: plan + refused-other → exit 0 + footer present.
  - AC-1 matrix: plan + no refused-other → exit 0 + no footer.
  - AC-2: apply + refused-other → `SomaCliError` exitCode 1 + footer + healthy pack still imported.
  - AC-2 matrix: apply + no refused-other → exit 0 + no footer + both packs landed.
  - AC-3: footer wording is byte-identical across plan + apply paths.
- UPDATED `test/pai-migration-issue-102.test.ts` AC-4: pre-#112 contract (plan + refused-other → `SomaCliError(1)`) was the #102 AC-4 mirror of #97. #112 intentionally inverts the plan path. Test rewritten in place to pin the new contract; unused `SomaCliError` import dropped.
- Implementation in `src/cli.ts` lines 2555-2577 (migrate plan branch): replaced `throw new SomaCliError(..., 1)` with a `return` of the same formatted string. Apply-mode branch (lines 2578+) unchanged.

## Verification

```
$ bun run typecheck    # clean
$ bun test             # 743 pass / 0 fail / 2364 expect() calls (was 742/2361 → +1 net test, +3 expects)
```

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` 743/0
- [ ] Post-merge smoke: `bun src/cli.ts migrate pai --pai-repo ~/work/PAI; echo $?` → 0
- [ ] Post-merge smoke: `bun src/cli.ts migrate pai --pai-repo ~/work/PAI --soma-home /tmp/smoke --apply; echo $?` → 1

Closes #112.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>