### PR TITLE
fix: account for rewrite intent in skill idempotency

### DIFF
--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -816,14 +816,26 @@ interface PlanResult {
   reads: SourceSkillReadResult[];
 }
 
-async function buildPlanCore(
-  fromDir: string,
-  somaHome: string,
-  includeClaudeSpecific: boolean,
-  prevManifest: ClaudeSkillsMigrationManifest | null,
-  homeRealPath: string,
-  progress: ProgressEmitter,
-): Promise<PlanResult> {
+interface BuildPlanCoreOptions {
+  fromDir: string;
+  somaHome: string;
+  includeClaudeSpecific: boolean;
+  prevManifest: ClaudeSkillsMigrationManifest | null;
+  rewriteDescriptionsAgent: RewriteDescriptionsAgent;
+  homeRealPath: string;
+  progress: ProgressEmitter;
+}
+
+async function buildPlanCore(options: BuildPlanCoreOptions): Promise<PlanResult> {
+  const {
+    fromDir,
+    somaHome,
+    includeClaudeSpecific,
+    prevManifest,
+    rewriteDescriptionsAgent,
+    homeRealPath,
+    progress,
+  } = options;
   const names = await listFlatSkillNames(fromDir);
   if (names.length === 0) {
     return { isFlatSkillsTree: false, outcomes: [], reads: [] };
@@ -940,7 +952,15 @@ async function buildPlanCore(
       disposition = "skipped-claude-specific";
     } else {
       const prior = prevBySource.get(read.sourceName);
-      if (prior?.sourceSha === read.sourceSha && prior?.tag === classification.tag) {
+      const sourceAndTagUnchanged =
+        prior?.sourceSha === read.sourceSha && prior?.tag === classification.tag;
+      const needsDescriptionRewrite =
+        rewriteDescriptionsAgent !== "none" &&
+        (read.descriptionStatus.kind === "oversize" || read.descriptionStatus.kind === "missing");
+      const rewriteAlreadySatisfiesIntent =
+        prior?.descriptionRewrite?.agent === rewriteDescriptionsAgent &&
+        prior.descriptionRewrite.originalDescriptionSha === read.originalDescriptionSha;
+      if (sourceAndTagUnchanged && (!needsDescriptionRewrite || rewriteAlreadySatisfiesIntent)) {
         disposition = "skipped-idempotent";
       } else {
         disposition = "imported";
@@ -1025,14 +1045,15 @@ export async function planClaudeSkillsMigration(
   // what an `--apply` invocation would do (e.g. a re-run on unchanged
   // source shows `skipped-idempotent`, not `imported`).
   const prevManifest = await readExistingManifest(somaHome);
-  const { isFlatSkillsTree, outcomes } = await buildPlanCore(
-    from,
+  const { isFlatSkillsTree, outcomes } = await buildPlanCore({
+    fromDir: from,
     somaHome,
     includeClaudeSpecific,
     prevManifest,
+    rewriteDescriptionsAgent,
     homeRealPath,
     progress,
-  );
+  });
   // #120 — surface refused-description-limit in plan mode too so a
   // dry-run shows what the apply will refuse without committing to
   // writes. Mirrors the apply path's classification logic.
@@ -1674,14 +1695,15 @@ export async function migrateClaudeSkills(
   }
 
   const readClassifyStart = Date.now();
-  const { isFlatSkillsTree, outcomes, reads } = await buildPlanCore(
-    from,
+  const { isFlatSkillsTree, outcomes, reads } = await buildPlanCore({
+    fromDir: from,
     somaHome,
     includeClaudeSpecific,
-    previousManifest,
+    prevManifest: previousManifest,
+    rewriteDescriptionsAgent,
     homeRealPath,
     progress,
-  );
+  });
   const readClassifyMs = Date.now() - readClassifyStart;
 
   if (!isFlatSkillsTree) {

--- a/test/claude-skills-migrator.test.ts
+++ b/test/claude-skills-migrator.test.ts
@@ -1019,6 +1019,17 @@ function buildSkillWithFrontmatterDescription(description: string): string {
   ].join("\n");
 }
 
+async function writeOversizeApifyFixture(home: string): Promise<{ fromDir: string; somaHome: string }> {
+  const fromDir = join(home, "skills");
+  const somaHome = join(home, "soma");
+  await writeFlatSkillsFixture(fromDir, {
+    Apify: {
+      skillMd: buildSkillWithFrontmatterDescription(APIFY_LIKE_DESCRIPTION_1318),
+    },
+  });
+  return { fromDir, somaHome };
+}
+
 test("description ≤1024 chars + no rewrite agent → ok status, no rewrite recorded", async () => {
   await withTempHome(async (home) => {
     const fromDir = join(home, "skills");
@@ -1040,13 +1051,7 @@ test("description ≤1024 chars + no rewrite agent → ok status, no rewrite rec
 
 test("oversize description + agent absent → refused-description-limit, skill not written", async () => {
   await withTempHome(async (home) => {
-    const fromDir = join(home, "skills");
-    const somaHome = join(home, "soma");
-    await writeFlatSkillsFixture(fromDir, {
-      Apify: {
-        skillMd: buildSkillWithFrontmatterDescription(APIFY_LIKE_DESCRIPTION_1318),
-      },
-    });
+    const { fromDir, somaHome } = await writeOversizeApifyFixture(home);
     const result = await migrateClaudeSkills({ from: fromDir, somaHome });
     expect(result.writtenCount).toBe(0);
     expect(result.refusedDescriptionLimitCount).toBe(1);
@@ -1086,13 +1091,7 @@ test("missing frontmatter + agent absent → refused-description-limit", async (
 
 test("oversize + --rewrite-descriptions claude (stubbed) → rewrites under cap and imports", async () => {
   await withTempHome(async (home) => {
-    const fromDir = join(home, "skills");
-    const somaHome = join(home, "soma");
-    await writeFlatSkillsFixture(fromDir, {
-      Apify: {
-        skillMd: buildSkillWithFrontmatterDescription(APIFY_LIKE_DESCRIPTION_1318),
-      },
-    });
+    const { fromDir, somaHome } = await writeOversizeApifyFixture(home);
     const dispatchCalls: Array<{ agent: string; status: string; sourceName: string }> = [];
     const result = await migrateClaudeSkills({
       from: fromDir,
@@ -1172,13 +1171,7 @@ test("missing frontmatter + --rewrite-descriptions codex (stubbed) → synthesiz
 
 test("rewrite idempotency: unchanged source description SHA skips dispatcher on rerun", async () => {
   await withTempHome(async (home) => {
-    const fromDir = join(home, "skills");
-    const somaHome = join(home, "soma");
-    await writeFlatSkillsFixture(fromDir, {
-      Apify: {
-        skillMd: buildSkillWithFrontmatterDescription(APIFY_LIKE_DESCRIPTION_1318),
-      },
-    });
+    const { fromDir, somaHome } = await writeOversizeApifyFixture(home);
     let callCount = 0;
     const stub = async () =>
       "Apify scraper - compressed. USE WHEN Instagram, LinkedIn, TikTok scraping.";
@@ -1205,15 +1198,133 @@ test("rewrite idempotency: unchanged source description SHA skips dispatcher on 
   });
 });
 
-test("rewrite re-runs when source description bytes change between invocations", async () => {
+test("#123 rewrite idempotency: pre-rewrite oversize manifest reimports when rewrite requested", async () => {
+  await withTempHome(async (home) => {
+    const { fromDir, somaHome } = await writeOversizeApifyFixture(home);
+
+    const refused = await migrateClaudeSkills({ from: fromDir, somaHome });
+    const legacyOutcome = refused.outcomes.find((o) => o.sourceName === "Apify");
+    expect(legacyOutcome?.disposition).toBe("refused-description-limit");
+    await mkdir(join(somaHome, "skills/apify"), { recursive: true });
+    await writeFile(
+      join(somaHome, "skills/apify/SKILL.md"),
+      buildSkillWithFrontmatterDescription(APIFY_LIKE_DESCRIPTION_1318),
+      "utf8",
+    );
+    const legacyManifest: ClaudeSkillsMigrationManifest = {
+      schema: "soma.claude-skills-migration.v1",
+      from: fromDir,
+      somaHome,
+      importedAt: "2026-05-19T22:50:00.000Z",
+      includeClaudeSpecific: false,
+      skills: [
+        {
+          sourceName: "Apify",
+          kebabName: "apify",
+          tag: legacyOutcome!.tag,
+          sourceSha: legacyOutcome!.sourceSha,
+          fileShas: { "SKILL.md": "legacy-pre-rewrite" },
+        },
+      ],
+    };
+    await mkdir(join(somaHome, "imports/claude-skills"), { recursive: true });
+    await writeFile(
+      join(somaHome, "imports/claude-skills/.manifest.json"),
+      JSON.stringify(legacyManifest, null, 2),
+      "utf8",
+    );
+
+    let callCount = 0;
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      rewriteDescriptionsAgent: "claude",
+      rewriteDispatchOverride: async () => {
+        callCount += 1;
+        return "Apify actors for social and commerce scraping. USE WHEN Apify platform actors are the right extractor.";
+      },
+    });
+
+    expect(callCount).toBe(1);
+    expect(result.writtenCount).toBe(1);
+    expect(result.skippedIdempotentCount).toBe(0);
+    expect(result.descriptionRewrittenCount).toBe(1);
+    const outcome = result.outcomes.find((o) => o.sourceName === "Apify");
+    expect(outcome?.disposition).toBe("imported");
+    expect(outcome?.descriptionRewrite?.agent).toBe("claude");
+    const manifest = JSON.parse(
+      await readFile(join(somaHome, "imports/claude-skills/.manifest.json"), "utf8"),
+    ) as ClaudeSkillsMigrationManifest;
+    expect(manifest.skills[0]?.descriptionRewrite?.agent).toBe("claude");
+  });
+});
+
+test("#123 rewrite idempotency: ok description remains skipped when rewrite agent is set", async () => {
   await withTempHome(async (home) => {
     const fromDir = join(home, "skills");
     const somaHome = join(home, "soma");
     await writeFlatSkillsFixture(fromDir, {
-      Apify: {
-        skillMd: buildSkillWithFrontmatterDescription(APIFY_LIKE_DESCRIPTION_1318),
+      OkSkill: {
+        skillMd: buildSkillWithFrontmatterDescription("short and sweet description"),
       },
     });
+
+    await migrateClaudeSkills({ from: fromDir, somaHome });
+    let callCount = 0;
+    const second = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      rewriteDescriptionsAgent: "claude",
+      rewriteDispatchOverride: async () => {
+        callCount += 1;
+        return "This should not be used.";
+      },
+    });
+
+    expect(callCount).toBe(0);
+    expect(second.writtenCount).toBe(0);
+    expect(second.skippedIdempotentCount).toBe(1);
+    expect(second.descriptionRewrittenCount).toBe(0);
+  });
+});
+
+test("#123 rewrite idempotency: different rewrite agent reimports and reruns dispatcher", async () => {
+  await withTempHome(async (home) => {
+    const { fromDir, somaHome } = await writeOversizeApifyFixture(home);
+
+    await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      rewriteDescriptionsAgent: "claude",
+      rewriteDispatchOverride: async () => "Compressed by Claude.",
+    });
+    let codexCalls = 0;
+    const second = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      rewriteDescriptionsAgent: "codex",
+      rewriteDispatchOverride: async (req) => {
+        codexCalls += 1;
+        expect(req.agent).toBe("codex");
+        return "Compressed by Codex.";
+      },
+    });
+
+    expect(codexCalls).toBe(1);
+    expect(second.writtenCount).toBe(1);
+    expect(second.skippedIdempotentCount).toBe(0);
+    expect(second.descriptionRewrittenCount).toBe(1);
+    const outcome = second.outcomes.find((o) => o.sourceName === "Apify");
+    expect(outcome?.disposition).toBe("imported");
+    expect(outcome?.descriptionRewrite?.agent).toBe("codex");
+    const landed = await readFile(join(somaHome, "skills/apify/SKILL.md"), "utf8");
+    expect(landed).toContain("Compressed by Codex.");
+  });
+});
+
+test("rewrite re-runs when source description bytes change between invocations", async () => {
+  await withTempHome(async (home) => {
+    const { fromDir, somaHome } = await writeOversizeApifyFixture(home);
     let callCount = 0;
     await migrateClaudeSkills({
       from: fromDir,
@@ -1249,13 +1360,7 @@ test("rewrite re-runs when source description bytes change between invocations",
 
 test("LLM returns >1024 once, ≤1024 on retry → accepts retry result", async () => {
   await withTempHome(async (home) => {
-    const fromDir = join(home, "skills");
-    const somaHome = join(home, "soma");
-    await writeFlatSkillsFixture(fromDir, {
-      Apify: {
-        skillMd: buildSkillWithFrontmatterDescription(APIFY_LIKE_DESCRIPTION_1318),
-      },
-    });
+    const { fromDir, somaHome } = await writeOversizeApifyFixture(home);
     let attempt = 0;
     const result = await migrateClaudeSkills({
       from: fromDir,
@@ -1279,13 +1384,7 @@ test("LLM returns >1024 once, ≤1024 on retry → accepts retry result", async 
 
 test("LLM returns >1024 twice → refuses with refused-other and surfaces the limit in reason", async () => {
   await withTempHome(async (home) => {
-    const fromDir = join(home, "skills");
-    const somaHome = join(home, "soma");
-    await writeFlatSkillsFixture(fromDir, {
-      Apify: {
-        skillMd: buildSkillWithFrontmatterDescription(APIFY_LIKE_DESCRIPTION_1318),
-      },
-    });
+    const { fromDir, somaHome } = await writeOversizeApifyFixture(home);
     let attempt = 0;
     const result = await migrateClaudeSkills({
       from: fromDir,


### PR DESCRIPTION
## Summary
- include --rewrite-descriptions intent and prior rewrite provenance in claude-skills idempotency
- force re-import for pre-rewrite oversize/missing skills when a rewrite agent is requested
- preserve idempotency for same-agent rewrites, ok descriptions, and no-rewrite reruns
- add fixture coverage for all #123 rewrite idempotency cells

Fixes #123

## Verification
- rtk bun test test/claude-skills-migrator.test.ts
- rtk bun run typecheck
- git diff --check
- rtk bun test