### PR TITLE
feat: add wisdom frame tools

### DIFF
--- a/docs/wisdom-contracts.md
+++ b/docs/wisdom-contracts.md
@@ -1,0 +1,46 @@
+# Soma Wisdom Contracts
+
+Wisdom Frames are a specialized Soma memory store. Tools must resolve their
+paths through `createPaths().wisdom()` and must not address substrate-specific
+assistant directories directly.
+
+## Frame Layout
+
+Frames live under `<soma-wisdom-root>/FRAMES/<domain>.md`, where the wisdom
+root is supplied by the Soma path resolver.
+
+Each frame is Markdown with these sections:
+
+- `Crystallized Principles`
+- `Contextual Rules`
+- `Predictive Model`
+- `Anti-Patterns`
+- `Cross-Frame Connections`
+- `Evolution Log`
+- `Metadata`
+
+Crystallized principles are marked with `[CRYSTAL]`. Cross-frame synthesis uses
+those marked lines as candidate principles and computes Jaccard similarity over
+their normalized word sets.
+
+## Observation Types
+
+`soma wisdom update` accepts these observation types:
+
+- `principle`
+- `contextual-rule`
+- `prediction`
+- `anti-pattern`
+- `evolution`
+
+Updates append to the matching section, append a dated evolution log entry, and
+increment `Observation Count` in metadata.
+
+## Synthesis Outputs
+
+`soma wisdom synthesize` writes:
+
+- `<soma-wisdom-root>/PRINCIPLES/verified.md`
+- `<soma-wisdom-root>/META/frame-health.md`
+
+`soma wisdom health` writes only the health report.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -135,6 +135,7 @@ import type {
 import { PAI_DOCS_IMPORT_SUBDIRS } from "./pai-docs-importer";
 import { runInferenceCli } from "./tools/inference/cli";
 import { runLearningCli, runMetricsCli, runOpinionCli, runSessionCli } from "./tools/learning/cli";
+import { runWisdomCli } from "./tools/wisdom/cli";
 
 /**
  * Typed CLI error carrying an exit code distinct from the default 1.
@@ -357,7 +358,7 @@ interface ParsedInferenceArgs {
 }
 
 interface ParsedRawToolArgs {
-  command: "learning" | "opinion" | "metrics" | "session";
+  command: "learning" | "opinion" | "metrics" | "session" | "wisdom";
   args: string[];
 }
 
@@ -405,6 +406,7 @@ const TOP_LEVEL_COMMANDS = [
   "session",
   "uninstall",
   "upgrade",
+  "wisdom",
 ] as const;
 
 const MIGRATE_PAI_USAGE =
@@ -477,6 +479,16 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
   },
   session: {
     usage: "Usage: soma session <create|decision|work|blocker|next|handoff|resume|list|complete> ...",
+  },
+  wisdom: {
+    usage: "Usage: soma wisdom <classify|list|update|synthesize|health> ...",
+    subcommands: {
+      classify: "Usage: soma wisdom classify <text> [--home-dir <dir>] [--soma-home <dir>]",
+      list: "Usage: soma wisdom list [--home-dir <dir>] [--soma-home <dir>]",
+      update: "Usage: soma wisdom update --domain <domain> --type <principle|contextual-rule|prediction|anti-pattern|evolution> --observation <text> [--home-dir <dir>] [--soma-home <dir>]",
+      synthesize: "Usage: soma wisdom synthesize [--dry-run] [--home-dir <dir>] [--soma-home <dir>]",
+      health: "Usage: soma wisdom health [--dry-run] [--home-dir <dir>] [--soma-home <dir>]",
+    },
   },
   result: {
     usage: "Usage: soma result <capture|search> ...",
@@ -1692,7 +1704,7 @@ function parseArgs(args: string[]): ParsedArgs {
     return { command: "inference", args: args.slice(1) };
   }
 
-  if (args[0] === "learning" || args[0] === "opinion" || args[0] === "metrics" || args[0] === "session") {
+  if (args[0] === "learning" || args[0] === "opinion" || args[0] === "metrics" || args[0] === "session" || args[0] === "wisdom") {
     return { command: args[0], args: args.slice(1) };
   }
 
@@ -3353,6 +3365,10 @@ export async function runSomaCli(args: string[]): Promise<string> {
 
   if (parsed.command === "session") {
     return runSessionCli(parsed.args);
+  }
+
+  if (parsed.command === "wisdom") {
+    return runWisdomCli(parsed.args);
   }
 
   if (parsed.command === "result") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,6 +223,23 @@ export {
   type ToolCall,
 } from "./tools/learning";
 export {
+  classifyDomains,
+  listFrames,
+  synthesizeWisdom,
+  updateFrame,
+  type CrossFramePrinciple,
+  type DomainClassification,
+  type FrameHealth,
+  type FrameHealthStatus,
+  type FrameUpdateInput,
+  type FrameUpdateResult,
+  type WisdomFrame,
+  type WisdomFrameSummary,
+  type WisdomObservationType,
+  type WisdomSynthesisResult,
+  type WisdomToolOptions,
+} from "./tools/wisdom";
+export {
   buildClaudeCodeHomeProjection,
   buildCodexHomeProjection,
   buildPiDevHomeProjection,

--- a/src/tools/wisdom/classifier.ts
+++ b/src/tools/wisdom/classifier.ts
@@ -1,0 +1,99 @@
+import { join } from "node:path";
+import { readAllWisdomFrames, readWisdomFrame } from "./frame";
+import { pathsForWisdomOptions, safeDomain } from "./paths";
+import type { DomainClassification, WisdomFrame, WisdomToolOptions } from "./types";
+
+const DEFAULT_DOMAIN_KEYWORDS: Record<string, { primary: string[]; secondary: string[] }> = {
+  communication: {
+    primary: ["discord", "message", "channel", "thread", "notification"],
+    secondary: ["team", "update", "post", "announce"],
+  },
+  development: {
+    primary: ["code", "test", "build", "deploy", "feature", "bug", "pr"],
+    secondary: ["refactor", "lint", "type", "ci", "review", "structure"],
+  },
+  deployment: {
+    primary: ["wrangler", "cloudflare", "pages", "worker", "dns"],
+    secondary: ["domain", "route", "certificate", "deploy"],
+  },
+  "content-creation": {
+    primary: ["write", "article", "blog", "documentation", "slides"],
+    secondary: ["draft", "edit", "publish", "media"],
+  },
+  "system-architecture": {
+    primary: ["architecture", "layer", "stack", "migration", "bus"],
+    secondary: ["nats", "myelin", "cortex", "surface"],
+  },
+};
+
+function words(text: string): string[] {
+  return [...new Set(text.toLowerCase().match(/[a-z0-9][a-z0-9-]{1,}/g) ?? [])];
+}
+
+function scoreKeywords(textWords: Set<string>, keywords: { primary: string[]; secondary: string[] }): { score: number; matches: string[] } {
+  const matches: string[] = [];
+  let score = 0;
+  for (const keyword of keywords.primary) {
+    if (textWords.has(keyword.toLowerCase())) {
+      score += 2;
+      matches.push(keyword);
+    }
+  }
+  for (const keyword of keywords.secondary) {
+    if (textWords.has(keyword.toLowerCase())) {
+      score += 1;
+      matches.push(keyword);
+    }
+  }
+  return { score, matches };
+}
+
+function frameKeywords(frameContent: string): { primary: string[]; secondary: string[] } {
+  const ranked = words(frameContent).filter((word) => word.length >= 4 && !["wisdom", "frame", "recorded", "observation", "count", "type"].includes(word));
+  return { primary: ranked.slice(0, 12), secondary: ranked.slice(12, 30) };
+}
+
+async function keywordMaps(options: WisdomToolOptions): Promise<Record<string, { primary: string[]; secondary: string[]; path: string }>> {
+  const maps: Record<string, { primary: string[]; secondary: string[]; path: string }> = {};
+  const framesDir = join(pathsForWisdomOptions(options).wisdom(), "FRAMES");
+  for (const [domain, keywords] of Object.entries(DEFAULT_DOMAIN_KEYWORDS)) {
+    maps[domain] = { ...keywords, path: join(framesDir, `${domain}.md`) };
+  }
+  for (const frame of await readAllWisdomFrames(options)) {
+    const dynamic = frameKeywords(frame.content);
+    const existing = maps[frame.domain];
+    maps[frame.domain] = {
+      primary: [...new Set([...(existing?.primary ?? []), ...dynamic.primary])],
+      secondary: [...new Set([...(existing?.secondary ?? []), ...dynamic.secondary])],
+      path: frame.path,
+    };
+  }
+  return maps;
+}
+
+export async function classifyDomains(text: string, options: WisdomToolOptions = {}): Promise<DomainClassification[]> {
+  if (!text.trim()) throw new Error("Wisdom classification text is required.");
+  const inputWords = new Set(words(text));
+  const maps = await keywordMaps(options);
+  const results = Object.entries(maps).map(([domain, keywords]) => {
+    const scored = scoreKeywords(inputWords, keywords);
+    return {
+      domain,
+      path: keywords.path,
+      relevance: Math.min(1, scored.score / (scored.score + 1)),
+      matches: scored.matches,
+    };
+  }).filter((result) => result.relevance > 0);
+
+  return results.sort((a, b) => b.relevance - a.relevance || a.domain.localeCompare(b.domain));
+}
+
+export async function loadRelevantFrames(text: string, options: WisdomToolOptions = {}): Promise<WisdomFrame[]> {
+  const classifications = await classifyDomains(text, options);
+  const frames: WisdomFrame[] = [];
+  for (const classification of classifications) {
+    const frame = await readWisdomFrame(safeDomain(classification.domain), options);
+    if (frame) frames.push(frame);
+  }
+  return frames;
+}

--- a/src/tools/wisdom/cli.ts
+++ b/src/tools/wisdom/cli.ts
@@ -1,0 +1,111 @@
+import { classifyDomains, listFrames, synthesizeWisdom, updateFrame } from "./index";
+import type { WisdomObservationType, WisdomToolOptions } from "./types";
+
+function readOption(args: string[], index: number, name: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${name} requires a value.`);
+  return value;
+}
+
+function readOptionText(args: string[], index: number, name: string): string {
+  const values: string[] = [];
+  for (let cursor = index + 1; cursor < args.length; cursor += 1) {
+    if (args[cursor]!.startsWith("--")) break;
+    values.push(args[cursor]!);
+  }
+  if (values.length === 0) throw new Error(`${name} requires a value.`);
+  return values.join(" ");
+}
+
+function commonOptions(args: string[]): WisdomToolOptions {
+  const options: WisdomToolOptions = {};
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === "--home-dir") options.homeDir = readOption(args, index, "--home-dir");
+    if (args[index] === "--soma-home") options.somaHome = readOption(args, index, "--soma-home");
+  }
+  return options;
+}
+
+function stripCommon(args: string[]): string[] {
+  const stripped: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === "--home-dir" || args[index] === "--soma-home") {
+      if (index > 0 && ["--domain", "--type", "--observation"].includes(args[index - 1]!)) {
+        stripped.push(args[index]!);
+        continue;
+      }
+      index += 1;
+      continue;
+    }
+    stripped.push(args[index]);
+  }
+  return stripped;
+}
+
+function parseUpdateArgs(args: string[]): { domain: string; type: WisdomObservationType; observation: string } {
+  const parsed: Partial<{ domain: string; type: WisdomObservationType; observation: string }> = {};
+  for (let index = 1; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--domain") {
+      parsed.domain = readOption(args, index, "--domain");
+      index += 1;
+      continue;
+    }
+    if (arg === "--type") {
+      parsed.type = readOption(args, index, "--type") as WisdomObservationType;
+      index += 1;
+      continue;
+    }
+    if (arg === "--observation") {
+      parsed.observation = readOptionText(args, index, "--observation");
+      while (args[index + 1] && !args[index + 1]!.startsWith("--")) index += 1;
+      continue;
+    }
+    throw new Error(`Unknown wisdom update argument: ${arg}`);
+  }
+  if (!parsed.domain || !parsed.type || !parsed.observation) {
+    throw new Error("Usage: soma wisdom update --domain <domain> --type <principle|contextual-rule|prediction|anti-pattern|evolution> --observation <text>");
+  }
+  return { domain: parsed.domain, type: parsed.type, observation: parsed.observation };
+}
+
+export async function runWisdomCli(args: string[]): Promise<string> {
+  const options = commonOptions(args);
+  const local = stripCommon(args);
+  const action = local[0];
+
+  if (action === "classify") {
+    const text = local.slice(1).join(" ");
+    const classifications = await classifyDomains(text, options);
+    return JSON.stringify(classifications, null, 2) + "\n";
+  }
+
+  if (action === "list") {
+    const frames = await listFrames(options);
+    return frames.map((frame) => `${frame.domain}\t${frame.observationCount}\t${frame.path}`).join("\n") + (frames.length ? "\n" : "");
+  }
+
+  if (action === "update") {
+    const parsed = parseUpdateArgs(local);
+    const result = await updateFrame({
+      ...options,
+      ...parsed,
+    });
+    return `${result.created ? "created" : "updated"} wisdom frame: ${result.domain} (${result.observationCount} observations)\n${result.path}\n`;
+  }
+
+  if (action === "synthesize" || action === "health") {
+    const result = await synthesizeWisdom({
+      ...options,
+      dryRun: local.includes("--dry-run"),
+      healthOnly: action === "health",
+    });
+    return [
+      `wisdom ${action}: ${result.principles.length} cross-frame principle(s), ${result.health.length} frame(s)`,
+      result.principlesPath ? `principles: ${result.principlesPath}` : "",
+      result.healthPath ? `health: ${result.healthPath}` : "",
+    ].filter(Boolean).join("\n") + "\n";
+  }
+
+  throw new Error("Usage: soma wisdom <classify|list|update|synthesize|health> ...");
+}

--- a/src/tools/wisdom/frame.ts
+++ b/src/tools/wisdom/frame.ts
@@ -1,0 +1,170 @@
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { pathsForWisdomOptions, safeDomain } from "./paths";
+import type { FrameUpdateInput, FrameUpdateResult, WisdomFrame, WisdomFrameSummary, WisdomObservationType, WisdomToolOptions } from "./types";
+
+const SECTION_BY_TYPE: Record<WisdomObservationType, string> = {
+  principle: "Crystallized Principles",
+  "contextual-rule": "Contextual Rules",
+  prediction: "Predictive Model",
+  "anti-pattern": "Anti-Patterns",
+  evolution: "Evolution Log",
+};
+
+function titleCaseDomain(domain: string): string {
+  return domain.split(/[-_]/).filter(Boolean).map((part) => part[0]!.toUpperCase() + part.slice(1)).join(" ");
+}
+
+export function emptyFrameMarkdown(domain: string, now = new Date()): string {
+  const title = titleCaseDomain(domain);
+  const date = now.toISOString().slice(0, 10);
+  return `# ${title} Wisdom Frame
+
+## Crystallized Principles
+
+No crystallized principles recorded.
+
+## Contextual Rules
+
+No contextual rules recorded.
+
+## Predictive Model
+
+No predictions recorded.
+
+## Anti-Patterns
+
+No anti-patterns recorded.
+
+## Cross-Frame Connections
+
+No cross-frame connections recorded.
+
+## Evolution Log
+
+- ${date}: Frame created (type: evolution)
+
+## Metadata
+
+- Observation Count: 0
+- Last Crystallized: ${date}
+`;
+}
+
+function framePath(domain: string, options: WisdomToolOptions): string {
+  return join(pathsForWisdomOptions(options).wisdom(), "FRAMES", `${safeDomain(domain)}.md`);
+}
+
+async function readFileIfExists(path: string): Promise<string | undefined> {
+  return readFile(path, "utf8").catch((error: unknown) => {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return undefined;
+    throw error;
+  });
+}
+
+async function readdirIfExists(path: string) {
+  return readdir(path, { withFileTypes: true }).catch((error: unknown) => {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+    throw error;
+  });
+}
+
+function readObservationCount(content: string): number {
+  const match = content.match(/^- Observation Count:\s*(\d+)/m);
+  return match ? Number(match[1]) : 0;
+}
+
+function readLastUpdated(content: string): string | undefined {
+  return content.match(/^- Last Crystallized:\s*(\d{4}-\d{2}-\d{2})/m)?.[1];
+}
+
+function sectionBullet(type: WisdomObservationType, observation: string, date: string): string {
+  if (type === "principle") return `- [CRYSTAL] ${observation}`;
+  if (type === "evolution") return `- ${date}: ${observation} (type: evolution)`;
+  return `- ${observation}`;
+}
+
+function appendToSection(content: string, section: string, bullet: string): string {
+  const heading = `## ${section}`;
+  const index = content.indexOf(heading);
+  if (index === -1) return `${content.trim()}\n\n${heading}\n\n${bullet}\n`;
+
+  const start = index + heading.length;
+  const next = content.slice(start).search(/\n## /);
+  const end = next === -1 ? content.length : start + next;
+  const before = content.slice(0, start);
+  const body = content.slice(start, end).replace(/\nNo [^\n]+ recorded\.\n?/i, "\n");
+  const after = content.slice(end);
+  return `${before}${body.trimEnd()}\n${bullet}\n${after}`;
+}
+
+function updateMetadata(content: string, count: number, date: string): string {
+  return content
+    .replace(/^- Observation Count:\s*\d+/m, `- Observation Count: ${count}`)
+    .replace(/^- Last Crystallized:\s*\d{4}-\d{2}-\d{2}/m, `- Last Crystallized: ${date}`);
+}
+
+export function parseWisdomFrame(domain: string, path: string, content: string): WisdomFrame {
+  const principles = [...content.matchAll(/\[CRYSTAL\]\s*(.+)/g)].map((match) => match[1]!.trim());
+  return {
+    domain,
+    path,
+    content,
+    observationCount: readObservationCount(content),
+    lastUpdated: readLastUpdated(content),
+    principles,
+  };
+}
+
+export async function readWisdomFrame(domain: string, options: WisdomToolOptions = {}): Promise<WisdomFrame | undefined> {
+  const safe = safeDomain(domain);
+  const path = framePath(safe, options);
+  const content = await readFileIfExists(path);
+  return content === undefined ? undefined : parseWisdomFrame(safe, path, content);
+}
+
+export async function readAllWisdomFrames(options: WisdomToolOptions = {}): Promise<WisdomFrame[]> {
+  const framesDir = join(pathsForWisdomOptions(options).wisdom(), "FRAMES");
+  const entries = await readdirIfExists(framesDir);
+  const frames = await Promise.all(entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map(async (entry) => {
+      const domain = safeDomain(basename(entry.name, ".md"));
+      const path = join(framesDir, entry.name);
+      const content = await readFile(path, "utf8");
+      return parseWisdomFrame(domain, path, content);
+    }));
+  return frames.sort((a, b) => a.domain.localeCompare(b.domain));
+}
+
+export async function listFrames(options: WisdomToolOptions = {}): Promise<WisdomFrameSummary[]> {
+  return (await readAllWisdomFrames(options)).map((frame) => ({
+    domain: frame.domain,
+    path: frame.path,
+    observationCount: frame.observationCount,
+    lastUpdated: frame.lastUpdated,
+  }));
+}
+
+export async function updateFrame(input: FrameUpdateInput): Promise<FrameUpdateResult> {
+  const domain = safeDomain(input.domain);
+  if (!input.observation.trim()) throw new Error("Wisdom observation is required.");
+  if (!(input.type in SECTION_BY_TYPE)) throw new Error(`Unknown wisdom observation type: ${input.type}`);
+
+  const path = framePath(domain, input);
+  const now = input.now ?? new Date();
+  const date = now.toISOString().slice(0, 10);
+  const existing = await readFileIfExists(path);
+  const created = existing === undefined;
+  const base = existing ?? emptyFrameMarkdown(domain, now);
+  const nextCount = readObservationCount(base) + 1;
+  let content = appendToSection(base, SECTION_BY_TYPE[input.type], sectionBullet(input.type, input.observation.trim(), date));
+  if (input.type !== "evolution") {
+    content = appendToSection(content, "Evolution Log", `- ${date}: ${input.observation.trim()} (type: ${input.type})`);
+  }
+  content = updateMetadata(content, nextCount, date);
+
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, "utf8");
+  return { domain, path, created, observationCount: nextCount };
+}

--- a/src/tools/wisdom/index.ts
+++ b/src/tools/wisdom/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./classifier";
+export * from "./frame";
+export * from "./synthesizer";

--- a/src/tools/wisdom/paths.ts
+++ b/src/tools/wisdom/paths.ts
@@ -1,0 +1,13 @@
+import { createPaths } from "../../paths";
+import type { SomaPaths } from "../../types";
+import type { WisdomToolOptions } from "./types";
+
+export function pathsForWisdomOptions(options: WisdomToolOptions = {}): SomaPaths {
+  return createPaths(options.somaHome ? { somaHome: options.somaHome } : { homeDir: options.homeDir });
+}
+
+export function safeDomain(value: string): string {
+  const safe = value.toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  if (!safe) throw new Error("Wisdom domain is required.");
+  return safe;
+}

--- a/src/tools/wisdom/synthesizer.ts
+++ b/src/tools/wisdom/synthesizer.ts
@@ -1,0 +1,118 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { readAllWisdomFrames } from "./frame";
+import { pathsForWisdomOptions } from "./paths";
+import type { CrossFramePrinciple, FrameHealth, WisdomFrame, WisdomSynthesisResult, WisdomToolOptions } from "./types";
+
+function principleWords(principle: string): Set<string> {
+  return new Set((principle.toLowerCase().match(/[a-z0-9][a-z0-9-]{2,}/g) ?? [])
+    .filter((word) => !["the", "and", "for", "with", "that", "this", "from", "into"].includes(word)));
+}
+
+interface ScoredPrinciple {
+  text: string;
+  words: Set<string>;
+}
+
+function similarity(left: Set<string>, right: Set<string>): number {
+  if (left.size === 0 && right.size === 0) return 0;
+  const intersection = [...left].filter((word) => right.has(word)).length;
+  const union = new Set([...left, ...right]).size;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export function jaccardSimilarity(left: string, right: string): number {
+  const a = principleWords(left);
+  const b = principleWords(right);
+  return similarity(a, b);
+}
+
+function daysSince(date: string | undefined, now: Date): number {
+  if (!date) return Number.POSITIVE_INFINITY;
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) return Number.POSITIVE_INFINITY;
+  return Math.floor((now.getTime() - parsed.getTime()) / 86_400_000);
+}
+
+export function assessFrameHealth(frame: WisdomFrame, now = new Date()): FrameHealth {
+  const age = daysSince(frame.lastUpdated, now);
+  const status = age <= 7 && frame.observationCount >= 10 ? "growing" : age <= 30 ? "stable" : "stale";
+  return { domain: frame.domain, status, observationCount: frame.observationCount, lastUpdated: frame.lastUpdated };
+}
+
+function synthesizeFramePair(left: WisdomFrame, right: WisdomFrame, threshold: number): CrossFramePrinciple[] {
+  const principles: CrossFramePrinciple[] = [];
+  const leftPrinciples = left.principles.map((text): ScoredPrinciple => ({ text, words: principleWords(text) }));
+  const rightPrinciples = right.principles.map((text): ScoredPrinciple => ({ text, words: principleWords(text) }));
+  for (const leftPrinciple of leftPrinciples) {
+    for (const rightPrinciple of rightPrinciples) {
+      const score = similarity(leftPrinciple.words, rightPrinciple.words);
+      if (score >= threshold) {
+        principles.push({
+          domains: [left.domain, right.domain].sort((a, b) => a.localeCompare(b)),
+          principle: leftPrinciple.text.length <= rightPrinciple.text.length ? leftPrinciple.text : rightPrinciple.text,
+          similarity: score,
+        });
+      }
+    }
+  }
+  return principles;
+}
+
+export function synthesizeCrossFramePrinciples(frames: WisdomFrame[], threshold = 0.3): CrossFramePrinciple[] {
+  const principles: CrossFramePrinciple[] = [];
+  for (let leftIndex = 0; leftIndex < frames.length; leftIndex += 1) {
+    for (let rightIndex = leftIndex + 1; rightIndex < frames.length; rightIndex += 1) {
+      principles.push(...synthesizeFramePair(frames[leftIndex]!, frames[rightIndex]!, threshold));
+    }
+  }
+  return principles.sort((a, b) => b.similarity - a.similarity || a.domains.join(",").localeCompare(b.domains.join(",")));
+}
+
+function renderPrinciples(result: WisdomSynthesisResult, now: Date): string {
+  return `# Verified Cross-Frame Wisdom Principles
+
+Generated: ${now.toISOString().slice(0, 10)}
+
+${result.principles.length === 0 ? "No cross-frame principles met the verification threshold." : result.principles.map((principle) =>
+    `- [${principle.domains.join(" + ")}] ${principle.principle} (similarity ${principle.similarity.toFixed(2)})`,
+  ).join("\n")}
+`;
+}
+
+function renderHealth(result: WisdomSynthesisResult, now: Date): string {
+  return `# Wisdom Frame Health
+
+Generated: ${now.toISOString().slice(0, 10)}
+
+${result.health.map((health) =>
+    `- ${health.domain}: ${health.status} (${health.observationCount} observations, last updated ${health.lastUpdated ?? "unknown"})`,
+  ).join("\n")}
+`;
+}
+
+export async function synthesizeWisdom(options: WisdomToolOptions & { dryRun?: boolean; healthOnly?: boolean } = {}): Promise<WisdomSynthesisResult> {
+  const now = options.now ?? new Date();
+  const frames = await readAllWisdomFrames(options);
+  const result: WisdomSynthesisResult = {
+    principles: options.healthOnly ? [] : synthesizeCrossFramePrinciples(frames),
+    health: frames.map((frame) => assessFrameHealth(frame, now)),
+  };
+
+  if (options.dryRun) return result;
+
+  const root = pathsForWisdomOptions(options).wisdom();
+  const healthPath = join(root, "META", "frame-health.md");
+  await mkdir(dirname(healthPath), { recursive: true });
+  await writeFile(healthPath, renderHealth(result, now), "utf8");
+  result.healthPath = healthPath;
+
+  if (!options.healthOnly) {
+    const principlesPath = join(root, "PRINCIPLES", "verified.md");
+    await mkdir(dirname(principlesPath), { recursive: true });
+    await writeFile(principlesPath, renderPrinciples(result, now), "utf8");
+    result.principlesPath = principlesPath;
+  }
+
+  return result;
+}

--- a/src/tools/wisdom/types.ts
+++ b/src/tools/wisdom/types.ts
@@ -1,0 +1,64 @@
+import type { SomaPathsOptions } from "../../paths";
+
+export type WisdomObservationType = "principle" | "contextual-rule" | "prediction" | "anti-pattern" | "evolution";
+export type FrameHealthStatus = "growing" | "stable" | "stale";
+
+export interface WisdomToolOptions extends SomaPathsOptions {
+  now?: Date;
+}
+
+export interface WisdomFrameSummary {
+  domain: string;
+  path: string;
+  observationCount: number;
+  lastUpdated?: string;
+}
+
+export interface DomainClassification {
+  domain: string;
+  path: string;
+  relevance: number;
+  matches: string[];
+}
+
+export interface WisdomFrame {
+  domain: string;
+  path: string;
+  content: string;
+  observationCount: number;
+  lastUpdated?: string;
+  principles: string[];
+}
+
+export interface FrameUpdateInput extends WisdomToolOptions {
+  domain: string;
+  type: WisdomObservationType;
+  observation: string;
+}
+
+export interface FrameUpdateResult {
+  domain: string;
+  path: string;
+  created: boolean;
+  observationCount: number;
+}
+
+export interface CrossFramePrinciple {
+  domains: string[];
+  principle: string;
+  similarity: number;
+}
+
+export interface FrameHealth {
+  domain: string;
+  status: FrameHealthStatus;
+  observationCount: number;
+  lastUpdated?: string;
+}
+
+export interface WisdomSynthesisResult {
+  principles: CrossFramePrinciple[];
+  health: FrameHealth[];
+  principlesPath?: string;
+  healthPath?: string;
+}

--- a/test/wisdom-tools.test.ts
+++ b/test/wisdom-tools.test.ts
@@ -1,0 +1,148 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import {
+  classifyDomains,
+  listFrames,
+  synthesizeWisdom,
+  updateFrame,
+} from "../src";
+import { runSomaCli } from "../src/cli";
+import { jaccardSimilarity } from "../src/tools/wisdom";
+
+async function withTempHome(fn: (homeDir: string, somaHome: string) => Promise<void>): Promise<void> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-wisdom-"));
+  await fn(homeDir, join(homeDir, ".soma"));
+}
+
+test("wisdom update creates frames, appends observations, and lists counts", async () => {
+  await withTempHome(async (homeDir, somaHome) => {
+    const created = await updateFrame({
+      homeDir,
+      domain: "development",
+      type: "principle",
+      observation: "TDD catches integration bugs earlier",
+      now: new Date("2026-05-19T12:00:00Z"),
+    });
+    expect(created.created).toBe(true);
+    expect(created.observationCount).toBe(1);
+
+    const updated = await updateFrame({
+      homeDir,
+      domain: "development",
+      type: "anti-pattern",
+      observation: "Claiming done before tests pass hides regressions",
+      now: new Date("2026-05-20T12:00:00Z"),
+    });
+    expect(updated.created).toBe(false);
+    expect(updated.observationCount).toBe(2);
+
+    const content = await readFile(join(somaHome, "memory/WISDOM/FRAMES/development.md"), "utf8");
+    expect(content).toContain("[CRYSTAL] TDD catches integration bugs earlier");
+    expect(content).toContain("- Observation Count: 2");
+    expect(content).not.toContain(".claude");
+
+    const frames = await listFrames({ homeDir });
+    expect(frames).toMatchObject([{ domain: "development", observationCount: 2 }]);
+  });
+});
+
+test("wisdom classifier handles default and dynamic frame domains", async () => {
+  await withTempHome(async (homeDir) => {
+    const defaults = await classifyDomains("how should I structure the PR review", { homeDir });
+    expect(defaults[0]).toMatchObject({ domain: "development" });
+    expect(defaults[0]!.relevance).toBeGreaterThanOrEqual(0.8);
+
+    await updateFrame({
+      homeDir,
+      domain: "security-review",
+      type: "principle",
+      observation: "Threat modeling catches auth boundary mistakes before release",
+    });
+    const dynamic = await classifyDomains("auth boundary threat modeling for release", { homeDir });
+    expect(dynamic.map((item) => item.domain)).toContain("security-review");
+  });
+});
+
+test("wisdom synthesis detects cross-frame principles and health thresholds", async () => {
+  await withTempHome(async (homeDir, somaHome) => {
+    await updateFrame({
+      homeDir,
+      domain: "development",
+      type: "principle",
+      observation: "Small PR review catches integration bugs early",
+      now: new Date("2026-05-19T12:00:00Z"),
+    });
+    await updateFrame({
+      homeDir,
+      domain: "deployment",
+      type: "principle",
+      observation: "Small deploy review catches integration failures early",
+      now: new Date("2026-05-19T12:00:00Z"),
+    });
+
+    const result = await synthesizeWisdom({ homeDir, now: new Date("2026-05-20T12:00:00Z") });
+    expect(jaccardSimilarity("small review catches bugs early", "small review catches failures early")).toBeGreaterThanOrEqual(0.6);
+    expect(result.principles.length).toBeGreaterThanOrEqual(1);
+    expect(result.health.map((item) => item.status)).toContain("stable");
+    await expect(readFile(join(somaHome, "memory/WISDOM/PRINCIPLES/verified.md"), "utf8")).resolves.toContain("deployment + development");
+    await expect(readFile(join(somaHome, "memory/WISDOM/META/frame-health.md"), "utf8")).resolves.toContain("stable");
+  });
+});
+
+test("wisdom CLI routes classify, list, update, synthesize, and health", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli([
+      "wisdom",
+      "update",
+      "--domain",
+      "communication",
+      "--type",
+      "contextual-rule",
+      "--observation",
+      "Thread-first",
+      "updates",
+      "reduce",
+      "channel",
+      "noise",
+      "--home-dir",
+      homeDir,
+    ]);
+
+    const list = await runSomaCli(["wisdom", "list", "--home-dir", homeDir]);
+    expect(list).toContain("communication");
+    await expect(readFile(join(homeDir, ".soma/memory/WISDOM/FRAMES/communication.md"), "utf8")).resolves.toContain("Thread-first updates reduce channel noise");
+    await expect(runSomaCli([
+      "wisdom",
+      "update",
+      "--observation",
+      "note",
+      "--domain",
+      "--type",
+      "principle",
+      "--home-dir",
+      homeDir,
+    ])).rejects.toThrow("--domain requires a value");
+    await expect(runSomaCli([
+      "wisdom",
+      "update",
+      "--domain",
+      "--home-dir",
+      homeDir,
+      "--type",
+      "principle",
+      "--observation",
+      "note",
+    ])).rejects.toThrow("--domain requires a value");
+
+    const classified = JSON.parse(await runSomaCli(["wisdom", "classify", "thread update", "--home-dir", homeDir]));
+    expect(classified[0].domain).toBe("communication");
+
+    const synth = await runSomaCli(["wisdom", "synthesize", "--home-dir", homeDir]);
+    expect(synth).toContain("wisdom synthesize");
+
+    const health = await runSomaCli(["wisdom", "health", "--home-dir", homeDir]);
+    expect(health).toContain("wisdom health");
+  });
+});


### PR DESCRIPTION
## Summary
- add Soma wisdom frame classify/list/update/synthesize/health tooling
- store frames, principles, and health reports through Soma wisdom paths
- document wisdom frame contracts and add focused tests

## Verification
- rtk bun test test/wisdom-tools.test.ts test/cli.test.ts test/paths.test.ts
- rtk bun run typecheck
- git diff --check
- rtk bun test

Closes #131