### PR TITLE
fix: stabilize claude-skills progress display

### DIFF
--- a/src/claude-skills-progress.ts
+++ b/src/claude-skills-progress.ts
@@ -162,6 +162,7 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
     total: number;
     concurrency: number;
     completedCount: number;
+    completedItems: Set<string>;
     inFlight: Set<string>;
     latestCompleted: string | null;
     elapsedSamples: number[]; // ms per stepComplete inside the phase
@@ -202,11 +203,15 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
     return !isatty || verbose;
   }
 
+  function writeTtyRewrite(body: string, close = false): void {
+    stderr.write(`\r${body}\x1b[K${close ? "\n" : ""}`);
+  }
+
   function renderConcurrentLine(phase: NonNullable<typeof activeConcurrentPhase>): void {
     const active = phase.latestCompleted ?? phase.inFlight.values().next().value ?? "skills";
     const visibleInFlight = phase.inFlight.has(active) ? phase.inFlight.size - 1 : phase.inFlight.size;
     const others = visibleInFlight > 0 ? ` + ${visibleInFlight} others` : "";
-    stderr.write(`\r[${phase.completedCount}/${phase.total}] processing ${active}${others}...`);
+    writeTtyRewrite(`[${phase.completedCount}/${phase.total}] processing ${active}${others}...`);
   }
 
   return {
@@ -233,7 +238,7 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
       if (isatty) {
         // TTY: open with `\r` to overwrite any prior fast-phase line.
         // No trailing `\n` — `stepComplete` will close the row.
-        stderr.write(`\r${body}`);
+        writeTtyRewrite(body);
       } else {
         // Non-TTY: append-only with `\n`.
         stderr.write(`${body}\n`);
@@ -251,7 +256,10 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
       if (activeConcurrentPhase) {
         const current = activeConcurrentPhase;
         current.elapsedSamples.push(elapsedMs);
-        current.completedCount += 1;
+        if (!current.completedItems.has(sourceName)) {
+          current.completedItems.add(sourceName);
+          current.completedCount += 1;
+        }
         current.latestCompleted = sourceName;
         current.inFlight.delete(sourceName);
         if (shouldAppendConcurrentLines()) {
@@ -272,7 +280,7 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
         // partial), then closes with `\n` so the next step starts
         // fresh. If no prior step() was issued for this index (some
         // phases skip the open-line), the `\r` is harmless.
-        stderr.write(`\r${body}${closer}\n`);
+        writeTtyRewrite(`${body}${closer}`, true);
       } else {
         // Non-TTY: emit a separate `\n` line so the elapsed suffix
         // appears under the corresponding step.
@@ -291,6 +299,7 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
         total: totalSteps,
         concurrency,
         completedCount: 0,
+        completedItems: new Set(),
         inFlight: new Set(),
         latestCompleted: null,
         elapsedSamples: [],
@@ -326,7 +335,11 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
       }
       const elapsed = fmtElapsedSeconds(elapsedMs);
       const summary = `[${name}: ${count} skills in ${elapsed} (avg ${avgMs}ms, max ${maxMs}ms)]`;
-      stderr.write(`${isatty && !verbose ? "\r" : ""}${summary}\n`);
+      if (isatty && !verbose) {
+        writeTtyRewrite(summary, true);
+      } else {
+        stderr.write(`${summary}\n`);
+      }
     },
 
     finishTimingSummary(timings: PhaseTimings): string {

--- a/src/claude-skills-progress.ts
+++ b/src/claude-skills-progress.ts
@@ -255,10 +255,10 @@ export function createProgressEmitter(opts: ProgressEmitterOptions): ProgressEmi
       if (quiet) return;
       if (activeConcurrentPhase) {
         const current = activeConcurrentPhase;
-        current.elapsedSamples.push(elapsedMs);
         if (!current.completedItems.has(sourceName)) {
           current.completedItems.add(sourceName);
           current.completedCount += 1;
+          current.elapsedSamples.push(elapsedMs);
         }
         current.latestCompleted = sourceName;
         current.inFlight.delete(sourceName);

--- a/test/claude-skills-progress.test.ts
+++ b/test/claude-skills-progress.test.ts
@@ -178,7 +178,7 @@ test("#139: beginConcurrentPhase starts a rolling line on TTY", () => {
   const { stream, capture } = makeCapturingStream();
   const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: true });
   emitter.beginConcurrentPhase("read + classify", 97, 4);
-  expect(capture.text).toBe("\r[0/97] processing skills...");
+  expect(capture.text).toBe("\r[0/97] processing skills...\x1b[K");
   expect(capture.text).not.toContain("\n");
 });
 
@@ -212,6 +212,33 @@ test("#139: TTY concurrent phase rolls one line instead of appending per-skill r
   expect(capture.text).toContain("\r[1/3] processing Foo + 1 others...");
   expect(capture.text).toContain("\r[2/3] processing Bar...");
   expect(capture.text).not.toContain("\n[");
+});
+
+test("#168: TTY concurrent counter counts each skill once across multi-step phases", () => {
+  const { stream, capture } = makeCapturingStream();
+  const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: true });
+  emitter.beginConcurrentPhase("read + classify", 2, 4);
+  emitter.stepComplete(1, "Foo", "reading + classifying", 12, "read");
+  emitter.stepComplete(1, "Foo", "classified", 0, "portable");
+  emitter.stepComplete(2, "Bar", "reading + classifying", 8, "read");
+  emitter.stepComplete(2, "Bar", "classified", 0, "needs-adapt");
+
+  expect(capture.text).toContain("\r[1/2] processing Foo...");
+  expect(capture.text).toContain("\r[2/2] processing Bar...");
+  expect(capture.text).not.toContain("[3/2]");
+  expect(capture.text).not.toContain("[4/2]");
+});
+
+test("#168: TTY rewrites clear residue from longer previous lines", () => {
+  const { stream, capture } = makeCapturingStream();
+  const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: true });
+  emitter.beginConcurrentPhase("read + classify", 2, 4);
+  emitter.step(1, "LongSkillNameWithVerboseSuffix", "reading + classifying", "read");
+  emitter.stepComplete(1, "A", "reading + classifying", 3, "read");
+
+  const writes = capture.bytes.map((b) => b.toString("utf8"));
+  expect(writes.every((write) => write.startsWith("\r"))).toBe(true);
+  expect(writes.every((write) => write.includes("\x1b[K"))).toBe(true);
 });
 
 test("#139: endConcurrentPhase emits a summary line with elapsed + avg + max", () => {

--- a/test/claude-skills-progress.test.ts
+++ b/test/claude-skills-progress.test.ts
@@ -229,6 +229,20 @@ test("#168: TTY concurrent counter counts each skill once across multi-step phas
   expect(capture.text).not.toContain("[4/2]");
 });
 
+test("#168: concurrent summary average samples each skill once across multi-step phases", () => {
+  const { stream, capture } = makeCapturingStream();
+  const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: false });
+  emitter.beginConcurrentPhase("read + classify", 2, 4);
+  emitter.stepComplete(1, "Foo", "reading + classifying", 10, "read");
+  emitter.stepComplete(1, "Foo", "classified", 1000, "portable");
+  emitter.stepComplete(2, "Bar", "reading + classifying", 30, "read");
+  emitter.stepComplete(2, "Bar", "classified", 1000, "needs-adapt");
+  emitter.endConcurrentPhase("read + classify", 100);
+
+  expect(capture.text).toContain("avg 20ms");
+  expect(capture.text).toContain("max 30ms");
+});
+
 test("#168: TTY rewrites clear residue from longer previous lines", () => {
   const { stream, capture } = makeCapturingStream();
   const emitter = createProgressEmitter({ stderr: stream, quiet: false, isatty: true });


### PR DESCRIPTION
## Summary
- count each skill once in TTY concurrent progress phases so read/classify counters cannot exceed the discovered total
- clear TTY progress rewrites to end-of-line so shorter updates do not leave stale suffix text
- add #168 regression coverage for multi-step progress counters and stale-line clearing

Fixes #168

## Test plan
- bun test test/claude-skills-progress.test.ts test/claude-skills-migrator-progress.test.ts
- bun test test/cli-migrate-claude-skills.test.ts test/claude-skills-migrator.test.ts
- bun run typecheck
- bun test