### PR TITLE
feat: add auto description rewrite mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,9 @@ skill projects cleanly into the named substrate — turns the heuristic verdict
 into a checked one before you trust it cross-substrate.
 
 If your skills carry oversize descriptions (Codex and Pi.dev cap at 1024
-chars) or missing frontmatter, add `--rewrite-descriptions claude` (or
-`codex`, `pi`) to compress / synthesize via an LLM agent in one pass.
+chars) or missing frontmatter, add `--rewrite-descriptions auto` to
+preapprove batch compression via Codex, or choose `claude`, `codex`, or
+`pi` explicitly.
 
 User-owned symlinks inside the skills tree (private skills you keep in
 another worktree) are followed automatically when their target resolves

--- a/docs/migration-from-pai.md
+++ b/docs/migration-from-pai.md
@@ -473,6 +473,10 @@ skill with no frontmatter at all). #120 added per-skill LLM rewrite
 to compress these descriptions under a 900-char safety target.
 
 ```bash
+# Non-interactive batch mode: preapprove every needed rewrite and use
+# the default provider, Codex.
+soma migrate claude-skills --from ~/.claude/skills --apply --rewrite-descriptions auto
+
 # Compress oversize descriptions via subscription-billed claude
 # (Sonnet for speed). 10 PAI skills go from 1037–1318 chars down to
 # ~800–900 chars and import cleanly.
@@ -491,6 +495,8 @@ soma migrate claude-skills --from ~/.claude/skills --apply --rewrite-description
 **Behavior:**
 
 - Description ≤ 1024 chars: untouched. Imports as-is.
+- `--rewrite-descriptions auto`: batch/non-interactive approval for
+  every needed rewrite; dispatches through Codex.
 - Description > 1024 chars (oversize): LLM compresses it; the
   rewritten text is spliced into the frontmatter; body untouched.
 - No frontmatter at all (missing): LLM synthesizes a description

--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -108,6 +108,12 @@ function normalizeSmokeSubstrates(
   return ALL_SMOKE_SUBSTRATES.filter((sub) => set.has(sub));
 }
 
+type ConcreteRewriteDescriptionsAgent = Exclude<RewriteDescriptionsAgent, "none" | "auto">;
+
+function resolveRewriteDescriptionsAgent(agent: Exclude<RewriteDescriptionsAgent, "none">): ConcreteRewriteDescriptionsAgent {
+  return agent === "auto" ? "codex" : agent;
+}
+
 // Parse the front-matter description of a source SKILL.md so the
 // per-substrate verifier can run the description-mismatch check
 // against the projected SKILL.md. The Pi.dev projector rewrites the
@@ -1130,8 +1136,8 @@ function applyDescriptionLimitClassification(args: {
       outcome.disposition = "refused-description-limit";
       outcome.target = null;
       outcome.refusalReason = status.kind === "oversize"
-        ? `description length ${status.length} exceeds substrate cap of ${status.threshold} — re-run with --rewrite-descriptions <claude|codex|pi>`
-        : `SKILL.md has no frontmatter description (substrate cap ${status.threshold}) — re-run with --rewrite-descriptions <claude|codex|pi> to synthesize one`;
+        ? `description length ${status.length} exceeds substrate cap of ${status.threshold} — re-run with --rewrite-descriptions auto or <claude|codex|pi>`
+        : `SKILL.md has no frontmatter description (substrate cap ${status.threshold}) — re-run with --rewrite-descriptions auto or <claude|codex|pi> to synthesize one`;
     }
   }
 }
@@ -1367,7 +1373,7 @@ function remediationForOutcome(outcome: ClaudeSkillOutcome): string | undefined 
     return "Re-run with --include-claude-specific if this Claude-only skill should still be imported.";
   }
   if (outcome.disposition === "refused-description-limit") {
-    return "Re-run with --rewrite-descriptions claude (or codex/pi) to compress the description before import.";
+    return "Re-run with --rewrite-descriptions auto (or claude/codex/pi) to compress the description before import.";
   }
   if (outcome.disposition !== "refused-other") return undefined;
   const reason = resolveOutcomeReason(outcome);
@@ -1994,9 +2000,7 @@ export async function migrateClaudeSkills(
         // The `needsRewrite` guard above ensured `rewriteDescriptions-
         // Agent !== "none"`; assign once so the narrowed type flows
         // through both the dispatcher call AND the provenance entry.
-        const activeAgent: Exclude<RewriteDescriptionsAgent, "none"> =
-          rewriteDescriptionsAgent === "claude" ? "claude" :
-          rewriteDescriptionsAgent === "codex" ? "codex" : "pi";
+        const activeAgent = resolveRewriteDescriptionsAgent(rewriteDescriptionsAgent);
         // #125 — bracket the LLM call with start + complete progress
         // lines so a principal sees `[N/total] <skill> [rewriting
         // via claude (1318 chars → target 900)... <elapsed>s → 836

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -448,7 +448,7 @@ const MIGRATE_PAI_USAGE =
 // from the usage line below for non-Phase-2 callers — they keep the
 // Phase-1 surface intact.
 const MIGRATE_CLAUDE_SKILLS_USAGE =
-  "Usage: soma migrate claude-skills --from <skills-dir> [--dry-run] [--apply] [--status] [--home-dir <dir>] [--soma-home <dir>] [--include-claude-specific] [--smoke <codex|pi-dev|all>] [--rewrite-descriptions <claude|codex|pi|none>] [--quiet] [--verbose]";
+  "Usage: soma migrate claude-skills --from <skills-dir> [--dry-run] [--apply] [--status] [--home-dir <dir>] [--soma-home <dir>] [--include-claude-specific] [--smoke <codex|pi-dev|all>] [--rewrite-descriptions <claude|codex|pi|none|auto>] [--quiet] [--verbose]";
 const ADOPT_CLAUDE_USAGE =
   "Usage: soma adopt claude [--dry-run] [--apply] [--uninstall] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 const INIT_USAGE =
@@ -2144,15 +2144,15 @@ function expandSmokeSubstrateArg(value: string): ClaudeSkillsSmokeSubstrate[] {
   );
 }
 
-// #120 — `--rewrite-descriptions <value>` enum gate. The four accepted
-// values are claude, codex, pi, none. Unknown rejects with a clear
-// error listing every valid form. `none` is permitted explicitly so
-// scripts can be parameterized without a separate "absent" branch.
+// #120/#174 — `--rewrite-descriptions <value>` enum gate. `auto` is
+// the batch/non-interactive approval mode; the migrator resolves it
+// to the default concrete provider at dispatch time.
 const VALID_REWRITE_DESCRIPTIONS_AGENTS: readonly RewriteDescriptionsAgent[] = [
   "claude",
   "codex",
   "pi",
   "none",
+  "auto",
 ];
 function parseRewriteDescriptionsAgent(value: string): RewriteDescriptionsAgent {
   if ((VALID_REWRITE_DESCRIPTIONS_AGENTS as readonly string[]).includes(value)) {
@@ -2829,7 +2829,7 @@ function formatClaudeSkillsMigrationPlan(plan: ClaudeSkillsMigrationPlan): strin
   }
   if (counts.refusedDescriptionLimit > 0) {
     lines.push(
-      `${counts.refusedDescriptionLimit} skill(s) refused-description-limit — re-run with --rewrite-descriptions claude (or codex/pi) to compress oversize descriptions via LLM.`,
+      `${counts.refusedDescriptionLimit} skill(s) refused-description-limit — re-run with --rewrite-descriptions auto (or claude/codex/pi) to compress oversize descriptions via LLM.`,
     );
   }
   appendMissingDependencyFooter(lines, plan.outcomes);
@@ -2884,7 +2884,7 @@ function formatClaudeSkillsMigrationResult(result: ClaudeSkillsMigrationResult):
   }
   if (result.refusedDescriptionLimitCount > 0) {
     lines.push(
-      `${result.refusedDescriptionLimitCount} skill(s) refused-description-limit — re-run with --rewrite-descriptions claude (or codex/pi) to compress oversize descriptions via LLM.`,
+      `${result.refusedDescriptionLimitCount} skill(s) refused-description-limit — re-run with --rewrite-descriptions auto (or claude/codex/pi) to compress oversize descriptions via LLM.`,
     );
   }
   appendMissingDependencyFooter(lines, result.outcomes);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1055,8 +1055,10 @@ export interface ClaudeSkillsMigrationOptions {
  *   - `claude` — subscription-billed `claude` subprocess (Sonnet).
  *   - `codex`  — `codex exec` subprocess (cross-vendor GPT path).
  *   - `pi`     — Pi.dev local LLM API (refused loud if unavailable).
+ *   - `auto`   — non-interactive batch approval; dispatches via the
+ *                default provider (`codex`) without prompting.
  */
-export type RewriteDescriptionsAgent = "claude" | "codex" | "pi" | "none";
+export type RewriteDescriptionsAgent = "claude" | "codex" | "pi" | "none" | "auto";
 
 /**
  * #120 — status of a skill's frontmatter description relative to the
@@ -1131,8 +1133,8 @@ export interface ClaudeSkillOutcome {
   // skill whose frontmatter description exceeds 1024 chars OR whose
   // SKILL.md has no frontmatter, AND `--rewrite-descriptions` was
   // absent or set to `none`. The skill is NOT imported; the CLI
-  // footer suggests re-running with `--rewrite-descriptions claude`
-  // (or codex / pi) so the LLM dispatcher can compress the text.
+  // footer suggests re-running with `--rewrite-descriptions auto`
+  // (or claude / codex / pi) so the LLM dispatcher can compress the text.
   disposition:
     | "imported"
     | "skipped-claude-specific"
@@ -1303,8 +1305,8 @@ export interface ClaudeSkillsMigrationResult extends ClaudeSkillsMigrationPlan {
   // #120 — skills refused because their frontmatter description
   // exceeded the 1024-char substrate cap (or was missing) AND no
   // `--rewrite-descriptions <agent>` was set. The CLI footer
-  // suggests re-running with `--rewrite-descriptions claude`
-  // (or codex / pi) so the LLM dispatcher compresses the text.
+  // suggests re-running with `--rewrite-descriptions auto`
+  // (or claude / codex / pi) so the LLM dispatcher compresses the text.
   refusedDescriptionLimitCount: number;
   // #120 — skills whose description was actually rewritten via the
   // LLM dispatcher this run. Reported separately from `writtenCount`

--- a/test/claude-skills-migrator.test.ts
+++ b/test/claude-skills-migrator.test.ts
@@ -1194,6 +1194,28 @@ test("oversize + --rewrite-descriptions claude (stubbed) → rewrites under cap 
   });
 });
 
+test("oversize + --rewrite-descriptions auto (stubbed) → preapproves rewrite via codex", async () => {
+  await withTempHome(async (home) => {
+    const { fromDir, somaHome } = await writeOversizeApifyFixture(home);
+    const dispatchAgents: string[] = [];
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      rewriteDescriptionsAgent: "auto",
+      rewriteDispatchOverride: async (req) => {
+        dispatchAgents.push(req.agent);
+        return "Apify scraping skill. USE WHEN social media, maps, e-commerce, and actor-backed extraction are needed.";
+      },
+    });
+
+    expect(dispatchAgents).toEqual(["codex"]);
+    expect(result.rewriteDescriptionsAgent).toBe("auto");
+    expect(result.descriptionRewrittenCount).toBe(1);
+    const outcome = result.outcomes.find((o) => o.sourceName === "Apify");
+    expect(outcome?.descriptionRewrite?.agent).toBe("codex");
+  });
+});
+
 test("missing frontmatter + --rewrite-descriptions codex (stubbed) → synthesizes + imports", async () => {
   await withTempHome(async (home) => {
     const fromDir = join(home, "skills");

--- a/test/cli-migrate-claude-skills.test.ts
+++ b/test/cli-migrate-claude-skills.test.ts
@@ -537,10 +537,10 @@ test("soma migrate claude-skills --rewrite-descriptions: unknown agent → error
   });
 });
 
-test("soma migrate claude-skills --rewrite-descriptions accepts claude|codex|pi|none", async () => {
+test("soma migrate claude-skills --rewrite-descriptions accepts claude|codex|pi|none|auto", async () => {
   await withTempHome(async (home) => {
     const fromDir = await writeFixture(home);
-    for (const agent of ["claude", "codex", "pi", "none"]) {
+    for (const agent of ["claude", "codex", "pi", "none", "auto"]) {
       // We only validate parser-acceptance here; the apply path with
       // each agent is exercised in the migrator integration tests with
       // a stubbed dispatcher. `claude`/`codex`/`pi` would invoke real
@@ -596,7 +596,7 @@ test("soma migrate claude-skills plan with oversize + no agent → refused-descr
       join(home, "soma"),
     ]);
     expect(output).toContain("refused-description-limit");
-    expect(output).toContain("--rewrite-descriptions claude");
+    expect(output).toContain("--rewrite-descriptions auto");
   });
 });
 
@@ -697,7 +697,7 @@ test("#124: plan output groups by disposition with correct section headers", asy
 
     // Footer suggestion preserved
     expect(output).toContain("--include-claude-specific");
-    expect(output).toContain("--rewrite-descriptions claude");
+    expect(output).toContain("--rewrite-descriptions auto");
   });
 });
 


### PR DESCRIPTION
Fixes #174.

## Summary

- Add `--rewrite-descriptions auto` as the non-interactive batch mode for oversized or missing skill descriptions.
- Resolve `auto` to Codex at dispatch time while preserving concrete rewrite provenance in per-skill metadata.
- Update refusal guidance and docs so CI/non-interactive users see `auto` as the first remediation path.

## Verification

- `bun test test/cli-migrate-claude-skills.test.ts test/claude-skills-migrator.test.ts --timeout 120000`
- `bunx tsc --noEmit`
- `bun run check-release-privacy`
- `bun test --timeout 120000`
