### PR TITLE
fix: persist Claude skills migration outcomes

### DIFF
--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -66,6 +66,8 @@ import type {
   ClaudeSkillSubstrateVerifySummary,
   ClaudeSkillsMigrationManifest,
   ClaudeSkillsMigrationManifestEntry,
+  ClaudeSkillsMigrationManifestLastRun,
+  ClaudeSkillsMigrationManifestOutcome,
   ClaudeSkillsMigrationOptions,
   ClaudeSkillsMigrationPlan,
   ClaudeSkillsMigrationResult,
@@ -1327,6 +1329,14 @@ function renderManifest(manifest: ClaudeSkillsMigrationManifest): string {
   const sorted: ClaudeSkillsMigrationManifest = {
     ...manifest,
     skills: [...manifest.skills].sort((a, b) => a.kebabName.localeCompare(b.kebabName)),
+    ...(manifest.lastRun
+      ? {
+          lastRun: {
+            ...manifest.lastRun,
+            outcomes: [...manifest.lastRun.outcomes].sort((a, b) => a.kebabName.localeCompare(b.kebabName)),
+          },
+        }
+      : {}),
   };
   return `${JSON.stringify(sorted, null, 2)}\n`;
 }
@@ -1350,6 +1360,86 @@ export function resolveOutcomeReason(outcome: ClaudeSkillOutcome): string {
     return outcome.refusalReason ?? outcome.reason;
   }
   return outcome.reason;
+}
+
+function remediationForOutcome(outcome: ClaudeSkillOutcome): string | undefined {
+  if (outcome.disposition === "skipped-claude-specific") {
+    return "Re-run with --include-claude-specific if this Claude-only skill should still be imported.";
+  }
+  if (outcome.disposition === "refused-description-limit") {
+    return "Re-run with --rewrite-descriptions claude (or codex/pi) to compress the description before import.";
+  }
+  if (outcome.disposition !== "refused-other") return undefined;
+  const reason = resolveOutcomeReason(outcome);
+  if (reason.includes("VCS metadata directory")) {
+    return "remove or move embedded VCS metadata such as .git/.hg/.svn out of the skill directory, then rerun.";
+  }
+  if (reason.includes("symlink cycle") || reason.includes("symlink loop")) {
+    return "Break the symlink cycle or replace the symlink with regular files, then rerun.";
+  }
+  if (reason.includes("broken link") || reason.includes("target does not exist")) {
+    return "Repair or remove the broken symlink target, then rerun.";
+  }
+  if (reason.includes("outside $HOME")) {
+    return "Move the symlink target under $HOME or copy the files into the skill tree, then rerun.";
+  }
+  if (reason.includes("denylisted")) {
+    return "Remove links to credential or secret-bearing home subpaths, then rerun.";
+  }
+  return "Fix the refused source path shown in the reason, then rerun.";
+}
+
+function isActionableManifestOutcome(outcome: ClaudeSkillOutcome): boolean {
+  return (
+    outcome.disposition === "skipped-claude-specific" ||
+    outcome.disposition === "refused-other" ||
+    outcome.disposition === "refused-description-limit" ||
+    (outcome.dependencyMissing?.length ?? 0) > 0
+  );
+}
+
+function buildManifestLastRun(
+  outcomes: readonly ClaudeSkillOutcome[],
+): ClaudeSkillsMigrationManifestLastRun | undefined {
+  const exceptional = outcomes.filter(isActionableManifestOutcome);
+  if (exceptional.length === 0) return undefined;
+  let imported = 0;
+  let skippedIdempotent = 0;
+  let skippedClaudeSpecific = 0;
+  let refusedOther = 0;
+  let refusedDescriptionLimit = 0;
+  for (const outcome of outcomes) {
+    if (outcome.disposition === "imported") imported += 1;
+    else if (outcome.disposition === "skipped-idempotent") skippedIdempotent += 1;
+    else if (outcome.disposition === "skipped-claude-specific") skippedClaudeSpecific += 1;
+    else if (outcome.disposition === "refused-other") refusedOther += 1;
+    else if (outcome.disposition === "refused-description-limit") refusedDescriptionLimit += 1;
+  }
+  const manifestOutcomes: ClaudeSkillsMigrationManifestOutcome[] = exceptional.map((outcome) => {
+    const remediation = remediationForOutcome(outcome);
+    return {
+      sourceName: outcome.sourceName,
+      kebabName: outcome.kebabName,
+      tag: outcome.tag,
+      disposition: outcome.disposition,
+      reason: outcome.reason,
+      ...(outcome.refusalReason ? { refusalReason: outcome.refusalReason } : {}),
+      ...(remediation ? { remediation } : {}),
+      ...(outcome.dependencyMissing && outcome.dependencyMissing.length > 0
+        ? { dependencyMissing: [...outcome.dependencyMissing].sort() }
+        : {}),
+    };
+  });
+  return {
+    totals: {
+      imported,
+      skippedIdempotent,
+      skippedClaudeSpecific,
+      refusedOther,
+      refusedDescriptionLimit,
+    },
+    outcomes: manifestOutcomes,
+  };
 }
 
 function renderPortabilityReport(
@@ -2121,6 +2211,7 @@ export async function migrateClaudeSkills(
     return previousManifest.importedAt;
   })();
 
+  const manifestLastRun = buildManifestLastRun(outcomes);
   const newManifest: ClaudeSkillsMigrationManifest = {
     schema: MANIFEST_SCHEMA,
     from,
@@ -2128,6 +2219,7 @@ export async function migrateClaudeSkills(
     importedAt,
     includeClaudeSpecific,
     skills: manifestEntries,
+    ...(manifestLastRun ? { lastRun: manifestLastRun } : {}),
     ...(smokeSubstrates.length > 0 ? { smokeSubstrates } : {}),
   };
   await writeFile(manifestPath, renderManifest(newManifest), "utf8");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2788,6 +2788,21 @@ function formatClaudeSkillsMigrationStatus(
   for (const entry of manifest.skills) {
     lines.push(`  - ${entry.kebabName} [${entry.tag}] (${Object.keys(entry.fileShas).length} files)`);
   }
+  if (manifest.lastRun && manifest.lastRun.outcomes.length > 0) {
+    const totals = manifest.lastRun.totals;
+    lines.push("");
+    lines.push("latest outcomes:");
+    lines.push(
+      `  imported: ${totals.imported}, skipped-idempotent: ${totals.skippedIdempotent}, skipped-claude-specific: ${totals.skippedClaudeSpecific}, refused-other: ${totals.refusedOther}, refused-description-limit: ${totals.refusedDescriptionLimit}`,
+    );
+    for (const outcome of manifest.lastRun.outcomes) {
+      const reason = outcome.refusalReason ?? outcome.reason;
+      const detail = outcome.remediation
+        ? `${reason}; remediation: ${outcome.remediation}`
+        : reason;
+      lines.push(`  - ${outcome.kebabName} [${outcome.disposition}] ${detail}`);
+    }
+  }
   lines.push("");
   return lines.join("\n");
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1358,6 +1358,28 @@ export interface ClaudeSkillsMigrationManifestEntry {
   descriptionRewrite?: ClaudeSkillDescriptionRewrite;
 }
 
+export interface ClaudeSkillsMigrationManifestOutcome {
+  sourceName: string;
+  kebabName: string;
+  tag: ClaudeSkillPortabilityTag;
+  disposition: ClaudeSkillOutcome["disposition"];
+  reason: string;
+  refusalReason?: string;
+  remediation?: string;
+  dependencyMissing?: string[];
+}
+
+export interface ClaudeSkillsMigrationManifestLastRun {
+  totals: {
+    imported: number;
+    skippedIdempotent: number;
+    skippedClaudeSpecific: number;
+    refusedOther: number;
+    refusedDescriptionLimit: number;
+  };
+  outcomes: ClaudeSkillsMigrationManifestOutcome[];
+}
+
 export interface ClaudeSkillsMigrationManifest {
   schema: "soma.claude-skills-migration.v1";
   from: string;
@@ -1372,6 +1394,11 @@ export interface ClaudeSkillsMigrationManifest {
   // SHA isn't an idempotency anchor for anything that landed.
   // Sorted by `kebabName` for byte-stable reruns.
   skills: ClaudeSkillsMigrationManifestEntry[];
+  // #175 — latest actionable skipped/refused outcomes. `skills`
+  // stays the idempotency anchor for landed payloads; this ledger lets
+  // `--status` report unresolved migration work without scraping the
+  // Markdown portability report.
+  lastRun?: ClaudeSkillsMigrationManifestLastRun;
   // #115 Phase 2 — substrate list captured at last write. Absent
   // when no `--smoke` was ever run; present so the next invocation
   // can detect a substrate-set change.

--- a/test/cli-migrate-claude-skills.test.ts
+++ b/test/cli-migrate-claude-skills.test.ts
@@ -164,6 +164,44 @@ test("soma migrate claude-skills --status (after apply) prints summary", async (
   });
 });
 
+test("soma migrate claude-skills --status shows refused outcomes from the latest apply", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = await writeFixture(home);
+    await mkdir(join(fromDir, "EmbeddedGit", ".git"), { recursive: true });
+    await writeFile(
+      join(fromDir, "EmbeddedGit", "SKILL.md"),
+      FM + "# EmbeddedGit\n\ncontains vcs metadata.\n",
+      "utf8",
+    );
+    const somaHome = join(home, "soma");
+
+    await expect(
+      runSomaCli([
+        "migrate",
+        "claude-skills",
+        "--from",
+        fromDir,
+        "--soma-home",
+        somaHome,
+        "--apply",
+      ]),
+    ).rejects.toThrow(/EmbeddedGit/);
+
+    const status = await runSomaCli([
+      "migrate",
+      "claude-skills",
+      "--status",
+      "--soma-home",
+      somaHome,
+    ]);
+    expect(status).toContain("latest outcomes:");
+    expect(status).toContain("refused-other: 1");
+    expect(status).toContain("embedded-git [refused-other]");
+    expect(status).toContain("remove or move embedded VCS metadata");
+    expect(status).toContain("claude-specific [skipped-claude-specific]");
+  });
+});
+
 test("soma migrate claude-skills --help surfaces usage", async () => {
   const output = await runSomaCli(["migrate", "claude-skills", "--help"]);
   expect(output).toContain("Usage: soma migrate claude-skills");


### PR DESCRIPTION
## Summary

Fixes #175.

- persists latest actionable Claude skills migration outcomes in the JSON manifest
- surfaces skipped/refused latest outcomes in `soma migrate claude-skills --status`
- adds remediation hints for `.git` metadata and symlink/refusal classes
- keeps all-success idempotent manifests byte-stable by only writing the latest-outcome ledger when actionable skipped/refused work exists

## Tests

- `bun test test/cli-migrate-claude-skills.test.ts --timeout 120000`
- `bun test test/claude-skills-migrator.test.ts --timeout 120000`
- `bunx tsc --noEmit`
- `bun test --timeout 120000` (964 pass)
