### PR TITLE
feat: add relationship reflection

### DIFF
--- a/docs/relationship-contracts.md
+++ b/docs/relationship-contracts.md
@@ -1,0 +1,38 @@
+# Soma Relationship Reflection Contracts
+
+Relationship reflection reads and writes through the Soma path resolver. It
+does not call notification services directly; callers can inject a notifier.
+
+## Relationship Notes
+
+Daily relationship notes live under the Soma relationship memory root in
+`YYYY-MM/YYYY-MM-DD.md` files.
+
+Each parseable line uses this shape:
+
+```text
+W: <entity> — <positive observation>
+B: <entity> — <negative observation>
+O: <entity> — <neutral observation>
+```
+
+`W` and `O` lines become supporting evidence for the entity opinion. `B` lines
+become counter evidence. Missing opinions are created in the relationship
+category before evidence is appended.
+
+## Milestones
+
+Default milestones:
+
+- `first-pushback`: pushed back, disagreed, or challenged
+- `genuine-unknown`: do not know, not sure, or uncertain
+- `voice-smile`: voice, smiled, or laughed
+- `100-sessions`: at least 100 non-empty ratings entries
+
+Milestones append to `identity/our-story.md` with hidden milestone IDs to avoid
+duplicates.
+
+## Notification
+
+Confidence shifts greater than `0.15` can notify through an injected
+`RelationshipNotifier`. The CLI default is silent.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -135,6 +135,7 @@ import type {
 import { PAI_DOCS_IMPORT_SUBDIRS } from "./pai-docs-importer";
 import { runInferenceCli } from "./tools/inference/cli";
 import { runLearningCli, runMetricsCli, runOpinionCli, runSessionCli } from "./tools/learning/cli";
+import { RELATIONSHIP_REFLECT_USAGE, runRelationshipCli } from "./tools/relationship/cli";
 import { runWisdomCli } from "./tools/wisdom/cli";
 
 /**
@@ -358,7 +359,7 @@ interface ParsedInferenceArgs {
 }
 
 interface ParsedRawToolArgs {
-  command: "learning" | "opinion" | "metrics" | "session" | "wisdom";
+  command: "learning" | "opinion" | "metrics" | "session" | "relationship" | "wisdom";
   args: string[];
 }
 
@@ -401,6 +402,7 @@ const TOP_LEVEL_COMMANDS = [
   "migrate",
   "opinion",
   "policy",
+  "relationship",
   "reproject",
   "result",
   "session",
@@ -479,6 +481,12 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
   },
   session: {
     usage: "Usage: soma session <create|decision|work|blocker|next|handoff|resume|list|complete> ...",
+  },
+  relationship: {
+    usage: RELATIONSHIP_REFLECT_USAGE,
+    subcommands: {
+      reflect: RELATIONSHIP_REFLECT_USAGE,
+    },
   },
   wisdom: {
     usage: "Usage: soma wisdom <classify|list|update|synthesize|health> ...",
@@ -1704,7 +1712,7 @@ function parseArgs(args: string[]): ParsedArgs {
     return { command: "inference", args: args.slice(1) };
   }
 
-  if (args[0] === "learning" || args[0] === "opinion" || args[0] === "metrics" || args[0] === "session" || args[0] === "wisdom") {
+  if (args[0] === "learning" || args[0] === "opinion" || args[0] === "metrics" || args[0] === "session" || args[0] === "relationship" || args[0] === "wisdom") {
     return { command: args[0], args: args.slice(1) };
   }
 
@@ -3365,6 +3373,10 @@ export async function runSomaCli(args: string[]): Promise<string> {
 
   if (parsed.command === "session") {
     return runSessionCli(parsed.args);
+  }
+
+  if (parsed.command === "relationship") {
+    return runRelationshipCli(parsed.args);
   }
 
   if (parsed.command === "wisdom") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,6 +223,17 @@ export {
   type ToolCall,
 } from "./tools/learning";
 export {
+  parseRelationshipNotes,
+  reflectRelationship,
+  type RelationshipMilestone,
+  type RelationshipNote,
+  type RelationshipNoteKind,
+  type RelationshipNotification,
+  type RelationshipNotifier,
+  type RelationshipReflectOptions,
+  type RelationshipReflectResult,
+} from "./tools/relationship";
+export {
   classifyDomains,
   listFrames,
   synthesizeWisdom,

--- a/src/tools/relationship/cli.ts
+++ b/src/tools/relationship/cli.ts
@@ -1,0 +1,40 @@
+import { reflectRelationship } from "./reflect";
+import type { RelationshipReflectOptions } from "./types";
+
+export const RELATIONSHIP_REFLECT_USAGE = "Usage: soma relationship reflect [--opinions-only|--milestones-only] [--dry-run] [--home-dir <dir>] [--soma-home <dir>]";
+
+function readOption(args: string[], index: number, name: string): string {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) throw new Error(`${name} requires a value.`);
+  return value;
+}
+
+function commonOptions(args: string[]): RelationshipReflectOptions {
+  const options: RelationshipReflectOptions = {};
+  for (let index = 0; index < args.length; index += 1) {
+    if (args[index] === "--home-dir") options.homeDir = readOption(args, index, "--home-dir");
+    if (args[index] === "--soma-home") options.somaHome = readOption(args, index, "--soma-home");
+  }
+  return options;
+}
+
+export async function runRelationshipCli(args: string[]): Promise<string> {
+  const action = args[0];
+  if (action !== "reflect") throw new Error(RELATIONSHIP_REFLECT_USAGE);
+  if (args.includes("--opinions-only") && args.includes("--milestones-only")) {
+    throw new Error("--opinions-only and --milestones-only cannot be combined.");
+  }
+  const result = await reflectRelationship({
+    ...commonOptions(args),
+    opinionsOnly: args.includes("--opinions-only"),
+    milestonesOnly: args.includes("--milestones-only"),
+    dryRun: args.includes("--dry-run"),
+  });
+  return [
+    `relationship reflect: ${result.notes.length} note(s)`,
+    `opinion updates: ${result.opinionUpdates.length}`,
+    `milestones: ${result.milestones.length}`,
+    result.storyPath ? `story: ${result.storyPath}` : "",
+    result.dryRun ? "dry-run: no writes" : "",
+  ].filter(Boolean).join("\n") + "\n";
+}

--- a/src/tools/relationship/index.ts
+++ b/src/tools/relationship/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./reflect";

--- a/src/tools/relationship/reflect.ts
+++ b/src/tools/relationship/reflect.ts
@@ -1,0 +1,186 @@
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import { createPaths } from "../../paths";
+import { addOpinion, addOpinionEvidence, listOpinions } from "../learning";
+import type { EvidenceType } from "../learning";
+import type { RelationshipMilestone, RelationshipNote, RelationshipReflectOptions, RelationshipReflectResult } from "./types";
+
+const DEFAULT_MILESTONES = [
+  { id: "first-pushback", description: "Principal pushed back on assistant", pattern: /pushed back|disagreed|challenged/i },
+  { id: "genuine-unknown", description: "Assistant admitted genuine uncertainty", pattern: /don't know|do not know|not sure|uncertain/i },
+  { id: "voice-smile", description: "Emotional response to voice interaction", pattern: /voice|smiled|laughed/i },
+];
+
+function pathsFor(options: RelationshipReflectOptions) {
+  return createPaths(options.somaHome ? { somaHome: options.somaHome } : { homeDir: options.homeDir });
+}
+
+function isoDate(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+function parseNoteLine(line: string, date: string, path: string): RelationshipNote | undefined {
+  const match = line.match(/^\s*([WBO]):\s*(.+?)\s+(?:—|--|-)\s+(.+?)\s*$/);
+  if (!match) return undefined;
+  return {
+    kind: match[1] as RelationshipNote["kind"],
+    entity: match[2]!.trim(),
+    observation: match[3]!.trim(),
+    date,
+    path,
+  };
+}
+
+export function parseRelationshipNotes(content: string, date: string, path = ""): RelationshipNote[] {
+  return content.split("\n")
+    .map((line) => parseNoteLine(line, date, path))
+    .filter((note): note is RelationshipNote => note !== undefined);
+}
+
+async function readDirIfExists(path: string) {
+  return readdir(path, { withFileTypes: true }).catch((error: unknown) => {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
+    throw error;
+  });
+}
+
+async function discoverNoteFiles(options: RelationshipReflectOptions): Promise<Array<{ path: string; date: string }>> {
+  const paths = pathsFor(options);
+  const now = options.now ?? new Date();
+  const recentDays = options.recentDays ?? 7;
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - recentDays);
+  const root = paths.relationship();
+  const months = await readDirIfExists(root);
+  const files: Array<{ path: string; date: string }> = [];
+  for (const month of months.filter((entry) => entry.isDirectory())) {
+    for (const entry of await readDirIfExists(join(root, month.name))) {
+      if (!entry.isFile() || !entry.name.endsWith(".md")) continue;
+      const date = basename(entry.name, ".md");
+      if (new Date(`${date}T00:00:00.000Z`) < cutoff) continue;
+      files.push({ path: join(root, month.name, entry.name), date });
+    }
+  }
+  return files.sort((a, b) => a.date.localeCompare(b.date));
+}
+
+async function readRelationshipNotes(options: RelationshipReflectOptions): Promise<RelationshipNote[]> {
+  const files = await discoverNoteFiles(options);
+  const nested = await Promise.all(files.map(async (file) => {
+    const content = await readFile(file.path, "utf8");
+    return parseRelationshipNotes(content, file.date, file.path);
+  }));
+  return nested.flat();
+}
+
+function noteEvidenceType(note: RelationshipNote): EvidenceType {
+  if (note.kind === "B") return "counter";
+  return "supporting";
+}
+
+function applyDryRunConfidence(confidence: number, note: RelationshipNote): number {
+  return Math.max(0.01, Math.min(0.99, confidence + (note.kind === "B" ? -0.05 : 0.02)));
+}
+
+async function emitConfidenceNotification(
+  statement: string,
+  oldConfidence: number,
+  newConfidence: number,
+  options: RelationshipReflectOptions,
+): Promise<boolean> {
+  const shouldNotify = Math.abs(newConfidence - oldConfidence) > 0.15;
+  const notified = shouldNotify && Boolean(options.notifier) && !options.dryRun;
+  if (notified && options.notifier) {
+    await options.notifier.notify({
+      title: "Relationship confidence shift",
+      message: `${statement}: ${oldConfidence.toFixed(2)} -> ${newConfidence.toFixed(2)}`,
+    });
+  }
+  return notified;
+}
+
+async function applyOpinionUpdates(notes: RelationshipNote[], options: RelationshipReflectOptions): Promise<RelationshipReflectResult["opinionUpdates"]> {
+  const grouped = new Map<string, RelationshipNote[]>();
+  for (const note of notes) {
+    const group = grouped.get(note.entity);
+    if (group) group.push(note);
+    else grouped.set(note.entity, [note]);
+  }
+  const updates: RelationshipReflectResult["opinionUpdates"] = [];
+  const cachedOpinions = new Map((await listOpinions(options)).map((opinion) => [opinion.statement.toLowerCase(), opinion]));
+
+  for (const [statement, group] of grouped) {
+    let existing = cachedOpinions.get(statement.toLowerCase());
+    if (!existing && !options.dryRun) {
+      existing = await addOpinion(statement, "relationship", options);
+      cachedOpinions.set(statement.toLowerCase(), existing);
+    }
+    const oldConfidence = existing?.confidence ?? 0.5;
+    let newConfidence = oldConfidence;
+
+    for (const note of group) {
+      if (options.dryRun) {
+        newConfidence = applyDryRunConfidence(newConfidence, note);
+        continue;
+      }
+      const result = await addOpinionEvidence(statement, noteEvidenceType(note), `${note.date}: ${note.observation}`, {
+        ...options,
+        sessionId: basename(note.path, ".md"),
+      });
+      newConfidence = result.opinion.confidence;
+    }
+
+    const notified = await emitConfidenceNotification(statement, oldConfidence, newConfidence, options);
+    updates.push({ statement, oldConfidence, newConfidence, evidenceCount: group.length, notified });
+  }
+
+  return updates;
+}
+
+async function ratingsCount(options: RelationshipReflectOptions): Promise<number> {
+  const content = await readFile(pathsFor(options).ratings(), "utf8").catch((error: unknown) => {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return "";
+    throw error;
+  });
+  return content.split("\n").filter((line) => line.trim()).length;
+}
+
+async function detectMilestones(notes: RelationshipNote[], options: RelationshipReflectOptions): Promise<RelationshipMilestone[]> {
+  const now = isoDate(options.now ?? new Date());
+  const milestones: RelationshipMilestone[] = [];
+  const patterns = options.milestones ?? DEFAULT_MILESTONES;
+  for (const milestone of patterns) {
+    const note = notes.find((candidate) => milestone.pattern.test(candidate.observation));
+    if (note) milestones.push({ id: milestone.id, description: milestone.description, evidence: note.observation, date: note.date });
+  }
+  if (await ratingsCount(options) >= 100) {
+    milestones.push({ id: "100-sessions", description: "Centennial session milestone", evidence: "ratings count reached at least 100", date: now });
+  }
+  return milestones;
+}
+
+async function appendStoryMilestones(milestones: RelationshipMilestone[], options: RelationshipReflectOptions): Promise<string | undefined> {
+  if (milestones.length === 0 || options.dryRun) return undefined;
+  const path = pathsFor(options).story();
+  const existing = await readFile(path, "utf8").catch((error: unknown) => {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return "# Our Story\n\n";
+    throw error;
+  });
+  const fresh = milestones.filter((milestone) => !existing.includes(`<!-- milestone:${milestone.id} -->`));
+  if (fresh.length === 0) return path;
+  const addition = fresh.map((milestone) => [
+    `<!-- milestone:${milestone.id} -->`,
+    `- ${milestone.date}: ${milestone.description} — ${milestone.evidence}`,
+  ].join("\n")).join("\n");
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${existing.trimEnd()}\n${addition}\n`, "utf8");
+  return path;
+}
+
+export async function reflectRelationship(options: RelationshipReflectOptions = {}): Promise<RelationshipReflectResult> {
+  const notes = await readRelationshipNotes(options);
+  const opinionUpdates = options.milestonesOnly ? [] : await applyOpinionUpdates(notes, options);
+  const milestones = options.opinionsOnly ? [] : await detectMilestones(notes, options);
+  const storyPath = options.opinionsOnly ? undefined : await appendStoryMilestones(milestones, options);
+  return { notes, opinionUpdates, milestones, storyPath, dryRun: options.dryRun ?? false };
+}

--- a/src/tools/relationship/types.ts
+++ b/src/tools/relationship/types.ts
@@ -1,0 +1,44 @@
+import type { LearningToolOptions } from "../learning";
+
+export type RelationshipNoteKind = "W" | "B" | "O";
+
+export interface RelationshipNote {
+  kind: RelationshipNoteKind;
+  entity: string;
+  observation: string;
+  date: string;
+  path: string;
+}
+
+export interface RelationshipMilestone {
+  id: string;
+  description: string;
+  evidence: string;
+  date: string;
+}
+
+export interface RelationshipNotification {
+  title: string;
+  message: string;
+}
+
+export interface RelationshipNotifier {
+  notify(notification: RelationshipNotification): Promise<void>;
+}
+
+export interface RelationshipReflectOptions extends LearningToolOptions {
+  opinionsOnly?: boolean;
+  milestonesOnly?: boolean;
+  dryRun?: boolean;
+  recentDays?: number;
+  notifier?: RelationshipNotifier;
+  milestones?: Array<{ id: string; description: string; pattern: RegExp }>;
+}
+
+export interface RelationshipReflectResult {
+  notes: RelationshipNote[];
+  opinionUpdates: Array<{ statement: string; oldConfidence: number; newConfidence: number; evidenceCount: number; notified: boolean }>;
+  milestones: RelationshipMilestone[];
+  storyPath?: string;
+  dryRun: boolean;
+}

--- a/test/relationship-tools.test.ts
+++ b/test/relationship-tools.test.ts
@@ -1,0 +1,101 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { addOpinion, parseRelationshipNotes, reflectRelationship, type RelationshipNotification } from "../src";
+import { runSomaCli } from "../src/cli";
+
+async function withTempHome(fn: (homeDir: string, somaHome: string) => Promise<void>): Promise<void> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-relationship-"));
+  await fn(homeDir, join(homeDir, ".soma"));
+}
+
+test("relationship note parsing maps WBO lines", () => {
+  const notes = parseRelationshipNotes([
+    "W: assistant — asked a sharp clarifying question",
+    "B: assistant — missed the direct request",
+    "O: collaboration — voice interaction felt natural",
+  ].join("\n"), "2026-05-19", "/notes.md");
+
+  expect(notes).toEqual([
+    { kind: "W", entity: "assistant", observation: "asked a sharp clarifying question", date: "2026-05-19", path: "/notes.md" },
+    { kind: "B", entity: "assistant", observation: "missed the direct request", date: "2026-05-19", path: "/notes.md" },
+    { kind: "O", entity: "collaboration", observation: "voice interaction felt natural", date: "2026-05-19", path: "/notes.md" },
+  ]);
+});
+
+test("relationship reflection updates opinions, detects milestones, and prevents duplicate story entries", async () => {
+  await withTempHome(async (homeDir, somaHome) => {
+    const noteDir = join(somaHome, "memory/RELATIONSHIP/2026-05");
+    await mkdir(noteDir, { recursive: true });
+    await writeFile(join(noteDir, "2026-05-19.md"), [
+      "W: assistant — pushed back with useful evidence",
+      "O: assistant — said do not know yet",
+      "B: assistant — missed the direct request",
+      "O: collaboration — voice exchange made the collaborator smile",
+    ].join("\n"), "utf8");
+
+    const result = await reflectRelationship({ homeDir, now: new Date("2026-05-20T12:00:00Z") });
+    expect(result.notes).toHaveLength(4);
+    expect(result.opinionUpdates.find((item) => item.statement === "assistant")?.evidenceCount).toBe(3);
+    expect(result.milestones.map((item) => item.id)).toContain("first-pushback");
+    expect(result.milestones.map((item) => item.id)).toContain("genuine-unknown");
+    expect(result.milestones.map((item) => item.id)).toContain("voice-smile");
+
+    const opinions = await readFile(join(somaHome, "identity/opinions.md"), "utf8");
+    expect(opinions).toContain("assistant");
+    expect(opinions).not.toContain(".claude");
+
+    const storyPath = join(somaHome, "identity/our-story.md");
+    const firstStory = await readFile(storyPath, "utf8");
+    await reflectRelationship({ homeDir, now: new Date("2026-05-20T12:00:00Z") });
+    const secondStory = await readFile(storyPath, "utf8");
+    expect(secondStory.match(/milestone:first-pushback/g)?.length).toBe(1);
+    expect(secondStory.length).toBe(firstStory.length);
+  });
+});
+
+test("relationship reflection supports dry-run and notification injection", async () => {
+  await withTempHome(async (homeDir, somaHome) => {
+    await addOpinion("assistant", "relationship", { homeDir, initialConfidence: 0.5 });
+    const noteDir = join(somaHome, "memory/RELATIONSHIP/2026-05");
+    await mkdir(noteDir, { recursive: true });
+    await writeFile(join(noteDir, "2026-05-19.md"), [
+      "B: assistant — missed request one",
+      "B: assistant — missed request two",
+      "B: assistant — missed request three",
+      "B: assistant — missed request four",
+    ].join("\n"), "utf8");
+
+    const dryRun = await reflectRelationship({ homeDir, dryRun: true, now: new Date("2026-05-20T12:00:00Z") });
+    expect(dryRun.opinionUpdates[0]?.newConfidence).toBeCloseTo(0.3);
+    expect(dryRun.opinionUpdates[0]?.notified).toBe(false);
+    await expect(readFile(join(somaHome, "identity/our-story.md"), "utf8")).rejects.toThrow();
+
+    const notifications: RelationshipNotification[] = [];
+    const result = await reflectRelationship({
+      homeDir,
+      now: new Date("2026-05-20T12:00:00Z"),
+      notifier: { notify: async (notification) => { notifications.push(notification); } },
+    });
+    expect(result.opinionUpdates[0]?.notified).toBe(true);
+    expect(notifications).toHaveLength(1);
+  });
+});
+
+test("relationship CLI reflects modes", async () => {
+  await withTempHome(async (homeDir, somaHome) => {
+    const noteDir = join(somaHome, "memory/RELATIONSHIP/2026-05");
+    await mkdir(noteDir, { recursive: true });
+    await writeFile(join(noteDir, "2026-05-19.md"), "W: assistant — challenged the vague plan\n", "utf8");
+
+    const full = await runSomaCli(["relationship", "reflect", "--home-dir", homeDir]);
+    expect(full).toContain("relationship reflect");
+    expect(full).toContain("milestones: 1");
+
+    const dryRun = await runSomaCli(["relationship", "reflect", "--dry-run", "--opinions-only", "--home-dir", homeDir]);
+    expect(dryRun).toContain("dry-run: no writes");
+
+    await expect(runSomaCli(["relationship", "reflect", "--opinions-only", "--milestones-only", "--home-dir", homeDir])).rejects.toThrow("cannot be combined");
+  });
+});


### PR DESCRIPTION
## Summary
- add Soma relationship reflection tooling and CLI
- parse W/B/O relationship notes into opinion evidence
- detect milestones, update our-story without duplicates, and support injected notifications
- document relationship note and milestone contracts

## Verification
- rtk bun test test/relationship-tools.test.ts test/learning-tools.test.ts test/cli.test.ts
- rtk bun run typecheck
- git diff --check
- rtk bun test

Closes #132