### PR TITLE
Fix top-level symlinked Claude skill discovery

### DIFF
--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -678,6 +678,20 @@ async function readSourceSkill(
   if (!(await pathExists(skillMdPath))) {
     throw new Error(`soma migrate claude-skills: ${sourceName}/SKILL.md not found.`);
   }
+  const rootStat = await lstat(skillDir);
+  if (rootStat.isSymbolicLink()) {
+    const resolvedRoot = await resolveSymlinkSafely(skillDir, homeRealPath, new Set());
+    if ("refused" in resolvedRoot) {
+      throw new Error(
+        `soma migrate claude-skills refused symlink path: ${sourceName} — ${resolvedRoot.reason}`,
+      );
+    }
+    if (resolvedRoot.kind !== "dir") {
+      throw new Error(
+        `soma migrate claude-skills refused symlink path: ${sourceName} — top-level skill symlink target is not a directory: ${resolvedRoot.realPath}`,
+      );
+    }
+  }
   // #118 — wrap collect errors with the source skill name so the
   // refusal reason includes `<sourceName>/<rel>` per AC-4. The walker's
   // error messages all follow the shape `soma migrate claude-skills
@@ -754,9 +768,20 @@ async function listFlatSkillNames(fromDir: string): Promise<string[]> {
   const entries = await readdir(fromDir, { withFileTypes: true });
   const names: string[] = [];
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
     if (entry.name.startsWith(".")) continue;
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
     const skillMdPath = join(fromDir, entry.name, "SKILL.md");
+    if (entry.isSymbolicLink()) {
+      // #166 — top-level symlinked skill directories are common in PAI
+      // development (`~/.claude/skills/name -> ~/work/.../skill`). List
+      // entries that look like skill roots so `readSourceSkill` can
+      // apply the same safe symlink policy used inside skill trees and
+      // classify failures per skill instead of silently skipping them.
+      if (await pathExists(skillMdPath)) {
+        names.push(entry.name);
+      }
+      continue;
+    }
     if (await pathExists(skillMdPath)) {
       // #118 — a symlinked top-level SKILL.md is no longer an outright
       // refusal at the listing phase. The walker in `collectSkillFiles`

--- a/test/claude-skills-migrator.test.ts
+++ b/test/claude-skills-migrator.test.ts
@@ -21,8 +21,8 @@
  *   - Mixed tree: per-skill routing decision is independent.
  *   - Manifest schema invariants.
  */
-import { mkdir, readFile, readdir, writeFile, symlink } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, mkdtemp, readFile, readdir, writeFile, symlink } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { expect, test } from "bun:test";
 import {
   classifySkillPortability,
@@ -640,6 +640,67 @@ test("#118 migrateClaudeSkills follows user-owned symlinked top-level SKILL.md",
     expect(result.writtenCount).toBe(1);
     const landed = await readFile(join(home, "soma/skills/linked/SKILL.md"), "utf8");
     expect(landed).toContain("followed top-level");
+  });
+});
+
+// #166: top-level skill entries can themselves be symlinked
+// directories, e.g. ~/.claude/skills/pilot-review-loop ->
+// ~/work/mf/pilot/skill. Discovery must surface the skill instead of
+// silently skipping it before the safe symlink handling layer runs.
+test("#166 migrateClaudeSkills imports user-owned top-level symlinked skill directory", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const targetDir = join(home, "work/mf/pilot/skill");
+    await mkdir(fromDir, { recursive: true });
+    await mkdir(join(targetDir, "Workflows"), { recursive: true });
+    await writeFile(
+      join(targetDir, "SKILL.md"),
+      withDefaultFrontmatter("# Pilot Review Loop\n\nreview loop.\n"),
+      "utf8",
+    );
+    await writeFile(join(targetDir, "Workflows/Run.md"), "# Run\n", "utf8");
+    await symlink(targetDir, join(fromDir, "pilot-review-loop"));
+
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome: join(home, "soma"),
+      homeDir: home,
+    });
+
+    const outcome = result.outcomes.find((o) => o.sourceName === "pilot-review-loop");
+    expect(outcome?.disposition).toBe("imported");
+    expect(result.writtenCount).toBe(1);
+    expect(
+      await readFile(
+        join(home, "soma/skills/pilot-review-loop/Workflows/Run.md"),
+        "utf8",
+      ),
+    ).toContain("Run");
+  });
+});
+
+test("#166 planClaudeSkillsMigration refuses unsafe top-level symlinked skill directory per skill", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const outsideDir = await mkdtemp(join(dirname(home), "outside-skill-"));
+    await mkdir(fromDir, { recursive: true });
+    await writeFile(
+      join(outsideDir, "SKILL.md"),
+      withDefaultFrontmatter("# Outside\n\noutside home.\n"),
+      "utf8",
+    );
+    await symlink(outsideDir, join(fromDir, "OutsideLink"));
+
+    const plan = await planClaudeSkillsMigration({
+      from: fromDir,
+      homeDir: home,
+    });
+
+    expect(plan.isFlatSkillsTree).toBe(true);
+    const outcome = plan.outcomes.find((o) => o.sourceName === "OutsideLink");
+    expect(outcome?.disposition).toBe("refused-other");
+    expect(outcome?.refusalReason).toContain("OutsideLink");
+    expect(outcome?.refusalReason).toContain("outside $HOME");
   });
 });
 


### PR DESCRIPTION
## Summary
- include top-level symlinked Claude skill directories in flat skill discovery when they expose SKILL.md
- validate symlinked skill roots through the existing safe symlink resolver before walking files
- add #166 regression tests for pilot-review-loop style symlinked skill roots and unsafe out-of-home skill roots

## Verification
- bun test test/claude-skills-migrator.test.ts
- bun run soma migrate claude-skills --from /Users/fischer/.claude/skills --dry-run
- bun run typecheck
- bun test
- git diff --check

Closes #166