### PR TITLE
feat(migrate): group claude-skills output by disposition (#124)

### DIFF
--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -539,6 +539,9 @@ function isProseFile(relPath: string): boolean {
   return PROSE_EXTENSIONS.test(relPath);
 }
 
+export const REASON_PREFIX_HOOK_BINDING = "hook binding";
+export const REASON_PREFIX_SLASH_COMMAND = "slash-command";
+
 export function classifySkillPortability(files: readonly SkillFilePayload[]): ClassificationResult {
   // Pass 1: claude-specific signals (highest priority).
   for (const file of files) {
@@ -547,7 +550,7 @@ export function classifySkillPortability(files: readonly SkillFilePayload[]): Cl
       const sample = HOOK_BINDING.exec(text)?.[0]?.trim() ?? "hook binding";
       return {
         tag: "claude-specific",
-        reason: `hook binding detected in ${file.relPath} (${sample.slice(0, 32)})`,
+        reason: `${REASON_PREFIX_HOOK_BINDING} detected in ${file.relPath} (${sample.slice(0, 32)})`,
       };
     }
     if (!isProseFile(file.relPath)) continue;
@@ -556,7 +559,7 @@ export function classifySkillPortability(files: readonly SkillFilePayload[]): Cl
       const sample = SLASH_COMMAND_REF.exec(stripped)?.[0]?.trim() ?? "/slash-command";
       return {
         tag: "claude-specific",
-        reason: `slash-command reference detected in ${file.relPath} (${sample.slice(0, 32)})`,
+        reason: `${REASON_PREFIX_SLASH_COMMAND} reference detected in ${file.relPath} (${sample.slice(0, 32)})`,
       };
     }
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,12 +103,15 @@ import {
   planClaudeSkillsMigration,
   readClaudeSkillsMigrationStatus,
   resolveOutcomeReason,
+  REASON_PREFIX_HOOK_BINDING,
+  REASON_PREFIX_SLASH_COMMAND,
 } from "./claude-skills-migrator";
 import type {
   ClaudeSkillsMigrationOptions,
   ClaudeSkillsMigrationPlan,
   ClaudeSkillsMigrationResult,
   ClaudeSkillsMigrationManifest,
+  ClaudeSkillOutcome,
   ClaudeSkillsSmokeSubstrate,
   RewriteDescriptionsAgent,
 } from "./types";
@@ -2124,9 +2127,191 @@ function formatPaiMigrationStatus(manifest: string | null): string {
   return `${manifest}\n`;
 }
 
+// #124 — Grouped outcome structure for disposition-bucketed output.
+interface GroupedOutcomes {
+  imported: {
+    portable: ClaudeSkillOutcome[];
+    needsAdapt: ClaudeSkillOutcome[];
+    descriptionRewritten: ClaudeSkillOutcome[];
+  };
+  skippedClaudeSpecific: {
+    slashCommand: ClaudeSkillOutcome[];
+    hookBinding: ClaudeSkillOutcome[];
+    other: ClaudeSkillOutcome[];
+  };
+  skippedIdempotent: ClaudeSkillOutcome[];
+  refusedDescriptionLimit: ClaudeSkillOutcome[];
+  refusedOther: ClaudeSkillOutcome[];
+}
+
+function groupOutcomesByDisposition(outcomes: readonly ClaudeSkillOutcome[]): GroupedOutcomes {
+  const groups: GroupedOutcomes = {
+    imported: { portable: [], needsAdapt: [], descriptionRewritten: [] },
+    skippedClaudeSpecific: { slashCommand: [], hookBinding: [], other: [] },
+    skippedIdempotent: [],
+    refusedDescriptionLimit: [],
+    refusedOther: [],
+  };
+  for (const o of outcomes) {
+    switch (o.disposition) {
+      case "imported":
+        if (o.tag === "portable") groups.imported.portable.push(o);
+        else if (o.tag === "needs-adapt") groups.imported.needsAdapt.push(o);
+        else groups.imported.portable.push(o);
+        if (o.descriptionRewrite) groups.imported.descriptionRewritten.push(o);
+        break;
+      case "skipped-claude-specific":
+        if (o.reason.startsWith(REASON_PREFIX_SLASH_COMMAND)) groups.skippedClaudeSpecific.slashCommand.push(o);
+        else if (o.reason.startsWith(REASON_PREFIX_HOOK_BINDING)) groups.skippedClaudeSpecific.hookBinding.push(o);
+        else groups.skippedClaudeSpecific.other.push(o);
+        break;
+      case "skipped-idempotent":
+        groups.skippedIdempotent.push(o);
+        break;
+      case "refused-description-limit":
+        groups.refusedDescriptionLimit.push(o);
+        break;
+      case "refused-other":
+        groups.refusedOther.push(o);
+        break;
+    }
+  }
+  return groups;
+}
+
+function renderGroupedOutcomeLines(
+  groups: GroupedOutcomes,
+  opts: {
+    smokeSubstrates?: readonly ClaudeSkillsSmokeSubstrate[];
+  },
+): string[] {
+  const lines: string[] = [];
+  const importedTotal =
+    groups.imported.portable.length +
+    groups.imported.needsAdapt.length;
+
+  if (importedTotal > 0) {
+    lines.push(`### Imported (${importedTotal})`);
+    lines.push("");
+    if (groups.imported.portable.length > 0) {
+      lines.push(`Portable (${groups.imported.portable.length}):`);
+      for (const o of groups.imported.portable) {
+        lines.push(`  - ${o.kebabName}${renderSkillSuffix(o, opts)}`);
+      }
+      lines.push("");
+    }
+    if (groups.imported.needsAdapt.length > 0) {
+      lines.push(`Needs-adapt (${groups.imported.needsAdapt.length}):`);
+      for (const o of groups.imported.needsAdapt) {
+        const refCount = extractRefCount(o.reason);
+        lines.push(`  - ${o.kebabName} (${refCount} refs)${renderSkillSuffix(o, opts)}`);
+      }
+      lines.push("");
+    }
+    if (groups.imported.descriptionRewritten.length > 0) {
+      lines.push(`Description rewritten (${groups.imported.descriptionRewritten.length}):`);
+      for (const o of groups.imported.descriptionRewritten) {
+        const rw = o.descriptionRewrite!;
+        lines.push(`  - ${o.kebabName} (${rw.originalLength} → ${rw.rewrittenLength} chars, ${rw.agent})`);
+      }
+      lines.push("");
+    }
+  }
+
+  const claudeSpecificTotal =
+    groups.skippedClaudeSpecific.slashCommand.length +
+    groups.skippedClaudeSpecific.hookBinding.length +
+    groups.skippedClaudeSpecific.other.length;
+
+  if (claudeSpecificTotal > 0) {
+    lines.push(`### Skipped — claude-specific (${claudeSpecificTotal})`);
+    lines.push("");
+    if (groups.skippedClaudeSpecific.slashCommand.length > 0) {
+      lines.push(`Slash-command refs (${groups.skippedClaudeSpecific.slashCommand.length}):`);
+      for (const o of groups.skippedClaudeSpecific.slashCommand) {
+        lines.push(`  - ${o.kebabName} (${extractClassifierDetail(o.reason)})`);
+      }
+      lines.push("");
+    }
+    if (groups.skippedClaudeSpecific.hookBinding.length > 0) {
+      lines.push(`Hook bindings (${groups.skippedClaudeSpecific.hookBinding.length}):`);
+      for (const o of groups.skippedClaudeSpecific.hookBinding) {
+        lines.push(`  - ${o.kebabName} (${extractClassifierDetail(o.reason)})`);
+      }
+      lines.push("");
+    }
+    if (groups.skippedClaudeSpecific.other.length > 0) {
+      lines.push(`Other (${groups.skippedClaudeSpecific.other.length}):`);
+      for (const o of groups.skippedClaudeSpecific.other) {
+        lines.push(`  - ${o.kebabName} (${o.reason})`);
+      }
+      lines.push("");
+    }
+  }
+
+  if (groups.skippedIdempotent.length > 0) {
+    lines.push(`### Skipped — idempotent (${groups.skippedIdempotent.length})`);
+    lines.push("");
+    for (const o of groups.skippedIdempotent) {
+      lines.push(`  - ${o.kebabName}`);
+    }
+    lines.push("");
+  }
+
+  if (groups.refusedDescriptionLimit.length > 0) {
+    lines.push(`### Refused — description-limit (${groups.refusedDescriptionLimit.length})`);
+    lines.push("");
+    for (const o of groups.refusedDescriptionLimit) {
+      lines.push(`  - ${o.kebabName} (${resolveOutcomeReason(o)})`);
+    }
+    lines.push("");
+  }
+
+  if (groups.refusedOther.length > 0) {
+    lines.push(`### Refused — other (${groups.refusedOther.length})`);
+    lines.push("");
+    for (const o of groups.refusedOther) {
+      lines.push(`  - ${o.kebabName} (${resolveOutcomeReason(o)})`);
+    }
+    lines.push("");
+  }
+
+  return lines;
+}
+
+function renderSkillSuffix(
+  o: ClaudeSkillOutcome,
+  opts: {
+    smokeSubstrates?: readonly ClaudeSkillsSmokeSubstrate[];
+  },
+): string {
+  let suffix = "";
+  if (opts.smokeSubstrates && opts.smokeSubstrates.length > 0 && o.substrates) {
+    const parts = opts.smokeSubstrates
+      .map((sub) => {
+        const v = o.substrates?.[sub];
+        return v ? `${sub}=${v.status}` : null;
+      })
+      .filter((s): s is string => s !== null);
+    if (parts.length > 0) suffix = ` [${parts.join(", ")}]`;
+  }
+  return suffix;
+}
+
+function extractRefCount(reason: string): number {
+  const match = reason.match(/^(\d+)\s/);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+function extractClassifierDetail(reason: string): string {
+  const inMatch = reason.match(/in\s+(.+)$/);
+  return inMatch ? inMatch[1] : reason;
+}
+
 // #115 — `soma migrate claude-skills` formatters. Mirrors the `migrate
 // pai` shape (header line + per-row table) so principals reading
 // both surfaces don't need to context-switch.
+// #124 — Grouped by disposition for scannable outcome summaries.
 function formatClaudeSkillsMigrationPlan(plan: ClaudeSkillsMigrationPlan): string {
   if (!plan.isFlatSkillsTree) {
     return [
@@ -2152,14 +2337,12 @@ function formatClaudeSkillsMigrationPlan(plan: ClaudeSkillsMigrationPlan): strin
     lines.push(`rewrite-descriptions: ${plan.rewriteDescriptionsAgent}`);
   }
   lines.push("");
-  lines.push("Per-skill plan:");
-  for (const o of plan.outcomes) {
-    // #118 / #120 — refusal dispositions surface `refusalReason`
-    // (embeds source path + cap). Centralized in
-    // `resolveOutcomeReason` (Holly r1 S1).
-    lines.push(`  - ${o.kebabName} [${o.tag}] → ${o.disposition} (${resolveOutcomeReason(o)})`);
-  }
+  const groups = groupOutcomesByDisposition(plan.outcomes);
+  lines.push(...renderGroupedOutcomeLines(groups, {
+    smokeSubstrates: plan.smokeSubstrates,
+  }));
   const counts = countOutcomesByDisposition(plan.outcomes);
+  lines.push("---");
   lines.push("");
   lines.push(
     `Totals: ${counts.imported} imported, ${counts.skippedIdempotent} skipped-idempotent, ${counts.skippedClaudeSpecific} skipped-claude-specific, ${counts.refusedOther} refused-other, ${counts.refusedDescriptionLimit} refused-description-limit.`,
@@ -2200,28 +2383,11 @@ function formatClaudeSkillsMigrationResult(result: ClaudeSkillsMigrationResult):
     lines.push(`rewrite-descriptions: ${result.rewriteDescriptionsAgent}`);
   }
   lines.push("");
-  lines.push("Per-skill outcomes:");
-  for (const o of result.outcomes) {
-    let suffix = "";
-    if (result.smokeSubstrates.length > 0 && o.substrates) {
-      const parts = result.smokeSubstrates
-        .map((sub) => {
-          const v = o.substrates?.[sub];
-          return v ? `${sub}=${v.status}` : null;
-        })
-        .filter((s): s is string => s !== null);
-      if (parts.length > 0) suffix = ` [${parts.join(", ")}]`;
-    }
-    // #118 / #120 — centralized in `resolveOutcomeReason` (Holly r1 S1).
-    const reason = resolveOutcomeReason(o);
-    // #120 — when a rewrite landed, append `(rewrote <orig>→<new>)`
-    // so the per-skill line carries the rewrite footprint without
-    // forcing the principal to open the portability report.
-    if (o.descriptionRewrite) {
-      suffix += ` (rewrote ${o.descriptionRewrite.originalLength}→${o.descriptionRewrite.rewrittenLength} via ${o.descriptionRewrite.agent})`;
-    }
-    lines.push(`  - ${o.kebabName} [${o.tag}] → ${o.disposition} (${reason})${suffix}`);
-  }
+  const groups = groupOutcomesByDisposition(result.outcomes);
+  lines.push(...renderGroupedOutcomeLines(groups, {
+    smokeSubstrates: result.smokeSubstrates,
+  }));
+  lines.push("---");
   lines.push("");
   lines.push(
     `Totals: ${result.writtenCount} written, ${result.skippedIdempotentCount} skipped-idempotent, ${result.skippedClaudeSpecificCount} skipped-claude-specific, ${result.refusedOtherCount} refused-other, ${result.refusedDescriptionLimitCount} refused-description-limit.`,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2174,6 +2174,10 @@ function groupOutcomesByDisposition(outcomes: readonly ClaudeSkillOutcome[]): Gr
       case "refused-other":
         groups.refusedOther.push(o);
         break;
+      default: {
+        const _exhaustive: never = o.disposition;
+        throw new Error(`unhandled disposition: ${_exhaustive}`);
+      }
     }
   }
   return groups;

--- a/test/cli-migrate-claude-skills.test.ts
+++ b/test/cli-migrate-claude-skills.test.ts
@@ -58,9 +58,14 @@ test("soma migrate claude-skills --from <dir> → plan", async () => {
       join(home, "soma"),
     ]);
     expect(output).toContain("plan (dry-run");
-    expect(output).toContain("portable [portable] → imported");
-    expect(output).toContain("needs-adapt [needs-adapt] → imported");
-    expect(output).toContain("claude-specific [claude-specific] → skipped-claude-specific");
+    // #124 — grouped output by disposition
+    expect(output).toContain("### Imported (2)");
+    expect(output).toContain("Portable (1):");
+    expect(output).toContain("  - portable");
+    expect(output).toContain("Needs-adapt (1):");
+    expect(output).toContain("  - needs-adapt (1 refs)");
+    expect(output).toContain("### Skipped — claude-specific (1)");
+    expect(output).toContain("  - claude-specific");
     expect(output).toContain("Totals: 2 imported, 0 skipped-idempotent, 1 skipped-claude-specific");
     // No writes — soma home shouldn't have a manifest yet.
     await expect(
@@ -468,4 +473,149 @@ test("soma migrate claude-skills plan with oversize + no agent → refused-descr
 test("soma migrate claude-skills --help surfaces --rewrite-descriptions", async () => {
   const output = await runSomaCli(["migrate", "claude-skills", "--help"]);
   expect(output).toContain("--rewrite-descriptions");
+});
+
+// ---------------------------------------------------------------------
+// #124 — Grouped disposition output tests.
+// ---------------------------------------------------------------------
+
+async function writeMixedFixture(home: string): Promise<string> {
+  const fromDir = join(home, "skills");
+  // Portable
+  await mkdir(join(fromDir, "AlphaPortable"), { recursive: true });
+  await writeFile(
+    join(fromDir, "AlphaPortable", "SKILL.md"),
+    FM + "# AlphaPortable\n\nclean.\n",
+    "utf8",
+  );
+  await mkdir(join(fromDir, "BetaPortable"), { recursive: true });
+  await writeFile(
+    join(fromDir, "BetaPortable", "SKILL.md"),
+    FM + "# BetaPortable\n\nclean.\n",
+    "utf8",
+  );
+  // Needs-adapt
+  await mkdir(join(fromDir, "GammaAdapt"), { recursive: true });
+  await writeFile(
+    join(fromDir, "GammaAdapt", "SKILL.md"),
+    FM + "# GammaAdapt\n\nsee ~/.claude/PAI/X.md and ~/.claude/PAI/Y.md\n",
+    "utf8",
+  );
+  // Claude-specific — hook binding
+  await mkdir(join(fromDir, "DeltaHook"), { recursive: true });
+  await writeFile(
+    join(fromDir, "DeltaHook", "SKILL.md"),
+    FM + "# DeltaHook\n\nStop: cleanup hook\n",
+    "utf8",
+  );
+  // Claude-specific — slash-command
+  await mkdir(join(fromDir, "EpsilonSlash"), { recursive: true });
+  await writeFile(
+    join(fromDir, "EpsilonSlash", "SKILL.md"),
+    FM + "# EpsilonSlash\n\nuse /plan to design\n",
+    "utf8",
+  );
+  // Oversize description (refused-description-limit)
+  const desc = "USE WHEN test " + "x".repeat(1186);
+  await mkdir(join(fromDir, "ZetaOversize"), { recursive: true });
+  await writeFile(
+    join(fromDir, "ZetaOversize", "SKILL.md"),
+    `---\nname: ZetaOversize\ndescription: "${desc}"\n---\n\n# ZetaOversize\n\nbody.\n`,
+    "utf8",
+  );
+  return fromDir;
+}
+
+test("#124: plan output groups by disposition with correct section headers", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeMixedFixture(home);
+    const output = await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--from",
+      fromDir,
+      "--soma-home",
+      join(home, "soma"),
+    ]);
+    // Imported group with sub-groups
+    expect(output).toContain("### Imported (3)");
+    expect(output).toContain("Portable (2):");
+    expect(output).toContain("  - alpha-portable");
+    expect(output).toContain("  - beta-portable");
+    expect(output).toContain("Needs-adapt (1):");
+    expect(output).toContain("  - gamma-adapt (2 refs)");
+
+    // Claude-specific group with sub-groups
+    expect(output).toContain("### Skipped — claude-specific (2)");
+    expect(output).toContain("Slash-command refs (1):");
+    expect(output).toContain("  - epsilon-slash");
+    expect(output).toContain("Hook bindings (1):");
+    expect(output).toContain("  - delta-hook");
+
+    // Refused group
+    expect(output).toContain("### Refused — description-limit (1)");
+    expect(output).toContain("  - zeta-oversize");
+
+    // Empty groups omitted
+    expect(output).not.toContain("### Skipped — idempotent");
+    expect(output).not.toContain("### Refused — other");
+
+    // Totals line preserved
+    expect(output).toContain("Totals: 3 imported");
+    expect(output).toContain("2 skipped-claude-specific");
+    expect(output).toContain("1 refused-description-limit");
+
+    // Footer suggestion preserved
+    expect(output).toContain("--include-claude-specific");
+    expect(output).toContain("--rewrite-descriptions claude");
+  });
+});
+
+test("#124: apply output groups by disposition", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeMixedFixture(home);
+    const output = await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--from",
+      fromDir,
+      "--soma-home",
+      join(home, "soma"),
+      "--apply",
+    ]);
+    expect(output).toContain("### Imported (3)");
+    expect(output).toContain("Portable (2):");
+    expect(output).toContain("Needs-adapt (1):");
+    expect(output).toContain("### Skipped — claude-specific (2)");
+    expect(output).toContain("Totals: 3 written");
+  });
+});
+
+test("#124: idempotent re-run shows Skipped — idempotent group", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeFixture(home);
+    const somaHome = join(home, "soma");
+    await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--from",
+      fromDir,
+      "--soma-home",
+      somaHome,
+      "--apply",
+    ]);
+    const second = await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--from",
+      fromDir,
+      "--soma-home",
+      somaHome,
+      "--apply",
+    ]);
+    expect(second).toContain("### Skipped — idempotent (2)");
+    expect(second).toContain("  - portable");
+    expect(second).toContain("  - needs-adapt");
+    expect(second).not.toContain("### Imported");
+  });
 });


### PR DESCRIPTION
## Summary
- Replaces flat per-skill listing with disposition-bucketed sections (Imported/Skipped/Refused) and sub-groups (portable, needs-adapt, slash-command, hook-binding) for scannable migration output
- Extracts `REASON_PREFIX_HOOK_BINDING` and `REASON_PREFIX_SLASH_COMMAND` constants from the classifier, eliminating stringly-typed coupling in the grouping function
- Narrows `smokeSubstrates` type from `readonly string[]` to `readonly ClaudeSkillsSmokeSubstrate[]`, removing an unsafe cast
- Removes dead `substrates` and `outcomes` params from `renderGroupedOutcomeLines` and `renderSkillSuffix`

Closes #124

## Test plan
- [x] All 848 existing tests pass
- [x] New tests: grouped plan output, grouped apply output, idempotent re-run shows Skipped group
- [x] Existing plan/apply test assertions updated for new grouped format
- [ ] Manual `soma migrate claude-skills --from ~/.claude/skills` to verify real output

🤖 Generated with [Claude Code](https://claude.com/claude-code)