### PR TITLE
feat: add onboarding init and doctor

### DIFF
--- a/src/adapters/codex/doctor.ts
+++ b/src/adapters/codex/doctor.ts
@@ -1,0 +1,23 @@
+import { join } from "node:path";
+import { pathMtimeMs } from "../../fs-utils";
+import type { SomaDoctorFinding } from "../../types";
+
+export async function diagnoseCodexProjectionDrift(options: {
+  homeDir: string;
+  profileMtime: number | null;
+}): Promise<SomaDoctorFinding[]> {
+  const projectionMtime = await pathMtimeMs(join(options.homeDir, ".codex/rules/soma.rules"));
+  if (options.profileMtime === null || (projectionMtime !== null && projectionMtime >= options.profileMtime)) {
+    return [];
+  }
+  return [
+    {
+      id: "codex-projection-stale",
+      severity: "warning",
+      message: projectionMtime === null
+        ? "Codex projection is missing."
+        : "Codex projection is older than the Soma profile files.",
+      action: "soma reproject codex",
+    },
+  ];
+}

--- a/src/adapters/doctor.ts
+++ b/src/adapters/doctor.ts
@@ -1,0 +1,15 @@
+import { diagnoseCodexProjectionDrift } from "./codex/doctor";
+import type { SomaDoctorFinding, SubstrateId } from "../types";
+
+type DoctorSubstrate = Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor">;
+
+export async function diagnoseProjectionDrift(options: {
+  substrate: DoctorSubstrate;
+  homeDir: string;
+  profileMtime: number | null;
+}): Promise<SomaDoctorFinding[]> {
+  if (options.substrate === "codex") {
+    return diagnoseCodexProjectionDrift(options);
+  }
+  throw new Error("soma doctor currently supports projection drift checks for --substrate codex only.");
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -85,6 +85,9 @@ import type {
   SomaInstallOptions,
   SomaInstallPlan,
   SomaInstallResult,
+  SomaDoctorDiagnosis,
+  SomaInitPlan,
+  SomaOnboardingOptions,
   SomaFeedbackCaptureOptions,
   SomaFeedbackCaptureResult,
   SomaLifecycleOptions,
@@ -143,6 +146,7 @@ import { runInferenceCli } from "./tools/inference/cli";
 import { runLearningCli, runMetricsCli, runOpinionCli, runSessionCli } from "./tools/learning/cli";
 import { RELATIONSHIP_REFLECT_USAGE, runRelationshipCli } from "./tools/relationship/cli";
 import { runWisdomCli } from "./tools/wisdom/cli";
+import { applySomaInit, diagnoseSomaDoctor, planSomaInit } from "./onboarding";
 
 /**
  * Typed CLI error carrying an exit code distinct from the default 1.
@@ -220,6 +224,17 @@ interface ParsedExportArgs {
 
 interface ParsedDaemonArgs {
   command: "daemon";
+}
+
+interface ParsedInitArgs {
+  command: "init";
+  apply: boolean;
+  options: SomaOnboardingOptions;
+}
+
+interface ParsedDoctorArgs {
+  command: "doctor";
+  options: SomaOnboardingOptions;
 }
 
 interface ParsedImportArgs {
@@ -379,6 +394,8 @@ type ParsedArgs =
   | ParsedUpgradeArgs
   | ParsedExportArgs
   | ParsedDaemonArgs
+  | ParsedInitArgs
+  | ParsedDoctorArgs
   | ParsedImportArgs
   | ParsedMigrateArgs
   | ParsedMigrateClaudeSkillsArgs
@@ -397,11 +414,13 @@ const TOP_LEVEL_COMMANDS = [
   "adopt",
   "algorithm",
   "daemon",
+  "doctor",
   "export",
   "feedback",
   "import",
   "inference",
   "install",
+  "init",
   "isa",
   "learning",
   "lifecycle",
@@ -432,6 +451,10 @@ const MIGRATE_CLAUDE_SKILLS_USAGE =
   "Usage: soma migrate claude-skills --from <skills-dir> [--dry-run] [--apply] [--status] [--home-dir <dir>] [--soma-home <dir>] [--include-claude-specific] [--smoke <codex|pi-dev|all>] [--rewrite-descriptions <claude|codex|pi|none>] [--quiet] [--verbose]";
 const ADOPT_CLAUDE_USAGE =
   "Usage: soma adopt claude [--dry-run] [--apply] [--uninstall] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
+const INIT_USAGE =
+  "Usage: soma init [--dry-run] [--yes] [--home-dir <dir>] [--soma-home <dir>] [--substrate <codex|pi-dev|claude-code|cursor>]";
+const DOCTOR_USAGE =
+  "Usage: soma doctor [--home-dir <dir>] [--soma-home <dir>] [--substrate codex]";
 const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string, string> }> = {
   algorithm: {
     usage: "Usage: soma algorithm <new|classify|list|show|capabilities|plan|decision|change|step|verify|learn|batch|advance> ...",
@@ -554,6 +577,12 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
   daemon: {
     usage: "Usage: soma daemon  (not yet implemented — placeholder reserves the runtime mode)",
   },
+  init: {
+    usage: INIT_USAGE,
+  },
+  doctor: {
+    usage: DOCTOR_USAGE,
+  },
   import: {
     usage: "Usage: soma import <pai|algorithm|pai-pack|pai-docs> ...",
     subcommands: {
@@ -600,6 +629,11 @@ const INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code", "cursor"] as const
 
 function isInstallSubstrate(value: string | undefined): value is InstallSubstrate {
   return value !== undefined && (INSTALL_SUBSTRATES as readonly string[]).includes(value);
+}
+
+function parseOnboardingSubstrate(value: string): InstallSubstrate {
+  if (isInstallSubstrate(value)) return value;
+  throw new Error("--substrate must be one of codex, pi-dev, claude-code, or cursor.");
 }
 
 function workspaceSubstrateHome(substrate: InstallSubstrate): string {
@@ -1763,6 +1797,14 @@ function parseArgs(args: string[]): ParsedArgs {
     return parseDaemonArgs(args);
   }
 
+  if (args[0] === "init") {
+    return parseInitArgs(args);
+  }
+
+  if (args[0] === "doctor") {
+    return parseDoctorArgs(args);
+  }
+
   if (args[0] === "import") {
     return parseImportArgs(args);
   }
@@ -1776,6 +1818,55 @@ function parseArgs(args: string[]): ParsedArgs {
   }
 
   throw new Error(renderUnknownCommand(args[0]));
+}
+
+function parseOnboardingOptions(rest: string[]): SomaOnboardingOptions {
+  const options: SomaOnboardingOptions = {};
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--substrate":
+        options.substrate = parseOnboardingSubstrate(readOption(rest, index, arg));
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return options;
+}
+
+function parseInitArgs(args: string[]): ParsedInitArgs {
+  const [, ...rest] = args;
+  let apply = false;
+  const optionArgs: string[] = [];
+  for (const arg of rest) {
+    if (arg === "--yes") {
+      apply = true;
+    } else if (arg === "--dry-run") {
+      apply = false;
+    } else {
+      optionArgs.push(arg);
+    }
+  }
+  return { command: "init", apply, options: parseOnboardingOptions(optionArgs) };
+}
+
+function parseDoctorArgs(args: string[]): ParsedDoctorArgs {
+  const [, ...rest] = args;
+  const options = parseOnboardingOptions(rest);
+  if (options.substrate && options.substrate !== "codex") {
+    throw new Error("soma doctor currently supports --substrate codex only.");
+  }
+  return { command: "doctor", options };
 }
 
 function parseAdoptArgs(args: string[]): ParsedAdoptArgs {
@@ -2207,6 +2298,63 @@ function formatInstallResult(result: SomaInstallResult): string {
     "",
     "Substrate files:",
     ...result.substrateHome.files.map((path) => `- ${path}`),
+  ].join("\n");
+}
+
+function formatSomaInitPlan(plan: SomaInitPlan): string {
+  return [
+    `soma init — ${plan.mode === "apply" ? "apply plan" : "plan (dry-run; pass --yes to execute)"}`,
+    "",
+    `Home:       ${plan.homeDir}`,
+    `Soma home:  ${plan.somaHome}`,
+    `Substrate:  ${plan.substrate}`,
+    "",
+    "Detected:",
+    `  - PAI install:    ${plan.detected.paiInstall ?? "not found"}`,
+    `  - Claude skills:  ${plan.detected.claudeSkillsDir ?? "not found"}`,
+    `  - CORE_USER:      ${plan.detected.coreUserDir ?? "not found"}`,
+    "",
+    "Soma state:",
+    `  - exists:          ${plan.soma.exists ? "yes" : "no"}`,
+    `  - starter profile: ${plan.soma.starterProfile ? "yes" : "no"}`,
+    `  - skills:          ${plan.soma.skillsPopulated ? "populated" : "empty"}`,
+    `  - Algorithm skill: ${plan.soma.algorithmSkillPresent ? "present" : "missing"}`,
+    "",
+    "Steps:",
+    ...plan.steps.map((step, index) => `${index + 1}. ${step.command}`),
+    "",
+  ].join("\n");
+}
+
+function formatSomaInitApplied(results: { id: string; status: "applied" | "skipped"; detail: string }[]): string {
+  return [
+    "soma init — applied",
+    "",
+    ...results.map((result) => `${result.id}: ${result.status}${result.detail ? ` (${result.detail})` : ""}`),
+    "",
+  ].join("\n");
+}
+
+function formatSomaDoctorDiagnosis(diagnosis: SomaDoctorDiagnosis): string {
+  if (diagnosis.status === "ok") {
+    return [
+      "soma doctor — ok",
+      "",
+      `Home:      ${diagnosis.homeDir}`,
+      `Soma home: ${diagnosis.somaHome}`,
+      "No onboarding drift detected.",
+      "",
+    ].join("\n");
+  }
+  return [
+    "soma doctor — drift detected",
+    "",
+    `Home:      ${diagnosis.homeDir}`,
+    `Soma home: ${diagnosis.somaHome}`,
+    "",
+    "Findings:",
+    ...diagnosis.findings.map((finding) => `- ${finding.id}: ${finding.message}\n  action: ${finding.action}`),
+    "",
   ].join("\n");
 }
 
@@ -3380,6 +3528,17 @@ export async function runSomaCli(args: string[]): Promise<string> {
     }
 
     return formatLifecycleResult(await runSomaLifecycleSessionEnd(parsed.options));
+  }
+
+  if (parsed.command === "doctor") {
+    return formatSomaDoctorDiagnosis(await diagnoseSomaDoctor(parsed.options));
+  }
+
+  if (parsed.command === "init") {
+    if (!parsed.apply) {
+      return formatSomaInitPlan(await planSomaInit(parsed.options));
+    }
+    return formatSomaInitApplied((await applySomaInit(parsed.options)).steps);
   }
 
   if (parsed.command === "algorithm") {

--- a/src/fs-utils.ts
+++ b/src/fs-utils.ts
@@ -1,0 +1,24 @@
+import { stat } from "node:fs/promises";
+
+export function isEnoent(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT";
+}
+
+export async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (isEnoent(error)) return false;
+    throw error;
+  }
+}
+
+export async function pathMtimeMs(path: string): Promise<number | null> {
+  try {
+    return (await stat(path)).mtimeMs;
+  } catch (error) {
+    if (isEnoent(error)) return null;
+    throw error;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,15 @@ export type {
   SomaInstallOptions,
   SomaInstallPlan,
   SomaInstallResult,
+  SomaDoctorDiagnosis,
+  SomaDoctorFinding,
+  SomaDoctorFindingId,
+  SomaInitPlan,
+  SomaInitApplyResult,
+  SomaInitApplyStepResult,
+  SomaInitStep,
+  SomaInitStepId,
+  SomaOnboardingOptions,
   SomaLifecycleEventName,
   SomaLifecycleOptions,
   SomaLifecycleResult,
@@ -215,6 +224,11 @@ export {
   type InferenceRequest,
   type InferenceResult,
 } from "./tools/inference";
+export {
+  applySomaInit,
+  diagnoseSomaDoctor,
+  planSomaInit,
+} from "./onboarding";
 export {
   addOpinion,
   addOpinionEvidence,

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,0 +1,279 @@
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { diagnoseProjectionDrift } from "./adapters/doctor";
+import { installSomaForClaudeCode, installSomaForCodex, installSomaForCursor, installSomaForPiDev } from "./install";
+import { migrateClaudeSkills } from "./claude-skills-migrator";
+import { migratePai } from "./pai-migration";
+import { isEnoent, pathExists, pathMtimeMs } from "./fs-utils";
+import type {
+  SomaDoctorDiagnosis,
+  SomaDoctorFinding,
+  SomaInitApplyResult,
+  SomaInitPlan,
+  SomaInitStep,
+  SomaInitStepId,
+  SomaOnboardingOptions,
+  SubstrateId,
+} from "./types";
+
+type InitSubstrate = Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor">;
+
+function resolveHomeDir(homeDir?: string): string {
+  return resolve(homeDir ?? homedir());
+}
+
+function resolveSomaHome(options: SomaOnboardingOptions, homeDir: string): string {
+  return resolve(options.somaHome ?? join(homeDir, ".soma"));
+}
+
+function initSubstrate(options: SomaOnboardingOptions): InitSubstrate {
+  return options.substrate ?? "codex";
+}
+
+function installStepId(substrate: InitSubstrate): SomaInitStepId {
+  return `install-${substrate}` as SomaInitStepId;
+}
+
+function installCommand(substrate: InitSubstrate, apply: boolean): string {
+  return `soma install ${substrate} ${apply ? "--apply" : "--dry-run"}`;
+}
+
+function shellQuote(value: string): string {
+  return /^[A-Za-z0-9_./:=@+-]+$/.test(value) ? value : `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function sharedPathFlags(plan: { homeDir: string; somaHome: string }): string {
+  return `--home-dir ${shellQuote(plan.homeDir)} --soma-home ${shellQuote(plan.somaHome)}`;
+}
+
+async function readOptionalTextFile(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (isEnoent(error)) return "";
+    throw error;
+  }
+}
+
+async function readOptionalDirEntries(path: string) {
+  try {
+    return await readdir(path, { withFileTypes: true });
+  } catch (error) {
+    if (isEnoent(error)) return [];
+    throw error;
+  }
+}
+
+async function isStarterProfile(somaHome: string): Promise<boolean> {
+  const principal = await readOptionalTextFile(join(somaHome, "profile/principal.md"));
+  return principal.includes("status: starter-profile");
+}
+
+async function hasSkillDirs(somaHome: string): Promise<boolean> {
+  const entries = await readOptionalDirEntries(join(somaHome, "skills"));
+  return entries.some((entry) => entry.isDirectory());
+}
+
+async function hasAlgorithmSkill(somaHome: string): Promise<boolean> {
+  return pathExists(join(somaHome, "skills/the-algorithm/SKILL.md"));
+}
+
+async function detectOnboarding(options: SomaOnboardingOptions): Promise<Omit<SomaInitPlan, "mode" | "steps">> {
+  const homeDir = resolveHomeDir(options.homeDir);
+  const somaHome = resolveSomaHome(options, homeDir);
+  const substrate = initSubstrate(options);
+  const paiInstall = join(homeDir, ".claude");
+  const paiUserDir = join(paiInstall, "PAI/USER");
+  const claudeSkillsDir = join(paiInstall, "skills");
+  const coreUserDir = join(homeDir, ".config/pai/CORE_USER");
+  const [
+    paiPresent,
+    paiUserPresent,
+    claudeSkillsPresent,
+    coreUserPresent,
+    somaExists,
+  ] = await Promise.all([
+    pathExists(join(paiInstall, "PAI")),
+    pathExists(paiUserDir),
+    pathExists(claudeSkillsDir),
+    pathExists(coreUserDir),
+    pathExists(somaHome),
+  ]);
+  const [starterProfile, skillsPopulated, algorithmSkillPresent] = somaExists
+    ? await Promise.all([
+        isStarterProfile(somaHome),
+        hasSkillDirs(somaHome),
+        hasAlgorithmSkill(somaHome),
+      ])
+    : [false, false, false];
+
+  return {
+    homeDir,
+    somaHome,
+    substrate,
+    detected: {
+      paiInstall: paiPresent ? paiInstall : null,
+      paiUserDir: paiUserPresent ? paiUserDir : null,
+      claudeSkillsDir: claudeSkillsPresent ? claudeSkillsDir : null,
+      coreUserDir: coreUserPresent ? coreUserDir : null,
+    },
+    soma: {
+      exists: somaExists,
+      starterProfile,
+      skillsPopulated,
+      algorithmSkillPresent,
+    },
+  };
+}
+
+export async function planSomaInit(options: SomaOnboardingOptions & { apply?: boolean } = {}): Promise<SomaInitPlan> {
+  const detected = await detectOnboarding(options);
+  const apply = options.apply === true;
+  const modeFlag = apply ? "--apply" : "--dry-run";
+  const steps: SomaInitStep[] = [];
+
+  if (detected.detected.claudeSkillsDir) {
+    steps.push({
+      id: "migrate-claude-skills",
+      command: `soma migrate claude-skills --from ${shellQuote(detected.detected.claudeSkillsDir)} ${modeFlag} ${sharedPathFlags(detected)}`,
+      description: "Import portable Claude skills into the Soma skills tree.",
+    });
+  }
+
+  if (detected.detected.paiInstall) {
+    steps.push({
+      id: "migrate-pai",
+      command: `soma migrate pai --pai-install ${shellQuote(detected.detected.paiInstall)} ${modeFlag} ${sharedPathFlags(detected)}`,
+      description: "Import PAI identity, Algorithm, memory, docs, and pack surfaces that are present.",
+    });
+  }
+
+  steps.push({
+    id: installStepId(detected.substrate),
+    command: `${installCommand(detected.substrate, apply)} ${sharedPathFlags(detected)}`,
+    description: "Project the Soma home into the selected host substrate.",
+  });
+
+  return {
+    ...detected,
+    mode: apply ? "apply" : "dry-run",
+    steps,
+  };
+}
+
+async function installForSubstrate(substrate: InitSubstrate, options: { homeDir: string; somaHome: string }) {
+  switch (substrate) {
+    case "codex":
+      return installSomaForCodex(options);
+    case "pi-dev":
+      return installSomaForPiDev(options);
+    case "claude-code":
+      return installSomaForClaudeCode(options);
+    case "cursor":
+      return installSomaForCursor(options);
+  }
+}
+
+export async function applySomaInit(options: SomaOnboardingOptions = {}): Promise<SomaInitApplyResult> {
+  const plan = await planSomaInit({ ...options, apply: true });
+  const steps: SomaInitApplyResult["steps"] = [];
+  for (const step of plan.steps) {
+    if (step.id === "migrate-claude-skills" && plan.detected.claudeSkillsDir) {
+      const result = await migrateClaudeSkills({
+        from: plan.detected.claudeSkillsDir,
+        homeDir: plan.homeDir,
+        somaHome: plan.somaHome,
+      });
+      if (result.refusedOtherCount > 0) {
+        const detail = result.outcomes
+          .filter((outcome) => outcome.disposition === "refused-other")
+          .map((outcome) => `${outcome.sourceName}: ${outcome.refusalReason ?? outcome.reason}`)
+          .join("; ");
+        throw new Error(`soma init migrate-claude-skills failed: ${detail}`);
+      }
+      steps.push({ id: step.id, status: "applied", detail: `${result.writtenCount} written` });
+    } else if (step.id === "migrate-pai" && plan.detected.paiInstall) {
+      const result = await migratePai({
+        homeDir: plan.homeDir,
+        claudeHome: plan.detected.paiInstall,
+        somaHome: plan.somaHome,
+      });
+      const refusedOther = result.packOutcomes.filter((outcome) => outcome.outcome === "refused-other");
+      if (refusedOther.length > 0) {
+        const detail = refusedOther
+          .map((outcome) => `${outcome.skillName ?? outcome.paiPackDir}: ${outcome.reason ?? "(no detail)"}`)
+          .join("; ");
+        throw new Error(`soma init migrate-pai failed: ${detail}`);
+      }
+      steps.push({ id: step.id, status: "applied", detail: `${result.filesWritten.length} files written` });
+    } else if (step.id.startsWith("install-")) {
+      const result = await installForSubstrate(plan.substrate, {
+        homeDir: plan.homeDir,
+        somaHome: plan.somaHome,
+      });
+      steps.push({ id: step.id, status: "applied", detail: `${result.substrateHome.files.length} files` });
+    }
+  }
+  return { plan, steps };
+}
+
+async function maxProfileMtime(somaHome: string): Promise<number | null> {
+  const mtimes = await Promise.all([
+    pathMtimeMs(join(somaHome, "profile/assistant.md")),
+    pathMtimeMs(join(somaHome, "profile/principal.md")),
+    pathMtimeMs(join(somaHome, "profile/telos.md")),
+  ]);
+  const present = mtimes.filter((value): value is number => value !== null);
+  return present.length === 0 ? null : Math.max(...present);
+}
+
+export async function diagnoseSomaDoctor(options: SomaOnboardingOptions = {}): Promise<SomaDoctorDiagnosis> {
+  const detected = await detectOnboarding(options);
+  const findings: SomaDoctorFinding[] = [];
+  if (detected.substrate !== "codex") {
+    throw new Error("soma doctor currently supports projection drift checks for --substrate codex only.");
+  }
+
+  if (detected.soma.starterProfile) {
+    findings.push({
+      id: "starter-profile",
+      severity: "warning",
+      message: "Soma profile still looks like the starter scaffold.",
+      action: detected.detected.paiInstall
+        ? `soma migrate pai --pai-install ${shellQuote(detected.detected.paiInstall)} --apply ${sharedPathFlags(detected)}`
+        : "Replace the starter profile with principal-specific Soma profile files.",
+    });
+  }
+
+  if (detected.detected.claudeSkillsDir && !(await pathExists(join(detected.somaHome, "imports/claude-skills/.manifest.json")))) {
+    findings.push({
+      id: "claude-skills-not-migrated",
+      severity: "warning",
+      message: "Claude skills source exists, but Soma has no Claude skills migration manifest.",
+      action: `soma migrate claude-skills --from ${shellQuote(detected.detected.claudeSkillsDir)} --apply ${sharedPathFlags(detected)}`,
+    });
+  }
+
+  if (detected.detected.paiInstall && !(await pathExists(join(detected.somaHome, "profile/imports/claude/MIGRATION.md")))) {
+    findings.push({
+      id: "pai-not-migrated",
+      severity: "warning",
+      message: "PAI source exists, but Soma has no PAI migration manifest.",
+      action: `soma migrate pai --pai-install ${shellQuote(detected.detected.paiInstall)} --apply ${sharedPathFlags(detected)}`,
+    });
+  }
+
+  findings.push(...await diagnoseProjectionDrift({
+    substrate: detected.substrate,
+    homeDir: detected.homeDir,
+    profileMtime: await maxProfileMtime(detected.somaHome),
+  }));
+
+  return {
+    status: findings.length === 0 ? "ok" : "drift",
+    homeDir: detected.homeDir,
+    somaHome: detected.somaHome,
+    findings,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1405,6 +1405,77 @@ export interface ClaudeSkillsMigrationManifest {
   smokeSubstrates?: ClaudeSkillsSmokeSubstrate[];
 }
 
+export type SomaInitStepId =
+  | "migrate-claude-skills"
+  | "migrate-pai"
+  | "install-codex"
+  | "install-pi-dev"
+  | "install-claude-code"
+  | "install-cursor";
+
+export type SomaDoctorFindingId =
+  | "starter-profile"
+  | "claude-skills-not-migrated"
+  | "pai-not-migrated"
+  | "codex-projection-stale";
+
+export interface SomaOnboardingOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate?: Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor">;
+}
+
+export interface SomaInitStep {
+  id: SomaInitStepId;
+  command: string;
+  description: string;
+}
+
+export interface SomaInitPlan {
+  mode: "dry-run" | "apply";
+  homeDir: string;
+  somaHome: string;
+  substrate: Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor">;
+  detected: {
+    paiInstall: string | null;
+    paiUserDir: string | null;
+    claudeSkillsDir: string | null;
+    coreUserDir: string | null;
+  };
+  soma: {
+    exists: boolean;
+    starterProfile: boolean;
+    skillsPopulated: boolean;
+    algorithmSkillPresent: boolean;
+  };
+  steps: SomaInitStep[];
+}
+
+export interface SomaInitApplyStepResult {
+  id: SomaInitStepId;
+  status: "applied" | "skipped";
+  detail: string;
+}
+
+export interface SomaInitApplyResult {
+  plan: SomaInitPlan;
+  steps: SomaInitApplyStepResult[];
+}
+
+export interface SomaDoctorFinding {
+  id: SomaDoctorFindingId;
+  severity: "info" | "warning";
+  message: string;
+  action: string;
+}
+
+export interface SomaDoctorDiagnosis {
+  status: "ok" | "drift";
+  homeDir: string;
+  somaHome: string;
+  findings: SomaDoctorFinding[];
+}
+
 export interface SomaMemoryEventInput {
   id?: string;
   timestamp?: string;

--- a/test/onboarding-doctor.test.ts
+++ b/test/onboarding-doctor.test.ts
@@ -1,0 +1,178 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { planSomaInit, diagnoseSomaDoctor } from "../src/onboarding";
+import { runSomaCli } from "../src/cli";
+import { withTempHome as withSharedTempHome } from "./fixtures/pai-migration-fixtures";
+
+const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
+  withSharedTempHome(fn, "soma-onboarding-");
+
+async function writeMinimalPaiInstall(homeDir: string): Promise<void> {
+  await mkdir(join(homeDir, ".claude/PAI/USER"), { recursive: true });
+  await mkdir(join(homeDir, ".claude/PAI/Algorithm"), { recursive: true });
+  await mkdir(join(homeDir, ".claude/skills/Portable"), { recursive: true });
+  await mkdir(join(homeDir, ".config/pai/CORE_USER"), { recursive: true });
+  await mkdir(join(homeDir, ".claude/PAI/USER/TELOS"), { recursive: true });
+  await writeFile(join(homeDir, ".claude/PAI/USER/PRINCIPAL_IDENTITY.md"), "Name: Principal\n", "utf8");
+  await writeFile(join(homeDir, ".claude/PAI/USER/DA_IDENTITY.md"), "Name: Soma\n", "utf8");
+  await writeFile(join(homeDir, ".claude/PAI/USER/TELOS/MISSION.md"), "Mission: Keep context portable.\n", "utf8");
+  await writeFile(join(homeDir, ".claude/PAI/USER/TELOS/GOALS.md"), "- Migrate safely.\n", "utf8");
+  await writeFile(join(homeDir, ".claude/PAI/USER/TELOS/BELIEFS.md"), "- Portability matters.\n", "utf8");
+  await writeFile(join(homeDir, ".claude/PAI/Algorithm/v6.3.0.md"), "# Algorithm\n", "utf8");
+  await writeFile(
+    join(homeDir, ".claude/skills/Portable/SKILL.md"),
+    "---\nname: Portable\ndescription: Portable test skill\n---\n# Portable\n",
+    "utf8",
+  );
+  await writeFile(join(homeDir, ".config/pai/CORE_USER/profile.md"), "core user\n", "utf8");
+}
+
+test("planSomaInit orders PAI migrant commands as dry-run copy-paste steps", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeMinimalPaiInstall(homeDir);
+
+    const plan = await planSomaInit({ homeDir });
+
+    expect(plan.mode).toBe("dry-run");
+    expect(plan.detected.paiInstall).toBe(join(homeDir, ".claude"));
+    expect(plan.detected.claudeSkillsDir).toBe(join(homeDir, ".claude/skills"));
+    expect(plan.detected.coreUserDir).toBe(join(homeDir, ".config/pai/CORE_USER"));
+    expect(plan.soma.starterProfile).toBe(false);
+    expect(plan.steps.map((step) => step.id)).toEqual([
+      "migrate-claude-skills",
+      "migrate-pai",
+      "install-codex",
+    ]);
+    expect(plan.steps.map((step) => step.command)).toEqual([
+      `soma migrate claude-skills --from ${join(homeDir, ".claude/skills")} --dry-run --home-dir ${homeDir} --soma-home ${join(homeDir, ".soma")}`,
+      `soma migrate pai --pai-install ${join(homeDir, ".claude")} --dry-run --home-dir ${homeDir} --soma-home ${join(homeDir, ".soma")}`,
+      `soma install codex --dry-run --home-dir ${homeDir} --soma-home ${join(homeDir, ".soma")}`,
+    ]);
+  });
+});
+
+test("planSomaInit shell-quotes paths in copy-paste commands", async () => {
+  await withTempHome(async (root) => {
+    const homeDir = join(root, "home with spaces");
+    await writeMinimalPaiInstall(homeDir);
+
+    const plan = await planSomaInit({
+      homeDir,
+      somaHome: join(homeDir, "soma home"),
+    });
+
+    expect(plan.steps[0]?.command).toContain(`--from '${join(homeDir, ".claude/skills")}'`);
+    expect(plan.steps[0]?.command).toContain(`--home-dir '${homeDir}'`);
+    expect(plan.steps[0]?.command).toContain(`--soma-home '${join(homeDir, "soma home")}'`);
+  });
+});
+
+test("soma init --yes applies detected migration phases", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeMinimalPaiInstall(homeDir);
+
+    const output = await runSomaCli(["init", "--yes", "--home-dir", homeDir]);
+
+    expect(output).toContain("soma init — applied");
+    expect(output).toContain("migrate-claude-skills: applied");
+    expect(output).toContain("migrate-pai: applied");
+    expect(output).toContain("install-codex: applied");
+    await expect(stat(join(homeDir, ".soma/imports/claude-skills/.manifest.json"))).resolves.toBeTruthy();
+    await expect(stat(join(homeDir, ".soma/profile/imports/claude/MIGRATION.md"))).resolves.toBeTruthy();
+    await expect(stat(join(homeDir, ".codex/rules/soma.rules"))).resolves.toBeTruthy();
+  });
+});
+
+test("soma doctor reports missing migrations and projection drift actions", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeMinimalPaiInstall(homeDir);
+    await mkdir(join(homeDir, ".soma/profile"), { recursive: true });
+    await mkdir(join(homeDir, ".codex/rules"), { recursive: true });
+    await writeFile(join(homeDir, ".codex/rules/soma.rules"), "old projection\n", "utf8");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await writeFile(join(homeDir, ".soma/profile/principal.md"), "# Principal\n\n## Profile\n\n- status: starter-profile\n", "utf8");
+
+    const diagnosis = await diagnoseSomaDoctor({ homeDir });
+    const output = await runSomaCli(["doctor", "--home-dir", homeDir]);
+
+    expect(diagnosis.status).toBe("drift");
+    expect(diagnosis.findings.map((finding) => finding.id)).toEqual([
+      "starter-profile",
+      "claude-skills-not-migrated",
+      "pai-not-migrated",
+      "codex-projection-stale",
+    ]);
+    expect(output).toContain("soma doctor — drift detected");
+    expect(output).toContain("soma migrate claude-skills --from");
+    expect(output).toContain("soma migrate pai --pai-install");
+    expect(output).toContain(`--home-dir ${homeDir}`);
+    expect(output).toContain(`--soma-home ${join(homeDir, ".soma")}`);
+    expect(output).toContain("soma reproject codex");
+  });
+});
+
+test("soma doctor reports a missing Codex projection as drift", async () => {
+  await withTempHome(async (homeDir) => {
+    await mkdir(join(homeDir, ".soma/profile"), { recursive: true });
+    await writeFile(join(homeDir, ".soma/profile/principal.md"), "# Principal\n\nName: Principal\n", "utf8");
+
+    const diagnosis = await diagnoseSomaDoctor({ homeDir });
+
+    expect(diagnosis.findings).toContainEqual({
+      id: "codex-projection-stale",
+      severity: "warning",
+      message: "Codex projection is missing.",
+      action: "soma reproject codex",
+    });
+  });
+});
+
+test("soma doctor surfaces broken Soma profile paths", async () => {
+  await withTempHome(async (homeDir) => {
+    await mkdir(join(homeDir, ".soma"), { recursive: true });
+    await writeFile(join(homeDir, ".soma/profile"), "not a directory\n", "utf8");
+
+    await expect(diagnoseSomaDoctor({ homeDir })).rejects.toThrow();
+  });
+});
+
+test("soma init surfaces broken Soma skills paths", async () => {
+  await withTempHome(async (homeDir) => {
+    await mkdir(join(homeDir, ".soma"), { recursive: true });
+    await writeFile(join(homeDir, ".soma/skills"), "not a directory\n", "utf8");
+
+    await expect(planSomaInit({ homeDir })).rejects.toThrow();
+  });
+});
+
+test("soma init --yes fails when Claude skills migration has refused errors", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeMinimalPaiInstall(homeDir);
+    await mkdir(join(homeDir, ".claude/skills/EmbeddedGit/.git"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".claude/skills/EmbeddedGit/SKILL.md"),
+      "---\nname: EmbeddedGit\ndescription: Bad skill\n---\n# EmbeddedGit\n",
+      "utf8",
+    );
+    await writeFile(join(homeDir, ".claude/skills/EmbeddedGit/.git/config"), "[core]\n", "utf8");
+
+    await expect(runSomaCli(["init", "--yes", "--home-dir", homeDir])).rejects.toThrow(
+      "soma init migrate-claude-skills failed",
+    );
+  });
+});
+
+test("soma doctor reports ok after init applies the detected plan", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeMinimalPaiInstall(homeDir);
+
+    await runSomaCli(["init", "--yes", "--home-dir", homeDir]);
+    const output = await runSomaCli(["doctor", "--home-dir", homeDir]);
+
+    expect(output).toContain("soma doctor — ok");
+    expect(output).not.toContain("soma migrate claude-skills --from");
+    const migration = await readFile(join(homeDir, ".soma/profile/imports/claude/MIGRATION.md"), "utf8");
+    expect(migration).toContain("Last migrated at:");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #171.

- adds `soma init` with dry-run planning and `--yes` execution for detected PAI migration phases
- adds `soma doctor` drift reporting for starter profile, missing migration manifests, and stale Codex projection
- exposes deterministic onboarding/doctor APIs for tests and future UI surfaces
- keeps substrate auto-detection out of scope; `--substrate` selects the projection target and defaults to Codex

## Tests

- `bun test test/onboarding-doctor.test.ts --timeout 120000`
- `bun test test/cli.test.ts test/onboarding-doctor.test.ts --timeout 120000`
- `bun run check-release-privacy`
- `bunx tsc --noEmit`
- `bun test --timeout 120000`
