### PR TITLE
fix(migrate): suppress per-skill progress during concurrent phases (#139 quick patch)

### DIFF
--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -811,6 +811,29 @@ async function buildPlanCore(
   // emitter handles TTY-vs-non-TTY mechanics; we only feed it
   // skill + phase + outcome detail.
   const nameToIndex = new Map<string, number>(names.map((n, i) => [n, i + 1]));
+  // #139 — bracket the read+classify phase with
+  // beginConcurrentPhase / endConcurrentPhase. The emitter suppresses
+  // per-skill output during the bracket and emits one banner + one
+  // summary, replacing the #125 behavior of 97 interleaved append-
+  // only lines (4-wide concurrent fan-out produced one stepComplete
+  // per skill, which the #125 emitter rendered as 97 `\n`-terminated
+  // lines because `\r`-overwrite would clobber 3 of 4 workers).
+  //
+  // The bracket extends across BOTH the concurrent read fan-out AND
+  // the sequential classification loop below — the `classified`
+  // stepComplete is conceptually part of the same "read + classify"
+  // phase (the principal sees one phase, not two), and emitting
+  // those 97 lines append-only would re-introduce the same #139
+  // symptom we're fixing.
+  //
+  // The migrator's own per-phase wall-clock timing
+  // (`readClassifyMs`) is computed by the outer caller around
+  // `buildPlanCore` and remains the source of truth for the
+  // stdout Timing block. The `concurrentStart` delta below is only
+  // used to feed the emitter's banner/summary line.
+  const READ_CLASSIFY_CONCURRENCY = 4;
+  const concurrentStart = Date.now();
+  progress.beginConcurrentPhase("read + classify", names.length, READ_CLASSIFY_CONCURRENCY);
   const readResults: ReadResult[] = await runBoundedConcurrent<string, ReadResult>(
     names,
     async (name) => {
@@ -826,7 +849,7 @@ async function buildPlanCore(
         return { ok: false, sourceName: name, reason };
       }
     },
-    4,
+    READ_CLASSIFY_CONCURRENCY,
   );
 
   const prevBySource = new Map<string, ClaudeSkillsMigrationManifestEntry>();
@@ -901,6 +924,12 @@ async function buildPlanCore(
     });
   }
   outcomes.sort((a, b) => a.sourceName.localeCompare(b.sourceName));
+  // #139 — close the concurrent phase here, AFTER the sequential
+  // classification loop. See the matching beginConcurrentPhase above:
+  // the bracket spans the full logical read+classify phase, not
+  // just the runBoundedConcurrent fan-out, so the per-skill
+  // `classified` stepComplete events stay suppressed too.
+  progress.endConcurrentPhase("read + classify", Date.now() - concurrentStart);
 
   return { isFlatSkillsTree: true, outcomes, reads };
 }

--- a/src/claude-skills-progress.ts
+++ b/src/claude-skills-progress.ts
@@ -87,6 +87,51 @@ export interface ProgressEmitter {
   ): void;
 
   /**
+   * #139 — open a concurrent phase. While a concurrent phase is
+   * active, all `step` / `stepComplete` calls are SUPPRESSED — only
+   * the begin banner (emitted here) and the end summary (emitted by
+   * `endConcurrentPhase`) reach stderr.
+   *
+   * Rationale: the read+classify phase runs 4-wide via
+   * `runBoundedConcurrent`. The #125 per-skill emitter falls through
+   * to `\n`-terminated lines for concurrent fan-out (because `\r`
+   * overwrite would clobber 3 of 4 in-flight lines), producing 97
+   * append-only lines for a real PAI tree (issue #139). The quick
+   * patch suppresses per-skill output entirely during the fan-out
+   * and emits one banner + one summary instead.
+   *
+   * `concurrency` is reported in the banner so a principal tail-ing
+   * stderr knows the fan-out width (`4-wide concurrent`).
+   *
+   * Banner line format (stable across re-runs):
+   *   `[<name>: <total> skills, <concurrency>-wide concurrent ...]\n`
+   *
+   * Multiple concurrent phases per run are supported (begin/end
+   * pairs). Nesting is NOT supported — a second `begin` before
+   * `end` is a contract violation (current implementation just
+   * overwrites the active-phase state; future enforcement TBD).
+   */
+  beginConcurrentPhase(name: string, total: number, concurrency: number): void;
+
+  /**
+   * #139 — close the active concurrent phase. Emits one summary
+   * line with elapsed total + per-step avg/max ms (tracked
+   * internally from suppressed `stepComplete` calls).
+   *
+   * Summary line format (stable across re-runs):
+   *   `[<name>: <total> skills in <elapsed>s (avg <avg>ms, max <max>ms)]\n`
+   *
+   * `elapsedMs` is the wall-clock duration of the concurrent phase
+   * (provided by the caller, NOT computed internally — the migrator
+   * already tracks phase elapsed times for the Timing block).
+   *
+   * If no `stepComplete` calls fired between begin and end (empty
+   * input), avg/max default to 0 (not NaN) so the summary stays
+   * readable.
+   */
+  endConcurrentPhase(name: string, elapsedMs: number): void;
+
+  /**
    * Render the Timing block. Returned for the caller to append to
    * stdout — NOT written to stderr by this helper. Stable formatting
    * across re-runs (numbers rounded to 1 decimal place).
@@ -112,6 +157,18 @@ interface ProgressEmitterOptions {
 export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmitter {
   const { stderr, quiet, isatty } = opts;
   let total = 0;
+
+  // #139 — concurrent-phase state. When non-null, the emitter is
+  // inside a `beginConcurrentPhase` / `endConcurrentPhase` bracket
+  // and per-skill `step` / `stepComplete` calls are suppressed.
+  // We record per-step elapsed ms so the end summary can report
+  // avg + max without the caller having to thread stats through.
+  // Nesting is not supported (a second begin overwrites state).
+  let activeConcurrentPhase: {
+    name: string;
+    total: number;
+    elapsedSamples: number[]; // ms per stepComplete inside the phase
+  } | null = null;
 
   // Per-step elapsed: under 1 second → `<N>ms` (live progress wants
   // millisecond resolution so a 12ms classify doesn't read as `0s`).
@@ -155,6 +212,11 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
 
     step(index: number, sourceName: string, phase: string, detail?: string): void {
       if (quiet) return;
+      // #139 — suppress per-skill output while a concurrent phase is
+      // active. The begin/end banner pair carries the user-facing
+      // signal; per-skill rows from 4-wide fan-out workers would
+      // otherwise produce ~totalSkills interleaved lines.
+      if (activeConcurrentPhase) return;
       const body = formatStepLine(index, sourceName, phase, detail);
       if (isatty) {
         // TTY: open with `\r` to overwrite any prior fast-phase line.
@@ -174,6 +236,15 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
       detail?: string,
     ): void {
       if (quiet) return;
+      // #139 — record per-step elapsed for the eventual summary,
+      // then suppress per-skill output while in a concurrent phase.
+      // The migrator still calls stepComplete inside the concurrent
+      // loop (so its own timing accumulators stay accurate); the
+      // suppression is purely an output concern.
+      if (activeConcurrentPhase) {
+        activeConcurrentPhase.elapsedSamples.push(elapsedMs);
+        return;
+      }
       const elapsed = fmtElapsed(elapsedMs);
       const body = formatStepLine(index, sourceName, phase, detail);
       const closer = ` (${elapsed})`;
@@ -189,6 +260,52 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
         // appears under the corresponding step.
         stderr.write(`${body}${closer}\n`);
       }
+    },
+
+    beginConcurrentPhase(name: string, totalSteps: number, concurrency: number): void {
+      // Open phase state regardless of `quiet` so the matching
+      // suppression in step/stepComplete still triggers (otherwise a
+      // quiet emitter would fall through to per-skill emission paths
+      // — though both paths are no-ops under quiet, keeping state in
+      // sync avoids surprise from future changes).
+      activeConcurrentPhase = {
+        name,
+        total: totalSteps,
+        elapsedSamples: [],
+      };
+      if (quiet) return;
+      // Banner is `\n`-terminated even on TTY: nothing subsequent
+      // overwrites it (per-skill rows are suppressed for the
+      // duration of the phase), and `\r` would be meaningless on
+      // non-TTY pipes. Stable byte sequence across both modes.
+      stderr.write(
+        `[${name}: ${totalSteps} skills, ${concurrency}-wide concurrent ...]\n`,
+      );
+    },
+
+    endConcurrentPhase(name: string, elapsedMs: number): void {
+      const phase = activeConcurrentPhase;
+      // Always clear state — even on quiet — so a subsequent
+      // sequential `step` call is no longer suppressed.
+      activeConcurrentPhase = null;
+      if (quiet) return;
+      // Defensive: end called without a matching begin. Emit
+      // nothing and don't crash — the migrator should never trigger
+      // this, but a misuse shouldn't blow up the run.
+      if (!phase) return;
+      const samples = phase.elapsedSamples;
+      const count = phase.total;
+      let avgMs = 0;
+      let maxMs = 0;
+      if (samples.length > 0) {
+        const sum = samples.reduce((a, b) => a + b, 0);
+        avgMs = Math.round(sum / samples.length);
+        maxMs = samples.reduce((a, b) => (b > a ? b : a), 0);
+      }
+      const elapsed = fmtElapsedSeconds(elapsedMs);
+      stderr.write(
+        `[${name}: ${count} skills in ${elapsed} (avg ${avgMs}ms, max ${maxMs}ms)]\n`,
+      );
     },
 
     finishTimingSummary(timings: PhaseTimings): string {
@@ -236,6 +353,8 @@ export function createNoopProgressEmitter(): ProgressEmitter {
     start: noop,
     step: noop,
     stepComplete: noop,
+    beginConcurrentPhase: noop,
+    endConcurrentPhase: noop,
     finishTimingSummary: (timings) => {
       // Even the no-op renders the Timing block — it's stdout
       // content the formatter wants regardless of stderr behavior.

--- a/test/claude-skills-migrator-progress.test.ts
+++ b/test/claude-skills-migrator-progress.test.ts
@@ -33,13 +33,16 @@ const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
 const FM = "---\nname: TestSkill\ndescription: \"short description\"\n---\n\n";
 
 interface RecordedCall {
-  method: "start" | "step" | "stepComplete";
+  method: "start" | "step" | "stepComplete" | "beginConcurrentPhase" | "endConcurrentPhase";
   index?: number;
   sourceName?: string;
   phase?: string;
   detail?: string;
   elapsedMs?: number;
   total?: number;
+  // #139 — concurrent-phase boundary args.
+  name?: string;
+  concurrency?: number;
 }
 
 interface CapturingEmitter extends ProgressEmitter {
@@ -58,6 +61,12 @@ function makeCapturingEmitter(): CapturingEmitter {
     },
     stepComplete(index, sourceName, phase, elapsedMs, detail) {
       calls.push({ method: "stepComplete", index, sourceName, phase, elapsedMs, detail });
+    },
+    beginConcurrentPhase(name, total, concurrency) {
+      calls.push({ method: "beginConcurrentPhase", name, total, concurrency });
+    },
+    endConcurrentPhase(name, elapsedMs) {
+      calls.push({ method: "endConcurrentPhase", name, elapsedMs });
     },
     finishTimingSummary(_t: PhaseTimings): string {
       return "Timing: 0s total";
@@ -219,6 +228,62 @@ test("library default (no emitter) does not error and produces a timing block", 
     });
     expect(result.timing).toBeDefined();
     expect(result.writtenCount).toBe(2);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────
+// #139 quick patch — migrator wraps the concurrent read+classify
+// loop with beginConcurrentPhase / endConcurrentPhase.
+//
+// Per-skill `stepComplete("reading + classifying", ...)` calls
+// during the concurrent loop still fire (the migrator records
+// them for timing) — but the real emitter (not this capturing
+// stub) suppresses their output. Here we just assert the phase
+// boundary methods are called with the right shape.
+// ──────────────────────────────────────────────────────────────
+
+test("#139: planClaudeSkillsMigration brackets concurrent read+classify with begin/endConcurrentPhase", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeFixture(home);
+    const emitter = makeCapturingEmitter();
+    await planClaudeSkillsMigration({
+      from: fromDir,
+      somaHome: join(home, "soma"),
+      progressEmitter: emitter,
+    });
+    const begins = emitter.calls.filter((c) => c.method === "beginConcurrentPhase");
+    const ends = emitter.calls.filter((c) => c.method === "endConcurrentPhase");
+    expect(begins.length).toBe(1);
+    expect(ends.length).toBe(1);
+    expect(begins[0].name).toBe("read + classify");
+    expect(begins[0].total).toBe(3);
+    expect(begins[0].concurrency).toBe(4);
+    expect(ends[0].name).toBe("read + classify");
+    expect(ends[0].elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+test("#139: beginConcurrentPhase fires BEFORE per-skill read+classify steps; endConcurrentPhase fires AFTER", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeFixture(home);
+    const emitter = makeCapturingEmitter();
+    await planClaudeSkillsMigration({
+      from: fromDir,
+      somaHome: join(home, "soma"),
+      progressEmitter: emitter,
+    });
+    const beginIdx = emitter.calls.findIndex((c) => c.method === "beginConcurrentPhase");
+    const endIdx = emitter.calls.findIndex((c) => c.method === "endConcurrentPhase");
+    const readIndices = emitter.calls
+      .map((c, i) => ({ c, i }))
+      .filter(({ c }) => c.method === "stepComplete" && c.phase === "reading + classifying")
+      .map(({ i }) => i);
+    expect(beginIdx).toBeGreaterThanOrEqual(0);
+    expect(endIdx).toBeGreaterThan(beginIdx);
+    for (const i of readIndices) {
+      expect(i).toBeGreaterThan(beginIdx);
+      expect(i).toBeLessThan(endIdx);
+    }
   });
 });
 

--- a/test/claude-skills-progress.test.ts
+++ b/test/claude-skills-progress.test.ts
@@ -154,3 +154,127 @@ test("quiet=true still produces a finishTimingSummary string (timing belongs on 
   expect(out).toContain("Timing:");
   expect(capture.text).toBe("");
 });
+
+// ──────────────────────────────────────────────────────────────
+// #139 quick patch — concurrent-phase suppression.
+//
+// Concurrent phases (read+classify with 4-wide fan-out) emit ONE
+// banner line at phase begin and ONE summary line at phase end.
+// Per-skill `step` / `stepComplete` calls inside the phase are
+// suppressed entirely — otherwise the 4-wide concurrent worker
+// pool produces 97 interleaved append-only lines (the #139
+// symptom).
+//
+// Sequential phases (rewrite, write, smoke verify) keep the #125
+// `\r`-overwrite behavior. `step` / `stepComplete` outside any
+// concurrent phase scope behave exactly as before.
+// ──────────────────────────────────────────────────────────────
+
+test("#139: beginConcurrentPhase emits one banner line on non-TTY", () => {
+  const { stream, capture } = makeCapturingStream();
+  const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: false });
+  emitter.beginConcurrentPhase("read + classify", 97, 4);
+  expect(capture.text).toBe("[read + classify: 97 skills, 4-wide concurrent ...]\n");
+});
+
+test("#139: beginConcurrentPhase emits one banner line on TTY (still \\n-terminated)", () => {
+  // Concurrent banner is a phase-boundary marker, NOT a rolling-line
+  // candidate. It's safe to terminate with `\n` on TTY because no
+  // subsequent step writes will overwrite it (steps are suppressed
+  // entirely while a concurrent phase is active).
+  const { stream, capture } = makeCapturingStream();
+  const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: true });
+  emitter.beginConcurrentPhase("read + classify", 97, 4);
+  expect(capture.text).toBe("[read + classify: 97 skills, 4-wide concurrent ...]\n");
+});
+
+test("#139: step + stepComplete are no-op while a concurrent phase is active", () => {
+  const { stream, capture } = makeCapturingStream();
+  const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: false });
+  emitter.beginConcurrentPhase("read + classify", 3, 4);
+  // 3 per-skill `stepComplete` calls inside the concurrent phase
+  // must NOT emit any output.
+  emitter.stepComplete(1, "Foo", "reading + classifying", 12, "read");
+  emitter.stepComplete(2, "Bar", "reading + classifying", 8, "read");
+  emitter.stepComplete(3, "Baz", "reading + classifying", 15, "read");
+  // Only the begin banner should be in the capture.
+  expect(capture.text).toBe("[read + classify: 3 skills, 4-wide concurrent ...]\n");
+});
+
+test("#139: endConcurrentPhase emits a summary line with elapsed + avg + max", () => {
+  const { stream, capture } = makeCapturingStream();
+  const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: false });
+  emitter.beginConcurrentPhase("read + classify", 3, 4);
+  emitter.stepComplete(1, "Foo", "reading + classifying", 10, "read");
+  emitter.stepComplete(2, "Bar", "reading + classifying", 20, "read");
+  emitter.stepComplete(3, "Baz", "reading + classifying", 30, "read");
+  emitter.endConcurrentPhase("read + classify", 900);
+  // Begin + end. Step calls suppressed.
+  const lines = capture.text.split("\n").filter((l) => l.length > 0);
+  expect(lines.length).toBe(2);
+  expect(lines[0]).toBe("[read + classify: 3 skills, 4-wide concurrent ...]");
+  // Summary: count, elapsed (seconds), avg (ms), max (ms).
+  expect(lines[1]).toContain("read + classify");
+  expect(lines[1]).toContain("3 skills");
+  expect(lines[1]).toContain("0.9s");
+  expect(lines[1]).toContain("avg 20ms");
+  expect(lines[1]).toContain("max 30ms");
+});
+
+test("#139: endConcurrentPhase with zero recorded steps emits avg 0ms max 0ms", () => {
+  // Edge case: phase began but no stepComplete fired (empty skill
+  // list reaches the phase wrapper). Avg/max default to 0 rather
+  // than NaN.
+  const { stream, capture } = makeCapturingStream();
+  const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: false });
+  emitter.beginConcurrentPhase("read + classify", 0, 4);
+  emitter.endConcurrentPhase("read + classify", 50);
+  expect(capture.text).toContain("avg 0ms");
+  expect(capture.text).toContain("max 0ms");
+});
+
+test("#139: sequential step + stepComplete behave normally after endConcurrentPhase", () => {
+  // After the concurrent phase closes, subsequent step/stepComplete
+  // calls must emit per-skill output (this is the sequential-phase
+  // contract — rewrite / write / smoke).
+  const { stream, capture } = makeCapturingStream();
+  const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: false });
+  emitter.beginConcurrentPhase("read + classify", 1, 4);
+  emitter.stepComplete(1, "Foo", "reading + classifying", 12, "read");
+  emitter.endConcurrentPhase("read + classify", 100);
+  // Now sequential — should emit normally.
+  emitter.step(1, "Foo", "writing", "120B");
+  emitter.stepComplete(1, "Foo", "writing", 8, "120B");
+  expect(capture.text).toContain("[1/0] Foo  [writing");
+  expect(capture.text).toContain("(8ms)");
+});
+
+test("#139: quiet=true suppresses concurrent banner + summary", () => {
+  const { stream, capture } = makeCapturingStream();
+  const emitter = createProgressEmitter({ stderr: stream, quiet: true, isatty: false });
+  emitter.beginConcurrentPhase("read + classify", 97, 4);
+  emitter.stepComplete(1, "Foo", "reading + classifying", 12, "read");
+  emitter.endConcurrentPhase("read + classify", 900);
+  expect(capture.text).toBe("");
+});
+
+test("#139: TTY non-quiet — concurrent phase still suppresses per-skill rows", () => {
+  // Regression guard: the #139 symptom (97 interleaved lines on
+  // TTY) was specifically because step/stepComplete fell through
+  // to per-skill emission with `\r` overwrite that couldn't keep
+  // up with 4-wide fan-out. With the concurrent-phase wrapper, the
+  // emitter must suppress regardless of TTY-ness.
+  const { stream, capture } = makeCapturingStream();
+  const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: true });
+  emitter.beginConcurrentPhase("read + classify", 2, 4);
+  emitter.stepComplete(1, "Foo", "reading + classifying", 10, "read");
+  emitter.stepComplete(2, "Bar", "reading + classifying", 12, "read");
+  emitter.endConcurrentPhase("read + classify", 80);
+  // No "Foo" or "Bar" per-skill lines should leak through.
+  expect(capture.text).not.toContain("Foo");
+  expect(capture.text).not.toContain("Bar");
+  // Begin banner and end summary present.
+  expect(capture.text).toContain("[read + classify: 2 skills, 4-wide concurrent ...]");
+  expect(capture.text).toContain("avg ");
+  expect(capture.text).toContain("max ");
+});


### PR DESCRIPTION
## Summary

Quick patch for #139: concurrent read+classify phase emits 97 interleaved per-skill lines on a real PAI tree (one per skill). 4-wide fan-out via `runBoundedConcurrent` defeats the #125 `\r`-overwrite (only one of 4 workers can hold the row).

This patch adds explicit concurrent-phase boundaries to the emitter — `beginConcurrentPhase(name, total, concurrency)` and `endConcurrentPhase(name, elapsedMs)`. While a concurrent phase is active, per-skill `step` / `stepComplete` are output no-ops (but still record elapsed times for the end summary's avg/max). The migrator wraps the read+classify loop with begin/end.

**Scope: quick patch only.** The full three-tier rolling-line proposal in #139's body (mutex-protected single rolling line with in-flight count) is deferred as Phase 2 follow-up — Option A (explicit phase boundaries with suppression) is the minimum change that closes the principal-reported UX gap.

Sequential phases (description rewrite, write-after-rewrite, smoke verify per-substrate) are untouched — `step`/`stepComplete` outside a concurrent bracket keeps the #125 `\r`-overwrite behavior.

## Quick patch ACs satisfied

- [x] Concurrent read+classify emits one banner + one summary, NOT 97 lines
- [x] Sequential phases preserve per-skill `\r`-overwrite from #125
- [x] Phase-end summary includes count + total elapsed + avg + max per-step ms
- [x] `--quiet` still suppresses both banner and summary
- [x] Non-TTY behavior preserved (banner/summary are `\n`-terminated)
- [x] stdout summary stays byte-stable (no banner strings leak into `result.outcomes`)

## Deferred (Phase 2 — not in this PR)

The original #139 proposal included a mutex-protected single rolling line with in-flight count display. That's a richer UX (`[N/total] processing <latest> + K others...` updating in place), but requires a render queue + render loop. The quick patch's "begin + suppressed steps + summary" is the minimum change that closes the spam symptom. Phase 2 can build on top of the begin/end boundaries this PR introduces.

## Before / after

Real PAI tree (97 skills):

```
# BEFORE (97 interleaved lines from 4-wide fan-out)
[discovering 97 skill(s) ...]
[2/97] AlexHormoziPitch  [reading + classifying ... read] (2ms)
[3/97] ApertureOscillation  [reading + classifying ... read] (3ms)
[6/97] AutoResearch  [reading + classifying ... read] (1ms)
[7/97] BeCreative  [reading + classifying ... read] (3ms)
[8/97] Blackboard  [reading + classifying ... read] (2ms)
[1/97] Agents  [reading + classifying ... read] (10ms)
... (91 more lines)

# AFTER (3 lines: discovery + begin banner + end summary)
[discovering 97 skill(s) ...]
[read + classify: 97 skills, 4-wide concurrent ...]
[read + classify: 97 skills in 12.7s (avg 18ms, max 522ms)]
```

## Test evidence

867 → 877 (+10 net):

- `test/claude-skills-progress.test.ts` (+8 unit tests): non-TTY banner shape, TTY banner shape (still `\n`-terminated), step/stepComplete no-op while active, end summary shape with elapsed + avg + max, zero-samples edge case (avg 0ms max 0ms not NaN), sequential resumption after `endConcurrentPhase`, `--quiet` suppresses both, TTY non-quiet still suppresses per-skill rows (the #139 regression guard)
- `test/claude-skills-migrator-progress.test.ts` (+2 integration tests): plan brackets read+classify with begin/end; all `stepComplete("reading + classifying", ...)` events fall strictly between begin and end indices

```
877 pass
0 fail
2818 expect() calls
Ran 877 tests across 58 files.
```

`bun run typecheck` clean.

## Files

- `src/claude-skills-progress.ts` — `beginConcurrentPhase` / `endConcurrentPhase` on `ProgressEmitter`; suppression flag inside `createProgressEmitter`; per-step elapsed accumulator for summary avg/max; no-op stubs on `createNoopProgressEmitter`
- `src/claude-skills-migrator.ts` — wrap the read+classify loop (including the sequential classification follow-on, which is part of the same logical phase) with begin/end inside `buildPlanCore`
- `test/claude-skills-progress.test.ts` — 8 new unit tests
- `test/claude-skills-migrator-progress.test.ts` — 2 new integration tests + emitter stub updated with phase methods

## Test plan

- [x] `bun test` — 877 pass
- [x] `bun run typecheck` — clean
- [x] Smoke: `bun src/cli.ts migrate claude-skills --from ~/.claude/skills 2>&1 | head -5` → 3 lines (was 97+)
- [x] Smoke: re-verified stdout summary byte-stable (no `[discovering` or `[read + classify` strings in `result.outcomes`)

Refs #139 (closes the principal-reported UX gap; full three-tier rolling-line proposal deferred as Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)