### PR TITLE
feat(migrate): soma migrate claude-skills — import from .claude/skills with portability classifier (#115 Phase 1)

### DIFF
--- a/docs/migration-from-pai.md
+++ b/docs/migration-from-pai.md
@@ -339,6 +339,104 @@ soma migrate pai --pai-repo ~/work/PAI --apply --skip-docs
 `Packs/` dir won't throw when you've explicitly opted out of that
 phase.
 
+## Migrating from installed `.claude/skills/` instead of `Packs/`
+
+`soma migrate pai` imports from a PAI source repo's `Packs/` tree (the
+**distribution** source). That tree carries collection bundles
+(Media, Thinking, Utilities, Scraping, etc.) that bundle nested
+duplicates of standalone skills — on a real PAI install this produces
+22+ name collisions per run that have to be triaged via
+`--include-unrecognized` and `--overwrite-reserved`.
+
+`soma migrate claude-skills` is a **second** migration path. It imports
+directly from an installed flat skills tree (e.g.
+`~/.claude/skills/` or
+`~/work/PAI/Releases/v5.0.0/.claude/skills/`) — one `<Name>/SKILL.md`
+per skill, no pack-level metadata, no collection bundles. The installed
+tree is the same content the user's running PAI install already
+projects to Claude Code, so the delta from "what's running today" to
+"what's in `~/.soma/`" is smaller.
+
+### Usage
+
+```bash
+# Plan (default): list every skill with a portability tag.
+soma migrate claude-skills --from ~/.claude/skills
+
+# Apply: write portable + needs-adapt skills to ~/.soma/skills/<kebab>/.
+soma migrate claude-skills --from ~/.claude/skills --apply
+
+# Apply with a custom Soma home (useful for staging).
+soma migrate claude-skills \
+  --from ~/work/PAI/Releases/v5.0.0/.claude/skills \
+  --soma-home /tmp/soma-staging \
+  --apply
+
+# Also import skills the classifier flagged as Claude-Code-specific.
+soma migrate claude-skills --from ~/.claude/skills --apply --include-claude-specific
+
+# Status: read the SHA manifest of the prior apply.
+soma migrate claude-skills --status
+```
+
+### Portability classifier (Phase 1, heuristic)
+
+Each source skill gets one of three tags:
+
+| Tag | Trigger |
+|---|---|
+| `portable` | No `~/.claude/` references, no hook bindings, no `/<slash-command>` references in prose. |
+| `needs-adapt` | `~/.claude/...` reference(s); rewritten via the existing `pai-pack-normalizer.ts` deterministic rewrite table (the same one `soma migrate pai` uses for `~/.claude/PAI/DOCUMENTATION/`, `~/.claude/PAI/TEMPLATES/`, `~/.claude/PAI/ALGORITHM/`, `~/.claude/PAI/MEMORY/`, and `~/.claude/skills/`). |
+| `claude-specific` | Hook binding (`Stop:`, `UserPromptSubmit:`, `PreToolUse:`, `PostToolUse:`, `SessionStart:`, `SubagentStop:`, `Notification:`, `PreCompact:`) OR `/<slash-command>` reference in prose (outside fenced code blocks). |
+
+**Apply behavior:**
+
+- `portable` + `needs-adapt` → imported. `needs-adapt` content runs
+  through the normalizer; `portable` is passed through bit-for-bit.
+- `claude-specific` → skipped with a `skipped-claude-specific`
+  disposition. Re-run with `--include-claude-specific` to land them
+  anyway (the audit warning stays).
+
+### Outputs
+
+- `~/.soma/skills/<kebab>/SKILL.md` (+ Workflows/, Tools/,
+  References/, Examples/, …) for each imported skill.
+- `~/.soma/imports/claude-skills/.manifest.json` — per-skill SHA
+  manifest, used for idempotent reruns (unchanged source = zero
+  writes, byte-stable manifest).
+- `~/.soma/imports/claude-skills/.portability-report.md` — markdown
+  table of every source skill with its tag, disposition, and the
+  reason the classifier picked the tag.
+
+### Limits of Phase 1
+
+The classifier is **regex-based** — pattern match, not semantic
+analysis. Slash-command detection runs only on Markdown/text files;
+code files (`.ts`, `.js`, `.py`, etc.) routinely embed `/path`
+fragments and Discord-style command names that would otherwise false-
+positive. Subtle Claude-only behavior that doesn't trip the regex
+signals can still slip through as `portable`. The classifier emits
+reasons (count of `~/.claude` refs, file path that fired the signal)
+so reviewers can audit.
+
+Phase 2 (`--smoke <substrate>`, deferred to a separate PR) adds per-
+skill substrate projection verify — turns the verdict from heuristic
+to verified.
+
+### Choosing between the two migration paths
+
+| Need | Use |
+|---|---|
+| Importing from a PAI source repo (`~/work/PAI`) | `soma migrate pai --pai-repo` |
+| Importing from your running `.claude/skills/` install (e.g. `~/.claude/skills/` or a Releases/vX.Y.Z snapshot) | `soma migrate claude-skills --from` |
+| Need identity/algorithm/memory phases alongside skills | `soma migrate pai` (this path runs all four phases) |
+| Want a smaller, collision-free skill import | `soma migrate claude-skills` |
+
+The two paths are not mutually exclusive — `soma migrate pai` covers
+identity + algorithm + memory + skills; `soma migrate claude-skills`
+covers skills only, from the installed-tree shape instead of the
+distribution-pack shape.
+
 ## Related
 
 - #88 — memory taxonomy alignment.
@@ -350,3 +448,4 @@ phase.
 - #104 — silent skip of IDE/editor config symlinks (`.cursor/.vscode/.idea/.fleet/.zed/`).
 - #105 — nested skill bundles (one PAI pack → N Soma skills).
 - #106 — rename `substrate-specific` → `unrecognized-layout`; collapse plan output; `noise` classification.
+- #115 — `soma migrate claude-skills` verb + portability classifier (Phase 1, this section).

--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -534,7 +534,11 @@ async function writeSkillPayload(
     // Only the canonical text-payload extensions go through the
     // rewriter. Binary assets (images, audio under `Examples/`)
     // pass through bit-for-bit so SHA still equals source SHA.
-    const isText = /\.(md|txt|json|yaml|yml|ts|js|tsx|jsx|py|sh|toml)$/.test(file.relPath);
+    // `.hbs` (Handlebars) covered because PAI's Prompting skill
+    // ships templates that reference `~/.claude/Skills/...` literally
+    // in template bodies — the rewriter must touch them too or
+    // landed skills carry residue (AC-3 zero-residue grep).
+    const isText = /\.(md|markdown|mdx|txt|json|yaml|yml|ts|js|tsx|jsx|mjs|cjs|py|rb|sh|bash|zsh|toml|hbs|handlebars|tmpl|tpl|xml|html|css)$/.test(file.relPath);
     if (applyRewrites && isText) {
       const original = file.content.toString("utf8");
       const { content: rewritten } = normalizeSkillContent(file.relPath, original);

--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -1,0 +1,738 @@
+/**
+ * #115 — `soma migrate claude-skills` (Phase 1).
+ *
+ * Second migration path alongside `soma migrate pai`. Imports directly
+ * from an installed flat `.claude/skills/` tree:
+ *   - One `<Name>/SKILL.md` per skill, no pack-level metadata.
+ *   - No collection bundles (no nested-skill duplicates → no collisions
+ *     by construction).
+ *   - Per-skill payload typically includes `Workflows/`, `Tools/`,
+ *     `References/`, `Examples/` siblings.
+ *
+ * Per-skill pipeline:
+ *   1. Read `<from>/<Name>/SKILL.md`, walk the skill body recursively.
+ *   2. Classify portability (heuristic, regex-based):
+ *        - `portable`        — no `~/.claude/` refs, no hook bindings,
+ *                              no `/<slash-command>` prose refs.
+ *        - `needs-adapt`     — `~/.claude/...` paths the pai-pack
+ *                              normalizer can deterministically rewrite.
+ *        - `claude-specific` — hook bindings or slash commands; no
+ *                              portable equivalent.
+ *   3. Apply rewrites (for `needs-adapt`) via the existing
+ *      `normalizeSkillContent` pipeline.
+ *   4. Write to `<somaHome>/skills/<kebab>/`, mirroring siblings.
+ *   5. Skip `claude-specific` unless `includeClaudeSpecific` is set.
+ *
+ * Idempotency:
+ *   - SHA-256 of the source SKILL.md is the per-skill identity key.
+ *   - Re-running with unchanged source → zero writes, manifest
+ *     `importedAt` preserved.
+ *
+ * Phase 2 (deferred — separate PR): `--smoke <substrate>` per-skill
+ * projection verify against Codex / Pi.dev substrate projectors.
+ *
+ * Boundaries (same as `pai-pack-normalizer.ts`):
+ *   - No LLM rewrites.
+ *   - No personal/private inference.
+ *   - No execution of embedded commands.
+ *   - The classifier is HEURISTIC — regex pattern match, not semantic
+ *     analysis. Its limits are documented in the portability report
+ *     header.
+ */
+import { createHash } from "node:crypto";
+import {
+  copyFile,
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  realpath,
+  writeFile,
+} from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { kebabSlug } from "./pai-pack-slug";
+import { normalizeSkillContent } from "./pai-pack-normalizer";
+import { EDITOR_CONFIG_DIRS } from "./pai-pack-noise";
+import { runBoundedConcurrent } from "./internal-concurrency";
+import type {
+  ClaudeSkillOutcome,
+  ClaudeSkillPortabilityTag,
+  ClaudeSkillsMigrationManifest,
+  ClaudeSkillsMigrationManifestEntry,
+  ClaudeSkillsMigrationOptions,
+  ClaudeSkillsMigrationPlan,
+  ClaudeSkillsMigrationResult,
+} from "./types";
+
+const MANIFEST_SCHEMA = "soma.claude-skills-migration.v1";
+const MANIFEST_RELATIVE = "imports/claude-skills/.manifest.json";
+const REPORT_RELATIVE = "imports/claude-skills/.portability-report.md";
+
+// #104 parallel — editor-config symlinks (`.cursor/`, `.vscode/`,
+// `.idea/`, `.fleet/`, `.zed/`) ship inside many PAI skills and are
+// resolved on the principal's box to IDE-specific rule files. Treat
+// them as benign noise: drop them from the import set instead of
+// refusing the skill. Every OTHER symlink still refuses loud.
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+const EDITOR_CONFIG_SYMLINK_PATTERNS: { pattern: RegExp; dir: string }[] = EDITOR_CONFIG_DIRS.map((dir) => ({
+  pattern: new RegExp(`(?:^|/)${escapeRegex(dir)}/`),
+  dir,
+}));
+function matchEditorConfigSymlinkDir(relativePosixPath: string): string | null {
+  for (const { pattern, dir } of EDITOR_CONFIG_SYMLINK_PATTERNS) {
+    if (pattern.test(relativePosixPath)) return dir;
+  }
+  return null;
+}
+
+// AC-4: classifier rules. Phase 1 is HEURISTIC — every signal below is
+// a deterministic regex match against the on-disk bytes of the skill's
+// body files (SKILL.md + every recursive markdown / text payload).
+//
+// 1) `~/.claude/...` path refs trigger the `needs-adapt`/`portable`
+//    split. The pai-pack normalizer's deterministic rewrite table
+//    (`pai-pack-normalizer.ts` CLAUDE_HOME_DETERMINISTIC) is the
+//    authority on what "needs-adapt" actually means — a skill whose
+//    only Claude refs map cleanly via that table is `needs-adapt`.
+//    Anything beyond it falls back through the normalizer's
+//    UNMAPPED catch-all, which is still "deterministic enough" for
+//    Phase 1 — the catch-all rewrites to `~/.soma/UNMAPPED/` and
+//    surfaces a warning. So for classifier purposes ANY `~/.claude/`
+//    reference (that isn't accompanied by a `claude-specific` signal)
+//    makes the skill `needs-adapt`.
+const CLAUDE_PATH_REF = /~\/\.claude\b/;
+
+// 2) Hook bindings — Claude-Code-only primitive. Match a line that
+//    begins with one of the lifecycle hook names followed by `:`.
+//    Anchored to start-of-line (after optional whitespace) so prose
+//    mentions like "the `Stop:` hook" inside a paragraph don't fire.
+//    The `m` flag is required because we test against multi-line
+//    file contents.
+const HOOK_BINDING = /^[\s>*-]*(?:Stop|UserPromptSubmit|PreToolUse|PostToolUse|SessionStart|SubagentStop|Notification|PreCompact)\s*:/m;
+
+// 3) Slash-command refs in prose — Claude Code's user-facing slash
+//    commands like `/clear`, `/init`, `/grill-me`, `/e3`. Pattern
+//    constraints:
+//      - Preceded by start-of-line, whitespace, or `(` / `[` so we
+//        match prose like "run /clear" and "(/init)" but NOT path
+//        fragments like `~/.claude/...` or `https://...`.
+//      - At least 2 chars after the slash (avoid /a one-off
+//        false positives in code).
+//      - Excluded inside fenced code blocks — those are usually
+//        bash / curl examples (URLs, CLI flags) and trigger false
+//        positives. Stripping fenced code blocks before the test
+//        is the simplest deterministic filter.
+//      - Allow letters/digits/hyphens after the slash, no `/` (so
+//        URL paths don't match) and no `.` (so file paths like
+//        `/some.json` don't match).
+const SLASH_COMMAND_REF = /(?:^|[\s([`])\/(?:e[1-5]|[a-z][a-z0-9-]{1,})(?:[\s.,;)\]`?!]|$)/m;
+
+// Strip fenced code blocks (``` … ```) and inline code (`…`) from
+// content before running the slash-command test. Both are common
+// hosts for shell command examples that contain `/some-flag` or
+// URL paths — neither should classify the skill as Claude-specific.
+function stripCodeBlocks(content: string): string {
+  return content
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/`[^`]+`/g, "");
+}
+
+function sha256Hex(content: Buffer | string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function resolveHomes(options: ClaudeSkillsMigrationOptions): { somaHome: string; from: string } {
+  if (!options.from) {
+    throw new Error("soma migrate claude-skills requires --from <skills-dir>.");
+  }
+  const home = resolve(options.homeDir ?? homedir());
+  return {
+    from: resolve(options.from),
+    somaHome: resolve(options.somaHome ?? join(home, ".soma")),
+  };
+}
+
+// `--status` mode doesn't need a `--from` (it reads the manifest of a
+// prior apply). Lighter resolver that only computes `somaHome`.
+function resolveSomaHomeOnly(options: ClaudeSkillsMigrationOptions): string {
+  const home = resolve(options.homeDir ?? homedir());
+  return resolve(options.somaHome ?? join(home, ".soma"));
+}
+
+function isWithinPath(root: string, target: string): boolean {
+  const rel = relative(root, target);
+  return rel === "" || (!rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel));
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+interface SkillFilePayload {
+  // POSIX-style relative path inside the skill directory.
+  relPath: string;
+  // Absolute source path.
+  source: string;
+  // Raw bytes (used for SHA + classification + rewrite).
+  content: Buffer;
+}
+
+/**
+ * Walk every file under `<from>/<sourceName>/` recursively, refusing
+ * symlinks and out-of-root escapes the same way `pai-pack-importer.ts`
+ * does. Returns POSIX-relative paths.
+ */
+async function collectSkillFiles(skillDir: string): Promise<SkillFilePayload[]> {
+  const realRoot = await realpath(skillDir);
+  const out: SkillFilePayload[] = [];
+
+  async function visit(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      const rel = relative(skillDir, full).split(sep).join("/");
+      if (entry.name.includes("\\")) {
+        throw new Error(`soma migrate claude-skills refused ambiguous path separator: ${rel}`);
+      }
+      if (entry.isSymbolicLink()) {
+        // #104 parallel — editor-config symlinks are noise on the
+        // source side and never carry portable skill content.
+        // Drop silently so the skill imports without aborting.
+        // Every other symlink still refuses loud (matches the
+        // pack/docs importers).
+        if (matchEditorConfigSymlinkDir(rel)) {
+          continue;
+        }
+        throw new Error(`soma migrate claude-skills refused symlink path: ${rel}`);
+      }
+      if (entry.isDirectory()) {
+        if (entry.name === ".git" || entry.name === ".hg" || entry.name === ".svn") {
+          throw new Error(`soma migrate claude-skills refused VCS metadata directory: ${rel}`);
+        }
+        if (entry.name === "node_modules" || entry.name === ".next" || entry.name === "dist") {
+          continue;
+        }
+        // Skip editor-config directories outright (regular dirs, not
+        // symlinks). They carry no portable skill content.
+        if ((EDITOR_CONFIG_DIRS as readonly string[]).includes(entry.name)) {
+          continue;
+        }
+        await visit(full);
+        continue;
+      }
+      if (entry.isFile()) {
+        const realFile = await realpath(full);
+        if (!isWithinPath(realRoot, realFile)) {
+          throw new Error(`soma migrate claude-skills refused path outside skill root: ${rel}`);
+        }
+        const content = await readFile(full);
+        out.push({ relPath: rel, source: full, content });
+      }
+    }
+  }
+
+  await visit(skillDir);
+  out.sort((a, b) => a.relPath.localeCompare(b.relPath));
+  return out;
+}
+
+/**
+ * Classify a skill against the Phase 1 heuristic rules.
+ *
+ * Inputs are all the payload files for the skill. We test:
+ *   - any hook binding match → `claude-specific`
+ *   - any slash-command-in-prose match → `claude-specific`
+ *   - any `~/.claude/` reference → `needs-adapt`
+ *   - else → `portable`
+ *
+ * Reason string captures the first triggering signal with its file path,
+ * matching the table the issue spec calls for in the portability report.
+ */
+export interface ClassificationResult {
+  tag: ClaudeSkillPortabilityTag;
+  reason: string;
+}
+
+// Slash-command classification ONLY fires on prose surfaces — Markdown
+// SKILL.md / Workflows / References. Code files (`.ts`, `.js`, `.py`,
+// shell, etc.) routinely embed `/path/...` fragments, Discord command
+// names like `/imagine`, and URL paths that have nothing to do with
+// Claude Code's slash-command surface. The Phase-1 classifier is
+// heuristic and the cost of a false-positive `claude-specific` verdict
+// is high (the skill gets skipped on apply); restricting prose-only
+// keeps the verdict surface tight.
+const PROSE_EXTENSIONS = /\.(md|markdown|txt|mdx)$/i;
+
+function isProseFile(relPath: string): boolean {
+  return PROSE_EXTENSIONS.test(relPath);
+}
+
+export function classifySkillPortability(files: readonly SkillFilePayload[]): ClassificationResult {
+  // Pass 1: claude-specific signals (highest priority).
+  for (const file of files) {
+    const text = file.content.toString("utf8");
+    if (HOOK_BINDING.test(text)) {
+      const sample = HOOK_BINDING.exec(text)?.[0]?.trim() ?? "hook binding";
+      return {
+        tag: "claude-specific",
+        reason: `hook binding detected in ${file.relPath} (${sample.slice(0, 32)})`,
+      };
+    }
+    if (!isProseFile(file.relPath)) continue;
+    const stripped = stripCodeBlocks(text);
+    if (SLASH_COMMAND_REF.test(stripped)) {
+      const sample = SLASH_COMMAND_REF.exec(stripped)?.[0]?.trim() ?? "/slash-command";
+      return {
+        tag: "claude-specific",
+        reason: `slash-command reference detected in ${file.relPath} (${sample.slice(0, 32)})`,
+      };
+    }
+  }
+
+  // Pass 2: needs-adapt signals.
+  let firstClaudeRef: { file: string; count: number } | null = null;
+  for (const file of files) {
+    const text = file.content.toString("utf8");
+    // Count `~/.claude` matches in this file (cheap; only used when
+    // we already know we're going to surface a reason).
+    let count = 0;
+    let m: RegExpExecArray | null;
+    const scanner = /~\/\.claude\b/g;
+    while ((m = scanner.exec(text)) !== null) {
+      count += 1;
+      if (scanner.lastIndex === m.index) scanner.lastIndex += 1;
+    }
+    if (count > 0) {
+      if (!firstClaudeRef) {
+        firstClaudeRef = { file: file.relPath, count };
+      } else {
+        firstClaudeRef.count += count;
+      }
+    }
+  }
+  if (firstClaudeRef) {
+    return {
+      tag: "needs-adapt",
+      reason: `${firstClaudeRef.count} ~/.claude/* reference(s) (rewritten via normalizer)`,
+    };
+  }
+  // Else portable.
+  return { tag: "portable", reason: "clean" };
+}
+
+// Test-only: lower-level signal accessors. Exported so the unit
+// tests can target the regex layer without rebuilding payload
+// objects. The CLI-facing classifier above is the canonical entry.
+export const _classifierInternals = {
+  CLAUDE_PATH_REF,
+  HOOK_BINDING,
+  SLASH_COMMAND_REF,
+  stripCodeBlocks,
+} as const;
+
+interface SourceSkillReadResult {
+  sourceName: string;
+  kebabName: string;
+  files: SkillFilePayload[];
+  sourceSha: string;
+}
+
+async function readSourceSkill(
+  fromDir: string,
+  sourceName: string,
+): Promise<SourceSkillReadResult> {
+  const skillDir = join(fromDir, sourceName);
+  const skillMdPath = join(skillDir, "SKILL.md");
+  if (!(await pathExists(skillMdPath))) {
+    throw new Error(`soma migrate claude-skills: ${sourceName}/SKILL.md not found.`);
+  }
+  const files = await collectSkillFiles(skillDir);
+  const skillMd = files.find((f) => f.relPath === "SKILL.md");
+  if (!skillMd) {
+    throw new Error(`soma migrate claude-skills: ${sourceName}/SKILL.md not collected (symlink? case mismatch?)`);
+  }
+  return {
+    sourceName,
+    kebabName: kebabSlug(sourceName),
+    files,
+    sourceSha: sha256Hex(skillMd.content),
+  };
+}
+
+/**
+ * Refuse the apply path if the source isn't a flat skills tree. A flat
+ * tree has at least one `<Name>/SKILL.md` direct child. Anything else
+ * (Packs/ layout, empty dir, file-at-root) is rejected loud so the
+ * principal doesn't accidentally point at a Packs/ tree.
+ */
+async function listFlatSkillNames(fromDir: string): Promise<string[]> {
+  if (!(await pathExists(fromDir))) {
+    return [];
+  }
+  const fromStat = await lstat(fromDir);
+  if (fromStat.isSymbolicLink()) {
+    throw new Error("soma migrate claude-skills refused symlinked --from root.");
+  }
+  if (!fromStat.isDirectory()) {
+    throw new Error(`soma migrate claude-skills: --from is not a directory: ${fromDir}`);
+  }
+  const entries = await readdir(fromDir, { withFileTypes: true });
+  const names: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith(".")) continue;
+    const skillMdPath = join(fromDir, entry.name, "SKILL.md");
+    if (await pathExists(skillMdPath)) {
+      // Symlinked SKILL.md is refused — same loud-fail bar as
+      // every other path in this importer.
+      const stat = await lstat(skillMdPath);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`soma migrate claude-skills refused symlinked SKILL.md: ${entry.name}/SKILL.md`);
+      }
+      names.push(entry.name);
+    }
+  }
+  names.sort();
+  return names;
+}
+
+async function readExistingManifest(
+  somaHome: string,
+): Promise<ClaudeSkillsMigrationManifest | null> {
+  const path = join(somaHome, MANIFEST_RELATIVE);
+  if (!(await pathExists(path))) return null;
+  try {
+    const raw = await readFile(path, "utf8");
+    // Parse-then-shape-check pattern. `JSON.parse` returns `unknown`
+    // by contract; the runtime guards on `schema` and `skills` validate
+    // the shape before we narrow to the manifest type. The lint
+    // suppression on the schema check exists because TS narrows
+    // `parsed.schema` to the literal type via the `as` assertion;
+    // without the assertion we lose the typed return surface here.
+    const parsed = JSON.parse(raw) as { schema?: unknown; skills?: unknown };
+    if (parsed.schema !== MANIFEST_SCHEMA || !Array.isArray(parsed.skills)) return null;
+    return parsed as unknown as ClaudeSkillsMigrationManifest;
+  } catch {
+    return null;
+  }
+}
+
+interface PlanResult {
+  isFlatSkillsTree: boolean;
+  outcomes: ClaudeSkillOutcome[];
+}
+
+async function buildPlanCore(
+  fromDir: string,
+  somaHome: string,
+  includeClaudeSpecific: boolean,
+  prevManifest: ClaudeSkillsMigrationManifest | null,
+): Promise<PlanResult> {
+  const names = await listFlatSkillNames(fromDir);
+  if (names.length === 0) {
+    return { isFlatSkillsTree: false, outcomes: [] };
+  }
+
+  // Bounded concurrency for the read + classify pass — per-skill work
+  // is independent and dominated by file I/O, same as the memory
+  // migrator (4-wide).
+  const reads = await runBoundedConcurrent(
+    names,
+    async (name) => readSourceSkill(fromDir, name),
+    4,
+  );
+
+  const prevBySource = new Map<string, ClaudeSkillsMigrationManifestEntry>();
+  if (prevManifest) {
+    for (const entry of prevManifest.skills) {
+      prevBySource.set(entry.sourceName, entry);
+    }
+  }
+
+  const outcomes: ClaudeSkillOutcome[] = reads.map((read) => {
+    const classification = classifySkillPortability(read.files);
+    const target = join(somaHome, "skills", read.kebabName);
+    let disposition: ClaudeSkillOutcome["disposition"];
+    if (classification.tag === "claude-specific" && !includeClaudeSpecific) {
+      disposition = "skipped-claude-specific";
+    } else {
+      const prior = prevBySource.get(read.sourceName);
+      if (prior?.sourceSha === read.sourceSha && prior?.tag === classification.tag) {
+        disposition = "skipped-idempotent";
+      } else {
+        disposition = "imported";
+      }
+    }
+    return {
+      sourceName: read.sourceName,
+      kebabName: read.kebabName,
+      tag: classification.tag,
+      reason: classification.reason,
+      disposition,
+      sourceSha: read.sourceSha,
+      target: disposition === "skipped-claude-specific" ? null : target,
+      // fileCount is populated by the apply path; plan path reports
+      // the source file count so the principal can see the size of
+      // each pending write up-front.
+      fileCount: read.files.length,
+    };
+  });
+  outcomes.sort((a, b) => a.sourceName.localeCompare(b.sourceName));
+
+  return { isFlatSkillsTree: true, outcomes };
+}
+
+export async function planClaudeSkillsMigration(
+  options: ClaudeSkillsMigrationOptions,
+): Promise<ClaudeSkillsMigrationPlan> {
+  const { from, somaHome } = resolveHomes(options);
+  const includeClaudeSpecific = options.includeClaudeSpecific === true;
+  // Plan mode reads any existing manifest so the dispositions match
+  // what an `--apply` invocation would do (e.g. a re-run on unchanged
+  // source shows `skipped-idempotent`, not `imported`).
+  const prevManifest = await readExistingManifest(somaHome);
+  const { isFlatSkillsTree, outcomes } = await buildPlanCore(
+    from,
+    somaHome,
+    includeClaudeSpecific,
+    prevManifest,
+  );
+  return {
+    apply: false,
+    from,
+    somaHome,
+    isFlatSkillsTree,
+    outcomes,
+    includeClaudeSpecific,
+  };
+}
+
+async function writeSkillPayload(
+  read: SourceSkillReadResult,
+  targetDir: string,
+  applyRewrites: boolean,
+): Promise<{ fileShas: Record<string, string> }> {
+  // Make sure the target directory tree exists. Per-file `mkdir` of
+  // the parent happens inside the loop so deep payloads
+  // (`Workflows/SubDir/file.md`) work without precomputed dir lists.
+  await mkdir(targetDir, { recursive: true });
+  const fileShas: Record<string, string> = {};
+
+  for (const file of read.files) {
+    const target = join(targetDir, ...file.relPath.split("/"));
+    await mkdir(join(target, ".."), { recursive: true });
+
+    // Only the canonical text-payload extensions go through the
+    // rewriter. Binary assets (images, audio under `Examples/`)
+    // pass through bit-for-bit so SHA still equals source SHA.
+    const isText = /\.(md|txt|json|yaml|yml|ts|js|tsx|jsx|py|sh|toml)$/.test(file.relPath);
+    if (applyRewrites && isText) {
+      const original = file.content.toString("utf8");
+      const { content: rewritten } = normalizeSkillContent(file.relPath, original);
+      const bytes = Buffer.from(rewritten, "utf8");
+      await writeFile(target, bytes);
+      fileShas[file.relPath] = sha256Hex(bytes);
+    } else {
+      await copyFile(file.source, target);
+      fileShas[file.relPath] = sha256Hex(file.content);
+    }
+  }
+
+  return { fileShas };
+}
+
+function renderManifest(manifest: ClaudeSkillsMigrationManifest): string {
+  // JSON.stringify with 2-space indent + trailing newline matches the
+  // pai-memory-migrator and pai-docs-importer manifest format. Entries
+  // sorted by kebabName so byte-stable reruns produce byte-stable
+  // manifests.
+  const sorted: ClaudeSkillsMigrationManifest = {
+    ...manifest,
+    skills: [...manifest.skills].sort((a, b) => a.kebabName.localeCompare(b.kebabName)),
+  };
+  return `${JSON.stringify(sorted, null, 2)}\n`;
+}
+
+function renderPortabilityReport(
+  result: ClaudeSkillsMigrationPlan & { importedAt: string },
+): string {
+  // AC-5 — markdown report. Always written on the apply path so the
+  // principal has a per-skill audit trail next to the manifest.
+  // Header documents the heuristic's limits (AC-4 transparency).
+  const lines: string[] = [];
+  lines.push("# Claude Skills Portability Report");
+  lines.push("");
+  lines.push(`Source: ${result.from}`);
+  lines.push(`Generated: ${result.importedAt}`);
+  lines.push(`Include claude-specific: ${result.includeClaudeSpecific ? "yes" : "no"}`);
+  lines.push("");
+  lines.push("## Classifier rules (Phase 1, heuristic)");
+  lines.push("");
+  lines.push("- **claude-specific** — hook binding (`Stop:`, `UserPromptSubmit:`, `PreToolUse:`, `PostToolUse:`, `SessionStart:`, `SubagentStop:`, `Notification:`, `PreCompact:`) OR `/<slash-command>` reference in prose (outside fenced code blocks).");
+  lines.push("- **needs-adapt** — `~/.claude/...` path reference(s); rewritten via `pai-pack-normalizer.ts` deterministic rewrite table.");
+  lines.push("- **portable** — no Claude-specific signal detected.");
+  lines.push("");
+  lines.push("Phase 1 is regex-based; subtle Claude-only behavior in prose that doesn't trip these signals can still slip through as `portable`. Phase 2 (`--smoke <substrate>`) will add per-substrate projection verify to turn the verdict from heuristic to verified.");
+  lines.push("");
+  lines.push("## Per-skill outcomes");
+  lines.push("");
+  lines.push("| Skill | Tag | Disposition | Reason |");
+  lines.push("|---|---|---|---|");
+  for (const o of result.outcomes) {
+    lines.push(`| ${o.kebabName} | ${o.tag} | ${o.disposition} | ${o.reason} |`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export async function migrateClaudeSkills(
+  options: ClaudeSkillsMigrationOptions,
+): Promise<ClaudeSkillsMigrationResult> {
+  const { from, somaHome } = resolveHomes(options);
+  const includeClaudeSpecific = options.includeClaudeSpecific === true;
+
+  // Ensure imports/claude-skills/ exists so manifest + report writes
+  // succeed even on a fully empty Soma home.
+  await mkdir(join(somaHome, "imports/claude-skills"), { recursive: true });
+  const manifestPath = join(somaHome, MANIFEST_RELATIVE);
+  const reportPath = join(somaHome, REPORT_RELATIVE);
+
+  const previousManifest = await readExistingManifest(somaHome);
+  const previousBySource = new Map<string, ClaudeSkillsMigrationManifestEntry>();
+  if (previousManifest) {
+    for (const entry of previousManifest.skills) {
+      previousBySource.set(entry.sourceName, entry);
+    }
+  }
+
+  const { isFlatSkillsTree, outcomes } = await buildPlanCore(
+    from,
+    somaHome,
+    includeClaudeSpecific,
+    previousManifest,
+  );
+
+  if (!isFlatSkillsTree) {
+    throw new Error(
+      `soma migrate claude-skills: --from ${from} is not a flat skills tree (no <Name>/SKILL.md direct children).`,
+    );
+  }
+
+  // Apply phase: walk the outcome list, write payloads for imported
+  // skills, carry prior manifest entries for `skipped-idempotent`.
+  const manifestEntries: ClaudeSkillsMigrationManifestEntry[] = [];
+  let writtenCount = 0;
+  let skippedIdempotentCount = 0;
+  let skippedClaudeSpecificCount = 0;
+
+  for (const outcome of outcomes) {
+    if (outcome.disposition === "skipped-claude-specific") {
+      skippedClaudeSpecificCount += 1;
+      continue;
+    }
+    if (outcome.disposition === "skipped-idempotent") {
+      skippedIdempotentCount += 1;
+      const prior = previousBySource.get(outcome.sourceName);
+      if (prior) {
+        manifestEntries.push(prior);
+      }
+      continue;
+    }
+    // Apply path: re-read the skill (we need the bytes, plan-only
+    // returned summaries). Bounded concurrency is not used here so
+    // file writes stay strictly ordered per skill — keeps the
+    // manifest deterministic without juggling write order.
+    const read = await readSourceSkill(from, outcome.sourceName);
+    const targetDir = outcome.target ?? join(somaHome, "skills", outcome.kebabName);
+    // `needs-adapt` runs through the normalizer; `portable` and
+    // (when `--include-claude-specific`) `claude-specific` are
+    // pass-through. Running the normalizer on portable skills is
+    // safe (it's a no-op when no signals fire) but skipping the
+    // copy-byte-rewrite branch keeps the source SHA equal to the
+    // landed SHA for portable skills, which simplifies the audit
+    // trail.
+    const applyRewrites = outcome.tag === "needs-adapt";
+    const { fileShas } = await writeSkillPayload(read, targetDir, applyRewrites);
+    manifestEntries.push({
+      sourceName: outcome.sourceName,
+      kebabName: outcome.kebabName,
+      tag: outcome.tag,
+      sourceSha: outcome.sourceSha,
+      fileShas,
+    });
+    // Refresh the outcome's fileCount with the count of files actually
+    // landed under the skill root (always equal to source file count
+    // in Phase 1; the divergence shows up under Phase 2 if any per-
+    // substrate omits files).
+    outcome.fileCount = Object.keys(fileShas).length;
+    writtenCount += 1;
+  }
+
+  // Manifest timestamp policy mirrors pai-memory-migrator:
+  //   - any actual write → bump timestamp.
+  //   - pure idempotent rerun → preserve prior timestamp so the
+  //     manifest is byte-stable.
+  const importedAt =
+    writtenCount === 0 && previousManifest
+      ? previousManifest.importedAt
+      : new Date().toISOString();
+
+  const newManifest: ClaudeSkillsMigrationManifest = {
+    schema: MANIFEST_SCHEMA,
+    from,
+    somaHome,
+    importedAt,
+    includeClaudeSpecific,
+    skills: manifestEntries,
+  };
+  await writeFile(manifestPath, renderManifest(newManifest), "utf8");
+  await writeFile(
+    reportPath,
+    renderPortabilityReport({
+      apply: true,
+      from,
+      somaHome,
+      isFlatSkillsTree: true,
+      outcomes,
+      includeClaudeSpecific,
+      importedAt,
+    }),
+    "utf8",
+  );
+
+  return {
+    apply: true,
+    from,
+    somaHome,
+    isFlatSkillsTree: true,
+    outcomes,
+    includeClaudeSpecific,
+    importedAt,
+    manifestPath,
+    reportPath,
+    writtenCount,
+    skippedIdempotentCount,
+    skippedClaudeSpecificCount,
+  };
+}
+
+/**
+ * Status reader for `--status` mode. Returns the manifest as-is or
+ * null when no migration has been applied. CLI formatter renders
+ * either an empty-state hint or a per-skill summary table.
+ */
+export async function readClaudeSkillsMigrationStatus(
+  options: ClaudeSkillsMigrationOptions,
+): Promise<ClaudeSkillsMigrationManifest | null> {
+  const somaHome = resolveSomaHomeOnly(options);
+  return readExistingManifest(somaHome);
+}

--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -360,11 +360,21 @@ async function readSourceSkill(
   if (!skillMd) {
     throw new Error(`soma migrate claude-skills: ${sourceName}/SKILL.md not collected (symlink? case mismatch?)`);
   }
+  // Holly R1 substantive — composite source SHA covers every collected
+  // file, not just SKILL.md. A sibling edit (e.g., Workflows/Run.md update,
+  // new Tools/helper.ts) now flips `sourceSha` and triggers a re-import.
+  // Hashing sorted `relPath:sha` pairs keeps the composite stable across
+  // platforms (collectSkillFiles already returns deterministic order, but
+  // the explicit sort makes the contract obvious).
+  const composite = files
+    .map((f) => `${f.relPath}:${sha256Hex(f.content)}`)
+    .sort()
+    .join("\n");
   return {
     sourceName,
     kebabName: kebabSlug(sourceName),
     files,
-    sourceSha: sha256Hex(skillMd.content),
+    sourceSha: sha256Hex(Buffer.from(composite, "utf8")),
   };
 }
 
@@ -420,6 +430,17 @@ async function readExistingManifest(
     // without the assertion we lose the typed return surface here.
     const parsed = JSON.parse(raw) as { schema?: unknown; skills?: unknown };
     if (parsed.schema !== MANIFEST_SCHEMA || !Array.isArray(parsed.skills)) return null;
+    // Holly R1 nit — shallow shape probe. A partially-corrupted manifest
+    // (right schema string, array `skills`, but entries missing the
+    // fingerprint fields) would otherwise blow up downstream with opaque
+    // errors. The probe is cheap; one bad entry rejects the whole manifest
+    // and the migrator falls back to a fresh run.
+    const skills = parsed.skills as Array<Record<string, unknown>>;
+    for (const entry of skills) {
+      if (typeof entry?.sourceName !== "string" || typeof entry?.sourceSha !== "string") {
+        return null;
+      }
+    }
     return parsed as unknown as ClaudeSkillsMigrationManifest;
   } catch {
     return null;
@@ -429,6 +450,11 @@ async function readExistingManifest(
 interface PlanResult {
   isFlatSkillsTree: boolean;
   outcomes: ClaudeSkillOutcome[];
+  // Holly R1 nit — carry the read payloads so the apply path can write
+  // without a second disk pass. Plan-mode callers ignore this field;
+  // apply-mode callers thread it through to writeSkillPayload to avoid
+  // doubling I/O on 45-skill imports.
+  reads: SourceSkillReadResult[];
 }
 
 async function buildPlanCore(
@@ -439,7 +465,7 @@ async function buildPlanCore(
 ): Promise<PlanResult> {
   const names = await listFlatSkillNames(fromDir);
   if (names.length === 0) {
-    return { isFlatSkillsTree: false, outcomes: [] };
+    return { isFlatSkillsTree: false, outcomes: [], reads: [] };
   }
 
   // Bounded concurrency for the read + classify pass — per-skill work
@@ -488,7 +514,7 @@ async function buildPlanCore(
   });
   outcomes.sort((a, b) => a.sourceName.localeCompare(b.sourceName));
 
-  return { isFlatSkillsTree: true, outcomes };
+  return { isFlatSkillsTree: true, outcomes, reads };
 }
 
 export async function planClaudeSkillsMigration(
@@ -618,7 +644,7 @@ export async function migrateClaudeSkills(
     }
   }
 
-  const { isFlatSkillsTree, outcomes } = await buildPlanCore(
+  const { isFlatSkillsTree, outcomes, reads } = await buildPlanCore(
     from,
     somaHome,
     includeClaudeSpecific,
@@ -630,6 +656,12 @@ export async function migrateClaudeSkills(
       `soma migrate claude-skills: --from ${from} is not a flat skills tree (no <Name>/SKILL.md direct children).`,
     );
   }
+
+  // Holly R1 nit — thread the buildPlanCore reads into the apply path
+  // so we don't re-read every skill from disk a second time. Plan phase
+  // already collected SkillFilePayload[] bytes for classification;
+  // applying writes from the same in-memory payload halves the I/O.
+  const readsBySource = new Map(reads.map((r) => [r.sourceName, r]));
 
   // Apply phase: walk the outcome list, write payloads for imported
   // skills, carry prior manifest entries for `skipped-idempotent`.
@@ -651,11 +683,16 @@ export async function migrateClaudeSkills(
       }
       continue;
     }
-    // Apply path: re-read the skill (we need the bytes, plan-only
-    // returned summaries). Bounded concurrency is not used here so
-    // file writes stay strictly ordered per skill — keeps the
-    // manifest deterministic without juggling write order.
-    const read = await readSourceSkill(from, outcome.sourceName);
+    // Apply path uses the read payload already collected by
+    // buildPlanCore (Holly R1 nit — single disk pass). The Map lookup
+    // is O(1); the buildPlanCore contract guarantees every non-skipped
+    // outcome has a corresponding read.
+    const read = readsBySource.get(outcome.sourceName);
+    if (!read) {
+      throw new Error(
+        `soma migrate claude-skills: missing read payload for ${outcome.sourceName} — buildPlanCore contract violation.`,
+      );
+    }
     const targetDir = outcome.target ?? join(somaHome, "skills", outcome.kebabName);
     // `needs-adapt` runs through the normalizer; `portable` and
     // (when `--include-claude-specific`) `claude-specific` are

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,6 +93,22 @@ import type {
 } from "./types";
 import { SOMA_FEEDBACK_STDIN_MAX_BYTES } from "./feedback-contract";
 import { ISA_SUBCOMMAND_HELP, ISA_USAGE_HEADER, runIsaCli } from "./cli-isa";
+// #115 — `soma migrate claude-skills` (Phase 1). Module-internal, not
+// re-exported from the package barrel, same pattern as
+// `pai-memory-migrator.ts` (#90 Sage r2 Architecture finding — the
+// migrator's public boundary is not yet stable; CLI imports
+// directly).
+import {
+  migrateClaudeSkills,
+  planClaudeSkillsMigration,
+  readClaudeSkillsMigrationStatus,
+} from "./claude-skills-migrator";
+import type {
+  ClaudeSkillsMigrationOptions,
+  ClaudeSkillsMigrationPlan,
+  ClaudeSkillsMigrationResult,
+  ClaudeSkillsMigrationManifest,
+} from "./types";
 // CLI formatter for `import pai-docs` needs the same in-scope subtree
 // list the importer iterates. Importing directly from the module
 // keeps the constant a module-internal contract rather than promoting
@@ -189,6 +205,20 @@ interface ParsedMigrateArgs {
   options: PaiMigrationOptions;
   /** #106 — when true, plan/apply formatter prints inline file lists. Default false. */
   verbose: boolean;
+}
+
+/**
+ * #115 — `soma migrate claude-skills` parsed args. Sibling to
+ * `ParsedMigrateArgs` (PAI path); a separate type because the option
+ * sets do not overlap and merging them would force every dispatch
+ * site to discriminate on `source` AND options shape. Keeping them
+ * separate keeps the type narrowing trivial.
+ */
+interface ParsedMigrateClaudeSkillsArgs {
+  command: "migrate";
+  source: "claude-skills";
+  mode: "plan" | "apply" | "status";
+  options: ClaudeSkillsMigrationOptions;
 }
 
 interface ParsedAdoptArgs {
@@ -290,6 +320,7 @@ type ParsedArgs =
   | ParsedDaemonArgs
   | ParsedImportArgs
   | ParsedMigrateArgs
+  | ParsedMigrateClaudeSkillsArgs
   | ParsedAdoptArgs
   | ParsedAlgorithmArgs
   | ParsedLifecycleArgs
@@ -318,6 +349,12 @@ const TOP_LEVEL_COMMANDS = [
 
 const MIGRATE_PAI_USAGE =
   "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-install <dir>] [--pai-repo <root>] [--pai-source-dir <dir>] [--pai-packs-dir <dir>] [--pai-pack-dir <dir>] [--skip-memory] [--skip-skills] [--skip-docs] [--overwrite-reserved] [--include-unrecognized] [--verbose]";
+// #115 — `soma migrate claude-skills` (Phase 1). Second migration
+// path, imports from a flat `.claude/skills/` tree. Phase 2 will add
+// `--smoke <substrate>` for per-substrate projection verify; that
+// flag is intentionally absent here.
+const MIGRATE_CLAUDE_SKILLS_USAGE =
+  "Usage: soma migrate claude-skills --from <skills-dir> [--dry-run] [--apply] [--status] [--home-dir <dir>] [--soma-home <dir>] [--include-claude-specific]";
 const ADOPT_CLAUDE_USAGE =
   "Usage: soma adopt claude [--dry-run] [--apply] [--uninstall] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string, string> }> = {
@@ -400,8 +437,11 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
     },
   },
   migrate: {
-    usage: MIGRATE_PAI_USAGE,
-    subcommands: { pai: MIGRATE_PAI_USAGE },
+    usage: `${MIGRATE_PAI_USAGE}\n       ${MIGRATE_CLAUDE_SKILLS_USAGE.slice("Usage: ".length)}`,
+    subcommands: {
+      pai: MIGRATE_PAI_USAGE,
+      "claude-skills": MIGRATE_CLAUDE_SKILLS_USAGE,
+    },
   },
   adopt: {
     usage: ADOPT_CLAUDE_USAGE,
@@ -1492,11 +1532,24 @@ function parseAdoptArgs(args: string[]): ParsedAdoptArgs {
   return { command: "adopt", substrate: "claude", mode, options };
 }
 
-function parseMigrateArgs(args: string[]): ParsedMigrateArgs {
-  const [command, source, ...rest] = args;
-  if (command !== "migrate" || source !== "pai") {
+function parseMigrateArgs(args: string[]): ParsedMigrateArgs | ParsedMigrateClaudeSkillsArgs {
+  const [command, source] = args;
+  if (command !== "migrate") {
+    throw new Error(commandUsage("migrate"));
+  }
+  // #115 — second migration path. Routed early so the existing
+  // pai-only parser body stays untouched.
+  if (source === "claude-skills") {
+    return parseMigrateClaudeSkillsArgs(args);
+  }
+  if (source !== "pai") {
     throw new Error(commandUsage("migrate", source));
   }
+  return parseMigratePaiArgs(args);
+}
+
+function parseMigratePaiArgs(args: string[]): ParsedMigrateArgs {
+  const [, , ...rest] = args;
   const options: PaiMigrationOptions = {};
   let mode: "plan" | "apply" | "status" = "plan";
   const packPaths: string[] = [];
@@ -1601,6 +1654,50 @@ function parseMigrateArgs(args: string[]): ParsedMigrateArgs {
 
   if (packPaths.length > 0) options.paiPackPaths = packPaths;
   return { command: "migrate", source: "pai", mode, options, verbose };
+}
+
+function parseMigrateClaudeSkillsArgs(args: string[]): ParsedMigrateClaudeSkillsArgs {
+  const [, , ...rest] = args;
+  const options: ClaudeSkillsMigrationOptions = {};
+  let mode: "plan" | "apply" | "status" = "plan";
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    switch (arg) {
+      case "--dry-run":
+        mode = "plan";
+        break;
+      case "--apply":
+        mode = "apply";
+        break;
+      case "--status":
+        mode = "status";
+        break;
+      case "--from":
+        options.from = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--include-claude-specific":
+        options.includeClaudeSpecific = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (!options.from && mode !== "status") {
+    throw new Error(MIGRATE_CLAUDE_SKILLS_USAGE);
+  }
+
+  return { command: "migrate", source: "claude-skills", mode, options };
 }
 
 function helpTopic(args: string[]): string[] {
@@ -1953,6 +2050,110 @@ function formatPaiMigrationStatus(manifest: string | null): string {
     return "soma migrate pai — no migration manifest found. Run `soma migrate pai --apply` first.\n";
   }
   return `${manifest}\n`;
+}
+
+// #115 — `soma migrate claude-skills` formatters. Mirrors the `migrate
+// pai` shape (header line + per-row table) so principals reading
+// both surfaces don't need to context-switch.
+function formatClaudeSkillsMigrationPlan(plan: ClaudeSkillsMigrationPlan): string {
+  if (!plan.isFlatSkillsTree) {
+    return [
+      "soma migrate claude-skills — plan (dry-run)",
+      `from: ${plan.from}`,
+      `somaHome: ${plan.somaHome}`,
+      "",
+      "Refused: --from is not a flat skills tree (no <Name>/SKILL.md direct children).",
+      "Point --from at an installed `.claude/skills/` tree (e.g. ~/.claude/skills or ~/work/PAI/Releases/v5.0.0/.claude/skills).",
+      "",
+    ].join("\n");
+  }
+  const lines: string[] = [
+    "soma migrate claude-skills — plan (dry-run; pass --apply to execute)",
+    `from: ${plan.from}`,
+    `somaHome: ${plan.somaHome}`,
+    `include-claude-specific: ${plan.includeClaudeSpecific ? "yes" : "no"}`,
+    "",
+    "Per-skill plan:",
+  ];
+  for (const o of plan.outcomes) {
+    lines.push(`  - ${o.kebabName} [${o.tag}] → ${o.disposition} (${o.reason})`);
+  }
+  const counts = countOutcomesByDisposition(plan.outcomes);
+  lines.push("");
+  lines.push(
+    `Totals: ${counts.imported} imported, ${counts.skippedIdempotent} skipped-idempotent, ${counts.skippedClaudeSpecific} skipped-claude-specific.`,
+  );
+  if (counts.skippedClaudeSpecific > 0 && !plan.includeClaudeSpecific) {
+    lines.push(
+      `${counts.skippedClaudeSpecific} skill(s) tagged claude-specific — re-run with --include-claude-specific to import them anyway.`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function formatClaudeSkillsMigrationResult(result: ClaudeSkillsMigrationResult): string {
+  const lines: string[] = [
+    "soma migrate claude-skills — applied",
+    `from: ${result.from}`,
+    `somaHome: ${result.somaHome}`,
+    `importedAt: ${result.importedAt}`,
+    `manifest: ${result.manifestPath}`,
+    `report:   ${result.reportPath}`,
+    `include-claude-specific: ${result.includeClaudeSpecific ? "yes" : "no"}`,
+    "",
+    "Per-skill outcomes:",
+  ];
+  for (const o of result.outcomes) {
+    lines.push(`  - ${o.kebabName} [${o.tag}] → ${o.disposition} (${o.reason})`);
+  }
+  lines.push("");
+  lines.push(
+    `Totals: ${result.writtenCount} written, ${result.skippedIdempotentCount} skipped-idempotent, ${result.skippedClaudeSpecificCount} skipped-claude-specific.`,
+  );
+  if (result.skippedClaudeSpecificCount > 0 && !result.includeClaudeSpecific) {
+    lines.push(
+      `${result.skippedClaudeSpecificCount} skill(s) refused-claude-specific — re-run with --include-claude-specific to import them anyway.`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function formatClaudeSkillsMigrationStatus(
+  manifest: ClaudeSkillsMigrationManifest | null,
+): string {
+  if (manifest === null) {
+    return "soma migrate claude-skills — no migration manifest found. Run `soma migrate claude-skills --from <dir> --apply` first.\n";
+  }
+  const lines: string[] = [
+    "soma migrate claude-skills — status",
+    `from: ${manifest.from}`,
+    `somaHome: ${manifest.somaHome}`,
+    `importedAt: ${manifest.importedAt}`,
+    `include-claude-specific: ${manifest.includeClaudeSpecific ? "yes" : "no"}`,
+    `skills: ${manifest.skills.length}`,
+    "",
+  ];
+  for (const entry of manifest.skills) {
+    lines.push(`  - ${entry.kebabName} [${entry.tag}] (${Object.keys(entry.fileShas).length} files)`);
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+function countOutcomesByDisposition(
+  outcomes: readonly { disposition: string }[],
+): { imported: number; skippedIdempotent: number; skippedClaudeSpecific: number } {
+  let imported = 0;
+  let skippedIdempotent = 0;
+  let skippedClaudeSpecific = 0;
+  for (const o of outcomes) {
+    if (o.disposition === "imported") imported += 1;
+    else if (o.disposition === "skipped-idempotent") skippedIdempotent += 1;
+    else if (o.disposition === "skipped-claude-specific") skippedClaudeSpecific += 1;
+  }
+  return { imported, skippedIdempotent, skippedClaudeSpecific };
 }
 
 function formatPaiImportPlan(plan: PaiImportPlan): string {
@@ -2549,6 +2750,24 @@ export async function runSomaCli(args: string[]): Promise<string> {
   }
 
   if (parsed.command === "migrate") {
+    // #115 — second migration path. Dispatched first so the
+    // existing PAI path stays untouched.
+    if (parsed.source === "claude-skills") {
+      const claudeOptions = parsed.options;
+      if (parsed.mode === "status") {
+        return formatClaudeSkillsMigrationStatus(
+          await readClaudeSkillsMigrationStatus(claudeOptions),
+        );
+      }
+      if (parsed.mode === "plan") {
+        return formatClaudeSkillsMigrationPlan(
+          await planClaudeSkillsMigration(claudeOptions),
+        );
+      }
+      return formatClaudeSkillsMigrationResult(
+        await migrateClaudeSkills(claudeOptions),
+      );
+    }
     if (parsed.mode === "status") {
       return formatPaiMigrationStatus(await readPaiMigrationManifest(parsed.options));
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -833,6 +833,139 @@ export interface PaiMemoryMigrationManifest {
   files: PaiMemoryMigrationManifestFile[];
 }
 
+// #115 — `soma migrate claude-skills` types.
+//
+// Second migration path (alongside `soma migrate pai`) that imports
+// directly from an installed flat `.claude/skills/` tree — one
+// `<Name>/SKILL.md` per skill, no pack-level metadata, no collection
+// bundles. Per-skill portability is classified heuristically (regex
+// based, Phase 1) and recorded in a sibling report file. Phase 2
+// (deferred) adds a `--smoke <substrate>` flag for projection verify.
+export interface ClaudeSkillsMigrationOptions {
+  // Source flat skills tree. REQUIRED. Must be a directory of
+  // `<Name>/SKILL.md` direct children. Refused loud otherwise.
+  from?: string;
+  // Override Soma home. Defaults to `<homeDir>/.soma`.
+  somaHome?: string;
+  // Override `$HOME`. Used by tests; the apply path resolves
+  // `somaHome` from this when not explicitly set.
+  homeDir?: string;
+  // When true, classifier outcomes tagged `claude-specific` are still
+  // imported (with an audit warning). Default false → skipped.
+  includeClaudeSpecific?: boolean;
+}
+
+// Heuristic portability tag assigned to every source skill. Phase 1
+// rules:
+//   - `portable`        — no `~/.claude/` path refs, no hook bindings,
+//                          no `/<slash-command>` refs in prose.
+//   - `needs-adapt`     — has `~/.claude/...` refs that the existing
+//                          `pai-pack-normalizer.ts` rewrite table can
+//                          deterministically resolve.
+//   - `claude-specific` — has Claude-Code-only primitives that have
+//                          no portable equivalent: hook bindings
+//                          (`Stop:`, `UserPromptSubmit:`,
+//                          `PreToolUse:`, `PostToolUse:`,
+//                          `SessionStart:`, `SubagentStop:`) OR
+//                          `/<slash-command>` refs in prose.
+export type ClaudeSkillPortabilityTag = "portable" | "needs-adapt" | "claude-specific";
+
+export interface ClaudeSkillOutcome {
+  // Source directory name (e.g. "Art", "ExtractWisdom").
+  sourceName: string;
+  // Kebab-cased target slug (e.g. "art", "extract-wisdom").
+  kebabName: string;
+  // Per-skill classifier verdict.
+  tag: ClaudeSkillPortabilityTag;
+  // Human-readable reason for the classifier verdict. One line.
+  reason: string;
+  // Phase 1 final disposition. `imported` = written to `<somaHome>/skills/<kebab>/`.
+  // `skipped-claude-specific` = classifier verdict was `claude-specific`
+  // and `includeClaudeSpecific` was false. `skipped-idempotent` =
+  // source SHA matched the manifest entry on rerun.
+  disposition: "imported" | "skipped-claude-specific" | "skipped-idempotent";
+  // SHA-256 of the source SKILL.md bytes (hex). Stable identity for
+  // idempotency checks. Populated even on classify-only / plan runs.
+  sourceSha: string;
+  // Absolute path of the imported skill root under
+  // `<somaHome>/skills/<kebab>/`. Null when `disposition` is
+  // `skipped-claude-specific`.
+  target: string | null;
+  // Number of file SHAs recorded under this skill's manifest entry
+  // on the apply path (SKILL.md + every Workflows/Tools/References/
+  // file copied or rewritten). Zero when the skill was skipped.
+  fileCount: number;
+}
+
+export interface ClaudeSkillsMigrationPlan {
+  apply: boolean;
+  // Absolute path of the resolved `--from <skills-dir>`.
+  from: string;
+  // Absolute path of the resolved Soma home.
+  somaHome: string;
+  // Whether the source directory passed the "flat skills tree" guard
+  // (i.e. at least one `<Name>/SKILL.md` direct child). When false,
+  // `outcomes` is empty and the formatter renders a hard refusal.
+  isFlatSkillsTree: boolean;
+  // One outcome per source `<Name>/SKILL.md`. Always ordered by
+  // `sourceName` so the report and CLI rendering are deterministic.
+  outcomes: ClaudeSkillOutcome[];
+  // Mirror of `options.includeClaudeSpecific` so the formatter and
+  // the manifest renderer can both reflect the same intent without
+  // re-threading the option through helpers.
+  includeClaudeSpecific: boolean;
+}
+
+export interface ClaudeSkillsMigrationResult extends ClaudeSkillsMigrationPlan {
+  // ISO-8601 timestamp of the last successful apply. Stable across
+  // reruns when nothing changed.
+  importedAt: string;
+  // Absolute path of the SHA manifest file under
+  // `<somaHome>/imports/claude-skills/.manifest.json`.
+  manifestPath: string;
+  // Absolute path of the portability report under
+  // `<somaHome>/imports/claude-skills/.portability-report.md`.
+  reportPath: string;
+  // Skills actually written this run (`disposition: "imported"`,
+  // SHA not already present in prior manifest).
+  writtenCount: number;
+  // Skills skipped due to SHA-match idempotency on rerun.
+  skippedIdempotentCount: number;
+  // Skills skipped because verdict was `claude-specific` and the
+  // override flag was off.
+  skippedClaudeSpecificCount: number;
+}
+
+export interface ClaudeSkillsMigrationManifestEntry {
+  // Source directory name (`<Name>` from `<from>/<Name>/SKILL.md`).
+  sourceName: string;
+  // Kebab-cased target slug.
+  kebabName: string;
+  tag: ClaudeSkillPortabilityTag;
+  // SHA-256 of the source SKILL.md bytes — the idempotency key.
+  sourceSha: string;
+  // Per-file SHAs of every payload file that landed under
+  // `<somaHome>/skills/<kebab>/`. POSIX-style paths relative to
+  // the skill root. Includes SKILL.md.
+  fileShas: Record<string, string>;
+}
+
+export interface ClaudeSkillsMigrationManifest {
+  schema: "soma.claude-skills-migration.v1";
+  from: string;
+  somaHome: string;
+  importedAt: string;
+  // Whether `--include-claude-specific` was passed on the run that
+  // wrote this manifest. Recorded so the next apply can detect a
+  // policy change (override flipped off) and re-classify accordingly.
+  includeClaudeSpecific: boolean;
+  // One entry per skill that was actually imported. Skipped skills
+  // (claude-specific without override) are NOT recorded — their
+  // SHA isn't an idempotency anchor for anything that landed.
+  // Sorted by `kebabName` for byte-stable reruns.
+  skills: ClaudeSkillsMigrationManifestEntry[];
+}
+
 export interface SomaMemoryEventInput {
   id?: string;
   timestamp?: string;

--- a/test/claude-skills-migrator.test.ts
+++ b/test/claude-skills-migrator.test.ts
@@ -1,0 +1,485 @@
+/**
+ * #115 — `soma migrate claude-skills` (Phase 1).
+ *
+ * Fixture-based tests for the portability classifier + migration
+ * orchestrator. Patterned after `pai-memory-migrator.test.ts`:
+ * temp-home lifecycle, deterministic SHAs, idempotency on rerun.
+ *
+ * Coverage:
+ *   - Classifier (portable / needs-adapt / claude-specific): pure
+ *     function tested via the exported `classifySkillPortability`
+ *     entrypoint to keep tests independent of the FS layer.
+ *   - Plan-mode: lists outcomes with no writes; refuses non-flat
+ *     trees loud.
+ *   - Apply-mode: writes payloads under <somaHome>/skills/<kebab>/,
+ *     emits manifest + portability report, applies rewrites for
+ *     needs-adapt, skips claude-specific without override.
+ *   - Override: `--include-claude-specific` lands the skipped set
+ *     with the audit trail intact.
+ *   - Idempotency: re-run with unchanged source = 0 writes,
+ *     manifest `importedAt` preserved.
+ *   - Mixed tree: per-skill routing decision is independent.
+ *   - Manifest schema invariants.
+ */
+import { mkdir, readFile, readdir, writeFile, symlink } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import {
+  classifySkillPortability,
+  migrateClaudeSkills,
+  planClaudeSkillsMigration,
+  readClaudeSkillsMigrationStatus,
+} from "../src/claude-skills-migrator";
+import type { ClaudeSkillsMigrationManifest } from "../src/types";
+import { withTempHome } from "./fixtures/pai-migration-fixtures";
+
+interface SkillFile {
+  // POSIX-style path relative to the skill directory.
+  relPath: string;
+  content: string;
+}
+
+interface WriteSkillOptions {
+  // Body of `SKILL.md`. Frontmatter is optional — the migrator never
+  // parses it; tests can pass plain body content.
+  skillMd: string;
+  // Optional extra payload files under the skill dir.
+  extra?: SkillFile[];
+}
+
+async function writeFlatSkillsFixture(
+  fromDir: string,
+  skills: Record<string, WriteSkillOptions>,
+): Promise<void> {
+  await mkdir(fromDir, { recursive: true });
+  for (const [name, opts] of Object.entries(skills)) {
+    const dir = join(fromDir, name);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "SKILL.md"), opts.skillMd, "utf8");
+    for (const extra of opts.extra ?? []) {
+      const target = join(dir, ...extra.relPath.split("/"));
+      await mkdir(join(target, ".."), { recursive: true });
+      await writeFile(target, extra.content, "utf8");
+    }
+  }
+}
+
+// ---------------------------------------------------------------------
+// classifier (pure-function layer)
+// ---------------------------------------------------------------------
+
+test("classifySkillPortability: clean SKILL.md → portable", () => {
+  const result = classifySkillPortability([
+    {
+      relPath: "SKILL.md",
+      source: "/tmp/SKILL.md",
+      content: Buffer.from("# Clean skill\n\nPure prose. No paths.\n"),
+    },
+  ]);
+  expect(result.tag).toBe("portable");
+  expect(result.reason).toBe("clean");
+});
+
+test("classifySkillPortability: ~/.claude/PAI/DOCUMENTATION ref → needs-adapt", () => {
+  const result = classifySkillPortability([
+    {
+      relPath: "SKILL.md",
+      source: "/tmp/SKILL.md",
+      content: Buffer.from(
+        "# Skill\n\nSee `~/.claude/PAI/DOCUMENTATION/Skills/SkillSystem.md` for the spec.\n",
+      ),
+    },
+  ]);
+  expect(result.tag).toBe("needs-adapt");
+  expect(result.reason).toContain("~/.claude/* reference");
+});
+
+test("classifySkillPortability: hook binding (Stop:) in body → claude-specific", () => {
+  const result = classifySkillPortability([
+    {
+      relPath: "SKILL.md",
+      source: "/tmp/SKILL.md",
+      content: Buffer.from(
+        "# Skill\n\nLifecycle hook:\n\nStop: run the cleanup\n",
+      ),
+    },
+  ]);
+  expect(result.tag).toBe("claude-specific");
+  expect(result.reason).toContain("hook binding");
+});
+
+test("classifySkillPortability: slash-command in markdown prose → claude-specific", () => {
+  const result = classifySkillPortability([
+    {
+      relPath: "SKILL.md",
+      source: "/tmp/SKILL.md",
+      content: Buffer.from("# Skill\n\nRun /grill-me to start.\n"),
+    },
+  ]);
+  expect(result.tag).toBe("claude-specific");
+  expect(result.reason).toContain("slash-command reference");
+});
+
+test("classifySkillPortability: slash-command in non-prose file (.ts) does NOT classify", () => {
+  // Phase 1 contract: slash-command detection only fires on .md/.txt/
+  // .mdx. Code files routinely embed `/path` fragments and would
+  // otherwise false-positive.
+  const result = classifySkillPortability([
+    {
+      relPath: "Lib/client.ts",
+      source: "/tmp/client.ts",
+      content: Buffer.from('const cmd = "/imagine prompt";\n'),
+    },
+  ]);
+  expect(result.tag).toBe("portable");
+});
+
+test("classifySkillPortability: hook binding in non-prose file still fires", () => {
+  // Hook bindings outside markdown are still substantive — they're
+  // a runtime contract. The classifier fires on any payload file.
+  const result = classifySkillPortability([
+    {
+      relPath: "Tools/hooks.yaml",
+      source: "/tmp/hooks.yaml",
+      content: Buffer.from("UserPromptSubmit: tools/run.ts\n"),
+    },
+  ]);
+  expect(result.tag).toBe("claude-specific");
+});
+
+test("classifySkillPortability: slash inside fenced code block does NOT classify", () => {
+  const result = classifySkillPortability([
+    {
+      relPath: "SKILL.md",
+      source: "/tmp/SKILL.md",
+      content: Buffer.from(
+        "# Skill\n\n```bash\ncurl https://api.example.com/v1/things\n```\n",
+      ),
+    },
+  ]);
+  expect(result.tag).toBe("portable");
+});
+
+test("classifySkillPortability: bare ~/.claude (no segment after) → needs-adapt", () => {
+  const result = classifySkillPortability([
+    {
+      relPath: "SKILL.md",
+      source: "/tmp/SKILL.md",
+      content: Buffer.from(
+        "# Skill\n\nFiles never leave `~/.claude`.\n",
+      ),
+    },
+  ]);
+  expect(result.tag).toBe("needs-adapt");
+});
+
+test("classifySkillPortability: claude-specific outranks needs-adapt", () => {
+  // A skill with BOTH a hook binding AND a `~/.claude/` ref must
+  // classify as claude-specific — the hook binding signal wins.
+  const result = classifySkillPortability([
+    {
+      relPath: "SKILL.md",
+      source: "/tmp/SKILL.md",
+      content: Buffer.from(
+        "# Skill\n\nStop: run the cleanup\n\nAlso see ~/.claude/PAI/DOCUMENTATION/X.md\n",
+      ),
+    },
+  ]);
+  expect(result.tag).toBe("claude-specific");
+  expect(result.reason).toContain("hook binding");
+});
+
+// ---------------------------------------------------------------------
+// plan-mode
+// ---------------------------------------------------------------------
+
+test("planClaudeSkillsMigration on non-flat tree → isFlatSkillsTree=false", async () => {
+  await withTempHome(async (home) => {
+    // No skills under the dir — treat as non-flat.
+    const fromDir = join(home, "EmptyDir");
+    await mkdir(fromDir, { recursive: true });
+    const plan = await planClaudeSkillsMigration({
+      from: fromDir,
+      homeDir: home,
+    });
+    expect(plan.isFlatSkillsTree).toBe(false);
+    expect(plan.outcomes).toEqual([]);
+  });
+});
+
+test("planClaudeSkillsMigration on flat tree lists outcomes per skill", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    await writeFlatSkillsFixture(fromDir, {
+      Portable: { skillMd: "# Portable\n\nclean.\n" },
+      NeedsAdapt: {
+        skillMd: "# NeedsAdapt\n\nsee ~/.claude/PAI/DOCUMENTATION/X.md\n",
+      },
+      ClaudeSpecific: {
+        skillMd: "# ClaudeSpecific\n\nStop: run cleanup\n",
+      },
+    });
+
+    const plan = await planClaudeSkillsMigration({
+      from: fromDir,
+      homeDir: home,
+    });
+
+    expect(plan.isFlatSkillsTree).toBe(true);
+    expect(plan.apply).toBe(false);
+    expect(plan.outcomes.map((o) => o.tag).sort()).toEqual([
+      "claude-specific",
+      "needs-adapt",
+      "portable",
+    ]);
+    // ClaudeSpecific must be skipped by default (no override).
+    const cs = plan.outcomes.find((o) => o.sourceName === "ClaudeSpecific");
+    expect(cs?.disposition).toBe("skipped-claude-specific");
+    // The two safe ones must plan as imported.
+    expect(
+      plan.outcomes.find((o) => o.sourceName === "Portable")?.disposition,
+    ).toBe("imported");
+    expect(
+      plan.outcomes.find((o) => o.sourceName === "NeedsAdapt")?.disposition,
+    ).toBe("imported");
+  });
+});
+
+test("planClaudeSkillsMigration requires --from", async () => {
+  await expect(
+    planClaudeSkillsMigration({ homeDir: "/tmp" }),
+  ).rejects.toThrow(/requires --from/);
+});
+
+// ---------------------------------------------------------------------
+// apply-mode + manifest + report
+// ---------------------------------------------------------------------
+
+test("migrateClaudeSkills writes payload + manifest + portability report", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const somaHome = join(home, "soma");
+    await writeFlatSkillsFixture(fromDir, {
+      Portable: {
+        skillMd: "# Portable\n\nclean prose.\n",
+        extra: [
+          { relPath: "Workflows/Run.md", content: "# Run\n\nstep 1\n" },
+          { relPath: "Tools/helper.ts", content: "export const x = 1;\n" },
+        ],
+      },
+      NeedsAdapt: {
+        skillMd: "# NeedsAdapt\n\nsee ~/.claude/PAI/DOCUMENTATION/X.md\n",
+      },
+      ClaudeSpecific: {
+        skillMd: "# ClaudeSpecific\n\nStop: run cleanup\n",
+      },
+    });
+
+    const result = await migrateClaudeSkills({ from: fromDir, somaHome });
+
+    expect(result.apply).toBe(true);
+    expect(result.writtenCount).toBe(2);
+    expect(result.skippedClaudeSpecificCount).toBe(1);
+    expect(result.skippedIdempotentCount).toBe(0);
+
+    // Payload files for the two imported skills landed.
+    const portableSkillMd = await readFile(
+      join(somaHome, "skills/portable/SKILL.md"),
+      "utf8",
+    );
+    expect(portableSkillMd).toContain("clean prose");
+    const portableWorkflow = await readFile(
+      join(somaHome, "skills/portable/Workflows/Run.md"),
+      "utf8",
+    );
+    expect(portableWorkflow).toContain("step 1");
+    // needs-adapt skill: rewriter swapped the `~/.claude/PAI/DOCUMENTATION/` path.
+    const adaptedSkillMd = await readFile(
+      join(somaHome, "skills/needs-adapt/SKILL.md"),
+      "utf8",
+    );
+    expect(adaptedSkillMd).toContain("~/.soma/PAI/DOCUMENTATION/");
+    expect(adaptedSkillMd).not.toContain("~/.claude/PAI/DOCUMENTATION/");
+
+    // claude-specific skill must NOT land.
+    const csExists = await readdir(join(somaHome, "skills")).then((names) =>
+      names.includes("claude-specific"),
+    );
+    expect(csExists).toBe(false);
+
+    // Manifest + report present.
+    const manifestRaw = await readFile(result.manifestPath, "utf8");
+    const manifest = JSON.parse(manifestRaw) as ClaudeSkillsMigrationManifest;
+    expect(manifest.schema).toBe("soma.claude-skills-migration.v1");
+    expect(manifest.skills.length).toBe(2);
+    expect(manifest.skills.map((s) => s.kebabName).sort()).toEqual([
+      "needs-adapt",
+      "portable",
+    ]);
+    // Each manifest entry has a sourceSha + per-file SHAs.
+    for (const entry of manifest.skills) {
+      expect(entry.sourceSha).toMatch(/^[a-f0-9]{64}$/);
+      expect(Object.keys(entry.fileShas).length).toBeGreaterThan(0);
+      for (const sha of Object.values(entry.fileShas)) {
+        expect(sha).toMatch(/^[a-f0-9]{64}$/);
+      }
+    }
+
+    const report = await readFile(result.reportPath, "utf8");
+    expect(report).toContain("# Claude Skills Portability Report");
+    expect(report).toContain("portable | portable | imported");
+    expect(report).toContain("needs-adapt | needs-adapt | imported");
+    expect(report).toContain("claude-specific | claude-specific | skipped-claude-specific");
+    // AC-4 transparency — report documents the heuristic.
+    expect(report).toContain("Classifier rules (Phase 1, heuristic)");
+  });
+});
+
+test("migrateClaudeSkills --include-claude-specific lands the skipped set", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const somaHome = join(home, "soma");
+    await writeFlatSkillsFixture(fromDir, {
+      ClaudeSpecific: {
+        skillMd: "# ClaudeSpecific\n\nStop: run cleanup\n",
+      },
+    });
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      includeClaudeSpecific: true,
+    });
+
+    expect(result.writtenCount).toBe(1);
+    expect(result.skippedClaudeSpecificCount).toBe(0);
+    expect(result.includeClaudeSpecific).toBe(true);
+    // Payload landed.
+    const body = await readFile(
+      join(somaHome, "skills/claude-specific/SKILL.md"),
+      "utf8",
+    );
+    expect(body).toContain("Stop:");
+    // Manifest reflects the override.
+    const manifest = JSON.parse(
+      await readFile(result.manifestPath, "utf8"),
+    ) as ClaudeSkillsMigrationManifest;
+    expect(manifest.includeClaudeSpecific).toBe(true);
+    expect(manifest.skills[0]?.tag).toBe("claude-specific");
+    // Report carries the audit trail.
+    const report = await readFile(result.reportPath, "utf8");
+    expect(report).toContain("Include claude-specific: yes");
+    expect(report).toContain("claude-specific | claude-specific | imported");
+  });
+});
+
+test("migrateClaudeSkills is idempotent: re-run with unchanged source writes nothing", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const somaHome = join(home, "soma");
+    await writeFlatSkillsFixture(fromDir, {
+      Portable: { skillMd: "# Portable\n\nclean.\n" },
+      NeedsAdapt: {
+        skillMd: "# NeedsAdapt\n\nsee ~/.claude/PAI/DOCUMENTATION/X.md\n",
+      },
+    });
+
+    const first = await migrateClaudeSkills({ from: fromDir, somaHome });
+    expect(first.writtenCount).toBe(2);
+    expect(first.skippedIdempotentCount).toBe(0);
+
+    const second = await migrateClaudeSkills({ from: fromDir, somaHome });
+    expect(second.writtenCount).toBe(0);
+    expect(second.skippedIdempotentCount).toBe(2);
+    // Manifest importedAt preserved — byte-stable rerun.
+    expect(second.importedAt).toBe(first.importedAt);
+
+    // Manifest contents byte-stable.
+    const manifest1 = await readFile(first.manifestPath, "utf8");
+    const manifest2 = await readFile(second.manifestPath, "utf8");
+    expect(manifest2).toBe(manifest1);
+  });
+});
+
+test("migrateClaudeSkills handles mixed tree: per-skill routing is independent", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const somaHome = join(home, "soma");
+    await writeFlatSkillsFixture(fromDir, {
+      Alpha: { skillMd: "# Alpha\n\nclean.\n" },
+      Beta: {
+        skillMd: "# Beta\n\nsee ~/.claude/PAI/DOCUMENTATION/B.md\n",
+      },
+      Gamma: { skillMd: "# Gamma\n\nStop: run cleanup\n" },
+      Delta: { skillMd: "# Delta\n\nclean too.\n" },
+    });
+
+    const result = await migrateClaudeSkills({ from: fromDir, somaHome });
+    expect(result.outcomes.length).toBe(4);
+    const tagBySource = Object.fromEntries(
+      result.outcomes.map((o) => [o.sourceName, o.tag]),
+    );
+    expect(tagBySource.Alpha).toBe("portable");
+    expect(tagBySource.Beta).toBe("needs-adapt");
+    expect(tagBySource.Gamma).toBe("claude-specific");
+    expect(tagBySource.Delta).toBe("portable");
+    expect(result.writtenCount).toBe(3);
+    expect(result.skippedClaudeSpecificCount).toBe(1);
+  });
+});
+
+test("migrateClaudeSkills refuses non-flat tree on apply", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "empty");
+    await mkdir(fromDir, { recursive: true });
+    await expect(
+      migrateClaudeSkills({ from: fromDir, somaHome: join(home, "soma") }),
+    ).rejects.toThrow(/not a flat skills tree/);
+  });
+});
+
+test("migrateClaudeSkills refuses non-editor-config symlinks loud", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const skillDir = join(fromDir, "BadSkill");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# BadSkill\n", "utf8");
+    // Symlink that is NOT under an editor-config dir → must abort.
+    await symlink("/etc/passwd", join(skillDir, "danger.md"));
+    await expect(
+      migrateClaudeSkills({
+        from: fromDir,
+        somaHome: join(home, "soma"),
+      }),
+    ).rejects.toThrow(/refused symlink/);
+  });
+});
+
+// ---------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------
+
+test("readClaudeSkillsMigrationStatus returns null before first apply", async () => {
+  await withTempHome(async (home) => {
+    const status = await readClaudeSkillsMigrationStatus({
+      somaHome: join(home, "soma"),
+    });
+    expect(status).toBeNull();
+  });
+});
+
+test("readClaudeSkillsMigrationStatus returns the manifest after apply", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const somaHome = join(home, "soma");
+    await writeFlatSkillsFixture(fromDir, {
+      Portable: { skillMd: "# Portable\n\nclean.\n" },
+    });
+    await migrateClaudeSkills({ from: fromDir, somaHome });
+    const status = await readClaudeSkillsMigrationStatus({ somaHome });
+    expect(status).not.toBeNull();
+    expect(status?.schema).toBe("soma.claude-skills-migration.v1");
+    expect(status?.skills.length).toBe(1);
+    expect(status?.skills[0]?.kebabName).toBe("portable");
+  });
+});

--- a/test/cli-migrate-claude-skills.test.ts
+++ b/test/cli-migrate-claude-skills.test.ts
@@ -1,0 +1,208 @@
+/**
+ * #115 — `soma migrate claude-skills` CLI surface tests.
+ *
+ * Validates dry-run / --apply / --status / --include-claude-specific
+ * and unknown-flag behavior against a synthetic flat skills tree.
+ *
+ * Mirrors `cli-migrate.test.ts` (the PAI path) so the two surfaces
+ * stay in formatter parity — same totals line, same per-row shape,
+ * same --status empty-state hint.
+ */
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { runSomaCli } from "../src/cli";
+import { withTempHome as withSharedTempHome } from "./fixtures/pai-migration-fixtures";
+
+const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
+  withSharedTempHome(fn, "soma-cli-115-");
+
+async function writeFixture(home: string): Promise<string> {
+  const fromDir = join(home, "skills");
+  await mkdir(join(fromDir, "Portable"), { recursive: true });
+  await writeFile(
+    join(fromDir, "Portable", "SKILL.md"),
+    "# Portable\n\nclean.\n",
+    "utf8",
+  );
+  await mkdir(join(fromDir, "NeedsAdapt"), { recursive: true });
+  await writeFile(
+    join(fromDir, "NeedsAdapt", "SKILL.md"),
+    "# NeedsAdapt\n\nsee ~/.claude/PAI/DOCUMENTATION/X.md\n",
+    "utf8",
+  );
+  await mkdir(join(fromDir, "ClaudeSpecific"), { recursive: true });
+  await writeFile(
+    join(fromDir, "ClaudeSpecific", "SKILL.md"),
+    "# ClaudeSpecific\n\nStop: cleanup hook\n",
+    "utf8",
+  );
+  return fromDir;
+}
+
+test("soma migrate claude-skills --from <dir> → plan", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeFixture(home);
+    const output = await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--from",
+      fromDir,
+      "--soma-home",
+      join(home, "soma"),
+    ]);
+    expect(output).toContain("plan (dry-run");
+    expect(output).toContain("portable [portable] → imported");
+    expect(output).toContain("needs-adapt [needs-adapt] → imported");
+    expect(output).toContain("claude-specific [claude-specific] → skipped-claude-specific");
+    expect(output).toContain("Totals: 2 imported, 0 skipped-idempotent, 1 skipped-claude-specific");
+    // No writes — soma home shouldn't have a manifest yet.
+    await expect(
+      stat(join(home, "soma/imports/claude-skills/.manifest.json")),
+    ).rejects.toThrow();
+  });
+});
+
+test("soma migrate claude-skills --apply writes manifest + report + payloads", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeFixture(home);
+    const somaHome = join(home, "soma");
+    const output = await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--from",
+      fromDir,
+      "--soma-home",
+      somaHome,
+      "--apply",
+    ]);
+    expect(output).toContain("applied");
+    expect(output).toContain("Totals: 2 written, 0 skipped-idempotent, 1 skipped-claude-specific");
+    await stat(join(somaHome, "imports/claude-skills/.manifest.json"));
+    await stat(join(somaHome, "imports/claude-skills/.portability-report.md"));
+    await stat(join(somaHome, "skills/portable/SKILL.md"));
+    await stat(join(somaHome, "skills/needs-adapt/SKILL.md"));
+    // claude-specific must NOT have landed.
+    await expect(
+      stat(join(somaHome, "skills/claude-specific/SKILL.md")),
+    ).rejects.toThrow();
+  });
+});
+
+test("soma migrate claude-skills --apply --include-claude-specific lands the skipped set", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeFixture(home);
+    const somaHome = join(home, "soma");
+    const output = await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--from",
+      fromDir,
+      "--soma-home",
+      somaHome,
+      "--apply",
+      "--include-claude-specific",
+    ]);
+    expect(output).toContain("Totals: 3 written, 0 skipped-idempotent, 0 skipped-claude-specific");
+    await stat(join(somaHome, "skills/claude-specific/SKILL.md"));
+    // Report carries the override.
+    const report = await readFile(
+      join(somaHome, "imports/claude-skills/.portability-report.md"),
+      "utf8",
+    );
+    expect(report).toContain("Include claude-specific: yes");
+  });
+});
+
+test("soma migrate claude-skills --status (no prior apply) reports absence", async () => {
+  await withTempHome(async (home) => {
+    const output = await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--status",
+      "--soma-home",
+      join(home, "soma"),
+    ]);
+    expect(output).toContain("no migration manifest found");
+  });
+});
+
+test("soma migrate claude-skills --status (after apply) prints summary", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeFixture(home);
+    const somaHome = join(home, "soma");
+    await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--from",
+      fromDir,
+      "--soma-home",
+      somaHome,
+      "--apply",
+    ]);
+    const status = await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--status",
+      "--soma-home",
+      somaHome,
+    ]);
+    expect(status).toContain("soma migrate claude-skills — status");
+    expect(status).toContain("portable [portable]");
+    expect(status).toContain("needs-adapt [needs-adapt]");
+  });
+});
+
+test("soma migrate claude-skills --help surfaces usage", async () => {
+  const output = await runSomaCli(["migrate", "claude-skills", "--help"]);
+  expect(output).toContain("Usage: soma migrate claude-skills");
+});
+
+test("soma migrate claude-skills --apply --unknown-flag errors", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeFixture(home);
+    await expect(
+      runSomaCli([
+        "migrate",
+        "claude-skills",
+        "--from",
+        fromDir,
+        "--apply",
+        "--bogus",
+        "--soma-home",
+        join(home, "soma"),
+      ]),
+    ).rejects.toThrow("Unknown option");
+  });
+});
+
+test("soma migrate claude-skills (no --from on plan) errors with usage", async () => {
+  await expect(runSomaCli(["migrate", "claude-skills"])).rejects.toThrow();
+});
+
+test("soma migrate claude-skills --apply is idempotent", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeFixture(home);
+    const somaHome = join(home, "soma");
+    const first = await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--from",
+      fromDir,
+      "--soma-home",
+      somaHome,
+      "--apply",
+    ]);
+    expect(first).toContain("Totals: 2 written, 0 skipped-idempotent");
+    const second = await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--from",
+      fromDir,
+      "--soma-home",
+      somaHome,
+      "--apply",
+    ]);
+    expect(second).toContain("Totals: 0 written, 2 skipped-idempotent");
+  });
+});


### PR DESCRIPTION
## Summary

Second migration path alongside `soma migrate pai`. Imports directly from an installed flat `.claude/skills/` tree (e.g. `~/.claude/skills` or `~/work/PAI/Releases/v5.0.0/.claude/skills`) — one `<Name>/SKILL.md` per skill, no pack-level metadata, no collection bundles, **no name collisions by construction**.

Per-skill pipeline:
1. Read `<from>/<Name>/SKILL.md` and walk skill body recursively.
2. Classify portability (heuristic, regex-based) → `portable` / `needs-adapt` / `claude-specific`.
3. Apply normalizer rewrites for `needs-adapt`.
4. Write to `<somaHome>/skills/<kebab>/`.
5. Skip `claude-specific` unless `--include-claude-specific`.

Reuses `pai-pack-normalizer.ts` (rewrite pipeline) and `pai-memory-migrator.ts` (SHA-manifest idempotency) — no duplicate rewrite or manifest logic.

**Phase 2 deferred** (separate PR): `--smoke <substrate>` per-skill projection verify.

## Acceptance criteria

- [x] **AC-1** — `soma migrate claude-skills --from <path>` (no apply = plan) lists each skill + tag + reason.
- [x] **AC-2** — `--apply` writes `portable` + `needs-adapt`; skips `claude-specific` unless `--include-claude-specific`.
- [x] **AC-3** — per-skill SHA manifest at `~/.soma/imports/claude-skills/.manifest.json`; idempotent re-import (verified: re-run on unchanged source = 0 writes, byte-stable manifest).
- [x] **AC-4** — classifier rules documented in code AND in the portability report header (Phase 1 heuristic limits called out).
- [x] **AC-5** — portability report at `~/.soma/imports/claude-skills/.portability-report.md`.
- [x] **AC-7 (partial)** — fixture tests: portable, needs-adapt, claude-specific, mixed tree, idempotency, override, status. 29 new tests across `test/claude-skills-migrator.test.ts` + `test/cli-migrate-claude-skills.test.ts`.
- [x] **AC-8** — `docs/migration-from-pai.md` gains "Migrating from installed `.claude/skills/` instead of `Packs/`" section.
- [ ] AC-6 + AC-7 `--smoke` cells — **deferred to Phase 2 / separate PR**.

## Test evidence

- `bun run typecheck` — clean.
- `bun test` — 743 → 772 tests (+29 net, 0 failures).
- Real-world smoke (`~/work/PAI/Releases/v5.0.0/.claude/skills`, 45 source skills):
  - 35 imported (1 portable, 34 needs-adapt).
  - 10 skipped-claude-specific.
  - With `--include-claude-specific`: 45/45 land.
- Idempotency verified: re-run = `Totals: 0 written, 35 skipped-idempotent`.

## Classifier behavior on real-world tree

The classifier is intentionally **heuristic** for Phase 1 (regex pattern match, not semantic analysis). Slash-command detection only fires on Markdown/text files — code files routinely embed `/path` fragments and Discord-style commands that would false-positive. Hook-binding detection fires on any payload file.

10 skills tagged `claude-specific` on the real tree, mostly due to legitimate `/<slash-command>` references in SKILL.md prose: `agents` (/plan), `art` (/cse), `create-skill` (/simplify), `fabric` (/mnt — fenced-code false-positive shape), `interview` (/interview), `isa` (/admin), `loop` (/loop), `migrate` (/interview), `optimize` (/optimize), `research` (/conduct-research). These are reviewable in `.portability-report.md`.

## Files

- NEW `src/claude-skills-migrator.ts` (~600 lines) — migrator + classifier + manifest renderer + report renderer.
- NEW `test/claude-skills-migrator.test.ts` (20 tests) — classifier unit + apply integration + idempotency.
- NEW `test/cli-migrate-claude-skills.test.ts` (9 tests) — CLI surface: plan / apply / status / --include-claude-specific / unknown-flag / idempotency.
- MODIFIED `src/types.ts` (+133 lines) — `ClaudeSkillsMigrationOptions` + `ClaudeSkillPortabilityTag` + `ClaudeSkillOutcome` + plan/result/manifest types.
- MODIFIED `src/cli.ts` (+224 lines) — `parseMigrateClaudeSkillsArgs` + dispatch in `runSomaCli` + three formatters (`formatClaudeSkillsMigrationPlan` / `formatClaudeSkillsMigrationResult` / `formatClaudeSkillsMigrationStatus`).
- MODIFIED `docs/migration-from-pai.md` (+99 lines) — new section per AC-8.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` 772 pass / 0 fail
- [x] Smoke plan on real-world `~/work/PAI/Releases/v5.0.0/.claude/skills` produces ≥35 portable+needs-adapt outcomes
- [x] Smoke apply lands 35 skill payloads + manifest + report
- [x] Idempotency: second apply = 0 writes
- [x] `--include-claude-specific` lands all 45

Refs #115