### PR TITLE
docs: add Arc upgrade recovery guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ Install the package with Arc:
 arc install @metafactory/soma
 ```
 
+If `arc upgrade soma` resolves the new version but refuses to replace an
+older active install, use Arc's remove-then-install recovery path:
+
+```bash
+arc remove soma
+arc install @metafactory/soma
+```
+
+See [Arc install troubleshooting](docs/arc-install-troubleshooting.md) for the
+full note and pinned-version variant.
+
 Or run it from a source checkout:
 
 ```bash

--- a/docs/arc-install-troubleshooting.md
+++ b/docs/arc-install-troubleshooting.md
@@ -1,0 +1,39 @@
+# Arc Install Troubleshooting
+
+## `arc upgrade soma` reports an older active install
+
+Some Arc registry installs cannot be upgraded in place when an older extracted
+package is already active. In that case Arc may resolve the newer
+`@metafactory/soma` version correctly, then refuse the install because the old
+`soma` package is still active.
+
+Use Arc's remove-then-install recovery path:
+
+```bash
+arc remove soma
+arc install @metafactory/soma
+```
+
+To pin a specific release:
+
+```bash
+arc remove soma
+arc install @metafactory/soma@0.4.1
+```
+
+This removes Arc's package registration and symlinks before installing the
+new registry version. Your Soma home and assistant memory are not stored inside
+the Arc package checkout, so normal package removal should not delete the
+assistant state.
+
+After reinstalling, refresh the substrate projections you use:
+
+```bash
+soma install codex --apply
+soma install pi-dev --apply
+soma install claude-code --apply
+```
+
+If Arc later supports transparent in-place upgrades for extracted registry
+packages, this workaround can be removed from the docs.
+


### PR DESCRIPTION
## Summary

Refs #127.

Adds Soma-side documentation for the Arc active-install upgrade failure mode:

- README now points users to Arc's remove-then-install recovery path
- new troubleshooting doc explains why arc upgrade soma may fail when an older extracted registry package is active
- includes both latest-version and pinned-version recovery commands
- clarifies that normal Arc package removal should not delete Soma home state

## Verification

- git diff --check
- rtk bun run typecheck
- rtk bun test (936 pass)

## Scope note

The underlying in-place arc upgrade behavior is owned by the Arc package manager, not this Soma repo. This PR documents the safe Soma-side recovery path rather than pretending Soma can change Arc's upgrade pipeline.