### PR TITLE
Refactor PAI telos import helper cleanup

### DIFF
--- a/src/pai-importer.ts
+++ b/src/pai-importer.ts
@@ -192,7 +192,12 @@ function meaningfulMarkdownLines(content: string): string[] {
 }
 
 function sourceContent(sources: Record<string, string>, role: PaiSourceRole): string | undefined {
-  return Object.entries(sources).find(([path]) => SOURCE_SPECS.find((spec) => spec.role === role)?.candidates.includes(path))?.[1];
+  const spec = SOURCE_SPECS.find((candidate) => candidate.role === role);
+  if (!spec) {
+    return undefined;
+  }
+
+  return Object.entries(sources).find(([path]) => spec.candidates.includes(path))?.[1];
 }
 
 function sourceLines(sources: Record<string, string>, role: PaiSourceRole): string[] {

--- a/test/pai-importer.test.ts
+++ b/test/pai-importer.test.ts
@@ -49,22 +49,19 @@ async function writePaiFixture(homeDir: string): Promise<void> {
     "utf8",
   );
 
-  await writeFile(join(userRoot, "TELOS", "MISSION.md"), "# Mission\n\nBuild useful test systems without leaking publisher context.\n", "utf8");
-  await writeFile(
-    join(userRoot, "TELOS", "GOALS.md"),
-    ["# Goals", "", "- Keep imported goals fixture-local.", "- Preserve assistant portability."].join("\n"),
-    "utf8",
-  );
-  await writeFile(
-    join(userRoot, "TELOS", "STRATEGIES.md"),
-    ["# Strategies", "", "- Verify projections after import.", "- Keep source snapshots under Soma home."].join("\n"),
-    "utf8",
-  );
-  await writeFile(
-    join(userRoot, "TELOS", "BELIEFS.md"),
-    ["# Beliefs", "", "- Tests should describe the imported fixture.", "- Generated profile summaries must come from selected sources."].join("\n"),
-    "utf8",
-  );
+  const telosFixtures = [
+    { file: "MISSION.md", content: "# Mission\n\nBuild useful test systems without leaking publisher context.\n" },
+    { file: "GOALS.md", content: ["# Goals", "", "- Keep imported goals fixture-local.", "- Preserve assistant portability."].join("\n") },
+    { file: "STRATEGIES.md", content: ["# Strategies", "", "- Verify projections after import.", "- Keep source snapshots under Soma home."].join("\n") },
+    {
+      file: "BELIEFS.md",
+      content: ["# Beliefs", "", "- Tests should describe the imported fixture.", "- Generated profile summaries must come from selected sources."].join("\n"),
+    },
+  ];
+
+  for (const fixture of telosFixtures) {
+    await writeFile(join(userRoot, "TELOS", fixture.file), fixture.content, "utf8");
+  }
 }
 
 test("plans a PAI import without writing files", async () => {


### PR DESCRIPTION
## Summary

Follow-up cleanup from the privacy fix for #170 after the repository history rewrite.

The privacy fix and 0.5.1 version bump are already present on the rewritten main branch. This PR now contains only the final maintainability cleanup requested by Sage:

- resolve the PAI source role spec before matching source paths
- table-drive the TELOS test fixture setup

## Verification

- `bun test test/pai-importer.test.ts`
- `bunx tsc --noEmit`
- `bun test`
- branch/tag history scan from a fresh mirror clone found no sensitive phrase matches in advertised refs
