### PR TITLE
fix(migrate): handle user-owned symlinks gracefully in claude-skills migrate (#118)

### DIFF
--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -57,6 +57,7 @@ import { EDITOR_CONFIG_DIRS } from "./pai-pack-noise";
 import { runBoundedConcurrent } from "./internal-concurrency";
 import { verifySubstrateProjection } from "./claude-skills-substrate-verify";
 import type {
+  ClaudeSkillAuditEntry,
   ClaudeSkillOutcome,
   ClaudeSkillPortabilityTag,
   ClaudeSkillSubstrateVerifyResult,
@@ -244,36 +245,212 @@ interface SkillFilePayload {
   content: Buffer;
 }
 
+// #118 — `realpath`-anchored security denylist for resolved symlink
+// targets. Even when a symlink chain resolves inside `$HOME`, paths
+// that almost certainly carry credentials (`.ssh/`, cloud-CLI creds,
+// the active user's keyring directories) must NEVER be slurped into
+// a Soma skill import. The list mirrors the existing secret-file
+// patterns in `pai-pack-importer.ts` (SECRET_FILE_PATTERNS) but
+// operates on the resolved target directory.
+//
+// Keep this list narrow — every entry widens the refusal envelope.
+// All entries are POSIX-style path segments anchored to `$HOME`.
+const HOME_SUBPATH_DENYLIST: readonly string[] = [
+  ".ssh",
+  ".aws",
+  ".gnupg",
+  ".kube",
+  ".docker",
+];
+
 /**
- * Walk every file under `<from>/<sourceName>/` recursively, refusing
- * symlinks and out-of-root escapes the same way `pai-pack-importer.ts`
- * does. Returns POSIX-relative paths.
+ * #118 — safely resolve a symlink target and answer two questions:
+ *   1. Does its realpath stay within `$HOME` (and outside the denylist)?
+ *   2. Is the resolved target a file, a directory, or broken?
+ *
+ * Uses `realpath` so multi-hop symlink chains can't escape `$HOME` via
+ * a symlink-to-symlink hop. Cycle detection is the caller's responsibility
+ * (it threads a `visitedRealPaths` Set keyed per-walk).
+ *
+ * Error semantics: every failure is returned as `{ refused: <kind> }`
+ * so the caller can decide whether to throw, audit, or skip. Never
+ * throws on its own.
  */
-async function collectSkillFiles(skillDir: string): Promise<SkillFilePayload[]> {
+type SymlinkResolution =
+  | { refused: "outside-home"; reason: string }
+  | { refused: "broken"; reason: string }
+  | { refused: "cycle"; reason: string }
+  | { refused: "denylist"; reason: string }
+  | { kind: "file" | "dir"; realPath: string };
+
+async function resolveSymlinkSafely(
+  absPath: string,
+  homeRealPath: string,
+  visitedRealPaths: Set<string>,
+): Promise<SymlinkResolution> {
+  let realPath: string;
+  try {
+    realPath = await realpath(absPath);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { refused: "broken", reason: `symlink target does not exist (broken link): ${absPath}` };
+    }
+    // ELOOP — kernel-level symlink loop. We surface as cycle so the
+    // refusal message stays consistent with the per-walk detection
+    // path below.
+    if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ELOOP") {
+      return { refused: "cycle", reason: `symlink loop detected by kernel: ${absPath}` };
+    }
+    throw error;
+  }
+  // Boundary check — exact `homeRealPath` is allowed (a symlink that
+  // points AT $HOME itself is benign), every descendant must sit
+  // under `homeRealPath + sep`.
+  if (realPath !== homeRealPath && !realPath.startsWith(`${homeRealPath}${sep}`)) {
+    return { refused: "outside-home", reason: `symlink target resolves outside $HOME: ${realPath}` };
+  }
+  // Denylist check — `<$HOME>/.ssh/...`, `<$HOME>/.aws/...`, etc.
+  const homeRel = relative(homeRealPath, realPath);
+  const firstSegment = homeRel.split(sep)[0] ?? "";
+  if (HOME_SUBPATH_DENYLIST.includes(firstSegment)) {
+    return { refused: "denylist", reason: `symlink target resolves into denylisted home subpath: ${realPath}` };
+  }
+  // Per-walk cycle detection. Once we've recorded this realpath, a
+  // second encounter inside the same walk means we're chasing a loop
+  // that didn't trip the kernel's ELOOP check (multi-hop dir cycle).
+  if (visitedRealPaths.has(realPath)) {
+    return { refused: "cycle", reason: `symlink cycle detected (revisited target): ${realPath}` };
+  }
+  // Stat the resolved target so the caller can decide file vs dir
+  // routing. We use the same Bun-friendly `lstat` then promote to
+  // file/dir from the realpath stat to keep the cost minimal — one
+  // extra stat per symlink resolution, never on the hot file path.
+  const targetStat = await lstat(realPath);
+  if (targetStat.isDirectory()) {
+    return { kind: "dir", realPath };
+  }
+  if (targetStat.isFile()) {
+    return { kind: "file", realPath };
+  }
+  // A device file or socket has no place in a skill import.
+  return { refused: "outside-home", reason: `symlink target is not a regular file or directory: ${realPath}` };
+}
+
+/**
+ * Walk every file under `<from>/<sourceName>/` recursively. Returns
+ * POSIX-relative paths.
+ *
+ * Symlink semantics (#118 rescope):
+ *   - Editor-config symlinks (`.cursor/`, `.vscode/`, etc.) silently
+ *     dropped, same as before (#104 parallel).
+ *   - Every other symlink resolves via `realpath`:
+ *       - target inside `$HOME` AND not denylisted → FOLLOWED. File
+ *         symlinks contribute their target bytes at the symlink's
+ *         relpath; directory symlinks are walked recursively.
+ *       - target outside `$HOME`, broken, cyclic, or denylisted →
+ *         throws so the caller can classify the containing skill as
+ *         `refused-other` (log-and-continue at the per-skill layer).
+ *   - Out-of-root absolute file paths still refuse — a regular file's
+ *     `realpath` must stay within the source-side tree the same way
+ *     pai-pack-importer enforces it.
+ *
+ * Per-file audit (`followed-user-owned-symlink`) is collected on the
+ * returned `audit` array so the surrounding skill outcome can record
+ * which symlinks were resolved.
+ */
+interface CollectSkillFilesResult {
+  files: SkillFilePayload[];
+  audit: ClaudeSkillAuditEntry[];
+}
+
+async function collectSkillFiles(
+  skillDir: string,
+  homeRealPath: string,
+): Promise<CollectSkillFilesResult> {
   const realRoot = await realpath(skillDir);
   const out: SkillFilePayload[] = [];
+  const audit: ClaudeSkillAuditEntry[] = [];
+  // Per-walk cycle detection — every directory we descend records its
+  // realpath here so a circular symlink chain triggers `refused: cycle`
+  // before infinite recursion. We seed with the resolved skill root.
+  const visitedRealPaths = new Set<string>([realRoot]);
 
-  async function visit(dir: string): Promise<void> {
+  // `relBase` lets the caller substitute the POSIX-relative path
+  // under the skill root when we recurse into a followed directory
+  // symlink. Without it, a target's children would land at their
+  // absolute-on-disk path; we need them at `<symlinkRel>/<childRel>`.
+  //
+  // `withinFollowedSymlink` flips the "within skill root" file-path
+  // check off — the followed branch's children have already been
+  // resolved through `realpath` and bounded to `$HOME`, which is the
+  // security anchor for symlink chases. The default branch (regular
+  // dir walk) keeps the strict check so a stray hardlink-out-of-root
+  // file still refuses.
+  async function visit(
+    dir: string,
+    relBase: string,
+    withinFollowedSymlink: boolean,
+  ): Promise<void> {
     const entries = await readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
       const full = join(dir, entry.name);
-      const rel = relative(skillDir, full).split(sep).join("/");
+      const rel = relBase === "" ? entry.name : `${relBase}/${entry.name}`;
       if (entry.name.includes("\\")) {
         throw new Error(`soma migrate claude-skills refused ambiguous path separator: ${rel}`);
       }
       if (entry.isSymbolicLink()) {
-        // #104 parallel — editor-config symlinks are noise on the
-        // source side and never carry portable skill content.
-        // Drop silently so the skill imports without aborting.
-        // Every other symlink still refuses loud (matches the
-        // pack/docs importers).
+        // #104 parallel — editor-config symlinks are pure noise.
         if (matchEditorConfigSymlinkDir(rel)) {
           continue;
         }
-        throw new Error(`soma migrate claude-skills refused symlink path: ${rel}`);
+        // #118 — resolve safely. User-owned (in-$HOME, non-denylisted)
+        // targets are followed; everything else throws so the
+        // surrounding skill classifies as `refused-other`.
+        const resolved = await resolveSymlinkSafely(full, homeRealPath, visitedRealPaths);
+        if ("refused" in resolved) {
+          throw new Error(
+            `soma migrate claude-skills refused symlink path: ${rel} — ${resolved.reason}`,
+          );
+        }
+        // Record audit entry — one per symlink resolution, regardless
+        // of file vs dir. The audit is per-skill; the surrounding skill
+        // outcome will surface this in the portability report.
+        audit.push({
+          kind: "followed-user-owned-symlink",
+          relPath: rel,
+          detail: resolved.realPath,
+        });
+        // Mark this target as visited so a later symlink under a
+        // descendant pointing back into this subtree triggers cycle
+        // refusal instead of infinite walk.
+        visitedRealPaths.add(resolved.realPath);
+        if (resolved.kind === "file") {
+          const content = await readFile(resolved.realPath);
+          out.push({ relPath: rel, source: resolved.realPath, content });
+          continue;
+        }
+        // Directory: recurse into the resolved target, but anchor the
+        // POSIX-relative path namespace at the symlink's `rel` so
+        // children land under `<rel>/<childName>`. From here down, the
+        // strict within-skill-root check is relaxed — children live
+        // under the followed target, not the skill root, and the
+        // resolveSymlinkSafely call above already enforced the
+        // $HOME boundary on the resolved target.
+        await visit(resolved.realPath, rel, true);
+        continue;
       }
       if (entry.isDirectory()) {
         if (entry.name === ".git" || entry.name === ".hg" || entry.name === ".svn") {
+          // #118 — VCS metadata dirs are still refused at the source-
+          // skill root (a Claude skill should never carry an inline
+          // `.git/`). Inside a followed user-owned symlink branch
+          // (which is, by construction, a separate worktree the user
+          // is developing alongside their Claude skill), `.git/` is
+          // expected; we silently skip it so the followed skill can
+          // import without poisoning the surrounding outcome.
+          if (withinFollowedSymlink) {
+            continue;
+          }
           throw new Error(`soma migrate claude-skills refused VCS metadata directory: ${rel}`);
         }
         if (entry.name === "node_modules" || entry.name === ".next" || entry.name === "dist") {
@@ -284,13 +461,28 @@ async function collectSkillFiles(skillDir: string): Promise<SkillFilePayload[]> 
         if ((EDITOR_CONFIG_DIRS as readonly string[]).includes(entry.name)) {
           continue;
         }
-        await visit(full);
+        // Cycle bookkeeping for plain dirs too — cheap and protects
+        // against bind-mount-style hard-link cycles (rare on macOS
+        // but POSIX permits them).
+        const realDir = await realpath(full);
+        if (visitedRealPaths.has(realDir)) {
+          throw new Error(
+            `soma migrate claude-skills refused symlink path: ${rel} — directory cycle detected at ${realDir}`,
+          );
+        }
+        visitedRealPaths.add(realDir);
+        await visit(full, rel, withinFollowedSymlink);
         continue;
       }
       if (entry.isFile()) {
-        const realFile = await realpath(full);
-        if (!isWithinPath(realRoot, realFile)) {
-          throw new Error(`soma migrate claude-skills refused path outside skill root: ${rel}`);
+        if (!withinFollowedSymlink) {
+          // Strict within-root check only applies outside the followed-
+          // symlink branch. Inside it, the safe-resolve helper already
+          // bounded the target to `$HOME`.
+          const realFile = await realpath(full);
+          if (!isWithinPath(realRoot, realFile)) {
+            throw new Error(`soma migrate claude-skills refused path outside skill root: ${rel}`);
+          }
         }
         const content = await readFile(full);
         out.push({ relPath: rel, source: full, content });
@@ -298,9 +490,10 @@ async function collectSkillFiles(skillDir: string): Promise<SkillFilePayload[]> 
     }
   }
 
-  await visit(skillDir);
+  await visit(skillDir, "", false);
   out.sort((a, b) => a.relPath.localeCompare(b.relPath));
-  return out;
+  audit.sort((a, b) => a.relPath.localeCompare(b.relPath));
+  return { files: out, audit };
 }
 
 /**
@@ -402,18 +595,40 @@ interface SourceSkillReadResult {
   kebabName: string;
   files: SkillFilePayload[];
   sourceSha: string;
+  // #118 — per-skill audit of followed symlinks. Empty array when the
+  // skill walked clean. Propagated onto the ClaudeSkillOutcome via the
+  // plan/apply path so the portability report can surface it.
+  audit: ClaudeSkillAuditEntry[];
 }
 
 async function readSourceSkill(
   fromDir: string,
   sourceName: string,
+  homeRealPath: string,
 ): Promise<SourceSkillReadResult> {
   const skillDir = join(fromDir, sourceName);
   const skillMdPath = join(skillDir, "SKILL.md");
   if (!(await pathExists(skillMdPath))) {
     throw new Error(`soma migrate claude-skills: ${sourceName}/SKILL.md not found.`);
   }
-  const files = await collectSkillFiles(skillDir);
+  // #118 — wrap collect errors with the source skill name so the
+  // refusal reason includes `<sourceName>/<rel>` per AC-4. The walker's
+  // error messages all follow the shape `soma migrate claude-skills
+  // refused <kind>: <rel>[ — <detail>]`; we splice the source name
+  // in front of `<rel>` so principals can locate the offending path
+  // without grep. Falls back to a `(in <sourceName>)` suffix when the
+  // shape doesn't match.
+  const { files, audit } = await collectSkillFiles(skillDir, homeRealPath).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    const fixed = message.replace(
+      /(soma migrate claude-skills refused [^:]+: )([^\s—]+)/,
+      (_full, prefix, rel) => `${prefix}${sourceName}/${rel}`,
+    );
+    const finalMessage = fixed === message
+      ? `${fixed} (in ${sourceName})`
+      : fixed;
+    throw new Error(finalMessage);
+  });
   const skillMd = files.find((f) => f.relPath === "SKILL.md");
   if (!skillMd) {
     throw new Error(`soma migrate claude-skills: ${sourceName}/SKILL.md not collected (symlink? case mismatch?)`);
@@ -433,6 +648,7 @@ async function readSourceSkill(
     kebabName: kebabSlug(sourceName),
     files,
     sourceSha: sha256Hex(Buffer.from(composite, "utf8")),
+    audit,
   };
 }
 
@@ -460,12 +676,15 @@ async function listFlatSkillNames(fromDir: string): Promise<string[]> {
     if (entry.name.startsWith(".")) continue;
     const skillMdPath = join(fromDir, entry.name, "SKILL.md");
     if (await pathExists(skillMdPath)) {
-      // Symlinked SKILL.md is refused — same loud-fail bar as
-      // every other path in this importer.
-      const stat = await lstat(skillMdPath);
-      if (stat.isSymbolicLink()) {
-        throw new Error(`soma migrate claude-skills refused symlinked SKILL.md: ${entry.name}/SKILL.md`);
-      }
+      // #118 — a symlinked top-level SKILL.md is no longer an outright
+      // refusal at the listing phase. The walker in `collectSkillFiles`
+      // resolves the symlink via the safe helper: user-owned in-$HOME
+      // targets follow + import; out-of-home / broken / cyclic targets
+      // throw and classify the whole `<Name>` skill as `refused-other`
+      // (per-skill log-and-continue at the orchestrator level).
+      // We DO still surface the skill name so the orchestrator can run
+      // `readSourceSkill` against it — that's where the safe-resolve
+      // and per-skill error isolation live.
       names.push(entry.name);
     }
   }
@@ -520,6 +739,7 @@ async function buildPlanCore(
   somaHome: string,
   includeClaudeSpecific: boolean,
   prevManifest: ClaudeSkillsMigrationManifest | null,
+  homeRealPath: string,
 ): Promise<PlanResult> {
   const names = await listFlatSkillNames(fromDir);
   if (names.length === 0) {
@@ -529,9 +749,26 @@ async function buildPlanCore(
   // Bounded concurrency for the read + classify pass — per-skill work
   // is independent and dominated by file I/O, same as the memory
   // migrator (4-wide).
-  const reads = await runBoundedConcurrent(
+  //
+  // #118 — per-skill log-and-continue. A read failure on one skill no
+  // longer aborts the whole migrate. We surface a `Result`-style
+  // tagged union per skill so the outcome builder can classify
+  // failures as `refused-other` while keeping the rest of the pipeline
+  // pure. Mirrors the pattern in `pai-migration.ts:728-737`.
+  type ReadResult =
+    | { ok: true; read: SourceSkillReadResult }
+    | { ok: false; sourceName: string; reason: string };
+  const readResults: ReadResult[] = await runBoundedConcurrent<string, ReadResult>(
     names,
-    async (name) => readSourceSkill(fromDir, name),
+    async (name) => {
+      try {
+        const read = await readSourceSkill(fromDir, name, homeRealPath);
+        return { ok: true, read };
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        return { ok: false, sourceName: name, reason };
+      }
+    },
     4,
   );
 
@@ -542,7 +779,31 @@ async function buildPlanCore(
     }
   }
 
-  const outcomes: ClaudeSkillOutcome[] = reads.map((read) => {
+  const reads: SourceSkillReadResult[] = [];
+  const outcomes: ClaudeSkillOutcome[] = [];
+  for (const r of readResults) {
+    if (!r.ok) {
+      // Per-skill refusal — preserve the source name + reason so the
+      // formatter can surface `<sourceName>/<rel>` per AC-4. The
+      // refusal has no sourceSha (we never finished reading the
+      // skill); we use a stable empty marker so manifest entries
+      // for `refused-other` are intentionally absent (idempotency
+      // anchors only land for successfully-read skills).
+      outcomes.push({
+        sourceName: r.sourceName,
+        kebabName: kebabSlug(r.sourceName),
+        tag: "portable",
+        reason: r.reason,
+        disposition: "refused-other",
+        sourceSha: "",
+        target: null,
+        fileCount: 0,
+        refusalReason: r.reason,
+      });
+      continue;
+    }
+    const read = r.read;
+    reads.push(read);
     const classification = classifySkillPortability(read.files);
     const target = join(somaHome, "skills", read.kebabName);
     let disposition: ClaudeSkillOutcome["disposition"];
@@ -556,7 +817,7 @@ async function buildPlanCore(
         disposition = "imported";
       }
     }
-    return {
+    outcomes.push({
       sourceName: read.sourceName,
       kebabName: read.kebabName,
       tag: classification.tag,
@@ -568,8 +829,9 @@ async function buildPlanCore(
       // the source file count so the principal can see the size of
       // each pending write up-front.
       fileCount: read.files.length,
-    };
-  });
+      ...(read.audit.length > 0 ? { audit: read.audit } : {}),
+    });
+  }
   outcomes.sort((a, b) => a.sourceName.localeCompare(b.sourceName));
 
   return { isFlatSkillsTree: true, outcomes, reads };
@@ -581,6 +843,11 @@ export async function planClaudeSkillsMigration(
   const { from, somaHome } = resolveHomes(options);
   const includeClaudeSpecific = options.includeClaudeSpecific === true;
   const smokeSubstrates = normalizeSmokeSubstrates(options.smokeSubstrates);
+  // #118 — resolve `$HOME` once via realpath so symlinks targeting
+  // paths under HOME (the common case on macOS where /tmp resolves to
+  // /private/tmp) are correctly identified as in-bounds. The resolved
+  // path is the security anchor for the safe-symlink helper.
+  const homeRealPath = await realpath(resolve(options.homeDir ?? homedir()));
   // Plan mode reads any existing manifest so the dispositions match
   // what an `--apply` invocation would do (e.g. a re-run on unchanged
   // source shows `skipped-idempotent`, not `imported`).
@@ -590,6 +857,7 @@ export async function planClaudeSkillsMigration(
     somaHome,
     includeClaudeSpecific,
     prevManifest,
+    homeRealPath,
   );
   return {
     apply: false,
@@ -702,12 +970,51 @@ function renderPortabilityReport(
   lines.push(`| ${headerCells.join(" | ")} |`);
   lines.push(`|${headerCells.map(() => "---").join("|")}|`);
   for (const o of result.outcomes) {
-    const row = [o.kebabName, o.tag, o.disposition, escapeMarkdownCell(o.reason)];
+    // #118 — refused-other rows surface the refusal reason instead of
+    // the classifier tag (which is meaningless for a skill whose read
+    // never completed). Other dispositions keep the classifier reason.
+    const reasonCell = o.disposition === "refused-other"
+      ? escapeMarkdownCell(o.refusalReason ?? o.reason)
+      : escapeMarkdownCell(o.reason);
+    const row = [o.kebabName, o.tag, o.disposition, reasonCell];
     for (const substrate of result.smokeSubstrates) {
       const verify = o.substrates?.[substrate];
       row.push(verify ? renderSubstrateCell(verify) : "—");
     }
     lines.push(`| ${row.join(" | ")} |`);
+  }
+  // #118 — audit section listing every followed-user-owned-symlink.
+  // Sorted by source skill, then by rel path. Absent when no skill
+  // recorded a followed symlink (Phase-1 byte-stable rerun).
+  // Audit kind is currently only `followed-user-owned-symlink`; future
+  // kinds will need a switch here. We flatten directly today.
+  const followedAuditRows: { source: string; rel: string; target: string }[] = [];
+  for (const o of result.outcomes) {
+    if (!o.audit) continue;
+    for (const entry of o.audit) {
+      followedAuditRows.push({ source: o.sourceName, rel: entry.relPath, target: entry.detail });
+    }
+  }
+  if (followedAuditRows.length > 0) {
+    followedAuditRows.sort(
+      (a, b) => a.source.localeCompare(b.source) || a.rel.localeCompare(b.rel),
+    );
+    lines.push("");
+    lines.push("## Followed user-owned symlinks");
+    lines.push("");
+    lines.push(
+      "These symlinks were resolved via `realpath` and their target bytes imported. Every resolved target stayed within `$HOME` and outside the credential-path denylist (`.ssh/`, `.aws/`, `.gnupg/`, `.kube/`, `.docker/`).",
+    );
+    lines.push("");
+    lines.push("| Source skill | Symlink path | Resolved target |");
+    lines.push("|---|---|---|");
+    for (const row of followedAuditRows) {
+      lines.push(`| ${row.source} | ${escapeMarkdownCell(row.rel)} | ${escapeMarkdownCell(row.target)} |`);
+    }
+    lines.push("");
+    // Mention the audit kind by name so principals grep'ing the report
+    // can find it. Also documented in `src/types.ts`.
+    lines.push("Audit kind: `followed-user-owned-symlink` (one entry per resolved symlink in the manifest).");
   }
   lines.push("");
   return lines.join("\n");
@@ -759,6 +1066,10 @@ async function runSmokeVerify(args: RunSmokeVerifyArgs): Promise<void> {
 
   for (const outcome of outcomes) {
     if (outcome.disposition === "skipped-claude-specific") continue;
+    // #118 — `refused-other` skills never landed bytes; nothing to
+    // verify against a substrate. Skip without classifying as a
+    // contract violation.
+    if (outcome.disposition === "refused-other") continue;
 
     // Resolve the post-rewrite payload. Three sources, in order:
     //   1. In-memory payload captured by the apply loop.
@@ -869,6 +1180,8 @@ export async function migrateClaudeSkills(
   const { from, somaHome } = resolveHomes(options);
   const includeClaudeSpecific = options.includeClaudeSpecific === true;
   const smokeSubstrates = normalizeSmokeSubstrates(options.smokeSubstrates);
+  // #118 — resolve `$HOME` once (see plan-mode helper above).
+  const homeRealPath = await realpath(resolve(options.homeDir ?? homedir()));
 
   // Ensure imports/claude-skills/ exists so manifest + report writes
   // succeed even on a fully empty Soma home.
@@ -889,6 +1202,7 @@ export async function migrateClaudeSkills(
     somaHome,
     includeClaudeSpecific,
     previousManifest,
+    homeRealPath,
   );
 
   if (!isFlatSkillsTree) {
@@ -909,6 +1223,7 @@ export async function migrateClaudeSkills(
   let writtenCount = 0;
   let skippedIdempotentCount = 0;
   let skippedClaudeSpecificCount = 0;
+  let refusedOtherCount = 0;
   // #115 Phase 2 — in-memory post-rewrite payload per imported skill,
   // ferried into the smoke pass below to avoid a second disk read.
   // Skipped-idempotent skills fall back to disk re-read inside the
@@ -918,6 +1233,15 @@ export async function migrateClaudeSkills(
   for (const outcome of outcomes) {
     if (outcome.disposition === "skipped-claude-specific") {
       skippedClaudeSpecificCount += 1;
+      continue;
+    }
+    if (outcome.disposition === "refused-other") {
+      // #118 — per-skill log-and-continue. The read failed (out-of-home
+      // symlink target, cycle, broken link, denylist). The outcome
+      // already carries `refusalReason`; nothing else to do here. The
+      // skill is NOT added to the manifest — only successfully-read
+      // skills earn an idempotency anchor.
+      refusedOtherCount += 1;
       continue;
     }
     if (outcome.disposition === "skipped-idempotent") {
@@ -1077,6 +1401,7 @@ export async function migrateClaudeSkills(
     writtenCount,
     skippedIdempotentCount,
     skippedClaudeSpecificCount,
+    refusedOtherCount,
     ...(smokeSubstrates.length > 0 ? { substrateVerifySummary } : {}),
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2121,16 +2121,25 @@ function formatClaudeSkillsMigrationPlan(plan: ClaudeSkillsMigrationPlan): strin
   lines.push("");
   lines.push("Per-skill plan:");
   for (const o of plan.outcomes) {
-    lines.push(`  - ${o.kebabName} [${o.tag}] → ${o.disposition} (${o.reason})`);
+    // #118 — refused-other rows include the refusalReason (which
+    // already embeds <sourceName>/<rel>) so principals can locate
+    // the offending path from the CLI output alone.
+    const reason = o.disposition === "refused-other" ? (o.refusalReason ?? o.reason) : o.reason;
+    lines.push(`  - ${o.kebabName} [${o.tag}] → ${o.disposition} (${reason})`);
   }
   const counts = countOutcomesByDisposition(plan.outcomes);
   lines.push("");
   lines.push(
-    `Totals: ${counts.imported} imported, ${counts.skippedIdempotent} skipped-idempotent, ${counts.skippedClaudeSpecific} skipped-claude-specific.`,
+    `Totals: ${counts.imported} imported, ${counts.skippedIdempotent} skipped-idempotent, ${counts.skippedClaudeSpecific} skipped-claude-specific, ${counts.refusedOther} refused-other.`,
   );
   if (counts.skippedClaudeSpecific > 0 && !plan.includeClaudeSpecific) {
     lines.push(
       `${counts.skippedClaudeSpecific} skill(s) tagged claude-specific — re-run with --include-claude-specific to import them anyway.`,
+    );
+  }
+  if (counts.refusedOther > 0) {
+    lines.push(
+      `${counts.refusedOther} skill(s) refused (out-of-home symlink, cycle, or other genuine error). Plan mode exits 0; apply mode exits 1.`,
     );
   }
   lines.push("");
@@ -2163,11 +2172,12 @@ function formatClaudeSkillsMigrationResult(result: ClaudeSkillsMigrationResult):
         .filter((s): s is string => s !== null);
       if (parts.length > 0) suffix = ` [${parts.join(", ")}]`;
     }
-    lines.push(`  - ${o.kebabName} [${o.tag}] → ${o.disposition} (${o.reason})${suffix}`);
+    const reason = o.disposition === "refused-other" ? (o.refusalReason ?? o.reason) : o.reason;
+    lines.push(`  - ${o.kebabName} [${o.tag}] → ${o.disposition} (${reason})${suffix}`);
   }
   lines.push("");
   lines.push(
-    `Totals: ${result.writtenCount} written, ${result.skippedIdempotentCount} skipped-idempotent, ${result.skippedClaudeSpecificCount} skipped-claude-specific.`,
+    `Totals: ${result.writtenCount} written, ${result.skippedIdempotentCount} skipped-idempotent, ${result.skippedClaudeSpecificCount} skipped-claude-specific, ${result.refusedOtherCount} refused-other.`,
   );
   if (result.substrateVerifySummary) {
     for (const substrate of result.smokeSubstrates) {
@@ -2211,16 +2221,18 @@ function formatClaudeSkillsMigrationStatus(
 
 function countOutcomesByDisposition(
   outcomes: readonly { disposition: string }[],
-): { imported: number; skippedIdempotent: number; skippedClaudeSpecific: number } {
+): { imported: number; skippedIdempotent: number; skippedClaudeSpecific: number; refusedOther: number } {
   let imported = 0;
   let skippedIdempotent = 0;
   let skippedClaudeSpecific = 0;
+  let refusedOther = 0;
   for (const o of outcomes) {
     if (o.disposition === "imported") imported += 1;
     else if (o.disposition === "skipped-idempotent") skippedIdempotent += 1;
     else if (o.disposition === "skipped-claude-specific") skippedClaudeSpecific += 1;
+    else if (o.disposition === "refused-other") refusedOther += 1;
   }
-  return { imported, skippedIdempotent, skippedClaudeSpecific };
+  return { imported, skippedIdempotent, skippedClaudeSpecific, refusedOther };
 }
 
 function formatPaiImportPlan(plan: PaiImportPlan): string {
@@ -2827,13 +2839,32 @@ export async function runSomaCli(args: string[]): Promise<string> {
         );
       }
       if (parsed.mode === "plan") {
+        // #118 — plan mode is informative; refused-other rows are
+        // displayed but the CLI exits 0 (mirror of #112's plan/apply
+        // split for `migrate pai`).
         return formatClaudeSkillsMigrationPlan(
           await planClaudeSkillsMigration(claudeOptions),
         );
       }
-      return formatClaudeSkillsMigrationResult(
-        await migrateClaudeSkills(claudeOptions),
-      );
+      const csResult = await migrateClaudeSkills(claudeOptions);
+      const formatted = formatClaudeSkillsMigrationResult(csResult);
+      // #118 — apply mode: surface a non-zero exit code when any skill
+      // refused with a genuine error (out-of-home symlink target,
+      // cycle, broken link, denylisted target). Plan mode already
+      // returned without throwing above. Other dispositions
+      // (skipped-claude-specific, skipped-idempotent) are policy-
+      // respected and stay zero-exit.
+      if (csResult.refusedOtherCount > 0) {
+        const refused = csResult.outcomes.filter((o) => o.disposition === "refused-other");
+        const detail = refused
+          .map((o) => `  - ${o.sourceName}: ${o.refusalReason ?? o.reason}`)
+          .join("\n");
+        throw new SomaCliError(
+          `${formatted}\nsoma migrate claude-skills — ${csResult.refusedOtherCount} skill(s) refused with genuine errors:\n${detail}\n`,
+          1,
+        );
+      }
+      return formatted;
     }
     if (parsed.mode === "status") {
       return formatPaiMigrationStatus(await readPaiMigrationManifest(parsed.options));

--- a/src/types.ts
+++ b/src/types.ts
@@ -941,7 +941,19 @@ export interface ClaudeSkillOutcome {
   // `skipped-claude-specific` = classifier verdict was `claude-specific`
   // and `includeClaudeSpecific` was false. `skipped-idempotent` =
   // source SHA matched the manifest entry on rerun.
-  disposition: "imported" | "skipped-claude-specific" | "skipped-idempotent";
+  //
+  // #118 — `refused-other` is the per-skill log-and-continue verdict
+  // (mirrors `PaiPackOutcomeKind.refused-other`). Genuine errors while
+  // reading a source skill (out-of-home symlink target, symlink cycle,
+  // broken target, secret refusal, …) classify the surrounding skill
+  // as `refused-other` and let the other skills continue. The CLI
+  // turns any `refused-other` outcome into a non-zero exit ONLY in
+  // apply mode (matches #112's mode-gated exit policy).
+  disposition:
+    | "imported"
+    | "skipped-claude-specific"
+    | "skipped-idempotent"
+    | "refused-other";
   // SHA-256 of the source SKILL.md bytes (hex). Stable identity for
   // idempotency checks. Populated even on classify-only / plan runs.
   sourceSha: string;
@@ -959,6 +971,35 @@ export interface ClaudeSkillOutcome {
   // (skipped skills have nothing to verify). Empty/undefined when
   // no smoke run was requested — preserves Phase 1 report shape.
   substrates?: Partial<Record<ClaudeSkillsSmokeSubstrate, ClaudeSkillSubstrateVerifyResult>>;
+  /**
+   * #118 — per-skill audit trail. Each entry records a non-fatal event
+   * the source-side walker decided to handle silently (followed
+   * symlink resolutions to date). The audit feeds the portability
+   * report so principals can see which symlinks were resolved without
+   * grepping for them. Absent when the skill walked clean.
+   *
+   * Kinds:
+   *   - `followed-user-owned-symlink` — a symlink whose realpath
+   *     target stayed within `$HOME` was resolved + its bytes
+   *     imported. `detail` carries `<rel> → <realpath>`.
+   */
+  audit?: ClaudeSkillAuditEntry[];
+  /**
+   * #118 — reason text for the `refused-other` disposition. Includes
+   * the `<sourceName>/<rel>` path of the symlink (or other refusal
+   * trigger) so principals can locate it without grep. Absent for
+   * non-refused dispositions; the higher-level `reason` field carries
+   * the classifier verdict for those.
+   */
+  refusalReason?: string;
+}
+
+export interface ClaudeSkillAuditEntry {
+  kind: "followed-user-owned-symlink";
+  /** POSIX-style path relative to the skill root that triggered the event. */
+  relPath: string;
+  /** Resolved realpath of the symlink target (for principal audit). */
+  detail: string;
 }
 
 export interface ClaudeSkillsMigrationPlan {
@@ -1002,6 +1043,11 @@ export interface ClaudeSkillsMigrationResult extends ClaudeSkillsMigrationPlan {
   // Skills skipped because verdict was `claude-specific` and the
   // override flag was off.
   skippedClaudeSpecificCount: number;
+  // #118 — skills that hit a genuine read failure (out-of-home symlink,
+  // symlink cycle, broken target, denylisted target, etc.). Other
+  // skills continue. The CLI gates exit-code on this count being > 0
+  // in apply mode (mirror of #112's plan/apply split).
+  refusedOtherCount: number;
   // #115 Phase 2 — per-substrate verify aggregate counts. Keyed by
   // substrate id; entries present only for substrates requested via
   // `--smoke`. Each entry counts `verified` / `verified-with-

--- a/test/claude-skills-migrator.test.ts
+++ b/test/claude-skills-migrator.test.ts
@@ -438,20 +438,388 @@ test("migrateClaudeSkills refuses non-flat tree on apply", async () => {
   });
 });
 
-test("migrateClaudeSkills refuses non-editor-config symlinks loud", async () => {
+// ---------------------------------------------------------------------
+// #118 — symlink handling: follow user-owned, refuse out-of-home,
+// per-skill log-and-continue, full path in error messages.
+// ---------------------------------------------------------------------
+
+// AC-1: a symlink whose realpath stays within $HOME is FOLLOWED and
+// its bytes are imported as if they lived at the symlink path. The
+// containing skill imports cleanly with a `followed-user-owned-symlink`
+// audit entry.
+test("#118 migrateClaudeSkills follows user-owned symlink to FILE inside $HOME", async () => {
   await withTempHome(async (home) => {
     const fromDir = join(home, "skills");
-    const skillDir = join(fromDir, "BadSkill");
+    const skillDir = join(fromDir, "WithLink");
     await mkdir(skillDir, { recursive: true });
-    await writeFile(join(skillDir, "SKILL.md"), "# BadSkill\n", "utf8");
-    // Symlink that is NOT under an editor-config dir → must abort.
-    await symlink("/etc/passwd", join(skillDir, "danger.md"));
-    await expect(
-      migrateClaudeSkills({
-        from: fromDir,
-        somaHome: join(home, "soma"),
-      }),
-    ).rejects.toThrow(/refused symlink/);
+    await mkdir(join(skillDir, "Workflows"), { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# WithLink\n\nclean.\n", "utf8");
+    // External (still inside $HOME) target file.
+    const externalDir = join(home, "external");
+    await mkdir(externalDir, { recursive: true });
+    await writeFile(join(externalDir, "Run.md"), "# External Run\n\nfollowed!\n", "utf8");
+    // Symlink Workflows/Run.md → ../../external/Run.md (relative form).
+    await symlink(join(externalDir, "Run.md"), join(skillDir, "Workflows/Run.md"));
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome: join(home, "soma"),
+      homeDir: home,
+    });
+    expect(result.writtenCount).toBe(1);
+    const outcome = result.outcomes.find((o) => o.sourceName === "WithLink");
+    expect(outcome?.disposition).toBe("imported");
+    // Followed-symlink bytes landed at the symlink-source path.
+    const landed = await readFile(
+      join(home, "soma/skills/with-link/Workflows/Run.md"),
+      "utf8",
+    );
+    expect(landed).toContain("followed!");
+    // Audit entry recorded.
+    expect(outcome?.audit?.some(
+      (a) => a.kind === "followed-user-owned-symlink" && a.relPath === "Workflows/Run.md",
+    )).toBe(true);
+  });
+});
+
+// AC-1 (b): a symlink to a DIRECTORY inside $HOME is walked recursively.
+// Matches user's real-world repro: ~/.claude/skills/Business/Accounting
+// → ~/work/invisible/Accounting (dir with SKILL.md + Workflows/).
+test("#118 migrateClaudeSkills walks user-owned symlinked DIRECTORY recursively", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const skillDir = join(fromDir, "Business");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# Business\n\ntop-level skill.\n", "utf8");
+
+    // External skill (private worktree) — has its own subtree.
+    const externalAccounting = join(home, "work/invisible/Accounting");
+    await mkdir(join(externalAccounting, "Workflows"), { recursive: true });
+    await writeFile(join(externalAccounting, "SKILL.md"), "# Accounting\n\nprivate skill.\n", "utf8");
+    await writeFile(join(externalAccounting, "Workflows/Compute.md"), "# Compute\n\nstep one\n", "utf8");
+
+    // Symlink the Accounting subdir inside Business/.
+    await symlink(externalAccounting, join(skillDir, "Accounting"));
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome: join(home, "soma"),
+      homeDir: home,
+    });
+    expect(result.writtenCount).toBe(1);
+    const business = result.outcomes.find((o) => o.sourceName === "Business");
+    expect(business?.disposition).toBe("imported");
+    // Followed subtree landed under Business kebab.
+    expect(
+      await readFile(
+        join(home, "soma/skills/business/Accounting/SKILL.md"),
+        "utf8",
+      ),
+    ).toContain("private skill");
+    expect(
+      await readFile(
+        join(home, "soma/skills/business/Accounting/Workflows/Compute.md"),
+        "utf8",
+      ),
+    ).toContain("step one");
+    // Two audit entries — one for the symlinked dir, one not needed
+    // since recursive walk happens after the dir resolve. We only
+    // need to record the symlink point itself.
+    const followed = business?.audit?.filter(
+      (a) => a.kind === "followed-user-owned-symlink",
+    ) ?? [];
+    expect(followed.length).toBeGreaterThanOrEqual(1);
+    expect(followed.some((a) => a.relPath === "Accounting")).toBe(true);
+  });
+});
+
+// AC-1 (c): top-level <Name>/SKILL.md is itself a symlink to a file
+// inside $HOME → followed + imported.
+test("#118 migrateClaudeSkills follows user-owned symlinked top-level SKILL.md", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const skillDir = join(fromDir, "Linked");
+    await mkdir(skillDir, { recursive: true });
+    const realSkill = join(home, "external/Linked-SKILL.md");
+    await mkdir(join(home, "external"), { recursive: true });
+    await writeFile(realSkill, "# Linked\n\nfollowed top-level.\n", "utf8");
+    await symlink(realSkill, join(skillDir, "SKILL.md"));
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome: join(home, "soma"),
+      homeDir: home,
+    });
+    expect(result.writtenCount).toBe(1);
+    const landed = await readFile(join(home, "soma/skills/linked/SKILL.md"), "utf8");
+    expect(landed).toContain("followed top-level");
+  });
+});
+
+// AC-2: an out-of-home symlink target still refuses. The surrounding
+// skill is classified `refused-other`; other skills continue (AC-3).
+test("#118 migrateClaudeSkills refuses out-of-home symlink as refused-other; others continue", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const somaHome = join(home, "soma");
+
+    // BadSkill: symlinks /etc/passwd into the skill tree.
+    const badDir = join(fromDir, "BadSkill");
+    await mkdir(badDir, { recursive: true });
+    await writeFile(join(badDir, "SKILL.md"), "# BadSkill\n", "utf8");
+    await symlink("/etc/passwd", join(badDir, "danger.md"));
+
+    // GoodSkill: clean import next to it.
+    const goodDir = join(fromDir, "GoodSkill");
+    await mkdir(goodDir, { recursive: true });
+    await writeFile(join(goodDir, "SKILL.md"), "# GoodSkill\n\nclean.\n", "utf8");
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      homeDir: home,
+    });
+    const bad = result.outcomes.find((o) => o.sourceName === "BadSkill");
+    expect(bad?.disposition).toBe("refused-other");
+    // AC-4: refusal reason includes the source skill name + relpath.
+    expect(bad?.refusalReason).toContain("BadSkill/danger.md");
+    // GoodSkill still imports.
+    const good = result.outcomes.find((o) => o.sourceName === "GoodSkill");
+    expect(good?.disposition).toBe("imported");
+    expect(result.writtenCount).toBe(1);
+  });
+});
+
+// AC-5 (c): symlink cycle (A → B → A) inside $HOME → detected and
+// refused gracefully (refused-other), no infinite loop.
+test("#118 migrateClaudeSkills detects symlink cycle and refuses gracefully", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const skillDir = join(fromDir, "Cyclic");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# Cyclic\n", "utf8");
+    // Build a cycle entirely inside $HOME: dirA → dirB → dirA.
+    const dirA = join(home, "cycle/a");
+    const dirB = join(home, "cycle/b");
+    await mkdir(dirA, { recursive: true });
+    await mkdir(dirB, { recursive: true });
+    await symlink(dirB, join(dirA, "to-b"));
+    await symlink(dirA, join(dirB, "to-a"));
+    // Symlink Cyclic/loop → dirA. Walker enters loop/to-b → to-a → ...
+    await symlink(dirA, join(skillDir, "loop"));
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome: join(home, "soma"),
+      homeDir: home,
+    });
+    const outcome = result.outcomes.find((o) => o.sourceName === "Cyclic");
+    expect(outcome?.disposition).toBe("refused-other");
+    expect(outcome?.refusalReason).toContain("Cyclic/");
+    expect(outcome?.refusalReason?.toLowerCase()).toContain("cycle");
+  });
+});
+
+// AC-5 (d): symlink-then-escape — target is itself a symlink to a path
+// outside $HOME. realpath must resolve the full chain and reject.
+test("#118 migrateClaudeSkills rejects symlink chain escaping $HOME", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const skillDir = join(fromDir, "Escape");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# Escape\n", "utf8");
+    // hop is inside $HOME but points OUTSIDE.
+    const hop = join(home, "hop");
+    await symlink("/etc/passwd", hop);
+    // The skill's inner symlink targets `hop` (which is inside $HOME by
+    // path string), but realpath resolves through to /etc/passwd.
+    await symlink(hop, join(skillDir, "leak.md"));
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome: join(home, "soma"),
+      homeDir: home,
+    });
+    const outcome = result.outcomes.find((o) => o.sourceName === "Escape");
+    expect(outcome?.disposition).toBe("refused-other");
+    expect(outcome?.refusalReason).toContain("Escape/leak.md");
+  });
+});
+
+// AC-5 (f): symlinked top-level SKILL.md whose target is OUTSIDE $HOME
+// → the whole <Name> skill classifies as refused-other; siblings continue.
+test("#118 migrateClaudeSkills refuses out-of-home symlinked top-level SKILL.md; siblings continue", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const somaHome = join(home, "soma");
+    const badDir = join(fromDir, "OutOfHome");
+    await mkdir(badDir, { recursive: true });
+    await symlink("/etc/passwd", join(badDir, "SKILL.md"));
+    const goodDir = join(fromDir, "Sibling");
+    await mkdir(goodDir, { recursive: true });
+    await writeFile(join(goodDir, "SKILL.md"), "# Sibling\n\nclean.\n", "utf8");
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      homeDir: home,
+    });
+    const bad = result.outcomes.find((o) => o.sourceName === "OutOfHome");
+    expect(bad?.disposition).toBe("refused-other");
+    expect(bad?.refusalReason).toContain("OutOfHome/SKILL.md");
+    expect(
+      result.outcomes.find((o) => o.sourceName === "Sibling")?.disposition,
+    ).toBe("imported");
+  });
+});
+
+// Real-world repro of the issue: user's Business/Accounting symlinks
+// to a private worktree. Imports must NOT abort the whole migrate.
+test("#118 real-world repro: Business/Accounting → ~/work/invisible/Accounting imports cleanly", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, ".claude/skills");
+    const somaHome = join(home, ".soma");
+    // The user's Business top-level skill carries an Accounting symlink.
+    const businessDir = join(fromDir, "Business");
+    await mkdir(businessDir, { recursive: true });
+    await writeFile(
+      join(businessDir, "SKILL.md"),
+      "# Business\n\nBusiness operations skill.\n",
+      "utf8",
+    );
+    // Private worktree skill the user is developing.
+    const privateAccounting = join(home, "work/invisible/Accounting");
+    await mkdir(join(privateAccounting, "Workflows"), { recursive: true });
+    await writeFile(
+      join(privateAccounting, "SKILL.md"),
+      "# Accounting\n\nPrivate accounting skill.\n",
+      "utf8",
+    );
+    await writeFile(
+      join(privateAccounting, "Workflows/Reconcile.md"),
+      "# Reconcile\n",
+      "utf8",
+    );
+    await symlink(privateAccounting, join(businessDir, "Accounting"));
+
+    // A second top-level skill to verify the rest of the migrate still
+    // proceeds (regression for the original abort behavior).
+    const otherDir = join(fromDir, "Other");
+    await mkdir(otherDir, { recursive: true });
+    await writeFile(join(otherDir, "SKILL.md"), "# Other\n", "utf8");
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      homeDir: home,
+    });
+    expect(result.writtenCount).toBe(2);
+    expect(
+      result.outcomes.find((o) => o.sourceName === "Business")?.disposition,
+    ).toBe("imported");
+    expect(
+      result.outcomes.find((o) => o.sourceName === "Other")?.disposition,
+    ).toBe("imported");
+    // The followed private skill body landed under Business.
+    expect(
+      await readFile(
+        join(somaHome, "skills/business/Accounting/SKILL.md"),
+        "utf8",
+      ),
+    ).toContain("Private accounting");
+    expect(
+      await readFile(
+        join(somaHome, "skills/business/Accounting/Workflows/Reconcile.md"),
+        "utf8",
+      ),
+    ).toContain("Reconcile");
+  });
+});
+
+// Followed user-owned worktree may carry a `.git/` directory (the
+// principal's private skill is itself a worktree). The walker must
+// silently skip it inside the followed branch instead of refusing
+// the whole skill — matches the real-world repro from the bug
+// report where `~/.claude/skills/Business/Accounting` is a symlink
+// to a git-managed worktree.
+test("#118 followed user-owned symlink that carries .git/ imports cleanly", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const skillDir = join(fromDir, "Business");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# Business\n", "utf8");
+    // External worktree: real skill files plus a .git/ marker that
+    // would otherwise refuse the import.
+    const ext = join(home, "work/private/Accounting");
+    await mkdir(join(ext, "Workflows"), { recursive: true });
+    await mkdir(join(ext, ".git"), { recursive: true });
+    await writeFile(join(ext, "SKILL.md"), "# Accounting\n", "utf8");
+    await writeFile(join(ext, "Workflows/Reconcile.md"), "# Reconcile\n", "utf8");
+    await writeFile(join(ext, ".git/config"), "[core]\n", "utf8");
+    await symlink(ext, join(skillDir, "Accounting"));
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome: join(home, "soma"),
+      homeDir: home,
+    });
+    const outcome = result.outcomes.find((o) => o.sourceName === "Business");
+    expect(outcome?.disposition).toBe("imported");
+    // Skill body landed; .git/ did NOT.
+    expect(
+      await readFile(
+        join(home, "soma/skills/business/Accounting/SKILL.md"),
+        "utf8",
+      ),
+    ).toContain("Accounting");
+    const accountingDir = await readdir(
+      join(home, "soma/skills/business/Accounting"),
+    );
+    expect(accountingDir).not.toContain(".git");
+  });
+});
+
+// A `.git/` at the TOP of a skill (no symlink in play) still refuses —
+// that's the original anti-leak guarantee.
+test("#118 .git inline in skill tree still refuses (no symlink)", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const skillDir = join(fromDir, "Bad");
+    await mkdir(join(skillDir, ".git"), { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# Bad\n", "utf8");
+    await writeFile(join(skillDir, ".git/config"), "[core]\n", "utf8");
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome: join(home, "soma"),
+      homeDir: home,
+    });
+    const outcome = result.outcomes.find((o) => o.sourceName === "Bad");
+    expect(outcome?.disposition).toBe("refused-other");
+    expect(outcome?.refusalReason).toContain("VCS metadata");
+    expect(outcome?.refusalReason).toContain("Bad/.git");
+  });
+});
+
+// Audit recorded in portability report (best-effort surface).
+test("#118 portability report lists followed-user-owned-symlink audit entries", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const somaHome = join(home, "soma");
+    const skillDir = join(fromDir, "Audit");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# Audit\n", "utf8");
+    const external = join(home, "ext.md");
+    await writeFile(external, "# Ext\n", "utf8");
+    await symlink(external, join(skillDir, "Ext.md"));
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      homeDir: home,
+    });
+    const report = await readFile(result.reportPath, "utf8");
+    expect(report).toContain("followed-user-owned-symlink");
   });
 });
 

--- a/test/claude-skills-migrator.test.ts
+++ b/test/claude-skills-migrator.test.ts
@@ -590,6 +590,41 @@ test("#118 migrateClaudeSkills refuses out-of-home symlink as refused-other; oth
   });
 });
 
+// Holly R1 S1 — denylist regression: a symlink targeting a path
+// inside `$HOME` but under a denylisted subpath (`.ssh`, `.aws`, etc.)
+// is refused even though it would otherwise be a user-owned-symlink
+// follow target. The denylist anchors the security boundary against
+// credential exfiltration via skill content references.
+test("#118 migrateClaudeSkills refuses denylisted home subpath (.ssh) as refused-other", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const somaHome = join(home, "soma");
+
+    // Create a fake `.ssh/id_rsa` inside $HOME to symlink at.
+    const sshDir = join(home, ".ssh");
+    await mkdir(sshDir, { recursive: true });
+    await writeFile(join(sshDir, "id_rsa"), "-----BEGIN OPENSSH PRIVATE KEY-----\n", "utf8");
+
+    // SneakySkill: symlinks ~/.ssh/id_rsa into the skill tree.
+    const sneakyDir = join(fromDir, "SneakySkill");
+    await mkdir(sneakyDir, { recursive: true });
+    await writeFile(join(sneakyDir, "SKILL.md"), "# SneakySkill\n", "utf8");
+    await symlink(join(home, ".ssh/id_rsa"), join(sneakyDir, "creds.md"));
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      homeDir: home,
+    });
+    const sneaky = result.outcomes.find((o) => o.sourceName === "SneakySkill");
+    expect(sneaky?.disposition).toBe("refused-other");
+    // Refusal reason mentions the denylisted path so the principal
+    // can locate the offending symlink without grep.
+    expect(sneaky?.refusalReason).toContain("SneakySkill/creds.md");
+    expect(sneaky?.refusalReason?.toLowerCase()).toContain("denylist");
+  });
+});
+
 // AC-5 (c): symlink cycle (A → B → A) inside $HOME → detected and
 // refused gracefully (refused-other), no infinite loop.
 test("#118 migrateClaudeSkills detects symlink cycle and refuses gracefully", async () => {


### PR DESCRIPTION
## Summary

Closes #118.

`soma migrate claude-skills --from ~/.claude/skills` aborted on the first non-editor-config symlink encountered inside any skill subtree. Real-world repro: user's `Business/Accounting` symlinks to `~/work/invisible/Accounting`, a legitimate private skill in another worktree. One symlink poisoned every other skill's import.

The rescope: **symlinks pointing to user-owned content are a normal pattern** (private/work-repo skills symlinked into `~/.claude/skills`). The fix follows them and imports the target bytes, instead of refusing.

## What changed

- **`resolveSymlinkSafely(absPath, homeRealPath, visitedRealPaths)`** — new helper that resolves a symlink via `realpath`, validates the target is inside `$HOME` (and outside a credential denylist: `.ssh/`, `.aws/`, `.gnupg/`, `.kube/`, `.docker/`), and detects cycles. Multi-hop chains can't escape via symlink-to-symlink hops because `realpath` resolves the full chain.
- **File symlinks** contribute their target bytes at the symlink's relpath. **Directory symlinks** are walked recursively; children land under `<symlinkRel>/<childName>`.
- **Out-of-home / broken / cyclic / denylisted targets** throw, which the orchestrator catches and classifies as `refused-other` (per-skill log-and-continue, mirror of #102/#112). Other skills continue.
- **Top-level `<Name>/SKILL.md` symlinks** are now resolved by the walker via the same helper, instead of being refused at listing time.
- **`.git/` inside a followed symlink branch** is silently skipped (worktrees commonly carry `.git/`); inline `.git/` at the skill root still refuses.
- **Error messages include `<SourceName>/<rel>`** so principals can locate the offending path (AC-4).
- **CLI exit-code gating**: apply mode exits 1 when any skill is `refused-other`; plan mode exits 0 (mirror of #112).
- **Portability report** gains a "Followed user-owned symlinks" table when any symlinks were resolved.

## ACs

- [x] **AC-1**: Symlink whose realpath is inside `$HOME` is **followed**; target bytes imported; per-skill `followed-user-owned-symlink` audit recorded.
- [x] **AC-2**: Out-of-home target (`/etc/`, `/var/`, …) refuses.
- [x] **AC-3**: Refusal → `refused-other` per skill; other skills continue.
- [x] **AC-4**: Error messages include `<SourceName>/<rel>`.
- [x] **AC-5**: Fixture coverage — file-symlink follow, dir-symlink recursive walk, top-level SKILL.md symlink, cycle, symlink-then-escape attack, out-of-home + sibling continue, real-world `Business/Accounting` repro, followed-worktree `.git/` silent skip, inline `.git/` still refuses, portability report audit surface.

## Before / after

```
$ bun soma migrate claude-skills --from ~/.claude/skills    # BEFORE
soma migrate claude-skills refused symlink path: Accounting
error: script "soma" exited with code 1
```

```
$ bun soma migrate claude-skills --from ~/.claude/skills    # AFTER
...
  - business [portable] → imported (clean)
  - design-explorer [portable] → refused-other (... refused VCS metadata directory: design-explorer/.git)
...
Totals: 78 imported, 0 skipped-idempotent, 18 skipped-claude-specific, 1 refused-other.
```

## Test plan

- [x] `bun run typecheck` — clean.
- [x] `bun test` — 814 pass / 0 fail (baseline 804, +10).
- [x] Smoke: `bun src/cli.ts migrate claude-skills --from ~/.claude/skills` no longer aborts. User's `Business/Accounting` imports cleanly via followed-symlink.
- [ ] Holly review (pilot+Holly path; Sage daemon offline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)