### PR TITLE
Fix concurrent claude-skills progress

### DIFF
--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -1720,6 +1720,19 @@ export async function migrateClaudeSkills(
   // Skipped-idempotent skills fall back to disk re-read inside the
   // verify helper when a NEW substrate gets requested on rerun.
   const pendingVerifyPayloads: Map<string, Array<{ relPath: string; content: Buffer }>> = new Map();
+  interface ApplyWriteCandidate {
+    outcome: ClaudeSkillOutcome;
+    read: SourceSkillReadResult;
+    targetDir: string;
+    rewrittenSkillMdContent: string | null;
+    descriptionRewrite?: ClaudeSkillDescriptionRewrite;
+  }
+  interface ApplyWriteResult extends ApplyWriteCandidate {
+    fileShas: Record<string, string>;
+    rewrittenFiles: Array<{ relPath: string; content: Buffer }>;
+    elapsedMs: number;
+  }
+  const applyWriteCandidates: ApplyWriteCandidate[] = [];
 
   // #125 — index lookup for progress `[N/total]` prefix during the
   // apply phase. Built once over the post-classify outcomes so the
@@ -1914,58 +1927,84 @@ export async function migrateClaudeSkills(
       }
     }
 
-    // `needs-adapt` runs through the normalizer; `portable` and
-    // (when `--include-claude-specific`) `claude-specific` are
-    // pass-through. Running the normalizer on portable skills is
-    // safe (it's a no-op when no signals fire) but skipping the
-    // copy-byte-rewrite branch keeps the source SHA equal to the
-    // landed SHA for portable skills, which simplifies the audit
-    // trail.
-    const applyRewrites = outcome.tag === "needs-adapt";
-    // #125 — write-phase progress. Bytes are counted from the
-    // returned `fileShas` (one entry per landed file). The progress
-    // line wraps the I/O so principals see which skill is mid-write.
-    const writeIdx = outcomeIndexBySource.get(outcome.sourceName) ?? 0;
-    const writeT0 = Date.now();
-    const { fileShas, rewrittenFiles } = await writeSkillPayload(
+    applyWriteCandidates.push({
+      outcome,
       read,
       targetDir,
-      applyRewrites,
       rewrittenSkillMdContent,
-    );
-    const writeElapsed = Date.now() - writeT0;
-    applyWriteMs += writeElapsed;
-    progress.stepComplete(
-      writeIdx,
-      outcome.sourceName,
-      "writing",
-      writeElapsed,
-      `${Object.keys(fileShas).length} files`,
-    );
-    manifestEntries.push({
-      sourceName: outcome.sourceName,
-      kebabName: outcome.kebabName,
-      tag: outcome.tag,
-      sourceSha: outcome.sourceSha,
-      fileShas,
       ...(descriptionRewrite ? { descriptionRewrite } : {}),
     });
-    if (descriptionRewrite) {
-      outcome.descriptionRewrite = descriptionRewrite;
-    }
-    // Refresh the outcome's fileCount with the count of files actually
-    // landed under the skill root (always equal to source file count
-    // in Phase 1; the divergence shows up under Phase 2 if any per-
-    // substrate omits files).
-    outcome.fileCount = Object.keys(fileShas).length;
-    writtenCount += 1;
+  }
 
-    // Stash the post-rewrite payload for the smoke pass below. We
-    // don't run verify inline here so the idempotency contract is
-    // unambiguous — a re-run with no source churn but a fresh
-    // `--smoke <new-sub>` flag still triggers verify on the new
-    // substrate, even when the skill was skipped-idempotent above.
-    pendingVerifyPayloads.set(outcome.sourceName, rewrittenFiles);
+  // #139 — apply writes are independent per target skill directory,
+  // so run them through the same bounded-concurrency progress phase
+  // as read+classify. Results are returned in input order by
+  // runBoundedConcurrent, preserving manifest/report stability.
+  const APPLY_WRITE_CONCURRENCY = 4;
+  const writePhaseStart = Date.now();
+  progress.beginConcurrentPhase("apply write", applyWriteCandidates.length, APPLY_WRITE_CONCURRENCY);
+  try {
+    const writeResults = await runBoundedConcurrent<ApplyWriteCandidate, ApplyWriteResult>(
+      applyWriteCandidates,
+      async (candidate) => {
+        const { outcome, read, targetDir, rewrittenSkillMdContent } = candidate;
+        const applyRewrites = outcome.tag === "needs-adapt";
+        const writeIdx = outcomeIndexBySource.get(outcome.sourceName) ?? 0;
+        progress.step(writeIdx, outcome.sourceName, "writing");
+        const writeT0 = Date.now();
+        const { fileShas, rewrittenFiles } = await writeSkillPayload(
+          read,
+          targetDir,
+          applyRewrites,
+          rewrittenSkillMdContent,
+        );
+        const elapsedMs = Date.now() - writeT0;
+        progress.stepComplete(
+          writeIdx,
+          outcome.sourceName,
+          "writing",
+          elapsedMs,
+          `${Object.keys(fileShas).length} files`,
+        );
+        return {
+          ...candidate,
+          fileShas,
+          rewrittenFiles,
+          elapsedMs,
+        };
+      },
+      APPLY_WRITE_CONCURRENCY,
+    );
+    for (const result of writeResults) {
+      const { outcome, fileShas, rewrittenFiles, descriptionRewrite } = result;
+      applyWriteMs += result.elapsedMs;
+      manifestEntries.push({
+        sourceName: outcome.sourceName,
+        kebabName: outcome.kebabName,
+        tag: outcome.tag,
+        sourceSha: outcome.sourceSha,
+        fileShas,
+        ...(descriptionRewrite ? { descriptionRewrite } : {}),
+      });
+      if (descriptionRewrite) {
+        outcome.descriptionRewrite = descriptionRewrite;
+      }
+      // Refresh the outcome's fileCount with the count of files actually
+      // landed under the skill root (always equal to source file count
+      // in Phase 1; the divergence shows up under Phase 2 if any per-
+      // substrate omits files).
+      outcome.fileCount = Object.keys(fileShas).length;
+      writtenCount += 1;
+
+      // Stash the post-rewrite payload for the smoke pass below. We
+      // don't run verify inline here so the idempotency contract is
+      // unambiguous — a re-run with no source churn but a fresh
+      // `--smoke <new-sub>` flag still triggers verify on the new
+      // substrate, even when the skill was skipped-idempotent above.
+      pendingVerifyPayloads.set(outcome.sourceName, rewrittenFiles);
+    }
+  } finally {
+    progress.endConcurrentPhase("apply write", Date.now() - writePhaseStart);
   }
 
   // #115 Phase 2 — smoke pass. For each (imported skill, requested

--- a/src/claude-skills-progress.ts
+++ b/src/claude-skills-progress.ts
@@ -87,18 +87,9 @@ export interface ProgressEmitter {
   ): void;
 
   /**
-   * #139 — open a concurrent phase. While a concurrent phase is
-   * active, all `step` / `stepComplete` calls are SUPPRESSED — only
-   * the begin banner (emitted here) and the end summary (emitted by
-   * `endConcurrentPhase`) reach stderr.
-   *
-   * Rationale: the read+classify phase runs 4-wide via
-   * `runBoundedConcurrent`. The #125 per-skill emitter falls through
-   * to `\n`-terminated lines for concurrent fan-out (because `\r`
-   * overwrite would clobber 3 of 4 in-flight lines), producing 97
-   * append-only lines for a real PAI tree (issue #139). The quick
-   * patch suppresses per-skill output entirely during the fan-out
-   * and emits one banner + one summary instead.
+   * #139 — open a concurrent phase. TTY output renders one rolling
+   * line for the whole worker pool; non-TTY and verbose output keep
+   * the append-only per-skill lines that are useful in logs.
    *
    * `concurrency` is reported in the banner so a principal tail-ing
    * stderr knows the fan-out width (`4-wide concurrent`).
@@ -152,21 +143,27 @@ interface ProgressEmitterOptions {
    * override).
    */
   isatty: boolean;
+  /**
+   * Preserve append-only per-skill output even for concurrent phases.
+   * This is intentionally separate from `quiet`: quiet suppresses all
+   * stderr progress, verbose asks for the most detailed stderr form.
+   */
+  verbose?: boolean;
 }
 
 export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmitter {
-  const { stderr, quiet, isatty } = opts;
+  const { stderr, quiet, isatty, verbose = false } = opts;
   let total = 0;
 
-  // #139 — concurrent-phase state. When non-null, the emitter is
-  // inside a `beginConcurrentPhase` / `endConcurrentPhase` bracket
-  // and per-skill `step` / `stepComplete` calls are suppressed.
-  // We record per-step elapsed ms so the end summary can report
-  // avg + max without the caller having to thread stats through.
-  // Nesting is not supported (a second begin overwrites state).
+  // #139 — concurrent-phase state. Nesting is not supported (a
+  // second begin overwrites state).
   let activeConcurrentPhase: {
     name: string;
     total: number;
+    concurrency: number;
+    completedCount: number;
+    inFlight: Set<string>;
+    latestCompleted: string | null;
     elapsedSamples: number[]; // ms per stepComplete inside the phase
   } | null = null;
 
@@ -201,6 +198,17 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
     return `${prefix} ${sourceName}  ${tail}`;
   }
 
+  function shouldAppendConcurrentLines(): boolean {
+    return !isatty || verbose;
+  }
+
+  function renderConcurrentLine(phase: NonNullable<typeof activeConcurrentPhase>): void {
+    const active = phase.latestCompleted ?? phase.inFlight.values().next().value ?? "skills";
+    const visibleInFlight = phase.inFlight.has(active) ? phase.inFlight.size - 1 : phase.inFlight.size;
+    const others = visibleInFlight > 0 ? ` + ${visibleInFlight} others` : "";
+    stderr.write(`\r[${phase.completedCount}/${phase.total}] processing ${active}${others}...`);
+  }
+
   return {
     start(t: number): void {
       total = t;
@@ -212,11 +220,15 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
 
     step(index: number, sourceName: string, phase: string, detail?: string): void {
       if (quiet) return;
-      // #139 — suppress per-skill output while a concurrent phase is
-      // active. The begin/end banner pair carries the user-facing
-      // signal; per-skill rows from 4-wide fan-out workers would
-      // otherwise produce ~totalSkills interleaved lines.
-      if (activeConcurrentPhase) return;
+      if (activeConcurrentPhase) {
+        activeConcurrentPhase.inFlight.add(sourceName);
+        if (shouldAppendConcurrentLines()) {
+          stderr.write(`${formatStepLine(index, sourceName, phase, detail)}\n`);
+        } else {
+          renderConcurrentLine(activeConcurrentPhase);
+        }
+        return;
+      }
       const body = formatStepLine(index, sourceName, phase, detail);
       if (isatty) {
         // TTY: open with `\r` to overwrite any prior fast-phase line.
@@ -236,13 +248,19 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
       detail?: string,
     ): void {
       if (quiet) return;
-      // #139 — record per-step elapsed for the eventual summary,
-      // then suppress per-skill output while in a concurrent phase.
-      // The migrator still calls stepComplete inside the concurrent
-      // loop (so its own timing accumulators stay accurate); the
-      // suppression is purely an output concern.
       if (activeConcurrentPhase) {
-        activeConcurrentPhase.elapsedSamples.push(elapsedMs);
+        const current = activeConcurrentPhase;
+        current.elapsedSamples.push(elapsedMs);
+        current.completedCount += 1;
+        current.latestCompleted = sourceName;
+        current.inFlight.delete(sourceName);
+        if (shouldAppendConcurrentLines()) {
+          const elapsed = fmtElapsed(elapsedMs);
+          const body = formatStepLine(index, sourceName, phase, detail);
+          stderr.write(`${body} (${elapsed})\n`);
+        } else {
+          renderConcurrentLine(current);
+        }
         return;
       }
       const elapsed = fmtElapsed(elapsedMs);
@@ -271,16 +289,20 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
       activeConcurrentPhase = {
         name,
         total: totalSteps,
+        concurrency,
+        completedCount: 0,
+        inFlight: new Set(),
+        latestCompleted: null,
         elapsedSamples: [],
       };
       if (quiet) return;
-      // Banner is `\n`-terminated even on TTY: nothing subsequent
-      // overwrites it (per-skill rows are suppressed for the
-      // duration of the phase), and `\r` would be meaningless on
-      // non-TTY pipes. Stable byte sequence across both modes.
-      stderr.write(
-        `[${name}: ${totalSteps} skills, ${concurrency}-wide concurrent ...]\n`,
-      );
+      if (shouldAppendConcurrentLines()) {
+        stderr.write(
+          `[${name}: ${totalSteps} skills, ${concurrency}-wide concurrent ...]\n`,
+        );
+      } else {
+        renderConcurrentLine(activeConcurrentPhase);
+      }
     },
 
     endConcurrentPhase(name: string, elapsedMs: number): void {
@@ -303,9 +325,8 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
         maxMs = samples.reduce((a, b) => (b > a ? b : a), 0);
       }
       const elapsed = fmtElapsedSeconds(elapsedMs);
-      stderr.write(
-        `[${name}: ${count} skills in ${elapsed} (avg ${avgMs}ms, max ${maxMs}ms)]\n`,
-      );
+      const summary = `[${name}: ${count} skills in ${elapsed} (avg ${avgMs}ms, max ${maxMs}ms)]`;
+      stderr.write(`${isatty && !verbose ? "\r" : ""}${summary}\n`);
     },
 
     finishTimingSummary(timings: PhaseTimings): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -248,6 +248,8 @@ interface ParsedMigrateClaudeSkillsArgs {
   // quiet emitter to the migrator). The Timing block on stdout is
   // unaffected — it's part of the summary, not stderr noise.
   quiet?: boolean;
+  /** #139 — preserve append-only per-skill stderr rows for debugging. */
+  verbose?: boolean;
 }
 
 interface ParsedAdoptArgs {
@@ -421,7 +423,7 @@ const MIGRATE_PAI_USAGE =
 // from the usage line below for non-Phase-2 callers — they keep the
 // Phase-1 surface intact.
 const MIGRATE_CLAUDE_SKILLS_USAGE =
-  "Usage: soma migrate claude-skills --from <skills-dir> [--dry-run] [--apply] [--status] [--home-dir <dir>] [--soma-home <dir>] [--include-claude-specific] [--smoke <codex|pi-dev|all>] [--rewrite-descriptions <claude|codex|pi|none>] [--quiet]";
+  "Usage: soma migrate claude-skills --from <skills-dir> [--dry-run] [--apply] [--status] [--home-dir <dir>] [--soma-home <dir>] [--include-claude-specific] [--smoke <codex|pi-dev|all>] [--rewrite-descriptions <claude|codex|pi|none>] [--quiet] [--verbose]";
 const ADOPT_CLAUDE_USAGE =
   "Usage: soma adopt claude [--dry-run] [--apply] [--uninstall] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string, string> }> = {
@@ -1948,6 +1950,7 @@ function parseMigrateClaudeSkillsArgs(args: string[]): ParsedMigrateClaudeSkills
   // stdout is unaffected; principals who pipe stderr to /dev/null in
   // CI scripts no longer need to.
   let quiet = false;
+  let verbose = false;
 
   for (let index = 0; index < rest.length; index += 1) {
     const arg = rest[index];
@@ -2000,6 +2003,12 @@ function parseMigrateClaudeSkillsArgs(args: string[]): ParsedMigrateClaudeSkills
         // friendly for scripts that don't want the progress noise.
         quiet = true;
         break;
+      case "--verbose":
+        // #139 — force append-only per-skill stderr progress even
+        // inside concurrent phases. Useful for diagnosing a specific
+        // skill without changing stdout formatting.
+        verbose = true;
+        break;
       default:
         throw new Error(`Unknown option: ${arg}`);
     }
@@ -2013,7 +2022,7 @@ function parseMigrateClaudeSkillsArgs(args: string[]): ParsedMigrateClaudeSkills
     throw new Error(MIGRATE_CLAUDE_SKILLS_USAGE);
   }
 
-  return { command: "migrate", source: "claude-skills", mode, options, quiet };
+  return { command: "migrate", source: "claude-skills", mode, options, quiet, verbose };
 }
 
 // #115 Phase 2 — expand `--smoke <value>`. `all` resolves to every
@@ -3476,6 +3485,7 @@ export async function runSomaCli(args: string[]): Promise<string> {
           stderr: process.stderr,
           quiet: parsed.quiet === true,
           isatty: process.stderr.isTTY === true,
+          verbose: parsed.verbose === true,
         });
       }
       if (parsed.mode === "plan") {

--- a/test/claude-skills-migrator-progress.test.ts
+++ b/test/claude-skills-migrator-progress.test.ts
@@ -158,6 +158,38 @@ test("migrateClaudeSkills --apply emits writing step for each imported skill", a
   });
 });
 
+test("#139: migrateClaudeSkills brackets apply write with begin/endConcurrentPhase", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeFixture(home);
+    const emitter = makeCapturingEmitter();
+    await migrateClaudeSkills({
+      from: fromDir,
+      somaHome: join(home, "soma"),
+      progressEmitter: emitter,
+    });
+    const begins = emitter.calls.filter((c) => c.method === "beginConcurrentPhase");
+    const ends = emitter.calls.filter((c) => c.method === "endConcurrentPhase");
+    expect(begins.map((c) => c.name)).toEqual(["read + classify", "apply write"]);
+    expect(ends.map((c) => c.name)).toEqual(["read + classify", "apply write"]);
+    expect(begins[1].total).toBe(2);
+    expect(begins[1].concurrency).toBe(4);
+    const writeBeginIdx = emitter.calls.findIndex(
+      (c) => c.method === "beginConcurrentPhase" && c.name === "apply write",
+    );
+    const writeEndIdx = emitter.calls.findIndex(
+      (c) => c.method === "endConcurrentPhase" && c.name === "apply write",
+    );
+    const writeStepIndices = emitter.calls
+      .map((c, i) => ({ c, i }))
+      .filter(({ c }) => c.method === "stepComplete" && c.phase === "writing")
+      .map(({ i }) => i);
+    for (const i of writeStepIndices) {
+      expect(i).toBeGreaterThan(writeBeginIdx);
+      expect(i).toBeLessThan(writeEndIdx);
+    }
+  });
+});
+
 test("migrateClaudeSkills brackets LLM rewrite with start + complete progress", async () => {
   await withTempHome(async (home) => {
     const fromDir = join(home, "skills");

--- a/test/claude-skills-progress.test.ts
+++ b/test/claude-skills-progress.test.ts
@@ -156,14 +156,11 @@ test("quiet=true still produces a finishTimingSummary string (timing belongs on 
 });
 
 // ──────────────────────────────────────────────────────────────
-// #139 quick patch — concurrent-phase suppression.
+// #139 — concurrent-phase rolling display.
 //
-// Concurrent phases (read+classify with 4-wide fan-out) emit ONE
-// banner line at phase begin and ONE summary line at phase end.
-// Per-skill `step` / `stepComplete` calls inside the phase are
-// suppressed entirely — otherwise the 4-wide concurrent worker
-// pool produces 97 interleaved append-only lines (the #139
-// symptom).
+// Concurrent phases (read+classify/apply write with 4-wide fan-out)
+// emit one rolling TTY line and one summary. Non-TTY and verbose
+// preserve append-only per-skill rows for logs/debugging.
 //
 // Sequential phases (rewrite, write, smoke verify) keep the #125
 // `\r`-overwrite behavior. `step` / `stepComplete` outside any
@@ -177,28 +174,44 @@ test("#139: beginConcurrentPhase emits one banner line on non-TTY", () => {
   expect(capture.text).toBe("[read + classify: 97 skills, 4-wide concurrent ...]\n");
 });
 
-test("#139: beginConcurrentPhase emits one banner line on TTY (still \\n-terminated)", () => {
-  // Concurrent banner is a phase-boundary marker, NOT a rolling-line
-  // candidate. It's safe to terminate with `\n` on TTY because no
-  // subsequent step writes will overwrite it (steps are suppressed
-  // entirely while a concurrent phase is active).
+test("#139: beginConcurrentPhase starts a rolling line on TTY", () => {
   const { stream, capture } = makeCapturingStream();
   const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: true });
   emitter.beginConcurrentPhase("read + classify", 97, 4);
-  expect(capture.text).toBe("[read + classify: 97 skills, 4-wide concurrent ...]\n");
+  expect(capture.text).toBe("\r[0/97] processing skills...");
+  expect(capture.text).not.toContain("\n");
 });
 
-test("#139: step + stepComplete are no-op while a concurrent phase is active", () => {
+test("#139: non-TTY concurrent phase preserves append-only per-skill rows", () => {
   const { stream, capture } = makeCapturingStream();
   const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: false });
   emitter.beginConcurrentPhase("read + classify", 3, 4);
-  // 3 per-skill `stepComplete` calls inside the concurrent phase
-  // must NOT emit any output.
+  emitter.step(1, "Foo", "reading + classifying", "read");
   emitter.stepComplete(1, "Foo", "reading + classifying", 12, "read");
   emitter.stepComplete(2, "Bar", "reading + classifying", 8, "read");
   emitter.stepComplete(3, "Baz", "reading + classifying", 15, "read");
-  // Only the begin banner should be in the capture.
-  expect(capture.text).toBe("[read + classify: 3 skills, 4-wide concurrent ...]\n");
+  expect(capture.text).not.toContain("\r");
+  expect(capture.text).toContain("[read + classify: 3 skills, 4-wide concurrent ...]\n");
+  expect(capture.text).toContain("Foo");
+  expect(capture.text).toContain("Bar");
+  expect(capture.text).toContain("Baz");
+  expect(capture.text.split("\n").filter((l) => l.length > 0).length).toBe(5);
+});
+
+test("#139: TTY concurrent phase rolls one line instead of appending per-skill rows", () => {
+  const { stream, capture } = makeCapturingStream();
+  const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: true });
+  emitter.beginConcurrentPhase("read + classify", 3, 4);
+  emitter.step(1, "Foo", "reading + classifying", "read");
+  emitter.step(2, "Bar", "reading + classifying", "read");
+  emitter.stepComplete(1, "Foo", "reading + classifying", 12, "read");
+  emitter.stepComplete(2, "Bar", "reading + classifying", 8, "read");
+  expect(capture.text).toContain("\r[0/3] processing skills...");
+  expect(capture.text).toContain("\r[0/3] processing Foo...");
+  expect(capture.text).toContain("\r[0/3] processing Foo + 1 others...");
+  expect(capture.text).toContain("\r[1/3] processing Foo + 1 others...");
+  expect(capture.text).toContain("\r[2/3] processing Bar...");
+  expect(capture.text).not.toContain("\n[");
 });
 
 test("#139: endConcurrentPhase emits a summary line with elapsed + avg + max", () => {
@@ -209,16 +222,15 @@ test("#139: endConcurrentPhase emits a summary line with elapsed + avg + max", (
   emitter.stepComplete(2, "Bar", "reading + classifying", 20, "read");
   emitter.stepComplete(3, "Baz", "reading + classifying", 30, "read");
   emitter.endConcurrentPhase("read + classify", 900);
-  // Begin + end. Step calls suppressed.
   const lines = capture.text.split("\n").filter((l) => l.length > 0);
-  expect(lines.length).toBe(2);
+  expect(lines.length).toBe(5);
   expect(lines[0]).toBe("[read + classify: 3 skills, 4-wide concurrent ...]");
   // Summary: count, elapsed (seconds), avg (ms), max (ms).
-  expect(lines[1]).toContain("read + classify");
-  expect(lines[1]).toContain("3 skills");
-  expect(lines[1]).toContain("0.9s");
-  expect(lines[1]).toContain("avg 20ms");
-  expect(lines[1]).toContain("max 30ms");
+  expect(lines[4]).toContain("read + classify");
+  expect(lines[4]).toContain("3 skills");
+  expect(lines[4]).toContain("0.9s");
+  expect(lines[4]).toContain("avg 20ms");
+  expect(lines[4]).toContain("max 30ms");
 });
 
 test("#139: endConcurrentPhase with zero recorded steps emits avg 0ms max 0ms", () => {
@@ -258,23 +270,22 @@ test("#139: quiet=true suppresses concurrent banner + summary", () => {
   expect(capture.text).toBe("");
 });
 
-test("#139: TTY non-quiet — concurrent phase still suppresses per-skill rows", () => {
-  // Regression guard: the #139 symptom (97 interleaved lines on
-  // TTY) was specifically because step/stepComplete fell through
-  // to per-skill emission with `\r` overwrite that couldn't keep
-  // up with 4-wide fan-out. With the concurrent-phase wrapper, the
-  // emitter must suppress regardless of TTY-ness.
+test("#139: verbose TTY preserves append-only per-skill rows", () => {
   const { stream, capture } = makeCapturingStream();
-  const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: true });
+  const emitter = createProgressEmitter({
+    stderr: stream,
+    quiet: false,
+    isatty: true,
+    verbose: true,
+  });
   emitter.beginConcurrentPhase("read + classify", 2, 4);
+  emitter.step(1, "Foo", "reading + classifying", "read");
   emitter.stepComplete(1, "Foo", "reading + classifying", 10, "read");
   emitter.stepComplete(2, "Bar", "reading + classifying", 12, "read");
   emitter.endConcurrentPhase("read + classify", 80);
-  // No "Foo" or "Bar" per-skill lines should leak through.
-  expect(capture.text).not.toContain("Foo");
-  expect(capture.text).not.toContain("Bar");
-  // Begin banner and end summary present.
+  expect(capture.text).not.toContain("\r");
   expect(capture.text).toContain("[read + classify: 2 skills, 4-wide concurrent ...]");
-  expect(capture.text).toContain("avg ");
-  expect(capture.text).toContain("max ");
+  expect(capture.text).toContain("Foo");
+  expect(capture.text).toContain("Bar");
+  expect(capture.text).toContain("avg 11ms");
 });

--- a/test/cli-migrate-claude-skills.test.ts
+++ b/test/cli-migrate-claude-skills.test.ts
@@ -167,6 +167,7 @@ test("soma migrate claude-skills --status (after apply) prints summary", async (
 test("soma migrate claude-skills --help surfaces usage", async () => {
   const output = await runSomaCli(["migrate", "claude-skills", "--help"]);
   expect(output).toContain("Usage: soma migrate claude-skills");
+  expect(output).toContain("[--verbose]");
 });
 
 // #125 — progress + timing + --quiet.


### PR DESCRIPTION
## Summary
- render concurrent claude-skills phases as one rolling TTY line with phase summaries
- keep non-TTY and --verbose output append-only, while --quiet still suppresses stderr
- run apply writes through the same bounded concurrent progress phase with stable result ordering

Fixes #139.

## Verification
- rtk bun test test/claude-skills-progress.test.ts test/claude-skills-migrator-progress.test.ts test/cli-migrate-claude-skills.test.ts
- rtk bun run typecheck
- git diff --check
- rtk bun test