### PR TITLE
feat(memory): capture searchable result events (#122)

### DIFF
--- a/docs/memory-policy-v0.md
+++ b/docs/memory-policy-v0.md
@@ -51,10 +51,27 @@ The initial portable operations are:
 - append learning notes through explicit tools or patches
 
 The first implemented recall surface is `soma memory search --query <text>`.
-It searches profile/import files plus WORK, KNOWLEDGE, LEARNING, RELATIONSHIP,
-and selected STATE files, then returns cited path/line/snippet matches. This is
-not semantic memory yet; it is the portable file-backed retrieval floor that
-substrates can call before answering.
+It searches profile/import files plus WORK, KNOWLEDGE, LEARNING, WISDOM,
+RELATIONSHIP, and selected STATE files, then returns cited path/line/snippet
+matches. This is not semantic memory yet; it is the portable file-backed
+retrieval floor that substrates can call before answering.
+
+The first implemented result-capture surface is
+`soma result capture --substrate <substrate> --source <source> --summary <text>`.
+It records a short result summary, provenance, optional skill/session metadata,
+and optional artifact paths as an append-only event. The default kind is
+`result.captured`; migrated PAI-style tools may use typed learning events:
+`learning.signal`, `learning.pattern`, `learning.failure`,
+`wisdom.frame-update`, `wisdom.cross-frame`, `relationship.reflection`, and
+`opinion.tracked`. Result capture records `promptStored: false` and
+`resultStored: false` by default. It does not store full prompts or full
+generated outputs.
+
+`soma result search --query <text>` searches captured result and typed tool
+events in `memory/STATE/events.jsonl` and returns event path/line, event id,
+summary, kind, score, and artifact path provenance. `soma memory search` also
+sees those JSONL events because STATE remains part of the normal memory search
+surface.
 
 The first implemented promotion surface is
 `soma memory promote --from-run <id> --store <learning|knowledge|relationship|work> --substrate <substrate>`.
@@ -71,6 +88,12 @@ learning, then appends a `feedback.candidate` event to
 `memory/STATE/events.jsonl`. Feedback capture never writes durable memory
 directly. Candidate events must be reviewed or promoted by a later explicit
 workflow.
+
+Feedback capture, result capture, and promotion are separate:
+feedback capture records candidate corrections or preferences, result capture
+records that useful work happened and where to inspect it, and promotion creates
+a durable memory note from verified source work. Later consolidation may read
+all three, but none silently performs another one's job.
 
 `PROMOTED/` has V0 merge semantics. Promoted notes are immutable additive
 records, keyed by sanitized title plus source run id. Creation is atomic and a

--- a/docs/writeback-and-policy.md
+++ b/docs/writeback-and-policy.md
@@ -74,15 +74,43 @@ Each line is one event:
   "id": "evt_...",
   "timestamp": "2026-05-14T12:00:00.000Z",
   "substrate": "codex",
-  "kind": "verification",
-  "summary": "Codex projection installed.",
-  "artifactPaths": ["~/.codex/skills/soma/SKILL.md"],
-  "metadata": {}
+  "kind": "result.captured",
+  "summary": "A skill produced a useful output for the current task.",
+  "artifactPaths": ["substrate-session/session.jsonl"],
+  "metadata": {
+    "source": "assistant-final",
+    "skill": "example-skill",
+    "sessionId": "session-123",
+    "promptStored": false,
+    "resultStored": false
+  }
 }
 ```
 
 This is not full shared memory yet. It is an audit log and inbox for later
 consolidation.
+
+V0 distinguishes four related flows:
+
+- **Feedback capture** appends `feedback.candidate` events for corrections,
+  preferences, missed surfaces, and similar candidate learning. It does not
+  store prompt excerpts unless explicitly requested.
+- **Result capture** appends `result.captured` events for useful agent or skill
+  outputs. It stores summary plus provenance by default, not the full prompt or
+  full generated result text.
+- **Typed PAI tool events** reuse the same event log with specific kinds:
+  `learning.signal`, `learning.pattern`, `learning.failure`,
+  `wisdom.frame-update`, `wisdom.cross-frame`, `relationship.reflection`, and
+  `opinion.tracked`.
+- **Promotion** writes a durable note under a reviewed memory store and appends
+  a `memory.promotion` event. Promotion is explicit and remains separate from
+  capture.
+
+Captured results are searchable through `soma result search --query <text>`.
+Search output cites the event path/line and event id, then includes artifact
+path provenance when present. The broader `soma memory search` also indexes
+STATE events and the shared artifact roots used by migrated tools, including
+LEARNING, WISDOM, RELATIONSHIP, KNOWLEDGE, WORK, STATE, and identity.
 
 Promotion from events into durable stores such as `KNOWLEDGE`, `WORK`, or
 `LEARNING` is a future design decision, not an oversight.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import {
   checkSomaPolicy,
   classifyAlgorithmPrompt,
   captureSomaFeedback,
+  captureSomaResult,
   createAlgorithmRun,
   importAlgorithm,
   importPaiDocs,
@@ -44,6 +45,7 @@ import {
   runSomaLifecycleSessionEnd,
   runSomaLifecycleSessionStart,
   searchSomaMemory,
+  searchSomaResults,
   setAlgorithmPlan,
   updateAlgorithmPlanStep,
   updateAlgorithmRunById,
@@ -86,6 +88,11 @@ import type {
   SomaMemoryPromotionStore,
   SomaMemorySearchOptions,
   SomaMemorySearchResult,
+  SomaResultCaptureOptions,
+  SomaResultCaptureResult,
+  SomaResultEventKind,
+  SomaResultSearchOptions,
+  SomaResultSearchResult,
   SomaPolicyCheckOptions,
   SomaPolicyCheckResult,
   SomaPolicyBatchTarget,
@@ -141,6 +148,8 @@ export class SomaCliError extends Error {
 }
 import { getCriteria, getGoal } from "./isa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
+import { isSomaResultEventKind } from "./result-capture";
+import { SOMA_RESULT_EVENT_KINDS } from "./types";
 
 /**
  * #106 — single-source helper for emitting the
@@ -307,6 +316,20 @@ interface ParsedFeedbackArgs {
   readTextFromStdin: boolean;
 }
 
+interface ParsedResultCaptureArgs {
+  command: "result";
+  action: "capture";
+  options: SomaResultCaptureOptions;
+}
+
+interface ParsedResultSearchArgs {
+  command: "result";
+  action: "search";
+  options: SomaResultSearchOptions;
+}
+
+type ParsedResultArgs = ParsedResultCaptureArgs | ParsedResultSearchArgs;
+
 interface ParsedPolicyArgs {
   command: "policy";
   action: "check";
@@ -341,6 +364,7 @@ type ParsedArgs =
   | ParsedLifecycleArgs
   | ParsedMemoryArgs
   | ParsedFeedbackArgs
+  | ParsedResultArgs
   | ParsedPolicyArgs
   | ParsedIsaArgs;
 
@@ -358,6 +382,7 @@ const TOP_LEVEL_COMMANDS = [
   "migrate",
   "policy",
   "reproject",
+  "result",
   "uninstall",
   "upgrade",
 ] as const;
@@ -405,6 +430,14 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
     usage: "Usage: soma feedback capture (--text <text> | --stdin) [--substrate <id>] [--source <source>] [--store-excerpt]",
     subcommands: {
       capture: "Usage: soma feedback capture (--text <text> | --stdin) [--substrate <id>] [--source <source>] [--store-excerpt]",
+    },
+  },
+  result: {
+    usage: "Usage: soma result <capture|search> ...",
+    subcommands: {
+      capture:
+        "Usage: soma result capture --substrate <id> --source <source> --summary <text> [--artifact-path <path>...] [--skill <id>] [--session-id <id>] [--kind <kind>] [--home-dir <dir>] [--soma-home <dir>]",
+      search: "Usage: soma result search --query <text> [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
     },
   },
   policy: {
@@ -1315,6 +1348,155 @@ function parseFeedbackArgs(args: string[]): ParsedFeedbackArgs {
   };
 }
 
+function parseResultKind(value: string): SomaResultEventKind {
+  if (isSomaResultEventKind(value)) {
+    return value;
+  }
+
+  throw new Error(`Unsupported result kind '${value}'. Expected one of: ${SOMA_RESULT_EVENT_KINDS.join(", ")}.`);
+}
+
+function readResultSharedOption(
+  options: Pick<Partial<SomaResultCaptureOptions & SomaResultSearchOptions>, "homeDir" | "somaHome">,
+  args: string[],
+  index: number,
+  arg: string,
+): number | undefined {
+  switch (arg) {
+    case "--home-dir":
+      options.homeDir = readOption(args, index, arg);
+      return index + 1;
+    case "--soma-home":
+      options.somaHome = readOption(args, index, arg);
+      return index + 1;
+    default:
+      return undefined;
+  }
+}
+
+function parsePositiveIntegerOption(args: string[], index: number, arg: string): number {
+  const raw = readOption(args, index, arg);
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`${arg} must be a positive integer.`);
+  }
+
+  return Number(raw);
+}
+
+function parseResultCaptureArgs(args: string[]): SomaResultCaptureOptions {
+  const options: Partial<SomaResultCaptureOptions> = {};
+  const artifactPaths: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const sharedOptionIndex = readResultSharedOption(options, args, index, arg);
+    if (sharedOptionIndex !== undefined) {
+      index = sharedOptionIndex;
+      continue;
+    }
+
+    switch (arg) {
+      case "--substrate":
+        options.substrate = parseSubstrate(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--source":
+        options.source = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--summary":
+        options.summary = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--artifact-path":
+        artifactPaths.push(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--skill":
+        options.skill = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--session-id":
+        options.sessionId = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--kind":
+        options.kind = parseResultKind(readOption(args, index, arg));
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  const missing: string[] = [];
+  if (!options.substrate) missing.push("--substrate");
+  if (!options.source) missing.push("--source");
+  if (!options.summary) missing.push("--summary");
+  if (missing.length > 0) {
+    throw new Error(`soma result capture is missing required option(s): ${missing.join(", ")}.`);
+  }
+
+  return {
+    ...options,
+    artifactPaths: artifactPaths.length > 0 ? artifactPaths : undefined,
+  } as SomaResultCaptureOptions;
+}
+
+function parseResultSearchArgs(args: string[]): SomaResultSearchOptions {
+  const options: Partial<SomaResultSearchOptions> = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const sharedOptionIndex = readResultSharedOption(options, args, index, arg);
+    if (sharedOptionIndex !== undefined) {
+      index = sharedOptionIndex;
+      continue;
+    }
+
+    switch (arg) {
+      case "--query":
+        options.query = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--limit":
+        options.limit = parsePositiveIntegerOption(args, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (!options.query) {
+    throw new Error("soma result search is missing required option: --query.");
+  }
+
+  return options as SomaResultSearchOptions;
+}
+
+function parseResultArgs(args: string[]): ParsedResultArgs {
+  const [command, action, ...rest] = args;
+
+  if (command !== "result" || (action !== "capture" && action !== "search")) {
+    throw new Error(commandUsage("result"));
+  }
+
+  if (action === "capture") {
+    return {
+      command,
+      action,
+      options: parseResultCaptureArgs(rest),
+    };
+  }
+
+  return {
+    command,
+    action,
+    options: parseResultSearchArgs(rest),
+  };
+}
+
 function parsePolicyArgs(args: string[]): ParsedPolicyArgs {
   const [command, action, ...rest] = args;
 
@@ -1458,6 +1640,10 @@ function parseArgs(args: string[]): ParsedArgs {
 
   if (args[0] === "feedback") {
     return parseFeedbackArgs(args);
+  }
+
+  if (args[0] === "result") {
+    return parseResultArgs(args);
   }
 
   if (args[0] === "algorithm") {
@@ -2796,6 +2982,50 @@ function formatFeedbackCaptureResult(result: SomaFeedbackCaptureResult): string 
     .join("\n");
 }
 
+function formatResultCaptureResult(result: SomaResultCaptureResult): string {
+  return [
+    "Soma result capture",
+    `event: ${result.event.id}`,
+    `kind: ${result.event.kind}`,
+    `somaHome: ${result.somaHome}`,
+    result.event.artifactPaths && result.event.artifactPaths.length > 0
+      ? `artifactPaths: ${result.event.artifactPaths.map((artifactPath) => sanitizeTerminalText(artifactPath)).join(", ")}`
+      : undefined,
+  ]
+    .filter((line) => line !== undefined)
+    .join("\n");
+}
+
+function sanitizeTerminalText(value: string): string {
+  return value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "").replace(/[\x00-\x1F\x7F]/g, " ");
+}
+
+function formatResultSearchResult(result: SomaResultSearchResult): string {
+  return [
+    "Soma result search",
+    `query: ${sanitizeTerminalText(result.query)}`,
+    `somaHome: ${result.somaHome}`,
+    "",
+    "Matches:",
+    ...(result.matches.length > 0
+      ? result.matches.map((match) =>
+          [
+            `- ${match.eventPath}:${match.line}`,
+            `[event ${match.eventId}]`,
+            `[kind ${match.kind}]`,
+            `[score ${match.score}]`,
+            sanitizeTerminalText(match.summary),
+            match.artifactPaths.length > 0
+              ? `(artifacts: ${match.artifactPaths.map((artifactPath) => sanitizeTerminalText(artifactPath)).join(", ")})`
+              : "",
+          ]
+            .filter(Boolean)
+            .join(" "),
+        )
+      : ["- none"]),
+  ].join("\n");
+}
+
 function formatPolicyCheckResult(result: SomaPolicyCheckResult): string {
   return [
     "Soma policy check",
@@ -3036,6 +3266,14 @@ export async function runSomaCli(args: string[]): Promise<string> {
   if (parsed.command === "feedback") {
     const options = parsed.readTextFromStdin ? { ...parsed.options, text: readLimitedFeedbackStdin() } : parsed.options;
     return formatFeedbackCaptureResult(await captureSomaFeedback(options));
+  }
+
+  if (parsed.command === "result") {
+    if (parsed.action === "capture") {
+      return formatResultCaptureResult(await captureSomaResult(parsed.options));
+    }
+
+    return formatResultSearchResult(await searchSomaResults(parsed.options));
   }
 
   if (parsed.command === "policy") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,12 @@ export type {
   SomaMemorySearchMatch,
   SomaMemorySearchOptions,
   SomaMemorySearchResult,
+  SomaResultCaptureOptions,
+  SomaResultCaptureResult,
+  SomaResultEventKind,
+  SomaResultSearchMatch,
+  SomaResultSearchOptions,
+  SomaResultSearchResult,
   SomaPolicyAction,
   SomaPolicyCheckOptions,
   SomaPolicyCheckResult,
@@ -88,6 +94,7 @@ export type {
   SomaSkillManifest,
   WrittenProjection,
 } from "./types";
+export { SOMA_RESULT_EVENT_KINDS } from "./types";
 
 export {
   addAlgorithmCapabilities,
@@ -208,6 +215,7 @@ export {
 export { captureSomaFeedback, classifySomaFeedback, maybeSomaFeedbackPrompt } from "./feedback";
 export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from "./memory";
 export { promoteAlgorithmRunMemory } from "./memory-promotion";
+export { captureSomaResult, isSomaResultEventKind, searchSomaResults } from "./result-capture";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";
 export {
   importPaiPack,

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -13,8 +13,10 @@ const SEARCH_ROOTS = [
   "memory/WORK",
   "memory/KNOWLEDGE",
   "memory/LEARNING",
+  "memory/WISDOM",
   "memory/RELATIONSHIP",
   "memory/STATE",
+  "identity",
 ] as const;
 
 const SEARCH_EXTENSIONS = new Set([".md", ".txt", ".json", ".jsonl", ".yaml", ".yml", ".toml"]);

--- a/src/result-capture.ts
+++ b/src/result-capture.ts
@@ -1,0 +1,204 @@
+import { createReadStream } from "node:fs";
+import { access } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+import { appendSomaMemoryEvent, somaMemoryEventsPath } from "./memory";
+import type {
+  SomaMemoryEvent,
+  SomaResultCaptureOptions,
+  SomaResultCaptureResult,
+  SomaResultEventKind,
+  SomaResultMemoryEvent,
+  SomaResultSearchOptions,
+  SomaResultSearchResult,
+} from "./types";
+import { SOMA_RESULT_EVENT_KINDS } from "./types";
+
+const RESULT_EVENT_KIND_SET = new Set<string>(SOMA_RESULT_EVENT_KINDS);
+const RESULT_SUMMARY_MAX_LENGTH = 500;
+
+function assertNonEmpty(value: string | undefined, field: string): string {
+  if (!value || value.trim().length === 0) {
+    throw new Error(`Soma result capture ${field} must not be empty.`);
+  }
+
+  return value;
+}
+
+function assertResultSummary(value: string | undefined): string {
+  const summary = assertNonEmpty(value, "summary");
+  if (summary.length > RESULT_SUMMARY_MAX_LENGTH) {
+    throw new Error(`Soma result capture summary must be ${RESULT_SUMMARY_MAX_LENGTH} characters or fewer.`);
+  }
+  if (/[\r\n]/.test(summary)) {
+    throw new Error("Soma result capture summary must be a single line.");
+  }
+
+  return summary;
+}
+
+function resolveSomaHome(options: Pick<SomaResultCaptureOptions | SomaResultSearchOptions, "homeDir" | "somaHome"> = {}): string {
+  return resolve(options.somaHome ?? join(options.homeDir ?? homedir(), ".soma"));
+}
+
+export function isSomaResultEventKind(kind: string): kind is SomaResultEventKind {
+  return RESULT_EVENT_KIND_SET.has(kind);
+}
+
+export async function captureSomaResult(options: SomaResultCaptureOptions): Promise<SomaResultCaptureResult> {
+  const somaHome = resolveSomaHome(options);
+  const kind: string = options.kind ?? "result.captured";
+  if (!isSomaResultEventKind(kind)) {
+    throw new Error(`Unsupported Soma result event kind: ${kind}`);
+  }
+
+  const source = assertNonEmpty(options.source, "source");
+  const summary = assertResultSummary(options.summary);
+
+  const event = (await appendSomaMemoryEvent(somaHome, {
+    substrate: options.substrate,
+    kind,
+    summary,
+    artifactPaths: options.artifactPaths,
+    metadata: {
+      source,
+      promptStored: false,
+      resultStored: false,
+      ...(options.skill ? { skill: options.skill } : {}),
+      ...(options.sessionId ? { sessionId: options.sessionId } : {}),
+      ...(kind === "result.captured" ? { resultKind: "skill-output" } : {}),
+    },
+  })) as SomaResultMemoryEvent;
+
+  return { somaHome, event };
+}
+
+function queryTerms(query: string): string[] {
+  return Array.from(
+    new Set(
+      query
+        .toLowerCase()
+        .split(/[^a-z0-9\u00c0-\u024f]+/i)
+        .map((term) => term.trim())
+        .filter((term) => term.length >= 2),
+    ),
+  );
+}
+
+function scoreEvent(event: SomaMemoryEvent, terms: string[], fallbackQuery: string): number {
+  const haystack = [
+    event.kind,
+    event.summary,
+    ...resultArtifactPaths(event),
+    event.metadata ? JSON.stringify(event.metadata) : "",
+  ]
+    .join(" ")
+    .toLowerCase();
+
+  if (terms.length === 0) {
+    return fallbackQuery.length > 0 && haystack.includes(fallbackQuery) ? 1 : 0;
+  }
+
+  return terms.reduce((score, term) => (haystack.includes(term) ? score + 1 : score), 0);
+}
+
+function resultSearchLimit(limit: number | undefined): number {
+  const value = limit ?? 8;
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error("Soma result search limit must be a positive safe integer.");
+  }
+
+  return Math.min(value, 100);
+}
+
+function resultArtifactPaths(event: SomaMemoryEvent): string[] {
+  return Array.isArray(event.artifactPaths) ? event.artifactPaths.filter((path): path is string => typeof path === "string") : [];
+}
+
+function isBetterResultMatch(
+  left: SomaResultSearchResult["matches"][number],
+  right: SomaResultSearchResult["matches"][number],
+): boolean {
+  return left.score > right.score || (left.score === right.score && left.line < right.line);
+}
+
+function retainTopResultMatch(
+  matches: SomaResultSearchResult["matches"],
+  match: SomaResultSearchResult["matches"][number],
+  limit: number,
+): void {
+  matches.push(match);
+  if (matches.length <= limit) return;
+
+  let worstIndex = 0;
+  for (let index = 1; index < matches.length; index += 1) {
+    if (isBetterResultMatch(matches[worstIndex]!, matches[index]!)) {
+      worstIndex = index;
+    }
+  }
+  matches.splice(worstIndex, 1);
+}
+
+export async function searchSomaResults(options: SomaResultSearchOptions): Promise<SomaResultSearchResult> {
+  const query = assertNonEmpty(options.query, "search query");
+  const somaHome = resolveSomaHome(options);
+  const eventPath = somaMemoryEventsPath(somaHome);
+  const terms = queryTerms(query);
+  const limit = resultSearchLimit(options.limit);
+  const fallbackQuery = query.trim().toLowerCase();
+
+  if (terms.length === 0 && fallbackQuery.length === 0) {
+    return { query, somaHome, matches: [] };
+  }
+
+  const exists = await access(eventPath).then(
+    () => true,
+    () => false,
+  );
+  if (!exists) {
+    return { query, somaHome, matches: [] };
+  }
+
+  const matches: SomaResultSearchResult["matches"] = [];
+  const lines = createInterface({
+    input: createReadStream(eventPath, { encoding: "utf8" }),
+    crlfDelay: Infinity,
+  });
+
+  let lineNumber = 0;
+  for await (const line of lines) {
+    lineNumber += 1;
+    if (line.trim().length === 0) continue;
+
+    let event: SomaMemoryEvent;
+    try {
+      event = JSON.parse(line) as SomaMemoryEvent;
+    } catch {
+      continue;
+    }
+
+    if (!isSomaResultEventKind(event.kind)) continue;
+    if (typeof event.id !== "string") continue;
+    if (typeof event.summary !== "string") continue;
+    const artifactPaths = resultArtifactPaths(event);
+    const score = scoreEvent(event, terms, fallbackQuery);
+    if (score === 0) continue;
+
+    retainTopResultMatch(matches, {
+      eventPath,
+      line: lineNumber,
+      eventId: event.id,
+      kind: event.kind,
+      score,
+      summary: event.summary,
+      artifactPaths,
+    }, limit);
+  }
+
+  return {
+    query,
+    somaHome,
+    matches: matches.sort((left, right) => right.score - left.score || left.line - right.line),
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1284,6 +1284,71 @@ export interface SomaMemorySearchResult {
   matches: SomaMemorySearchMatch[];
 }
 
+export const SOMA_RESULT_EVENT_KINDS = [
+  "result.captured",
+  "learning.signal",
+  "learning.pattern",
+  "learning.failure",
+  "wisdom.frame-update",
+  "wisdom.cross-frame",
+  "relationship.reflection",
+  "opinion.tracked",
+] as const;
+
+export type SomaResultEventKind = (typeof SOMA_RESULT_EVENT_KINDS)[number];
+
+export interface SomaResultMemoryEvent extends Omit<SomaMemoryEvent, "kind" | "metadata"> {
+  kind: SomaResultEventKind;
+  metadata: Record<string, unknown> & {
+    source: string;
+    promptStored: false;
+    resultStored: false;
+    skill?: string;
+    sessionId?: string;
+    resultKind?: "skill-output";
+  };
+}
+
+export interface SomaResultCaptureOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate: SubstrateId;
+  source: string;
+  summary: string;
+  artifactPaths?: string[];
+  skill?: string;
+  sessionId?: string;
+  kind?: SomaResultEventKind;
+}
+
+export interface SomaResultCaptureResult {
+  somaHome: string;
+  event: SomaResultMemoryEvent;
+}
+
+export interface SomaResultSearchOptions {
+  homeDir?: string;
+  somaHome?: string;
+  query: string;
+  limit?: number;
+}
+
+export interface SomaResultSearchMatch {
+  eventPath: string;
+  line: number;
+  eventId: string;
+  kind: SomaResultEventKind;
+  score: number;
+  summary: string;
+  artifactPaths: string[];
+}
+
+export interface SomaResultSearchResult {
+  query: string;
+  somaHome: string;
+  matches: SomaResultSearchMatch[];
+}
+
 export type SomaMemoryPromotionStore = "learning" | "knowledge" | "relationship" | "work";
 
 export interface SomaMemoryPromotionOptions {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -384,6 +384,169 @@ test("cli captures feedback candidates", async () => {
   });
 });
 
+test("cli captures and searches result events", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);
+
+    const capture = await runSomaCli([
+      "result",
+      "capture",
+      "--home-dir",
+      homeDir,
+      "--substrate",
+      "codex",
+      "--source",
+      "assistant-final",
+      "--summary",
+      "OfferPitch produced a concise offer draft.",
+      "--skill",
+      "OfferPitch",
+      "--session-id",
+      "session-123",
+      "--artifact-path",
+      "codex-sessions/session-123.jsonl",
+    ]);
+
+    expect(capture).toContain("Soma result capture");
+    expect(capture).toContain("kind: result.captured");
+    expect(capture).toContain("artifactPaths: codex-sessions/session-123.jsonl");
+
+    const search = await runSomaCli([
+      "result",
+      "search",
+      "--home-dir",
+      homeDir,
+      "--query",
+      "OfferPitch concise offer",
+    ]);
+
+    expect(search).toContain("Soma result search");
+    expect(search).toContain("events.jsonl:");
+    expect(search).toContain("[event ");
+    expect(search).toContain("codex-sessions/session-123.jsonl");
+  });
+});
+
+test("cli result search strips terminal control characters from captured fields", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli([
+      "result",
+      "capture",
+      "--home-dir",
+      homeDir,
+      "--substrate",
+      "codex",
+      "--source",
+      "assistant-final",
+      "--summary",
+      "OfferPitch \x1B[31mred\x1B[0m result",
+      "--artifact-path",
+      "codex-sessions/\x1B[2Jsession.jsonl",
+    ]);
+
+    const search = await runSomaCli(["result", "search", "--home-dir", homeDir, "--query", "OfferPitch"]);
+
+    expect(search).toContain("OfferPitch red result");
+    expect(search).toContain("codex-sessions/session.jsonl");
+    expect(search).not.toContain("\x1B[31m");
+    expect(search).not.toContain("\x1B[2J");
+  });
+});
+
+test("cli result search strips terminal control characters from echoed query", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli([
+      "result",
+      "capture",
+      "--home-dir",
+      homeDir,
+      "--substrate",
+      "codex",
+      "--source",
+      "assistant-final",
+      "--summary",
+      "OfferPitch result",
+    ]);
+
+    const search = await runSomaCli(["result", "search", "--home-dir", homeDir, "--query", "OfferPitch \x1B[2J"]);
+
+    expect(search).toContain("query: OfferPitch ");
+    expect(search).not.toContain("\x1B[2J");
+  });
+});
+
+test("cli result capture strips terminal control characters from displayed artifact paths", async () => {
+  await withTempHome(async (homeDir) => {
+    const capture = await runSomaCli([
+      "result",
+      "capture",
+      "--home-dir",
+      homeDir,
+      "--substrate",
+      "codex",
+      "--source",
+      "assistant-final",
+      "--summary",
+      "OfferPitch result",
+      "--artifact-path",
+      "codex-sessions/\x1B[2Jsession.jsonl",
+    ]);
+
+    expect(capture).toContain("artifactPaths: codex-sessions/session.jsonl");
+    expect(capture).not.toContain("\x1B[2J");
+  });
+});
+
+test("cli captures typed Pi.dev learning result events", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli(["install", "pi-dev", "--apply", "--home-dir", homeDir]);
+
+    const output = await runSomaCli([
+      "result",
+      "capture",
+      "--home-dir",
+      homeDir,
+      "--substrate",
+      "pi-dev",
+      "--source",
+      "pai-tool",
+      "--kind",
+      "learning.signal",
+      "--summary",
+      "GetCounts appended a rating signal.",
+      "--artifact-path",
+      "memory/LEARNING/SIGNALS/ratings.jsonl",
+    ]);
+
+    expect(output).toContain("Soma result capture");
+    expect(output).toContain("kind: learning.signal");
+    await expect(readFile(join(homeDir, ".soma/memory/STATE/events.jsonl"), "utf8")).resolves.toContain("learning.signal");
+  });
+});
+
+test("cli rejects malformed result search limits", async () => {
+  await expect(runSomaCli(["result", "search", "--query", "offer", "--limit", "2abc"])).rejects.toThrow(
+    "--limit must be a positive integer.",
+  );
+});
+
+test("cli does not expose result capture timestamp override", async () => {
+  await expect(
+    runSomaCli([
+      "result",
+      "capture",
+      "--substrate",
+      "codex",
+      "--source",
+      "assistant-final",
+      "--summary",
+      "OfferPitch produced a concise offer draft.",
+      "--timestamp",
+      "2026-01-01T00:00:00.000Z",
+    ]),
+  ).rejects.toThrow("Unknown option: --timestamp");
+});
+
 test("cli warns when explicit feedback excerpt storage is enabled", async () => {
   await withTempHome(async (homeDir) => {
     await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
@@ -6,11 +6,14 @@ import {
   appendSomaMemoryEvent,
   bootstrapSomaHome,
   captureSomaFeedback,
+  captureSomaResult,
   classifySomaFeedback,
   createAlgorithmRun,
   promoteAlgorithmRunMemory,
   searchSomaMemory,
+  searchSomaResults,
   somaMemoryEventsPath,
+  SOMA_RESULT_EVENT_KINDS,
   writeAlgorithmRun,
   type SomaMemoryEvent,
 } from "../src/index";
@@ -247,6 +250,201 @@ test("does not capture non-feedback prompts", async () => {
   });
 });
 
+test("captures Codex skill results as append-only result events without full output text", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const result = await captureSomaResult({
+      homeDir,
+      substrate: "codex",
+      source: "assistant-final",
+      summary: "OfferPitch produced an offer draft for the current task.",
+      skill: "OfferPitch",
+      sessionId: "codex-session-1",
+      artifactPaths: ["codex-sessions/session.jsonl"],
+    });
+
+    expect(result.event).toMatchObject({
+      substrate: "codex",
+      kind: "result.captured",
+      summary: "OfferPitch produced an offer draft for the current task.",
+      artifactPaths: ["codex-sessions/session.jsonl"],
+      metadata: {
+        skill: "OfferPitch",
+        sessionId: "codex-session-1",
+        source: "assistant-final",
+        promptStored: false,
+        resultStored: false,
+        resultKind: "skill-output",
+      },
+    });
+
+    const events = await readFile(somaMemoryEventsPath(somaHome), "utf8");
+    expect(events).toContain("OfferPitch produced an offer draft");
+    expect(events).not.toContain("Full generated pitch text");
+  });
+});
+
+test("captures Pi.dev typed learning result events", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    const result = await captureSomaResult({
+      homeDir,
+      substrate: "pi-dev",
+      source: "pai-tool",
+      kind: "learning.signal",
+      summary: "GetCounts appended a rating signal for the completed review.",
+      artifactPaths: ["memory/LEARNING/SIGNALS/ratings.jsonl"],
+    });
+
+    expect(result.event).toMatchObject({
+      substrate: "pi-dev",
+      kind: "learning.signal",
+      artifactPaths: ["memory/LEARNING/SIGNALS/ratings.jsonl"],
+      metadata: {
+        source: "pai-tool",
+        promptStored: false,
+        resultStored: false,
+      },
+    });
+  });
+});
+
+test("rejects full-result shaped capture summaries", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+
+    await expect(
+      captureSomaResult({
+        homeDir,
+        substrate: "codex",
+        source: "assistant-final",
+        summary: `Short heading\nFull generated result body follows.`,
+      }),
+    ).rejects.toThrow("summary must be a single line");
+    await expect(
+      captureSomaResult({
+        homeDir,
+        substrate: "codex",
+        source: "assistant-final",
+        summary: "x".repeat(501),
+      }),
+    ).rejects.toThrow("500 characters or fewer");
+  });
+});
+
+test("searches captured result events with event and artifact provenance", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const capture = await captureSomaResult({
+      homeDir,
+      substrate: "codex",
+      source: "assistant-final",
+      summary: "CourseBuilder produced a backward design outline for crisis training.",
+      skill: "CourseBuilder",
+      artifactPaths: ["codex-sessions/coursebuilder.jsonl"],
+    });
+
+    const result = await searchSomaResults({
+      homeDir,
+      query: "CourseBuilder crisis training",
+    });
+
+    expect(result.matches[0]).toMatchObject({
+      eventPath: somaMemoryEventsPath(somaHome),
+      line: 1,
+      eventId: capture.event.id,
+      kind: "result.captured",
+      artifactPaths: ["codex-sessions/coursebuilder.jsonl"],
+    });
+  });
+});
+
+test("result search skips malformed result-shaped events", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    await appendFile(
+      somaMemoryEventsPath(somaHome),
+      [
+        JSON.stringify({ id: "bad-summary", kind: "result.captured", artifactPaths: ["bad.jsonl"] }),
+        JSON.stringify({ kind: "result.captured", summary: "AI missing id" }),
+        JSON.stringify({ id: "bad-artifacts", kind: "result.captured", summary: "AI malformed", artifactPaths: "bad.jsonl" }),
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await searchSomaResults({ homeDir, query: "AI malformed" });
+
+    expect(result.matches).toEqual([
+      expect.objectContaining({
+        eventId: "bad-artifacts",
+        summary: "AI malformed",
+        artifactPaths: [],
+      }),
+    ]);
+  });
+});
+
+test("searches short result queries such as AI and Pi", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    await captureSomaResult({
+      homeDir,
+      substrate: "pi-dev",
+      source: "pai-tool",
+      summary: "Pi tool produced an AI signal.",
+    });
+
+    await expect(searchSomaResults({ homeDir, query: "AI" })).resolves.toMatchObject({
+      matches: [expect.objectContaining({ summary: "Pi tool produced an AI signal." })],
+    });
+    await expect(searchSomaResults({ homeDir, query: "Pi" })).resolves.toMatchObject({
+      matches: [expect.objectContaining({ summary: "Pi tool produced an AI signal." })],
+    });
+  });
+});
+
+test("rejects invalid result search limits at the API boundary", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+
+    await expect(searchSomaResults({ homeDir, query: "AI", limit: 0 })).rejects.toThrow("positive safe integer");
+    await expect(searchSomaResults({ homeDir, query: "AI", limit: -1 })).rejects.toThrow("positive safe integer");
+    await expect(searchSomaResults({ homeDir, query: "AI", limit: 1.5 })).rejects.toThrow("positive safe integer");
+  });
+});
+
+test("caps large result search limits at the API boundary", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    for (let index = 0; index < 105; index += 1) {
+      await captureSomaResult({
+        homeDir,
+        substrate: "codex",
+        source: "test",
+        summary: `Repeated result ${index}`,
+      });
+    }
+
+    const result = await searchSomaResults({ homeDir, query: "repeated", limit: 1000 });
+
+    expect(result.matches).toHaveLength(100);
+  });
+});
+
+test("defines migrated PAI tool event vocabulary", () => {
+  expect(SOMA_RESULT_EVENT_KINDS).toEqual([
+    "result.captured",
+    "learning.signal",
+    "learning.pattern",
+    "learning.failure",
+    "wisdom.frame-update",
+    "wisdom.cross-frame",
+    "relationship.reflection",
+    "opinion.tracked",
+  ]);
+});
+
 test("searches Soma memory and profile files with cited snippets", async () => {
   await withTempHome(async (homeDir) => {
     const { somaHome } = await bootstrapSomaHome({ homeDir });
@@ -269,6 +467,23 @@ test("searches Soma memory and profile files with cited snippets", async () => {
     });
     expect(result.matches[0]?.path).toEndWith("memory/KNOWLEDGE/consulting/autonomy.md");
     expect(result.matches[0]?.snippet).toContain("Client sovereignty");
+  });
+});
+
+test("searches migrated PAI artifact roots without exposing root constants", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    await mkdir(join(somaHome, "memory/WISDOM/FRAMES"), { recursive: true });
+    await mkdir(join(somaHome, "identity"), { recursive: true });
+    await writeFile(join(somaHome, "memory/WISDOM/FRAMES/frame.md"), "Crystal clarity connects cross-frame synthesis.\n", "utf8");
+    await writeFile(join(somaHome, "identity/opinions.md"), "Opinion confidence favors explicit provenance.\n", "utf8");
+
+    await expect(searchSomaMemory({ homeDir, query: "crystal synthesis" })).resolves.toMatchObject({
+      matches: [expect.objectContaining({ snippet: expect.stringContaining("Crystal clarity") })],
+    });
+    await expect(searchSomaMemory({ homeDir, query: "opinion provenance" })).resolves.toMatchObject({
+      matches: [expect.objectContaining({ snippet: expect.stringContaining("Opinion confidence") })],
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- adds typed result capture through STATE/events.jsonl with result.captured plus migrated PAI tool event kinds
- adds soma result capture/search CLI surfaces with event id, event path/line, and artifact provenance
- expands memory search roots for migrated tool artifacts and documents feedback/result/promotion boundaries

## Acceptance Criteria
- [x] Add a result.captured event kind or equivalent typed result-capture API.
- [x] Add CLI support for capturing a result with substrate, source, summary, optional skill id, optional session id, kind, and artifact paths.
- [x] Captured results append to ~/.soma/memory/STATE/events.jsonl through the existing writeback path.
- [x] soma result search can find captured result summaries from another substrate.
- [x] Search output includes cited event path/line or event id plus artifact path provenance.
- [x] Default capture does not store full prompts or full generated result text.
- [x] Tests cover Codex and Pi.dev-style result capture inputs.
- [x] Docs update docs/memory-policy-v0.md and docs/writeback-and-policy.md to distinguish feedback capture, result capture, promotion, and later consolidation.
- [x] Define event kind vocabulary for migrated PAI tool outputs.
- [x] Verify existing search roots cover all shared memory paths where migrated tools write artifacts.

## Verification
- bun run typecheck
- bun test test/memory.test.ts test/cli.test.ts
- bun test
- bunx eslint src/result-capture.ts

Note: full bun run lint still reports pre-existing failures outside this change; the new result-capture module linted cleanly.

Closes #122