### PR TITLE
Fix Claude skill dependency gap reporting

### DIFF
--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -58,6 +58,7 @@ import { runBoundedConcurrent } from "./internal-concurrency";
 import { verifySubstrateProjection } from "./claude-skills-substrate-verify";
 import type {
   ClaudeSkillAuditEntry,
+  ClaudeSkillDependency,
   ClaudeSkillDescriptionRewrite,
   ClaudeSkillOutcome,
   ClaudeSkillPortabilityTag,
@@ -148,6 +149,9 @@ function buildSomaSkillFromPayload(
 // refusing the skill. Every OTHER symlink still refuses loud.
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+function sourceSkillKebabName(sourceName: string): string {
+  return kebabSlug(sourceName);
 }
 const EDITOR_CONFIG_SYMLINK_PATTERNS: { pattern: RegExp; dir: string }[] = EDITOR_CONFIG_DIRS.map((dir) => ({
   pattern: new RegExp(`(?:^|/)${escapeRegex(dir)}/`),
@@ -596,6 +600,42 @@ export function classifySkillPortability(files: readonly SkillFilePayload[]): Cl
   return { tag: "portable", reason: "clean" };
 }
 
+const CLAUDE_SKILL_DEP_RE = /~\/\.claude\/skills\/([^/\s`"'()<>\[\]{}]+)(?:\/([^\s`"'()<>\[\]{}]+))?/g;
+const DEPENDENCY_SCAN_EXTENSIONS = /\.(md|markdown|mdx|txt|json|yaml|yml|ts|js|tsx|jsx|mjs|cjs|py|rb|sh|bash|zsh|toml|hbs|handlebars|tmpl|tpl|xml|html|css)$/i;
+
+function isDependencyScannableFile(file: SkillFilePayload): boolean {
+  return DEPENDENCY_SCAN_EXTENSIONS.test(file.relPath) && file.content.byteLength <= 1024 * 1024;
+}
+
+function scanSkillDependencies(files: readonly SkillFilePayload[]): ClaudeSkillDependency[] {
+  const bySkill = new Map<string, { references: Set<string>; sourceFiles: Set<string> }>();
+  for (const file of files) {
+    if (!isDependencyScannableFile(file)) continue;
+    const text = file.content.toString("utf8");
+    CLAUDE_SKILL_DEP_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = CLAUDE_SKILL_DEP_RE.exec(text)) !== null) {
+      const skill = sourceSkillKebabName(match[1]);
+      const reference = (match[2] ?? "").replace(/[.,;:!?]+$/g, "") || "(root)";
+      let entry = bySkill.get(skill);
+      if (!entry) {
+        entry = { references: new Set<string>(), sourceFiles: new Set<string>() };
+        bySkill.set(skill, entry);
+      }
+      entry.references.add(reference);
+      entry.sourceFiles.add(file.relPath);
+      if (CLAUDE_SKILL_DEP_RE.lastIndex === match.index) CLAUDE_SKILL_DEP_RE.lastIndex += 1;
+    }
+  }
+  return [...bySkill.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([skill, entry]) => ({
+      skill,
+      references: [...entry.references].sort(),
+      sourceFiles: [...entry.sourceFiles].sort(),
+    }));
+}
+
 // Test-only: lower-level signal accessors. Exported so the unit
 // tests can target the regex layer without rebuilding payload
 // objects. The CLI-facing classifier above is the canonical entry.
@@ -625,6 +665,7 @@ interface SourceSkillReadResult {
   // status is `missing` (no source bytes to hash). Idempotency
   // anchor for the rewrite path.
   originalDescriptionSha: string;
+  dependencies: ClaudeSkillDependency[];
 }
 
 async function readSourceSkill(
@@ -682,13 +723,14 @@ async function readSourceSkill(
     : sha256Utf8(originalDescription);
   return {
     sourceName,
-    kebabName: kebabSlug(sourceName),
+    kebabName: sourceSkillKebabName(sourceName),
     files,
     sourceSha: sha256Hex(Buffer.from(composite, "utf8")),
     audit,
     descriptionStatus,
     originalDescription: originalDescription ?? "",
     originalDescriptionSha,
+    dependencies: scanSkillDependencies(files),
   };
 }
 
@@ -871,7 +913,7 @@ async function buildPlanCore(
       // anchors only land for successfully-read skills).
       outcomes.push({
         sourceName: r.sourceName,
-        kebabName: kebabSlug(r.sourceName),
+        kebabName: sourceSkillKebabName(r.sourceName),
         tag: "portable",
         reason: r.reason,
         disposition: "refused-other",
@@ -917,6 +959,7 @@ async function buildPlanCore(
       // each pending write up-front.
       fileCount: read.files.length,
       ...(read.audit.length > 0 ? { audit: read.audit } : {}),
+      ...(read.dependencies.length > 0 ? { dependencies: read.dependencies } : {}),
       // #120 — every successfully-read skill carries a description
       // status so the portability report can show the original
       // length even when no rewrite was requested.
@@ -932,6 +975,34 @@ async function buildPlanCore(
   progress.endConcurrentPhase("read + classify", Date.now() - concurrentStart);
 
   return { isFlatSkillsTree: true, outcomes, reads };
+}
+
+function applyDependencyWarnings(outcomes: ClaudeSkillOutcome[]): void {
+  const dispositionBySkill = new Map(outcomes.map((o) => [o.kebabName, o.disposition]));
+  for (const outcome of outcomes) {
+    if (!outcome.dependencies || outcome.dependencies.length === 0) {
+      outcome.dependencyMissing = undefined;
+      continue;
+    }
+    const missing = new Set<string>();
+    for (const dependency of outcome.dependencies) {
+      if (dependency.skill === outcome.kebabName) continue;
+      const disposition = dispositionBySkill.get(dependency.skill);
+      if (
+        disposition === undefined ||
+        disposition === "skipped-claude-specific" ||
+        disposition === "refused-other" ||
+        disposition === "refused-description-limit"
+      ) {
+        missing.add(dependency.skill);
+      }
+    }
+    if (missing.size > 0) {
+      outcome.dependencyMissing = [...missing].sort();
+    } else {
+      outcome.dependencyMissing = undefined;
+    }
+  }
 }
 
 export async function planClaudeSkillsMigration(
@@ -969,6 +1040,7 @@ export async function planClaudeSkillsMigration(
     outcomes,
     rewriteDescriptionsAgent,
   });
+  applyDependencyWarnings(outcomes);
   return {
     apply: false,
     from,
@@ -1279,7 +1351,7 @@ function renderPortabilityReport(
   // `--rewrite-descriptions` was used. Without the flag the table
   // shape is byte-stable for principals who haven't opted in.
   const includeRewriteColumns = result.rewriteDescriptionsAgent !== "none";
-  const headerCells = ["Skill", "Tag", "Disposition", "Reason"];
+  const headerCells = ["Skill", "Tag", "Disposition", "Reason", "Dependencies"];
   if (includeRewriteColumns) {
     headerCells.push("Description");
     headerCells.push("Rewrite");
@@ -1294,7 +1366,7 @@ function renderPortabilityReport(
     // non-refusal dispositions surface the classifier `reason`.
     // Centralized in `resolveOutcomeReason` (Holly r1 S1).
     const reasonCell = escapeMarkdownCell(resolveOutcomeReason(o));
-    const row = [o.kebabName, o.tag, o.disposition, reasonCell];
+    const row = [o.kebabName, o.tag, o.disposition, reasonCell, renderDependenciesCell(o)];
     if (includeRewriteColumns) {
       row.push(renderDescriptionCell(o));
       row.push(renderRewriteCell(o));
@@ -1338,6 +1410,11 @@ function renderPortabilityReport(
     // can find it. Also documented in `src/types.ts`.
     lines.push("Audit kind: `followed-user-owned-symlink` (one entry per resolved symlink in the manifest).");
   }
+  const missingDependencyCount = countOutcomesWithMissingDependencies(result.outcomes);
+  if (missingDependencyCount > 0) {
+    lines.push("");
+    lines.push(`${missingDependencyCount} skill(s) depend on skipped/refused skills — see report for details.`);
+  }
   lines.push("");
   return lines.join("\n");
 }
@@ -1356,6 +1433,23 @@ function renderSubstrateCell(verify: ClaudeSkillSubstrateVerifyResult): string {
   // manifest (`substrates[].issues`) for audit.
   const trimmed = escapeMarkdownCell(verify.reason).slice(0, 120);
   return `${verify.status}: ${trimmed}`;
+}
+
+function renderDependenciesCell(outcome: ClaudeSkillOutcome): string {
+  if (!outcome.dependencies || outcome.dependencies.length === 0) return "—";
+  const missing = new Set(outcome.dependencyMissing ?? []);
+  return outcome.dependencies
+    .map((dep) => {
+      const refs = dep.references.join(", ");
+      const suffix = missing.has(dep.skill) ? " missing" : "";
+      return `${dep.skill} (${refs})${suffix}`;
+    })
+    .map(escapeMarkdownCell)
+    .join("<br>");
+}
+
+export function countOutcomesWithMissingDependencies(outcomes: readonly ClaudeSkillOutcome[]): number {
+  return outcomes.filter((outcome) => (outcome.dependencyMissing?.length ?? 0) > 0).length;
 }
 
 // #120 — Description column. Shows `<orig>→<rewrite>` when a rewrite
@@ -1609,6 +1703,7 @@ export async function migrateClaudeSkills(
     outcomes,
     rewriteDescriptionsAgent,
   });
+  applyDependencyWarnings(outcomes);
 
   // Apply phase: walk the outcome list, write payloads for imported
   // skills, carry prior manifest entries for `skipped-idempotent`.

--- a/src/claude-skills-substrate-verify.ts
+++ b/src/claude-skills-substrate-verify.ts
@@ -252,6 +252,40 @@ export function verifySubstrateProjection(
     }
   }
 
+  // #126: executable TypeScript helpers under Tools/ are part of
+  // the skill's runtime surface. The smoke verifier does not execute
+  // them, but it must prove that projection kept the file and that
+  // the projected payload is non-empty.
+  const projectedToolByRelPath = new Map<string, ProjectedFile>();
+  for (const file of projected) {
+    const match = /(?:^|\/)(Tools\/.*\.ts)$/i.exec(file.path);
+    if (match) projectedToolByRelPath.set(match[1], file);
+  }
+  for (const file of skill.files ?? []) {
+    if (!/^Tools\/.*\.ts$/i.test(file.path)) continue;
+    const projectedTool = projectedToolByRelPath.get(file.path);
+    const expected = substrate === "codex"
+      ? `skills/${skill.name}/${file.path}`
+      : `agent/skills/<skill-id>/${file.path}`;
+    if (!projectedTool) {
+      issues.push({
+        kind: "unresolved-tool-path",
+        severity: "warning",
+        message: `${expected} is missing from ${substrate} projection`,
+        file: expected,
+      });
+      continue;
+    }
+    if (Buffer.byteLength(projectedTool.content, "utf8") === 0) {
+      issues.push({
+        kind: "unresolved-tool-path",
+        severity: "warning",
+        message: `${expected} is empty in ${substrate} projection`,
+        file: expected,
+      });
+    }
+  }
+
   // Step 4: SKILL.md frontmatter parsability + metadata.
   const skillMd = findSkillMd(projected);
   let fm: FrontmatterFields | undefined;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,6 +106,7 @@ import { ISA_SUBCOMMAND_HELP, ISA_USAGE_HEADER, runIsaCli } from "./cli-isa";
 // migrator's public boundary is not yet stable; CLI imports
 // directly).
 import {
+  countOutcomesWithMissingDependencies,
   migrateClaudeSkills,
   planClaudeSkillsMigration,
   readClaudeSkillsMigrationStatus,
@@ -2571,6 +2572,7 @@ function formatClaudeSkillsMigrationPlan(plan: ClaudeSkillsMigrationPlan): strin
       `${counts.refusedDescriptionLimit} skill(s) refused-description-limit — re-run with --rewrite-descriptions claude (or codex/pi) to compress oversize descriptions via LLM.`,
     );
   }
+  appendMissingDependencyFooter(lines, plan.outcomes);
   lines.push("");
   return lines.join("\n");
 }
@@ -2625,6 +2627,7 @@ function formatClaudeSkillsMigrationResult(result: ClaudeSkillsMigrationResult):
       `${result.refusedDescriptionLimitCount} skill(s) refused-description-limit — re-run with --rewrite-descriptions claude (or codex/pi) to compress oversize descriptions via LLM.`,
     );
   }
+  appendMissingDependencyFooter(lines, result.outcomes);
   // #125 — Timing block. Appended to the standard summary so script
   // parsers that anchor on `Totals: ` keep working; the new block
   // lives BELOW the totals and rerun-suggestion lines. Renders even
@@ -2642,6 +2645,17 @@ function formatClaudeSkillsMigrationResult(result: ClaudeSkillsMigrationResult):
   }
   lines.push("");
   return lines.join("\n");
+}
+
+function appendMissingDependencyFooter(
+  lines: string[],
+  outcomes: readonly ClaudeSkillOutcome[],
+): void {
+  const missingDependencyCount = countOutcomesWithMissingDependencies(outcomes);
+  if (missingDependencyCount === 0) return;
+  lines.push(
+    `${missingDependencyCount} skill(s) depend on skipped/refused skills — see report for details.`,
+  );
 }
 
 function formatClaudeSkillsMigrationStatus(

--- a/src/types.ts
+++ b/src/types.ts
@@ -877,6 +877,7 @@ export interface ClaudeSkillSubstrateVerifyIssue {
     | "missing-description"
     | "description-mismatch"
     | "dangling-internal-ref"
+    | "unresolved-tool-path"
     | "substrate-only-primitive"
     | "empty-projection"
     | "oversized-projection"
@@ -1084,6 +1085,28 @@ export interface ClaudeSkillOutcome {
    * no rewrite was attempted.
    */
   descriptionRewrite?: ClaudeSkillDescriptionRewrite;
+  /**
+   * #126 — one-hop cross-skill code/documentation dependencies found
+   * while scanning source payloads for `~/.claude/skills/<Other>/...`
+   * references. `skill` is the kebab-cased referenced skill name;
+   * `references` are the relative paths inside that referenced skill
+   * (for example `Tools/ComposeAgent.ts`); `sourceFiles` are the
+   * current skill files that mention the dependency.
+   */
+  dependencies?: ClaudeSkillDependency[];
+  /**
+   * #126 — referenced skills whose own migration outcome means they
+   * will not be available in the projected skill tree. The dependent
+   * skill still imports, but reports and CLI output surface this
+   * loudly so the principal does not discover it at runtime.
+   */
+  dependencyMissing?: string[];
+}
+
+export interface ClaudeSkillDependency {
+  skill: string;
+  references: string[];
+  sourceFiles: string[];
 }
 
 /**

--- a/test/claude-skills-migrator-smoke.test.ts
+++ b/test/claude-skills-migrator-smoke.test.ts
@@ -119,6 +119,59 @@ test("--smoke codex --smoke pi-dev: both substrates populated", async () => {
   });
 });
 
+test("--smoke codex --smoke pi-dev verifies Tools/*.ts files project non-empty", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    await writeSkillsFixture(fromDir, [
+      {
+        name: "ToolRunner",
+        skillMd: PORTABLE_SKILL_MD.replace("Portable", "ToolRunner"),
+        extras: [
+          { relPath: "Tools/Run.ts", content: "export const run = () => 'ok';\n" },
+        ],
+      },
+    ]);
+    const somaHome = join(home, "soma");
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      smokeSubstrates: ["codex", "pi-dev"],
+    });
+
+    const landedTool = await readFile(join(somaHome, "skills/tool-runner/Tools/Run.ts"), "utf8");
+    expect(landedTool).toContain("export const run");
+    const toolRunner = result.outcomes.find((o) => o.kebabName === "tool-runner");
+    expect(toolRunner?.substrates?.codex?.status).toBe("verified");
+    expect(toolRunner?.substrates?.["pi-dev"]?.status).toBe("verified");
+    expect(toolRunner?.substrates?.codex?.issues.some((issue) => issue.kind === "unresolved-tool-path")).toBe(false);
+    expect(toolRunner?.substrates?.["pi-dev"]?.issues.some((issue) => issue.kind === "unresolved-tool-path")).toBe(false);
+  });
+});
+
+test("--smoke codex surfaces empty Tools/*.ts as unresolved-tool-path warning", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    await writeSkillsFixture(fromDir, [
+      {
+        name: "EmptyTool",
+        skillMd: PORTABLE_SKILL_MD.replace("Portable", "EmptyTool"),
+        extras: [
+          { relPath: "Tools/Empty.ts", content: "" },
+        ],
+      },
+    ]);
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome: join(home, "soma"),
+      smokeSubstrates: ["codex"],
+    });
+
+    const emptyTool = result.outcomes.find((o) => o.kebabName === "empty-tool");
+    expect(emptyTool?.substrates?.codex?.status).toBe("verified-with-warnings");
+    expect(emptyTool?.substrates?.codex?.issues.some((issue) => issue.kind === "unresolved-tool-path")).toBe(true);
+  });
+});
+
 test("--smoke <substrate>: codex-incompatible skill (hook binding under include-claude-specific) → failed", async () => {
   await withTempHome(async (home) => {
     const fromDir = join(home, "skills");
@@ -215,11 +268,11 @@ test("report contains substrate columns when --smoke given, absent without", asy
     });
     const reportWithSmoke = await readFile(reportPath, "utf8");
     expect(reportWithSmoke).toContain("Smoke substrates: codex, pi-dev");
-    expect(reportWithSmoke).toContain("| Skill | Tag | Disposition | Reason | codex | pi-dev |");
+    expect(reportWithSmoke).toContain("| Skill | Tag | Disposition | Reason | Dependencies | codex | pi-dev |");
     // Verified outcome appears in both substrate cells. The second
     // run rendered the row as skipped-idempotent (same source SHA),
     // but the substrate cells should still carry the prior verdict.
-    expect(reportWithSmoke).toMatch(/\|\s*portable\s*\|\s*portable\s*\|\s*(imported|skipped-idempotent)\s*\|[^|]+\|\s*verified\s*\|\s*verified\s*\|/);
+    expect(reportWithSmoke).toMatch(/\|\s*portable\s*\|\s*portable\s*\|\s*(imported|skipped-idempotent)\s*\|[^|]+\|\s*[^|]+\|\s*verified\s*\|\s*verified\s*\|/);
   });
 });
 

--- a/test/claude-skills-migrator.test.ts
+++ b/test/claude-skills-migrator.test.ts
@@ -360,6 +360,68 @@ test("migrateClaudeSkills writes payload + manifest + portability report", async
   });
 });
 
+test("migrateClaudeSkills records cross-skill dependencies and warns when dependency is skipped", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const somaHome = join(home, "soma");
+    await writeFlatSkillsFixture(fromDir, {
+      Council: {
+        skillMd: [
+          "# Council",
+          "",
+          "Run `bun run ~/.claude/skills/Agents/Tools/ComposeAgent.ts` before debate.",
+        ].join("\n"),
+      },
+      Agents: {
+        skillMd: [
+          "# Agents",
+          "",
+          "Use /plan before composing an agent.",
+        ].join("\n"),
+        extra: [
+          { relPath: "Tools/ComposeAgent.ts", content: "export const compose = true;\n" },
+        ],
+      },
+    });
+
+    const result = await migrateClaudeSkills({ from: fromDir, somaHome });
+    const council = result.outcomes.find((o) => o.kebabName === "council");
+    expect(council?.dependencies).toEqual([
+      {
+        skill: "agents",
+        references: ["Tools/ComposeAgent.ts"],
+        sourceFiles: ["SKILL.md"],
+      },
+    ]);
+    expect(council?.dependencyMissing).toEqual(["agents"]);
+    expect(council?.disposition).toBe("imported");
+
+    const report = await readFile(result.reportPath, "utf8");
+    expect(report).toContain("| Skill | Tag | Disposition | Reason | Dependencies |");
+    expect(report).toContain("agents (Tools/ComposeAgent.ts) missing");
+    expect(report).toContain("1 skill(s) depend on skipped/refused skills");
+  });
+});
+
+test("migrateClaudeSkills dependency names use source skill kebab normalization", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    await writeFlatSkillsFixture(fromDir, {
+      Referrer: {
+        skillMd: "See ~/.claude/skills/MySkill/Tools/x.ts for setup.\n",
+      },
+      MySkill: {
+        skillMd: "# MySkill\n\nportable dependency.\n",
+      },
+    });
+
+    const result = await migrateClaudeSkills({ from: fromDir, somaHome: join(home, "soma") });
+    const referrer = result.outcomes.find((o) => o.kebabName === "referrer");
+    expect(referrer?.dependencies?.[0]?.skill).toBe("my-skill");
+    expect(referrer?.dependencyMissing).toBeUndefined();
+  });
+});
+
 test("migrateClaudeSkills --include-claude-specific lands the skipped set", async () => {
   await withTempHome(async (home) => {
     const fromDir = join(home, "skills");
@@ -1241,4 +1303,3 @@ test("LLM returns >1024 twice → refuses with refused-other and surfaces the li
     expect(outcome?.refusalReason ?? "").toMatch(/1024|cap|limit/);
   });
 });
-


### PR DESCRIPTION
## Summary
- detect one-hop ~/.claude/skills/<Other>/... references during claude-skills migration and attach dependency metadata to outcomes
- surface skipped/refused dependency gaps in the portability report and CLI footer
- verify projected Tools/*.ts payloads during --smoke for Codex and Pi.dev, reporting unresolved-tool-path warnings for missing or empty files

## Verification
- bun test test/claude-skills-migrator.test.ts
- bun test test/claude-skills-migrator-smoke.test.ts
- bun test test/cli-migrate-claude-skills.test.ts
- bun run typecheck
- bun test

Fixes #126