### PR TITLE
Add shared Soma path resolver

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ export type {
   Projection,
   ProjectionInput,
   SomaMemoryLayout,
+  SomaPaths,
   SomaProfile,
   SomaRunResult,
   SomaSkill,
@@ -170,6 +171,7 @@ export {
 // runtime shape in the follow-up PR. Tests can import the helpers
 // directly from the substrate path.
 export { writeProjection } from "./projection";
+export { createPaths, type SomaPathsOptions } from "./paths";
 export {
   buildClaudeCodeHomeProjection,
   buildCodexHomeProjection,

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -1,6 +1,6 @@
 import { mkdir, appendFile, readFile, readdir, stat } from "node:fs/promises";
-import { homedir } from "node:os";
-import { basename, dirname, extname, join, resolve } from "node:path";
+import { basename, dirname, extname, join } from "node:path";
+import { createPaths } from "./paths";
 import type {
   SomaMemoryEvent,
   SomaMemoryEventInput,
@@ -46,7 +46,7 @@ export async function appendSomaMemoryEvent(somaHome: string, input: SomaMemoryE
     artifactPaths: input.artifactPaths,
     metadata: input.metadata,
   };
-  const eventPath = resolve(somaHome, "memory/STATE/events.jsonl");
+  const eventPath = createPaths(somaHome).events();
 
   await mkdir(dirname(eventPath), { recursive: true });
   await appendFile(eventPath, `${JSON.stringify(event)}\n`, "utf8");
@@ -55,11 +55,11 @@ export async function appendSomaMemoryEvent(somaHome: string, input: SomaMemoryE
 }
 
 export function somaMemoryEventsPath(somaHome: string): string {
-  return join(somaHome, "memory/STATE/events.jsonl");
+  return createPaths(somaHome).events();
 }
 
 function resolveSomaHome(options: Pick<SomaMemorySearchOptions, "homeDir" | "somaHome"> = {}): string {
-  return resolve(options.somaHome ?? join(options.homeDir ?? homedir(), ".soma"));
+  return createPaths(options).root();
 }
 
 function queryTerms(query: string): string[] {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,0 +1,52 @@
+import { homedir } from "node:os";
+import { isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
+import type { SomaPaths } from "./types";
+
+export interface SomaPathsOptions {
+  homeDir?: string;
+  somaHome?: string;
+}
+
+function defaultSomaHome(options: SomaPathsOptions = {}): string {
+  return resolvePath(options.somaHome ?? join(options.homeDir ?? homedir(), ".soma"));
+}
+
+function assertInsideRoot(root: string, target: string): void {
+  const rel = relative(root, target);
+  if (rel === "" || (!rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel))) {
+    return;
+  }
+  throw new Error(`Soma path escapes root: ${target}`);
+}
+
+export function createPaths(optionsOrSomaHome: SomaPathsOptions | string = {}): SomaPaths {
+  const options = typeof optionsOrSomaHome === "string"
+    ? { somaHome: optionsOrSomaHome }
+    : optionsOrSomaHome;
+  const root = defaultSomaHome(options);
+
+  const underRoot = (...segments: string[]): string => {
+    const target = resolvePath(root, ...segments);
+    assertInsideRoot(root, target);
+    return target;
+  };
+
+  return {
+    root: () => root,
+    identity: () => underRoot("identity"),
+    memory: () => underRoot("memory"),
+    profile: () => underRoot("profile"),
+    skills: () => underRoot("skills"),
+    learning: () => underRoot("memory", "LEARNING"),
+    signals: () => underRoot("memory", "LEARNING", "SIGNALS"),
+    wisdom: () => underRoot("memory", "WISDOM"),
+    relationship: () => underRoot("memory", "RELATIONSHIP"),
+    state: () => underRoot("memory", "STATE"),
+    work: () => underRoot("memory", "WORK"),
+    ratings: () => underRoot("memory", "LEARNING", "SIGNALS", "ratings.jsonl"),
+    opinions: () => underRoot("identity", "opinions.md"),
+    story: () => underRoot("identity", "our-story.md"),
+    events: () => underRoot("memory", "STATE", "events.jsonl"),
+    resolve: (...segments: string[]) => underRoot(...segments),
+  };
+}

--- a/src/soma-home.ts
+++ b/src/soma-home.ts
@@ -1,7 +1,7 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { dirname, join, relative, resolve, sep } from "node:path";
+import { dirname, join, relative, sep } from "node:path";
 import { SOMA_MEMORY_CATEGORIES, SOMA_MEMORY_CATEGORY_READMES } from "./memory-readmes";
+import { createPaths } from "./paths";
 import type { ProjectionInput, SomaHomeBootstrapOptions, SomaHomeBootstrapResult, SomaSkill } from "./types";
 
 // #88 / DD-2: canonical PAI v5.0.0 memory taxonomy (17 substrate-neutral +
@@ -11,7 +11,7 @@ import type { ProjectionInput, SomaHomeBootstrapOptions, SomaHomeBootstrapResult
 const MEMORY_DIRS = SOMA_MEMORY_CATEGORIES;
 
 function resolveSomaHome(options: SomaHomeBootstrapOptions = {}): string {
-  return resolve(options.somaHome ?? join(resolve(options.homeDir ?? homedir()), ".soma"));
+  return createPaths(options).root();
 }
 
 function renderAssistantProfile(): string {
@@ -150,7 +150,8 @@ async function collectSkillFiles(root: string, current = root): Promise<{ path: 
 }
 
 async function loadSomaSkills(somaHome: string): Promise<SomaSkill[]> {
-  const skillsRoot = join(somaHome, "skills");
+  const paths = createPaths(somaHome);
+  const skillsRoot = paths.skills();
   const entries = await readdir(skillsRoot, { withFileTypes: true }).catch(() => []);
   const skills: SomaSkill[] = [];
 
@@ -179,10 +180,10 @@ async function loadSomaSkills(somaHome: string): Promise<SomaSkill[]> {
 }
 
 export async function loadSomaHome(somaHome: string): Promise<ProjectionInput> {
-  const assistant = await readFile(join(somaHome, "profile/assistant.md"), "utf8");
-  const principal = await readFile(join(somaHome, "profile/principal.md"), "utf8");
-  const telos = await readFile(join(somaHome, "profile/telos.md"), "utf8");
-  const memoryRoot = join(somaHome, "memory");
+  const paths = createPaths(somaHome);
+  const assistant = await readFile(paths.resolve("profile", "assistant.md"), "utf8");
+  const principal = await readFile(paths.resolve("profile", "principal.md"), "utf8");
+  const telos = await readFile(paths.resolve("profile", "telos.md"), "utf8");
   const skills = await loadSomaSkills(somaHome);
 
   return {
@@ -204,12 +205,12 @@ export async function loadSomaHome(somaHome: string): Promise<ProjectionInput> {
         commitments: sectionBullets(telos, "Commitments"),
       },
       memory: {
-        root: memoryRoot,
-        work: join(memoryRoot, "WORK"),
-        knowledge: join(memoryRoot, "KNOWLEDGE"),
-        learning: join(memoryRoot, "LEARNING"),
-        relationship: join(memoryRoot, "RELATIONSHIP"),
-        state: join(memoryRoot, "STATE"),
+        root: paths.memory(),
+        work: paths.work(),
+        knowledge: paths.resolve("memory", "KNOWLEDGE"),
+        learning: paths.learning(),
+        relationship: paths.relationship(),
+        state: paths.state(),
       },
       skills,
     },
@@ -218,6 +219,7 @@ export async function loadSomaHome(somaHome: string): Promise<ProjectionInput> {
 
 export async function bootstrapSomaHome(options: SomaHomeBootstrapOptions = {}): Promise<SomaHomeBootstrapResult> {
   const somaHome = resolveSomaHome(options);
+  const paths = createPaths(somaHome);
   const files = [
     {
       path: "profile/assistant.md",
@@ -258,11 +260,11 @@ export async function bootstrapSomaHome(options: SomaHomeBootstrapOptions = {}):
   // substrate provenance. README write uses `flag: "wx"` so principal edits
   // survive re-runs (idempotent contract — see test AC-3).
   for (const directory of MEMORY_DIRS) {
-    await mkdir(join(somaHome, "memory", directory), { recursive: true });
+    await mkdir(paths.resolve("memory", directory), { recursive: true });
   }
 
   for (const entry of SOMA_MEMORY_CATEGORY_READMES) {
-    const readmePath = join(somaHome, "memory", entry.category, "README.md");
+    const readmePath = paths.resolve("memory", entry.category, "README.md");
     // `flag: "wx"` makes README writes idempotent — principal edits survive
     // re-install (test AC-3). Sage R1: only record the path in `writtenFiles`
     // when the write actually happened, so callers don't see a skipped EEXIST

--- a/src/types.ts
+++ b/src/types.ts
@@ -206,6 +206,25 @@ export interface SomaMemoryLayout {
   state: string;
 }
 
+export interface SomaPaths {
+  root(): string;
+  identity(): string;
+  memory(): string;
+  profile(): string;
+  skills(): string;
+  learning(): string;
+  signals(): string;
+  wisdom(): string;
+  relationship(): string;
+  state(): string;
+  work(): string;
+  ratings(): string;
+  opinions(): string;
+  story(): string;
+  events(): string;
+  resolve(...segments: string[]): string;
+}
+
 export interface SomaProfile {
   assistant: AssistantIdentity;
   principal: PrincipalIdentity;

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -1,0 +1,62 @@
+import { join, resolve } from "node:path";
+import { expect, test } from "bun:test";
+import { createPaths, type SomaPaths } from "../src/index";
+
+test("createPaths defaults under a home directory", () => {
+  const homeDir = "/tmp/soma-paths-home";
+  const paths = createPaths({ homeDir });
+  const root = join(resolve(homeDir), ".soma");
+
+  expect(paths.root()).toBe(root);
+  expect(paths.memory()).toBe(join(root, "memory"));
+  expect(paths.skills()).toBe(join(root, "skills"));
+});
+
+test("createPaths accepts explicit somaHome and resolves core shared paths", () => {
+  const root = resolve("/tmp/custom-soma");
+  const paths = createPaths({ somaHome: root });
+
+  expect(paths.root()).toBe(root);
+  expect(paths.identity()).toBe(join(root, "identity"));
+  expect(paths.learning()).toBe(join(root, "memory", "LEARNING"));
+  expect(paths.signals()).toBe(join(root, "memory", "LEARNING", "SIGNALS"));
+  expect(paths.wisdom()).toBe(join(root, "memory", "WISDOM"));
+  expect(paths.relationship()).toBe(join(root, "memory", "RELATIONSHIP"));
+  expect(paths.state()).toBe(join(root, "memory", "STATE"));
+  expect(paths.work()).toBe(join(root, "memory", "WORK"));
+});
+
+test("createPaths resolves migrated tool files", () => {
+  const root = "/tmp/soma-tool-paths";
+  const paths = createPaths(root);
+
+  expect(paths.ratings()).toBe(`${root}/memory/LEARNING/SIGNALS/ratings.jsonl`);
+  expect(paths.opinions()).toBe(`${root}/identity/opinions.md`);
+  expect(paths.story()).toBe(`${root}/identity/our-story.md`);
+  expect(paths.events()).toBe(`${root}/memory/STATE/events.jsonl`);
+});
+
+test("generic resolver stays inside somaHome", () => {
+  const root = "/tmp/soma-resolve";
+  const paths = createPaths(root);
+
+  expect(paths.resolve("memory", "WISDOM", "FRAMES", "development.md")).toBe(
+    `${root}/memory/WISDOM/FRAMES/development.md`,
+  );
+  expect(() => paths.resolve("memory", "..", "..", "escape.md")).toThrow("escapes root");
+  expect(() => paths.resolve("/tmp/outside.md")).toThrow("escapes root");
+});
+
+test("path resolver does not vary by caller", () => {
+  const root = "/tmp/shared-soma";
+  const codexCaller = createPaths({ somaHome: root });
+  const piCaller = createPaths({ somaHome: root });
+
+  expect(codexCaller.ratings()).toBe(piCaller.ratings());
+  expect(codexCaller.root()).toBe(resolve(root));
+});
+
+test("SomaPaths type is importable by migrated tools", () => {
+  const paths: SomaPaths = createPaths("/tmp/soma-types");
+  expect(paths.ratings()).toContain("ratings.jsonl");
+});


### PR DESCRIPTION
## Summary
- add exported createPaths()/SomaPaths resolver rooted at the shared Soma home or explicit somaHome
- add helper paths for identity, memory categories, migrated tool files, and safe generic resolve(...segments)
- route soma-home and memory event path assembly through the shared resolver

Fixes #134.

## Verification
- rtk bun test test/paths.test.ts test/soma-home.test.ts test/memory.test.ts
- rtk bun run typecheck
- rtk bun test