### PR TITLE
Add Soma inference engine

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -133,6 +133,7 @@ import type {
 // keeps the constant a module-internal contract rather than promoting
 // importer policy through the package root surface.
 import { PAI_DOCS_IMPORT_SUBDIRS } from "./pai-docs-importer";
+import { runInferenceCli } from "./tools/inference/cli";
 
 /**
  * Typed CLI error carrying an exit code distinct from the default 1.
@@ -349,6 +350,11 @@ interface ParsedIsaArgs {
   args: string[];
 }
 
+interface ParsedInferenceArgs {
+  command: "inference";
+  args: string[];
+}
+
 type ParsedArgs =
   | ParsedHelpArgs
   | ParsedInstallArgs
@@ -367,7 +373,8 @@ type ParsedArgs =
   | ParsedFeedbackArgs
   | ParsedResultArgs
   | ParsedPolicyArgs
-  | ParsedIsaArgs;
+  | ParsedIsaArgs
+  | ParsedInferenceArgs;
 
 const TOP_LEVEL_COMMANDS = [
   "adopt",
@@ -376,6 +383,7 @@ const TOP_LEVEL_COMMANDS = [
   "export",
   "feedback",
   "import",
+  "inference",
   "install",
   "isa",
   "lifecycle",
@@ -432,6 +440,9 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
     subcommands: {
       capture: "Usage: soma feedback capture (--text <text> | --stdin) [--substrate <id>] [--source <source>] [--store-excerpt]",
     },
+  },
+  inference: {
+    usage: "Usage: soma inference [--level <fast|standard|smart>] [--mode <inference|advisor>] [--backend <auto|claude-code|anthropic-api>] [--allow-network] [--json] [--timeout <ms>] [--auto-state] [--home-dir <dir>] [--soma-home <dir>] [prompt...]",
   },
   result: {
     usage: "Usage: soma result <capture|search> ...",
@@ -1641,6 +1652,10 @@ function parseArgs(args: string[]): ParsedArgs {
 
   if (args[0] === "feedback") {
     return parseFeedbackArgs(args);
+  }
+
+  if (args[0] === "inference") {
+    return { command: "inference", args: args.slice(1) };
   }
 
   if (args[0] === "result") {
@@ -3280,6 +3295,10 @@ export async function runSomaCli(args: string[]): Promise<string> {
   if (parsed.command === "feedback") {
     const options = parsed.readTextFromStdin ? { ...parsed.options, text: readLimitedFeedbackStdin() } : parsed.options;
     return formatFeedbackCaptureResult(await captureSomaFeedback(options));
+  }
+
+  if (parsed.command === "inference") {
+    return runInferenceCli(parsed.args);
   }
 
   if (parsed.command === "result") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,20 @@ export {
 export { writeProjection } from "./projection";
 export { createPaths, type SomaPathsOptions } from "./paths";
 export {
+  advisor,
+  inference,
+  parseInferenceJson,
+  synthesizeAdvisorState,
+  type AdvisorStateOptions,
+  type InferenceBackend,
+  type InferenceBackendKind,
+  type InferenceLevel,
+  type InferenceMode,
+  type InferenceOptions,
+  type InferenceRequest,
+  type InferenceResult,
+} from "./tools/inference";
+export {
   buildClaudeCodeHomeProjection,
   buildCodexHomeProjection,
   buildPiDevHomeProjection,

--- a/src/tools/inference/backends/anthropic-api.ts
+++ b/src/tools/inference/backends/anthropic-api.ts
@@ -1,0 +1,63 @@
+import type { InferenceBackend, InferenceLevel, InferenceMode, InferenceRequest } from "../types";
+
+const ANTHROPIC_MODEL_BY_LEVEL: Record<InferenceLevel, string> = {
+  fast: "claude-3-5-haiku-20241022",
+  standard: "claude-sonnet-4-20250514",
+  smart: "claude-opus-4-1-20250805",
+};
+
+export interface AnthropicApiBackendOptions {
+  apiKey?: string;
+  fetch?: typeof fetch;
+}
+
+export class AnthropicApiBackend implements InferenceBackend {
+  readonly kind = "anthropic-api" as const;
+  private readonly apiKey?: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: AnthropicApiBackendOptions = {}) {
+    this.apiKey = options.apiKey ?? process.env.ANTHROPIC_API_KEY;
+    this.fetchImpl = options.fetch ?? fetch;
+  }
+
+  resolveModel(level: InferenceLevel, mode: InferenceMode): string {
+    return mode === "advisor" ? ANTHROPIC_MODEL_BY_LEVEL.smart : ANTHROPIC_MODEL_BY_LEVEL[level];
+  }
+
+  async invoke(prompt: string, request: InferenceRequest): Promise<string> {
+    if (!this.apiKey) {
+      throw new Error("Anthropic API backend requires ANTHROPIC_API_KEY.");
+    }
+
+    const response = await this.fetchImpl("https://api.anthropic.com/v1/messages", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": this.apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: this.resolveModel(request.level, request.mode),
+        max_tokens: 4096,
+        messages: [{ role: "user", content: prompt }],
+      }),
+      signal: AbortSignal.timeout(request.timeoutMs),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Anthropic API inference failed: ${response.status} ${await response.text()}`);
+    }
+
+    const payload = await response.json() as { content?: { type?: string; text?: string }[] };
+    return payload.content
+      ?.filter((item) => item.type === "text" && typeof item.text === "string")
+      .map((item) => item.text)
+      .join("\n")
+      .trim() ?? "";
+  }
+}
+
+export function createAnthropicApiBackend(options: AnthropicApiBackendOptions = {}): AnthropicApiBackend {
+  return new AnthropicApiBackend(options);
+}

--- a/src/tools/inference/backends/claude-code.ts
+++ b/src/tools/inference/backends/claude-code.ts
@@ -1,0 +1,136 @@
+import type { InferenceBackend, InferenceLevel, InferenceMode, InferenceRequest } from "../types";
+
+const CLAUDE_MODEL_BY_LEVEL: Record<InferenceLevel, string> = {
+  fast: "haiku",
+  standard: "sonnet",
+  smart: "opus",
+};
+
+const MAX_STDOUT_BYTES = 2 * 1024 * 1024;
+const MAX_STDERR_BYTES = 128 * 1024;
+
+const ALLOWED_ENV = new Set([
+  "PATH",
+  "HOME",
+  "SHELL",
+  "USER",
+  "LOGNAME",
+  "TMPDIR",
+  "TEMP",
+  "TMP",
+  "XDG_CONFIG_HOME",
+  "XDG_CACHE_HOME",
+  "XDG_STATE_HOME",
+  "CLAUDE_CONFIG_DIR",
+]);
+
+export interface ClaudeCodeBackendOptions {
+  binary?: string;
+  spawn?: typeof Bun.spawn;
+  env?: NodeJS.ProcessEnv;
+}
+
+function allowedSubprocessEnv(env: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => ALLOWED_ENV.has(key)),
+  ) as NodeJS.ProcessEnv;
+}
+
+function promptStream(prompt: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(prompt));
+      controller.close();
+    },
+  });
+}
+
+async function readStreamWithLimit(stream: ReadableStream<Uint8Array>, limit: number, label: string): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > limit) {
+        throw new Error(`claude inference ${label} exceeded ${limit} bytes.`);
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+export class ClaudeCodeBackend implements InferenceBackend {
+  readonly kind = "claude-code" as const;
+  private readonly binary: string;
+  private readonly spawn: typeof Bun.spawn;
+  private readonly env: NodeJS.ProcessEnv;
+
+  constructor(options: ClaudeCodeBackendOptions = {}) {
+    this.binary = options.binary ?? "claude";
+    this.spawn = options.spawn ?? Bun.spawn;
+    this.env = allowedSubprocessEnv(options.env);
+  }
+
+  resolveModel(level: InferenceLevel, mode: InferenceMode): string {
+    return mode === "advisor" ? CLAUDE_MODEL_BY_LEVEL.smart : CLAUDE_MODEL_BY_LEVEL[level];
+  }
+
+  async invoke(prompt: string, request: InferenceRequest): Promise<string> {
+    const model = this.resolveModel(request.level, request.mode);
+    const proc = this.spawn([
+      this.binary,
+      "-p",
+      "--model",
+      model,
+      "--allowedTools",
+      "",
+      "--hookTimeout",
+      "1",
+    ], {
+      stdin: promptStream(prompt),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: this.env,
+    });
+
+    const killTimer = setTimeout(() => {
+      proc.kill();
+    }, request.timeoutMs);
+
+    try {
+      const stdoutText = readStreamWithLimit(proc.stdout, MAX_STDOUT_BYTES, "stdout").catch((error: unknown) => {
+        proc.kill();
+        throw error;
+      });
+      const stderrText = readStreamWithLimit(proc.stderr, MAX_STDERR_BYTES, "stderr").catch((error: unknown) => {
+        proc.kill();
+        throw error;
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        stdoutText,
+        stderrText,
+        proc.exited,
+      ]);
+
+      if (exitCode !== 0) {
+        throw new Error(`claude inference exited ${exitCode}: ${stderr.slice(-512).trim()}`);
+      }
+
+      return stdout.trim();
+    } finally {
+      clearTimeout(killTimer);
+    }
+  }
+}
+
+export function createClaudeCodeBackend(options: ClaudeCodeBackendOptions = {}): ClaudeCodeBackend {
+  return new ClaudeCodeBackend(options);
+}

--- a/src/tools/inference/cli.ts
+++ b/src/tools/inference/cli.ts
@@ -1,0 +1,161 @@
+import { advisor, inference } from "./index";
+import { createAutoInferenceBackend } from "./factory";
+import { createAnthropicApiBackend } from "./backends/anthropic-api";
+import { createClaudeCodeBackend } from "./backends/claude-code";
+import type { InferenceBackend, InferenceLevel, InferenceMode, InferenceOptions } from "./types";
+
+type InferenceCliBackendKind = "auto" | "claude-code" | "anthropic-api";
+
+export interface InferenceCliOptions extends InferenceOptions {
+  prompt?: string;
+  autoState?: boolean;
+  allowNetwork?: boolean;
+  backendKind?: InferenceCliBackendKind;
+}
+
+export interface InferenceCliDeps {
+  backend?: InferenceBackend;
+  readStdin?: () => string | Promise<string>;
+}
+
+const LEVELS = new Set(["fast", "standard", "smart"]);
+
+function parseLevel(value: string): InferenceLevel {
+  if (LEVELS.has(value)) {
+    return value as InferenceLevel;
+  }
+  throw new Error("--level must be one of fast, standard, or smart.");
+}
+
+function parseMode(value: string): InferenceMode {
+  if (value === "advisor") {
+    return "advisor";
+  }
+  if (value === "inference") {
+    return "inference";
+  }
+  throw new Error("--mode must be one of inference or advisor.");
+}
+
+function parseBackend(value: string): InferenceCliBackendKind {
+  if (value === "auto" || value === "claude-code" || value === "anthropic-api") {
+    return value;
+  }
+  throw new Error("--backend must be one of auto, claude-code, or anthropic-api.");
+}
+
+function readOption(args: string[], index: number, name: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value.`);
+  }
+  return value;
+}
+
+export function parseInferenceCliArgs(args: string[]): InferenceCliOptions {
+  const options: InferenceCliOptions = {};
+  const promptParts: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--level":
+        options.level = parseLevel(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--mode":
+        options.mode = parseMode(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--json":
+        options.json = true;
+        break;
+      case "--timeout":
+        options.timeoutMs = Number(readOption(args, index, arg));
+        if (!Number.isInteger(options.timeoutMs) || options.timeoutMs <= 0) {
+          throw new Error("--timeout must be a positive integer number of milliseconds.");
+        }
+        index += 1;
+        break;
+      case "--home-dir":
+        options.homeDir = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--auto-state":
+        options.autoState = true;
+        break;
+      case "--allow-network":
+        options.allowNetwork = true;
+        break;
+      case "--backend":
+        options.backendKind = parseBackend(readOption(args, index, arg));
+        index += 1;
+        break;
+      default:
+        if (arg.startsWith("--")) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+        promptParts.push(arg);
+        break;
+    }
+  }
+
+  options.prompt = promptParts.join(" ").trim();
+  return options;
+}
+
+async function readNodeStdin(): Promise<string> {
+  return new Response(Bun.stdin.stream()).text();
+}
+
+async function resolveCliBackend(options: InferenceCliOptions, deps: InferenceCliDeps): Promise<InferenceBackend> {
+  if (deps.backend) {
+    return deps.backend;
+  }
+  if (options.backend) {
+    return options.backend;
+  }
+
+  switch (options.backendKind ?? "auto") {
+    case "claude-code":
+      return createClaudeCodeBackend();
+    case "anthropic-api":
+      if (options.mode === "advisor" && options.autoState === true && options.allowNetwork !== true) {
+        throw new Error("Advisor auto-state requires Claude Code or explicit network opt-in via --allow-network.");
+      }
+      return createAnthropicApiBackend();
+    case "auto":
+      return createAutoInferenceBackend({
+        allowNetwork: options.allowNetwork === true,
+        includesAutoState: options.mode === "advisor" && options.autoState === true,
+      });
+  }
+}
+
+export async function runInferenceCli(args: string[], deps: InferenceCliDeps = {}): Promise<string> {
+  const options = parseInferenceCliArgs(args);
+  const prompt = options.prompt
+    || (options.mode === "advisor" && options.autoState ? "" : (await (deps.readStdin ?? readNodeStdin)()).trim());
+  if (!prompt && !(options.mode === "advisor" && options.autoState)) {
+    throw new Error("soma inference requires a prompt argument or stdin input.");
+  }
+
+  const common = {
+    ...options,
+    backend: await resolveCliBackend(options, deps),
+  };
+  const result = options.mode === "advisor"
+    ? await advisor(prompt, common)
+    : await inference(prompt, common);
+
+  if (options.json) {
+    return `${JSON.stringify(result.json, null, 2)}\n`;
+  }
+
+  return `${result.text}\n`;
+}

--- a/src/tools/inference/factory.ts
+++ b/src/tools/inference/factory.ts
@@ -1,0 +1,28 @@
+import { createAnthropicApiBackend } from "./backends/anthropic-api";
+import { createClaudeCodeBackend } from "./backends/claude-code";
+import type { InferenceBackend } from "./types";
+
+export interface BackendDetectionOptions {
+  commandExists?: (command: string) => Promise<boolean>;
+  allowNetwork?: boolean;
+  includesAutoState?: boolean;
+}
+
+async function defaultCommandExists(command: string): Promise<boolean> {
+  const proc = Bun.spawn(["which", command], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  return await proc.exited === 0;
+}
+
+export async function createAutoInferenceBackend(options: BackendDetectionOptions = {}): Promise<InferenceBackend> {
+  const commandExists = options.commandExists ?? defaultCommandExists;
+  if (await commandExists("claude")) {
+    return createClaudeCodeBackend();
+  }
+  if (options.includesAutoState && !options.allowNetwork) {
+    throw new Error("Advisor auto-state requires Claude Code or explicit network opt-in via --allow-network.");
+  }
+  return createAnthropicApiBackend();
+}

--- a/src/tools/inference/index.ts
+++ b/src/tools/inference/index.ts
@@ -1,0 +1,163 @@
+import { readFile } from "node:fs/promises";
+import { createPaths } from "../../paths";
+import type {
+  AdvisorStateOptions,
+  InferenceBackend,
+  InferenceLevel,
+  InferenceMode,
+  InferenceOptions,
+  InferenceRequest,
+  InferenceResult,
+} from "./types";
+
+const DEFAULT_TIMEOUT_MS: Record<InferenceLevel | "advisor", number> = {
+  fast: 15_000,
+  standard: 30_000,
+  smart: 90_000,
+  advisor: 120_000,
+};
+
+export type {
+  AdvisorStateOptions,
+  InferenceBackend,
+  InferenceBackendKind,
+  InferenceLevel,
+  InferenceMode,
+  InferenceOptions,
+  InferenceRequest,
+  InferenceResult,
+} from "./types";
+function normalizeLevel(level: InferenceLevel | undefined, mode: InferenceMode): InferenceLevel {
+  return level ?? (mode === "advisor" ? "smart" : "standard");
+}
+
+function normalizeRequest(options: InferenceOptions = {}): InferenceRequest {
+  const mode = options.mode ?? "inference";
+  const level = normalizeLevel(options.level, mode);
+  return {
+    level,
+    mode,
+    json: options.json === true,
+    timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS[mode === "advisor" ? "advisor" : level],
+  };
+}
+
+export function parseInferenceJson(text: string): unknown {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Inference response did not contain JSON.");
+  }
+
+  for (const candidate of balancedJsonCandidates(trimmed)) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error("Inference response did not contain a JSON object or array.");
+}
+
+function* balancedJsonCandidates(text: string): Generator<string> {
+  const stack: string[] = [];
+  let inString = false;
+  let escaped = false;
+  let start: number | undefined;
+
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (start === undefined && char !== "{" && char !== "[") {
+      continue;
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === "\"") {
+      inString = true;
+      continue;
+    }
+
+    if (char === "{" || char === "[") {
+      if (start === undefined) {
+        start = index;
+      }
+      stack.push(char === "{" ? "}" : "]");
+      continue;
+    }
+
+    if (char === "}" || char === "]") {
+      if (stack.pop() !== char) {
+        stack.length = 0;
+        start = undefined;
+        inString = false;
+        escaped = false;
+        continue;
+      }
+      if (stack.length === 0 && start !== undefined) {
+        yield text.slice(start, index + 1);
+        start = undefined;
+      }
+    }
+  }
+}
+
+export async function inference<T = unknown>(
+  prompt: string,
+  options: InferenceOptions = {},
+): Promise<InferenceResult<T>> {
+  const request = normalizeRequest(options);
+  const backend = options.backend;
+  if (!backend) {
+    throw new Error("Inference backend is required. Use the CLI or inject an InferenceBackend.");
+  }
+  const text = await backend.invoke(prompt, request);
+  return {
+    text,
+    json: request.json ? parseInferenceJson(text) as T : undefined,
+    backend: backend.kind,
+    level: request.level,
+    mode: request.mode,
+    model: backend.resolveModel(request.level, request.mode),
+  };
+}
+
+export async function synthesizeAdvisorState(options: AdvisorStateOptions = {}): Promise<string> {
+  const paths = createPaths(options.somaHome ? { somaHome: options.somaHome } : { homeDir: options.homeDir });
+  const statePath = paths.resolve("memory", "STATE", "work.json");
+  const state = await readFile(statePath, "utf8").catch((error: unknown) => {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return "{}";
+    }
+    throw error;
+  });
+
+  return [
+    "Synthesize current working state from Soma memory.",
+    "",
+    "State file:",
+    statePath,
+    "",
+    "State JSON:",
+    state.trim() || "{}",
+  ].join("\n");
+}
+
+export async function advisor<T = unknown>(
+  prompt: string,
+  options: InferenceOptions & { autoState?: boolean } = {},
+): Promise<InferenceResult<T>> {
+  const statePrompt = options.autoState
+    ? `${await synthesizeAdvisorState(options)}\n\nAdvisor request:\n${prompt}`
+    : prompt;
+  return inference<T>(statePrompt, { ...options, mode: "advisor", level: options.level ?? "smart" });
+}

--- a/src/tools/inference/types.ts
+++ b/src/tools/inference/types.ts
@@ -1,0 +1,40 @@
+export type InferenceLevel = "fast" | "standard" | "smart";
+export type InferenceMode = "inference" | "advisor";
+export type InferenceBackendKind = "claude-code" | "anthropic-api";
+
+export interface InferenceOptions {
+  level?: InferenceLevel;
+  mode?: InferenceMode;
+  json?: boolean;
+  timeoutMs?: number;
+  somaHome?: string;
+  homeDir?: string;
+  backend?: InferenceBackend;
+}
+
+export interface InferenceRequest {
+  level: InferenceLevel;
+  mode: InferenceMode;
+  json: boolean;
+  timeoutMs: number;
+}
+
+export interface InferenceResult<T = unknown> {
+  text: string;
+  json?: T;
+  backend: InferenceBackendKind;
+  level: InferenceLevel;
+  mode: InferenceMode;
+  model: string;
+}
+
+export interface InferenceBackend {
+  readonly kind: InferenceBackendKind;
+  resolveModel(level: InferenceLevel, mode: InferenceMode): string;
+  invoke(prompt: string, request: InferenceRequest): Promise<string>;
+}
+
+export interface AdvisorStateOptions {
+  somaHome?: string;
+  homeDir?: string;
+}

--- a/test/inference.test.ts
+++ b/test/inference.test.ts
@@ -1,0 +1,252 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { expect, test } from "bun:test";
+import {
+  advisor,
+  inference,
+  parseInferenceJson,
+  synthesizeAdvisorState,
+  type InferenceBackend,
+  type InferenceRequest,
+} from "../src/index";
+import { createClaudeCodeBackend } from "../src/tools/inference/backends/claude-code";
+import { createAnthropicApiBackend } from "../src/tools/inference/backends/anthropic-api";
+import { createAutoInferenceBackend } from "../src/tools/inference/factory";
+import { parseInferenceCliArgs, runInferenceCli } from "../src/tools/inference/cli";
+
+class MockBackend implements InferenceBackend {
+  readonly kind = "claude-code" as const;
+  requests: { prompt: string; request: InferenceRequest }[] = [];
+
+  constructor(private readonly response: string) {}
+
+  resolveModel(level: InferenceRequest["level"], mode: InferenceRequest["mode"]): string {
+    if (mode === "advisor") return "opus";
+    return level === "fast" ? "haiku" : level === "standard" ? "sonnet" : "opus";
+  }
+
+  async invoke(prompt: string, request: InferenceRequest): Promise<string> {
+    this.requests.push({ prompt, request });
+    return this.response;
+  }
+}
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-inference-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+function textStream(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
+
+test("parseInferenceJson greedily extracts object and array payloads", () => {
+  expect(parseInferenceJson("prefix {\"a\":{\"b\":1}} suffix")).toEqual({ a: { b: 1 } });
+  expect(parseInferenceJson("notes\n[{\"a\":1},{\"b\":[2,3]}]\ntrailer")).toEqual([{ a: 1 }, { b: [2, 3] }]);
+  expect(parseInferenceJson("nested [{\"a\":[1,{\"b\":2}]}] done")).toEqual([{ a: [1, { b: 2 }] }]);
+  expect(parseInferenceJson("prose [not json] then {\"usable\":true} trailing [noise]")).toEqual({ usable: true });
+  expect(parseInferenceJson("prose {\"brace\":\"}\"} trailing")).toEqual({ brace: "}" });
+  expect(() => parseInferenceJson("no structured payload")).toThrow("JSON object or array");
+});
+
+test("inference maps levels to backend model capabilities and parses JSON", async () => {
+  const backend = new MockBackend("```json\n{\"label\":\"ok\"}\n```");
+  const result = await inference<{ label: string }>("classify this", {
+    level: "fast",
+    json: true,
+    backend,
+  });
+
+  expect(result.backend).toBe("claude-code");
+  expect(result.model).toBe("haiku");
+  expect(result.json?.label).toBe("ok");
+  expect(backend.requests[0]?.request.timeoutMs).toBe(15_000);
+});
+
+test("advisor auto-state reads Soma state through createPaths", async () => {
+  await withTempHome(async (homeDir) => {
+    const stateDir = join(homeDir, ".soma/memory/STATE");
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(join(stateDir, "work.json"), JSON.stringify({ active: "issue-129" }), "utf8");
+
+    const statePrompt = await synthesizeAdvisorState({ homeDir });
+    expect(statePrompt).toContain(join(homeDir, ".soma/memory/STATE/work.json"));
+    expect(statePrompt).toContain("issue-129");
+
+    const backend = new MockBackend("advisor response");
+    await advisor("what next?", { homeDir, autoState: true, backend });
+    expect(backend.requests[0]?.prompt).toContain("State JSON:");
+    expect(backend.requests[0]?.prompt).toContain("Advisor request:");
+    expect(backend.requests[0]?.request.timeoutMs).toBe(120_000);
+  });
+});
+
+test("runInferenceCli supports prompt args, JSON output, and stdin", async () => {
+  const jsonBackend = new MockBackend("{\"ok\":true}");
+  const jsonOutput = await runInferenceCli(["--level", "smart", "--json", "analyze", "this"], {
+    backend: jsonBackend,
+  });
+
+  expect(JSON.parse(jsonOutput)).toEqual({ ok: true });
+  expect(jsonBackend.requests[0]?.prompt).toBe("analyze this");
+  expect(jsonBackend.requests[0]?.request.level).toBe("smart");
+
+  const stdinBackend = new MockBackend("standard response");
+  const stdinOutput = await runInferenceCli(["--level", "standard"], {
+    backend: stdinBackend,
+    readStdin: () => "large prompt from stdin",
+  });
+
+  expect(stdinOutput).toBe("standard response\n");
+  expect(stdinBackend.requests[0]?.prompt).toBe("large prompt from stdin");
+});
+
+test("runInferenceCli rejects partial timeout values", async () => {
+  await expect(
+    runInferenceCli(["--timeout", "1000abc", "classify"], { backend: new MockBackend("ok") }),
+  ).rejects.toThrow("--timeout must be a positive integer");
+});
+
+test("runInferenceCli advisor auto-state does not require stdin", async () => {
+  await withTempHome(async (homeDir) => {
+    const backend = new MockBackend("advisor response");
+    const output = await runInferenceCli(["--mode", "advisor", "--auto-state", "--home-dir", homeDir], {
+      backend,
+      readStdin: () => {
+        throw new Error("stdin should not be read");
+      },
+    });
+
+    expect(output).toBe("advisor response\n");
+    expect(backend.requests[0]?.prompt).toContain("State JSON:");
+  });
+});
+
+test("createAutoInferenceBackend prefers Claude Code when detected", async () => {
+  const claude = await createAutoInferenceBackend({ commandExists: async (command) => command === "claude" });
+  const fallback = await createAutoInferenceBackend({ commandExists: async () => false });
+
+  expect(claude.kind).toBe("claude-code");
+  expect(fallback.kind).toBe("anthropic-api");
+});
+
+test("auto backend blocks advisor state network fallback without opt-in", async () => {
+  await expect(
+    createAutoInferenceBackend({
+      commandExists: async () => false,
+      includesAutoState: true,
+    }),
+  ).rejects.toThrow("explicit network opt-in");
+
+  const fallback = await createAutoInferenceBackend({
+    commandExists: async () => false,
+    includesAutoState: true,
+    allowNetwork: true,
+  });
+
+  expect(fallback.kind).toBe("anthropic-api");
+  expect(parseInferenceCliArgs(["--backend", "anthropic-api", "--allow-network", "prompt"])).toMatchObject({
+    backendKind: "anthropic-api",
+    allowNetwork: true,
+  });
+
+  await expect(
+    runInferenceCli(["--mode", "advisor", "--auto-state", "--backend", "anthropic-api"]),
+  ).rejects.toThrow("explicit network opt-in");
+});
+
+test("Anthropic API backend maps levels to valid Messages API model ids", () => {
+  const backend = createAnthropicApiBackend({ apiKey: "test-key" });
+
+  expect(backend.resolveModel("fast", "inference")).toBe("claude-3-5-haiku-20241022");
+  expect(backend.resolveModel("standard", "inference")).toBe("claude-sonnet-4-20250514");
+  expect(backend.resolveModel("smart", "inference")).toBe("claude-opus-4-1-20250805");
+  expect(backend.resolveModel("fast", "advisor")).toBe("claude-opus-4-1-20250805");
+});
+
+test("Claude Code backend scrubs Anthropic env, writes prompt to stdin, and times out", async () => {
+  const launches: {
+    command: string[];
+    env?: Record<string, string | undefined>;
+    prompt: string;
+    promptRead: Promise<void>;
+    killed: boolean;
+  }[] = [];
+  let resolveExit: (code: number) => void = () => {};
+  const exited = new Promise<number>((resolve) => {
+    resolveExit = resolve;
+  });
+  const spawn = ((command: string[], options: { env?: Record<string, string | undefined>; stdin?: ReadableStream<Uint8Array> }) => {
+    const launch = {
+      command,
+      env: options.env,
+      prompt: "",
+      promptRead: Promise.resolve(),
+      killed: false,
+    };
+    if (options.stdin) {
+      launch.promptRead = new Response(options.stdin).text().then((text) => {
+        launch.prompt = text;
+      });
+    }
+    launches.push(launch);
+    return {
+      stdout: textStream(""),
+      stderr: textStream("timed out"),
+      exited,
+      kill: () => {
+        launch.killed = true;
+        resolveExit(1);
+      },
+    };
+  }) as unknown as typeof Bun.spawn;
+
+  const backend = createClaudeCodeBackend({
+    spawn,
+    env: {
+      ANTHROPIC_API_KEY: "secret",
+      ANTHROPIC_AUTH_TOKEN: "secret-token",
+      KEEP_ME: "yes",
+      PATH: "/usr/bin",
+    },
+  });
+
+  await expect(
+    backend.invoke("large prompt", {
+      level: "standard",
+      mode: "inference",
+      json: false,
+      timeoutMs: 1,
+    }),
+  ).rejects.toThrow("claude inference exited 1");
+
+  await launches[0]?.promptRead;
+  expect(launches[0]?.command).toEqual([
+    "claude",
+    "-p",
+    "--model",
+    "sonnet",
+    "--allowedTools",
+    "",
+    "--hookTimeout",
+    "1",
+  ]);
+  expect(launches[0]?.env?.ANTHROPIC_API_KEY).toBeUndefined();
+  expect(launches[0]?.env?.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+  expect(launches[0]?.env?.KEEP_ME).toBeUndefined();
+  expect(launches[0]?.env?.PATH).toBe("/usr/bin");
+  expect(launches[0]?.prompt).toBe("large prompt");
+  expect(launches[0]?.killed).toBe(true);
+
+  await expect(readFile(join(import.meta.dir, "..", "src/tools/inference/index.ts"), "utf8")).resolves.not.toContain(".claude");
+});


### PR DESCRIPTION
## Summary
- add a native Soma inference module with inference(), advisor(), synthesizeAdvisorState(), backend types, and exported API surface
- add Claude Code subprocess backend with stdin prompt delivery, env scrubbing, timeout kill, and model-level mapping
- add Anthropic API fallback backend plus backend auto-detection
- wire soma inference CLI for levels, advisor mode, JSON output, timeouts, prompt args, stdin, and auto-state

Fixes #129.

## Verification
- rtk bun test test/inference.test.ts
- rtk bun test test/inference.test.ts test/cli.test.ts
- rtk bun run typecheck
- rtk bun test

Notes: tests use injected/mock backends and do not call a real LLM in CI.