### PR TITLE
feat: add PAI pack resolution flow

### DIFF
--- a/docs/migration-from-pai.md
+++ b/docs/migration-from-pai.md
@@ -462,6 +462,35 @@ already marked `verified` for the same source SHA. Warnings and
 failures re-run every invocation so fixing the adapter can flip the
 verdict without source churn.
 
+### Resolving duplicate PAI pack skills
+
+Some PAI repos include collection packs whose nested skills duplicate
+standalone packs. A dry run reports these as `refused-name-collision`
+rows. Without extra flags Soma keeps the existing first-wins behavior:
+the earliest sorted pack owns the skill slug and later duplicates are
+skipped.
+
+To make the choice explicit, emit a resolution file:
+
+```bash
+soma migrate pai --pai-repo ~/work/PAI --emit-resolution migration-resolve.yaml
+```
+
+Edit each `pick:` to the source pack that should win. Set `pick: null`
+or comment out the `pick:` line to skip all versions of that collision.
+In this first non-interactive flow, each `source` value is the pack
+directory that produced the duplicate skill slug.
+Then apply with the edited file:
+
+```bash
+soma migrate pai --pai-repo ~/work/PAI --apply --resolution migration-resolve.yaml
+```
+
+The resolution file is intentionally small and forward-compatible:
+extra fields under known collisions are ignored, but a collision key
+that does not exist in the current pack set refuses loud so stale files
+do not silently select the wrong import.
+
 ### Phase 3: `--rewrite-descriptions <agent>` LLM description compression
 
 PAI skills routinely pack multi-paragraph descriptions with usage

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -439,7 +439,7 @@ const TOP_LEVEL_COMMANDS = [
 ] as const;
 
 const MIGRATE_PAI_USAGE =
-  "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-install <dir>] [--pai-repo <root>] [--pai-source-dir <dir>] [--pai-packs-dir <dir>] [--pai-pack-dir <dir>] [--skip-memory] [--skip-skills] [--skip-docs] [--overwrite-reserved] [--include-unrecognized] [--verbose]";
+  "Usage: soma migrate pai [--dry-run] [--apply] [--status] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--pai-install <dir>] [--pai-repo <root>] [--pai-source-dir <dir>] [--pai-packs-dir <dir>] [--pai-pack-dir <dir>] [--emit-resolution <path>] [--resolution <path>] [--skip-memory] [--skip-skills] [--skip-docs] [--overwrite-reserved] [--include-unrecognized] [--verbose]";
 // #115 — `soma migrate claude-skills`. Phase 1 verb + classifier
 // (#116) ships the flat-tree import; Phase 2 adds `--smoke
 // <substrate>` (repeatable) for per-skill static-shape verify
@@ -1989,6 +1989,14 @@ function parseMigratePaiArgs(args: string[]): ParsedMigrateArgs {
         // always win — `--pai-repo` only fills the unset slots. See
         // `applyPaiRepoDerivation` in `src/pai-migration.ts`.
         options.paiRepo = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--emit-resolution":
+        options.emitResolutionPath = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--resolution":
+        options.resolutionPath = readOption(rest, index, arg);
         index += 1;
         break;
       case "--skip-memory":

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -677,7 +677,11 @@ async function planAllPacksWithHandles(
 
 function workflowCountForPlan(plan: PaiPackImportPlan): number {
   const skillRootSegment = `/skills/${plan.skillName}/Workflows/`;
-  return plan.files.filter((file) => file.target.includes(skillRootSegment)).length;
+  let count = 0;
+  for (const file of plan.files) {
+    if (file.target.includes(skillRootSegment)) count += 1;
+  }
+  return count;
 }
 
 async function collectCollisionGroups(
@@ -780,7 +784,7 @@ function renderPaiMigrationResolution(groups: CollisionGroups): string {
 function parseQuotedYamlScalar(trimmed: string): string | undefined {
   if (trimmed.startsWith("\"")) {
     for (let index = 1; index < trimmed.length; index += 1) {
-      if (trimmed[index] !== "\"" || trimmed[index - 1] === "\\") continue;
+      if (trimmed[index] !== "\"" || isEscapedDoubleQuote(trimmed, index)) continue;
       try {
         return JSON.parse(trimmed.slice(0, index + 1));
       } catch {
@@ -804,6 +808,14 @@ function parseQuotedYamlScalar(trimmed: string): string | undefined {
     }
   }
   return undefined;
+}
+
+function isEscapedDoubleQuote(value: string, quoteIndex: number): boolean {
+  let backslashes = 0;
+  for (let index = quoteIndex - 1; index >= 0 && value[index] === "\\"; index -= 1) {
+    backslashes += 1;
+  }
+  return backslashes % 2 === 1;
 }
 
 function parseUnquotedYamlScalar(trimmed: string): string | null {

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -569,6 +569,10 @@ interface ResolutionOption {
 type CollisionGroups = Map<string, ResolutionOption[]>;
 type ResolutionChoices = Map<string, string | null>;
 
+interface CollisionGroupCandidate extends ResolutionOption {
+  plan: PaiPackImportPlan;
+}
+
 /**
  * Single source for partitioning a pack's plans into `collided`
  * (slug already landed)
@@ -683,7 +687,7 @@ async function collectCollisionGroups(
   planRows: readonly SharedPlanRow[],
   collectionOptions: { includeSizeBytes: boolean },
 ): Promise<CollisionGroups> {
-  const grouped = new Map<string, ResolutionOption[]>();
+  const grouped = new Map<string, CollisionGroupCandidate[]>();
   for (const row of planRows) {
     if (row.kind !== "planned") continue;
     for (const plan of row.plans) {
@@ -693,7 +697,8 @@ async function collectCollisionGroups(
         source: row.paiPackDir,
         description: plan.description,
         workflows: workflowCountForPlan(plan),
-        sizeBytes: collectionOptions.includeSizeBytes ? await sizeBytesForPlan(plan) : 0,
+        sizeBytes: 0,
+        plan,
       });
       grouped.set(plan.skillName, options);
     }
@@ -702,7 +707,21 @@ async function collectCollisionGroups(
     const uniqueSources = new Set(options.map((option) => resolve(option.source)));
     if (uniqueSources.size < 2) grouped.delete(slug);
   }
-  return grouped;
+  const collisions: CollisionGroups = new Map();
+  for (const [slug, options] of grouped.entries()) {
+    const resolvedOptions: ResolutionOption[] = [];
+    for (const option of options) {
+      resolvedOptions.push({
+        slug: option.slug,
+        source: option.source,
+        description: option.description,
+        workflows: option.workflows,
+        sizeBytes: collectionOptions.includeSizeBytes ? await sizeBytesForPlan(option.plan) : 0,
+      });
+    }
+    collisions.set(slug, resolvedOptions);
+  }
+  return collisions;
 }
 
 function yamlString(value: string): string {
@@ -737,7 +756,22 @@ function renderPaiMigrationResolution(groups: CollisionGroups): string {
 }
 
 function parseYamlScalar(raw: string): string | null {
-  const value = raw.split(/\s+#/, 1)[0].trim();
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("\"")) {
+    for (let index = 1; index < trimmed.length; index += 1) {
+      if (trimmed[index] !== "\"" || trimmed[index - 1] === "\\") continue;
+      try {
+        return JSON.parse(trimmed.slice(0, index + 1));
+      } catch {
+        return trimmed.slice(1, index);
+      }
+    }
+  }
+  if (trimmed.startsWith("'")) {
+    const end = trimmed.indexOf("'", 1);
+    if (end !== -1) return trimmed.slice(1, end);
+  }
+  const value = trimmed.split(/\s+#/, 1)[0].trim();
   if (value === "" || value === "null" || value === "~") return null;
   if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
     try {

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -679,7 +679,10 @@ async function sizeBytesForPlan(plan: PaiPackImportPlan): Promise<number> {
   return total;
 }
 
-async function collectCollisionGroups(planRows: readonly SharedPlanRow[]): Promise<CollisionGroups> {
+async function collectCollisionGroups(
+  planRows: readonly SharedPlanRow[],
+  collectionOptions: { includeSizeBytes: boolean },
+): Promise<CollisionGroups> {
   const grouped = new Map<string, ResolutionOption[]>();
   for (const row of planRows) {
     if (row.kind !== "planned") continue;
@@ -690,7 +693,7 @@ async function collectCollisionGroups(planRows: readonly SharedPlanRow[]): Promi
         source: row.paiPackDir,
         description: plan.description,
         workflows: workflowCountForPlan(plan),
-        sizeBytes: await sizeBytesForPlan(plan),
+        sizeBytes: collectionOptions.includeSizeBytes ? await sizeBytesForPlan(plan) : 0,
       });
       grouped.set(plan.skillName, options);
     }
@@ -794,6 +797,27 @@ async function maybeWriteResolutionFile(path: string | undefined, groups: Collis
   await writeFile(target, renderPaiMigrationResolution(groups), "utf8");
 }
 
+function sameResolvedPath(left: string | undefined, right: string | undefined): boolean {
+  return left !== undefined && right !== undefined && resolve(left) === resolve(right);
+}
+
+async function prepareResolutionChoices(
+  inputs: BulkImportInputs,
+  planRows: readonly SharedPlanRow[],
+): Promise<ResolutionChoices> {
+  if (!inputs.emitResolutionPath && !inputs.resolutionPath) return new Map();
+  if (sameResolvedPath(inputs.emitResolutionPath, inputs.resolutionPath)) {
+    throw new Error("PAI migration --emit-resolution and --resolution must use different files.");
+  }
+
+  const collisionGroups = await collectCollisionGroups(planRows, {
+    includeSizeBytes: inputs.emitResolutionPath !== undefined,
+  });
+  const resolutionChoices = await loadResolutionChoices(inputs.resolutionPath, collisionGroups);
+  await maybeWriteResolutionFile(inputs.emitResolutionPath, collisionGroups);
+  return resolutionChoices;
+}
+
 /**
  * Shared cross-pack collision walk.
  * Walks `planRows` in sorted order; for each `planned` row, partitions
@@ -845,9 +869,7 @@ async function importPacksWithOutcomes(
   // both the public per-skill plan view AND an opaque handle so Phase 2
   // can apply WITHOUT a second `buildPaiPackImportPlan` pass.
   const planRows = await planAllPacksWithHandles(inputs);
-  const collisionGroups = await collectCollisionGroups(planRows);
-  await maybeWriteResolutionFile(inputs.emitResolutionPath, collisionGroups);
-  const resolutionChoices = await loadResolutionChoices(inputs.resolutionPath, collisionGroups);
+  const resolutionChoices = await prepareResolutionChoices(inputs, planRows);
 
   // Phase 2: sequential apply with collision tracking.
   // Invariant: the cross-pack collision set grows ONLY after a
@@ -1236,9 +1258,7 @@ async function planPacksWithOutcomes(inputs: BulkImportInputs): Promise<BulkPlan
   // disk; it just emits advisory `imported` rows for every survivor
   // plus the same collision outcomes the apply path would produce.
   const planRows = await planAllPacksWithHandles(inputs);
-  const collisionGroups = await collectCollisionGroups(planRows);
-  await maybeWriteResolutionFile(inputs.emitResolutionPath, collisionGroups);
-  const resolutionChoices = await loadResolutionChoices(inputs.resolutionPath, collisionGroups);
+  const resolutionChoices = await prepareResolutionChoices(inputs, planRows);
   const { resolved } = walkPlanRowsForCollisions(planRows, inputs.overwriteReserved, resolutionChoices);
 
   const packs: PaiPackImportPlan[] = [];

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -764,7 +764,7 @@ function renderPaiMigrationResolution(groups: CollisionGroups): string {
   }
   for (const slug of slugs) {
     const options = [...(groups.get(slug) ?? [])].sort((a, b) => a.source.localeCompare(b.source));
-    lines.push(`  ${slug}:`);
+    lines.push(`  ${yamlString(slug)}:`);
     lines.push(`    pick: ${yamlString(options[0]?.source ?? "")}`);
     lines.push("    options:");
     for (const option of options) {
@@ -817,6 +817,15 @@ function parseYamlScalar(raw: string): string | null {
   return parseQuotedYamlScalar(trimmed) ?? parseUnquotedYamlScalar(trimmed);
 }
 
+function parseCollisionKeyLine(line: string): string | null {
+  if (!line.startsWith("  ") || line.startsWith("    ") || !line.trimEnd().endsWith(":")) return null;
+  const rawKey = line.trim().slice(0, -1).trim();
+  const quotedKey = parseQuotedYamlScalar(rawKey);
+  if (quotedKey !== undefined) return quotedKey;
+  if (/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(rawKey)) return rawKey;
+  throw new Error(`PAI migration resolution contains invalid collision key '${rawKey}'. Re-run --emit-resolution for the current pack set.`);
+}
+
 function parsePaiMigrationResolution(content: string): ResolutionChoices {
   const choices: ResolutionChoices = new Map();
   let currentSlug: string | null = null;
@@ -829,15 +838,11 @@ function parsePaiMigrationResolution(content: string): ResolutionChoices {
       continue;
     }
     if (inCollisions && line === "  {}") continue;
-    const slugMatch = inCollisions ? /^  ([a-z0-9]+(?:-[a-z0-9]+)*):\s*$/.exec(line) : null;
-    if (slugMatch) {
-      currentSlug = slugMatch[1];
+    const collisionKey = inCollisions ? parseCollisionKeyLine(line) : null;
+    if (collisionKey !== null) {
+      currentSlug = collisionKey;
       seenSlugs.add(currentSlug);
       continue;
-    }
-    const invalidSlugMatch = inCollisions ? /^  ([^ ].*):\s*$/.exec(line) : null;
-    if (inCollisions && invalidSlugMatch) {
-      throw new Error(`PAI migration resolution contains invalid collision key '${invalidSlugMatch[1]}'. Re-run --emit-resolution for the current pack set.`);
     }
     const pickMatch = inCollisions ? /^    pick:\s*(.*)$/.exec(line) : null;
     if (pickMatch && currentSlug) {

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -782,8 +782,19 @@ function parseQuotedYamlScalar(trimmed: string): string | undefined {
     }
   }
   if (trimmed.startsWith("'")) {
-    const end = trimmed.indexOf("'", 1);
-    if (end !== -1) return trimmed.slice(1, end);
+    let value = "";
+    for (let index = 1; index < trimmed.length; index += 1) {
+      if (trimmed[index] !== "'") {
+        value += trimmed[index];
+        continue;
+      }
+      if (trimmed[index + 1] === "'") {
+        value += "'";
+        index += 1;
+        continue;
+      }
+      return value;
+    }
   }
   return undefined;
 }
@@ -791,13 +802,6 @@ function parseQuotedYamlScalar(trimmed: string): string | undefined {
 function parseUnquotedYamlScalar(trimmed: string): string | null {
   const value = trimmed.split(/\s+#/, 1)[0].trim();
   if (value === "" || value === "null" || value === "~") return null;
-  if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
-    try {
-      return JSON.parse(value);
-    } catch {
-      return value.slice(1, -1);
-    }
-  }
   return value;
 }
 

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -673,24 +673,6 @@ function workflowCountForPlan(plan: PaiPackImportPlan): number {
   return plan.files.filter((file) => file.target.includes(skillRootSegment)).length;
 }
 
-async function sizeBytesForPlan(plan: PaiPackImportPlan): Promise<number> {
-  const sourceFiles = plan.files.filter((file) => file.origin === "source");
-  const sizes = await runBoundedConcurrent(
-    sourceFiles,
-    async (file) => {
-      try {
-        return (await stat(file.source)).size;
-      } catch {
-        // Resolution metadata is advisory; a raced source deletion will
-        // be handled by the actual import path. Keep the file writable.
-        return 0;
-      }
-    },
-    16,
-  );
-  return sizes.reduce((total, size) => total + size, 0);
-}
-
 async function collectCollisionGroups(
   planRows: readonly SharedPlanRow[],
   collectionOptions: { includeSizeBytes: boolean },
@@ -718,9 +700,26 @@ async function collectCollisionGroups(
   const candidates = [...grouped.values()].flat();
   const sizeByCandidate = new Map<CollisionGroupCandidate, number>();
   if (collectionOptions.includeSizeBytes) {
-    const sizes = await runBoundedConcurrent(candidates, (option) => sizeBytesForPlan(option.plan), 16);
-    for (let index = 0; index < candidates.length; index += 1) {
-      sizeByCandidate.set(candidates[index], sizes[index] ?? 0);
+    const statTargets = candidates.flatMap((candidate) =>
+      candidate.plan.files
+        .filter((file) => file.origin === "source")
+        .map((file) => ({ candidate, source: file.source }))
+    );
+    const sizes = await runBoundedConcurrent(
+      statTargets,
+      async (target) => {
+        try {
+          return { candidate: target.candidate, size: (await stat(target.source)).size };
+        } catch {
+          // Resolution metadata is advisory; a raced source deletion will
+          // be handled by the actual import path. Keep the file writable.
+          return { candidate: target.candidate, size: 0 };
+        }
+      },
+      16,
+    );
+    for (const item of sizes) {
+      sizeByCandidate.set(item.candidate, (sizeByCandidate.get(item.candidate) ?? 0) + item.size);
     }
   }
   const collisions: CollisionGroups = new Map();
@@ -819,17 +818,17 @@ function parsePaiMigrationResolution(content: string): ResolutionChoices {
       continue;
     }
     if (inCollisions && line === "  {}") continue;
-    const slugMatch = /^  ([a-z0-9]+(?:-[a-z0-9]+)*):\s*$/.exec(line);
+    const slugMatch = inCollisions ? /^  ([a-z0-9]+(?:-[a-z0-9]+)*):\s*$/.exec(line) : null;
     if (slugMatch) {
       currentSlug = slugMatch[1];
       seenSlugs.add(currentSlug);
       continue;
     }
-    const invalidSlugMatch = /^  ([^ ].*):\s*$/.exec(line);
+    const invalidSlugMatch = inCollisions ? /^  ([^ ].*):\s*$/.exec(line) : null;
     if (inCollisions && invalidSlugMatch) {
       throw new Error(`PAI migration resolution contains invalid collision key '${invalidSlugMatch[1]}'. Re-run --emit-resolution for the current pack set.`);
     }
-    const pickMatch = /^    pick:\s*(.*)$/.exec(line);
+    const pickMatch = inCollisions ? /^    pick:\s*(.*)$/.exec(line) : null;
     if (pickMatch && currentSlug) {
       choices.set(currentSlug, parseYamlScalar(pickMatch[1]));
     }

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -157,6 +157,16 @@ export interface PaiMigrationOptions {
    * is filtered out before the highest is picked.
    */
   paiRepo?: string;
+  /**
+   * #114 — write a principal-editable resolution file during plan mode
+   * for cross-pack skill-name collisions.
+   */
+  emitResolutionPath?: string;
+  /**
+   * #114 — apply an edited resolution file. Each collision slug can
+   * pick one source pack path or `null` to skip every option.
+   */
+  resolutionPath?: string;
 }
 
 export interface PaiMigrationPlan {
@@ -474,6 +484,8 @@ interface BulkImportInputs {
   packPaths: readonly string[];
   overwriteReserved: boolean;
   includeSubstrateSpecific: boolean;
+  emitResolutionPath?: string;
+  resolutionPath?: string;
 }
 
 interface BulkImportResult {
@@ -537,9 +549,25 @@ interface ResolvedPlanRow {
   paiPackDir: string;
   plans: PaiPackImportPlan[];
   handle: PaiPackImportPlanHandle;
-  collided: string[];
+  denied: DeniedSkill[];
   survivors: string[];
 }
+
+interface DeniedSkill {
+  slug: string;
+  reason: string;
+}
+
+interface ResolutionOption {
+  slug: string;
+  source: string;
+  description: string;
+  workflows: number;
+  sizeBytes: number;
+}
+
+type CollisionGroups = Map<string, ResolutionOption[]>;
+type ResolutionChoices = Map<string, string | null>;
 
 /**
  * Single source for partitioning a pack's plans into `collided`
@@ -561,10 +589,23 @@ function partitionPlansByCollision(
   plans: readonly PaiPackImportPlan[],
   landedSlugs: ReadonlySet<string>,
   overwriteReserved: boolean,
+  resolutionChoices: ResolutionChoices,
+  paiPackDir: string,
 ): { collided: string[]; survivors: string[] } {
   const collided: string[] = [];
   const survivors: string[] = [];
   for (const plan of plans) {
+    if (resolutionChoices.has(plan.skillName)) {
+      const pick = resolutionChoices.get(plan.skillName) ?? null;
+      if (pick === null) {
+        collided.push(plan.skillName);
+      } else if (resolve(pick) === resolve(paiPackDir)) {
+        survivors.push(plan.skillName);
+      } else {
+        collided.push(plan.skillName);
+      }
+      continue;
+    }
     if (landedSlugs.has(plan.skillName) && !overwriteReserved) {
       collided.push(plan.skillName);
     } else {
@@ -581,12 +622,26 @@ function partitionPlansByCollision(
  * construction prevents the reason text + outcome kind from drifting
  * across the two surfaces.
  */
-function crossPackCollisionOutcome(paiPackDir: string, slug: string): PaiPackOutcome {
+function deniedSkillReason(
+  slug: string,
+  deniedByResolution: ResolutionChoices,
+  paiPackDir: string,
+): string {
+  if (deniedByResolution.has(slug)) {
+    const pick = deniedByResolution.get(slug) ?? null;
+    return pick === null
+      ? `Resolution file set '${slug}' pick to null — skipped all collision options.`
+      : `Resolution file picked ${pick}; skipped ${paiPackDir}.`;
+  }
+  return `Soma skill '${slug}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`;
+}
+
+function crossPackCollisionOutcome(paiPackDir: string, slug: string, reason?: string): PaiPackOutcome {
   return {
     paiPackDir,
     outcome: "refused-name-collision",
     skillName: slug,
-    reason: `Soma skill '${slug}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
+    reason: reason ?? `Soma skill '${slug}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
   };
 }
 
@@ -605,6 +660,140 @@ async function planAllPacksWithHandles(
   );
 }
 
+function workflowCountForPlan(plan: PaiPackImportPlan): number {
+  const skillRootSegment = `/skills/${plan.skillName}/Workflows/`;
+  return plan.files.filter((file) => file.target.includes(skillRootSegment)).length;
+}
+
+async function sizeBytesForPlan(plan: PaiPackImportPlan): Promise<number> {
+  let total = 0;
+  for (const file of plan.files) {
+    if (file.origin !== "source") continue;
+    try {
+      total += (await stat(file.source)).size;
+    } catch {
+      // Resolution metadata is advisory; a raced source deletion will
+      // be handled by the actual import path. Keep the file writable.
+    }
+  }
+  return total;
+}
+
+async function collectCollisionGroups(planRows: readonly SharedPlanRow[]): Promise<CollisionGroups> {
+  const grouped = new Map<string, ResolutionOption[]>();
+  for (const row of planRows) {
+    if (row.kind !== "planned") continue;
+    for (const plan of row.plans) {
+      const options = grouped.get(plan.skillName) ?? [];
+      options.push({
+        slug: plan.skillName,
+        source: row.paiPackDir,
+        description: plan.description,
+        workflows: workflowCountForPlan(plan),
+        sizeBytes: await sizeBytesForPlan(plan),
+      });
+      grouped.set(plan.skillName, options);
+    }
+  }
+  for (const [slug, options] of [...grouped.entries()]) {
+    const uniqueSources = new Set(options.map((option) => resolve(option.source)));
+    if (uniqueSources.size < 2) grouped.delete(slug);
+  }
+  return grouped;
+}
+
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function renderPaiMigrationResolution(groups: CollisionGroups): string {
+  const lines = [
+    "# soma migrate pai — resolution file",
+    "# Edit each pick field to choose which source pack wins on collision.",
+    "# Set pick: null, or comment out the pick line, to skip every option for that slug.",
+    "collisions:",
+  ];
+  const slugs = [...groups.keys()].sort();
+  if (slugs.length === 0) {
+    lines.push("  {}");
+    return `${lines.join("\n")}\n`;
+  }
+  for (const slug of slugs) {
+    const options = [...(groups.get(slug) ?? [])].sort((a, b) => a.source.localeCompare(b.source));
+    lines.push(`  ${slug}:`);
+    lines.push(`    pick: ${yamlString(options[0]?.source ?? "")}`);
+    lines.push("    options:");
+    for (const option of options) {
+      lines.push(`      - source: ${yamlString(option.source)}`);
+      lines.push(`        description: ${yamlString(option.description)}`);
+      lines.push(`        workflows: ${option.workflows}`);
+      lines.push(`        sizeBytes: ${option.sizeBytes}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function parseYamlScalar(raw: string): string | null {
+  const value = raw.split(/\s+#/, 1)[0].trim();
+  if (value === "" || value === "null" || value === "~") return null;
+  if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value.slice(1, -1);
+    }
+  }
+  return value;
+}
+
+function parsePaiMigrationResolution(content: string): ResolutionChoices {
+  const choices: ResolutionChoices = new Map();
+  let currentSlug: string | null = null;
+  const seenSlugs = new Set<string>();
+  for (const line of content.split(/\r?\n/)) {
+    if (/^\s*(#|$)/.test(line)) continue;
+    const slugMatch = /^  ([a-z0-9]+(?:-[a-z0-9]+)*):\s*$/.exec(line);
+    if (slugMatch) {
+      currentSlug = slugMatch[1];
+      seenSlugs.add(currentSlug);
+      continue;
+    }
+    const pickMatch = /^    pick:\s*(.*)$/.exec(line);
+    if (pickMatch && currentSlug) {
+      choices.set(currentSlug, parseYamlScalar(pickMatch[1]));
+    }
+  }
+  for (const slug of seenSlugs) {
+    if (!choices.has(slug)) choices.set(slug, null);
+  }
+  return choices;
+}
+
+async function loadResolutionChoices(path: string | undefined, groups: CollisionGroups): Promise<ResolutionChoices> {
+  if (!path) return new Map();
+  const choices = parsePaiMigrationResolution(await readFile(resolve(path), "utf8"));
+  for (const slug of choices.keys()) {
+    if (!groups.has(slug)) {
+      throw new Error(`PAI migration resolution contains unknown collision '${slug}'. Re-run --emit-resolution for the current pack set.`);
+    }
+  }
+  for (const [slug, pick] of choices.entries()) {
+    if (pick === null) continue;
+    const allowed = new Set((groups.get(slug) ?? []).map((option) => resolve(option.source)));
+    if (!allowed.has(resolve(pick))) {
+      throw new Error(`PAI migration resolution pick for '${slug}' does not match any current option: ${pick}`);
+    }
+  }
+  return choices;
+}
+
+async function maybeWriteResolutionFile(path: string | undefined, groups: CollisionGroups): Promise<void> {
+  if (!path) return;
+  const target = resolve(path);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, renderPaiMigrationResolution(groups), "utf8");
+}
+
 /**
  * Shared cross-pack collision walk.
  * Walks `planRows` in sorted order; for each `planned` row, partitions
@@ -616,13 +805,20 @@ async function planAllPacksWithHandles(
 function walkPlanRowsForCollisions(
   planRows: readonly SharedPlanRow[],
   overwriteReserved: boolean,
+  resolutionChoices: ResolutionChoices,
 ): { resolved: ResolvedPlanRow[] } {
   const resolved: ResolvedPlanRow[] = [];
   const landedSlugs = new Set<string>();
 
   for (const row of planRows) {
     if (row.kind === "refused") continue;
-    const { collided, survivors } = partitionPlansByCollision(row.plans, landedSlugs, overwriteReserved);
+    const { collided, survivors } = partitionPlansByCollision(
+      row.plans,
+      landedSlugs,
+      overwriteReserved,
+      resolutionChoices,
+      row.paiPackDir,
+    );
     // Plan-only mode: reserve every survivor up front. Plan can't
     // fail mid-apply, so the optimistic-landing partition is correct.
     // The apply path manages its own `landedSlugs` to track only
@@ -632,7 +828,10 @@ function walkPlanRowsForCollisions(
       paiPackDir: row.paiPackDir,
       plans: row.plans,
       handle: row.handle,
-      collided,
+      denied: collided.map((slug) => ({
+        slug,
+        reason: deniedSkillReason(slug, resolutionChoices, row.paiPackDir),
+      })),
       survivors,
     });
   }
@@ -646,6 +845,9 @@ async function importPacksWithOutcomes(
   // both the public per-skill plan view AND an opaque handle so Phase 2
   // can apply WITHOUT a second `buildPaiPackImportPlan` pass.
   const planRows = await planAllPacksWithHandles(inputs);
+  const collisionGroups = await collectCollisionGroups(planRows);
+  await maybeWriteResolutionFile(inputs.emitResolutionPath, collisionGroups);
+  const resolutionChoices = await loadResolutionChoices(inputs.resolutionPath, collisionGroups);
 
   // Phase 2: sequential apply with collision tracking.
   // Invariant: the cross-pack collision set grows ONLY after a
@@ -672,10 +874,16 @@ async function importPacksWithOutcomes(
     // so its slug is available to us. Same partitioning logic as the
     // plan-only walker, via the shared `partitionPlansByCollision`
     // helper.
-    const { collided, survivors } = partitionPlansByCollision(row.plans, landedSlugs, inputs.overwriteReserved);
+    const { collided, survivors } = partitionPlansByCollision(
+      row.plans,
+      landedSlugs,
+      inputs.overwriteReserved,
+      resolutionChoices,
+      row.paiPackDir,
+    );
 
     for (const slug of collided) {
-      outcomes.push(crossPackCollisionOutcome(row.paiPackDir, slug));
+      outcomes.push(crossPackCollisionOutcome(row.paiPackDir, slug, deniedSkillReason(slug, resolutionChoices, row.paiPackDir)));
     }
     if (survivors.length === 0) continue;
 
@@ -1028,7 +1236,10 @@ async function planPacksWithOutcomes(inputs: BulkImportInputs): Promise<BulkPlan
   // disk; it just emits advisory `imported` rows for every survivor
   // plus the same collision outcomes the apply path would produce.
   const planRows = await planAllPacksWithHandles(inputs);
-  const { resolved } = walkPlanRowsForCollisions(planRows, inputs.overwriteReserved);
+  const collisionGroups = await collectCollisionGroups(planRows);
+  await maybeWriteResolutionFile(inputs.emitResolutionPath, collisionGroups);
+  const resolutionChoices = await loadResolutionChoices(inputs.resolutionPath, collisionGroups);
+  const { resolved } = walkPlanRowsForCollisions(planRows, inputs.overwriteReserved, resolutionChoices);
 
   const packs: PaiPackImportPlan[] = [];
   const outcomes: PaiPackOutcome[] = [];
@@ -1042,8 +1253,8 @@ async function planPacksWithOutcomes(inputs: BulkImportInputs): Promise<BulkPlan
   // surviving "imported" rows so the principal-facing summary table
   // groups by pack identically to the apply path.
   for (const resolvedRow of resolved) {
-    for (const slug of resolvedRow.collided) {
-      outcomes.push(crossPackCollisionOutcome(resolvedRow.paiPackDir, slug));
+    for (const denied of resolvedRow.denied) {
+      outcomes.push(crossPackCollisionOutcome(resolvedRow.paiPackDir, denied.slug, denied.reason));
     }
     const survivorSet = new Set(resolvedRow.survivors);
     for (const plan of resolvedRow.plans) {
@@ -1259,6 +1470,8 @@ export async function planPaiMigration(options: PaiMigrationOptions = {}): Promi
         packPaths,
         overwriteReserved: options.overwriteReserved === true,
         includeSubstrateSpecific: options.includeSubstrateSpecific === true,
+        emitResolutionPath: options.emitResolutionPath,
+        resolutionPath: options.resolutionPath,
       });
   const memory = options.skipMemory === true
     ? null
@@ -1592,6 +1805,8 @@ export async function migratePai(options: PaiMigrationOptions = {}): Promise<Pai
         packPaths,
         overwriteReserved: options.overwriteReserved === true,
         includeSubstrateSpecific: options.includeSubstrateSpecific === true,
+        emitResolutionPath: options.emitResolutionPath,
+        resolutionPath: options.resolutionPath,
       });
   for (const r of packs) filesWritten.push(...r.files);
 

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -849,6 +849,9 @@ function parsePaiMigrationResolution(content: string): ResolutionChoices {
       choices.set(currentSlug, parseYamlScalar(pickMatch[1]));
     }
   }
+  if (!inCollisions && content.trim() !== "") {
+    throw new Error("PAI migration resolution file is missing a collisions block. Re-run --emit-resolution for the current pack set.");
+  }
   for (const slug of seenSlugs) {
     if (!choices.has(slug)) choices.set(slug, null);
   }

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -598,22 +598,29 @@ function partitionPlansByCollision(
 ): { collided: string[]; survivors: string[] } {
   const collided: string[] = [];
   const survivors: string[] = [];
+  const survivorSlugs = new Set<string>();
   for (const plan of plans) {
     if (resolutionChoices.has(plan.skillName)) {
       const pick = resolutionChoices.get(plan.skillName) ?? null;
       if (pick === null) {
         collided.push(plan.skillName);
       } else if (resolve(pick) === resolve(paiPackDir)) {
-        survivors.push(plan.skillName);
+        if (landedSlugs.has(plan.skillName) || survivorSlugs.has(plan.skillName)) {
+          collided.push(plan.skillName);
+        } else {
+          survivors.push(plan.skillName);
+          survivorSlugs.add(plan.skillName);
+        }
       } else {
         collided.push(plan.skillName);
       }
       continue;
     }
-    if (landedSlugs.has(plan.skillName) && !overwriteReserved) {
+    if ((landedSlugs.has(plan.skillName) && !overwriteReserved) || survivorSlugs.has(plan.skillName)) {
       collided.push(plan.skillName);
     } else {
       survivors.push(plan.skillName);
+      survivorSlugs.add(plan.skillName);
     }
   }
   return { collided, survivors };

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -709,30 +709,9 @@ async function collectCollisionGroups(
     if (uniqueSources.size < 2) grouped.delete(slug);
   }
   const candidates = [...grouped.values()].flat();
-  const sizeByCandidate = new Map<CollisionGroupCandidate, number>();
-  if (collectionOptions.includeSizeBytes) {
-    const statTargets = candidates.flatMap((candidate) =>
-      candidate.plan.files
-        .filter((file) => file.origin === "source")
-        .map((file) => ({ candidate, source: file.source }))
-    );
-    const sizes = await runBoundedConcurrent(
-      statTargets,
-      async (target) => {
-        try {
-          return { candidate: target.candidate, size: (await stat(target.source)).size };
-        } catch {
-          // Resolution metadata is advisory; a raced source deletion will
-          // be handled by the actual import path. Keep the file writable.
-          return { candidate: target.candidate, size: 0 };
-        }
-      },
-      16,
-    );
-    for (const item of sizes) {
-      sizeByCandidate.set(item.candidate, (sizeByCandidate.get(item.candidate) ?? 0) + item.size);
-    }
-  }
+  const sizeByCandidate = collectionOptions.includeSizeBytes
+    ? await collectCandidateSizes(candidates)
+    : new Map<CollisionGroupCandidate, number>();
   const collisions: CollisionGroups = new Map();
   for (const [slug, options] of grouped.entries()) {
     const resolvedOptions: ResolutionOption[] = [];
@@ -748,6 +727,34 @@ async function collectCollisionGroups(
     collisions.set(slug, resolvedOptions);
   }
   return collisions;
+}
+
+async function collectCandidateSizes(
+  candidates: readonly CollisionGroupCandidate[],
+): Promise<Map<CollisionGroupCandidate, number>> {
+  const statTargets = candidates.flatMap((candidate) =>
+    candidate.plan.files
+      .filter((file) => file.origin === "source")
+      .map((file) => ({ candidate, source: file.source }))
+  );
+  const sizes = await runBoundedConcurrent(
+    statTargets,
+    async (target) => {
+      try {
+        return { candidate: target.candidate, size: (await stat(target.source)).size };
+      } catch {
+        // Resolution metadata is advisory; a raced source deletion will
+        // be handled by the actual import path. Keep the file writable.
+        return { candidate: target.candidate, size: 0 };
+      }
+    },
+    16,
+  );
+  const sizeByCandidate = new Map<CollisionGroupCandidate, number>();
+  for (const item of sizes) {
+    sizeByCandidate.set(item.candidate, (sizeByCandidate.get(item.candidate) ?? 0) + item.size);
+  }
+  return sizeByCandidate;
 }
 
 function yamlString(value: string): string {
@@ -785,6 +792,10 @@ function parseQuotedYamlScalar(trimmed: string): string | undefined {
   if (trimmed.startsWith("\"")) {
     for (let index = 1; index < trimmed.length; index += 1) {
       if (trimmed[index] !== "\"" || isEscapedDoubleQuote(trimmed, index)) continue;
+      const trailing = trimmed.slice(index + 1).trim();
+      if (trailing !== "" && !trailing.startsWith("#")) {
+        throw new Error(`PAI migration resolution contains invalid quoted scalar trailing content: ${trailing}`);
+      }
       try {
         return JSON.parse(trimmed.slice(0, index + 1));
       } catch {
@@ -803,6 +814,10 @@ function parseQuotedYamlScalar(trimmed: string): string | undefined {
         value += "'";
         index += 1;
         continue;
+      }
+      const trailing = trimmed.slice(index + 1).trim();
+      if (trailing !== "" && !trailing.startsWith("#")) {
+        throw new Error(`PAI migration resolution contains invalid quoted scalar trailing content: ${trailing}`);
       }
       return value;
     }

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -715,6 +715,14 @@ async function collectCollisionGroups(
     const uniqueSources = new Set(options.map((option) => resolve(option.source)));
     if (uniqueSources.size < 2) grouped.delete(slug);
   }
+  const candidates = [...grouped.values()].flat();
+  const sizeByCandidate = new Map<CollisionGroupCandidate, number>();
+  if (collectionOptions.includeSizeBytes) {
+    const sizes = await runBoundedConcurrent(candidates, (option) => sizeBytesForPlan(option.plan), 16);
+    for (let index = 0; index < candidates.length; index += 1) {
+      sizeByCandidate.set(candidates[index], sizes[index] ?? 0);
+    }
+  }
   const collisions: CollisionGroups = new Map();
   for (const [slug, options] of grouped.entries()) {
     const resolvedOptions: ResolutionOption[] = [];
@@ -724,7 +732,7 @@ async function collectCollisionGroups(
         source: option.source,
         description: option.description,
         workflows: option.workflows,
-        sizeBytes: collectionOptions.includeSizeBytes ? await sizeBytesForPlan(option.plan) : 0,
+        sizeBytes: sizeByCandidate.get(option) ?? 0,
       });
     }
     collisions.set(slug, resolvedOptions);
@@ -763,8 +771,7 @@ function renderPaiMigrationResolution(groups: CollisionGroups): string {
   return `${lines.join("\n")}\n`;
 }
 
-function parseYamlScalar(raw: string): string | null {
-  const trimmed = raw.trim();
+function parseQuotedYamlScalar(trimmed: string): string | undefined {
   if (trimmed.startsWith("\"")) {
     for (let index = 1; index < trimmed.length; index += 1) {
       if (trimmed[index] !== "\"" || trimmed[index - 1] === "\\") continue;
@@ -779,6 +786,10 @@ function parseYamlScalar(raw: string): string | null {
     const end = trimmed.indexOf("'", 1);
     if (end !== -1) return trimmed.slice(1, end);
   }
+  return undefined;
+}
+
+function parseUnquotedYamlScalar(trimmed: string): string | null {
   const value = trimmed.split(/\s+#/, 1)[0].trim();
   if (value === "" || value === "null" || value === "~") return null;
   if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
@@ -791,17 +802,32 @@ function parseYamlScalar(raw: string): string | null {
   return value;
 }
 
+function parseYamlScalar(raw: string): string | null {
+  const trimmed = raw.trim();
+  return parseQuotedYamlScalar(trimmed) ?? parseUnquotedYamlScalar(trimmed);
+}
+
 function parsePaiMigrationResolution(content: string): ResolutionChoices {
   const choices: ResolutionChoices = new Map();
   let currentSlug: string | null = null;
   const seenSlugs = new Set<string>();
+  let inCollisions = false;
   for (const line of content.split(/\r?\n/)) {
     if (/^\s*(#|$)/.test(line)) continue;
+    if (line === "collisions:") {
+      inCollisions = true;
+      continue;
+    }
+    if (inCollisions && line === "  {}") continue;
     const slugMatch = /^  ([a-z0-9]+(?:-[a-z0-9]+)*):\s*$/.exec(line);
     if (slugMatch) {
       currentSlug = slugMatch[1];
       seenSlugs.add(currentSlug);
       continue;
+    }
+    const invalidSlugMatch = /^  ([^ ].*):\s*$/.exec(line);
+    if (inCollisions && invalidSlugMatch) {
+      throw new Error(`PAI migration resolution contains invalid collision key '${invalidSlugMatch[1]}'. Re-run --emit-resolution for the current pack set.`);
     }
     const pickMatch = /^    pick:\s*(.*)$/.exec(line);
     if (pickMatch && currentSlug) {

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -876,7 +876,7 @@ function parsePaiMigrationResolution(content: string): ResolutionChoices {
       choices.set(currentSlug, parseYamlScalar(pickMatch[1]));
     }
   }
-  if (!inCollisions && content.trim() !== "") {
+  if (!inCollisions) {
     throw new Error("PAI migration resolution file is missing a collisions block. Re-run --emit-resolution for the current pack set.");
   }
   for (const slug of seenSlugs) {

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -637,6 +637,10 @@ function deniedSkillReason(
       ? `Resolution file set '${slug}' pick to null — skipped all collision options.`
       : `Resolution file picked ${pick}; skipped ${paiPackDir}.`;
   }
+  return defaultCrossPackCollisionReason(slug);
+}
+
+function defaultCrossPackCollisionReason(slug: string): string {
   return `Soma skill '${slug}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`;
 }
 
@@ -645,7 +649,7 @@ function crossPackCollisionOutcome(paiPackDir: string, slug: string, reason?: st
     paiPackDir,
     outcome: "refused-name-collision",
     skillName: slug,
-    reason: reason ?? `Soma skill '${slug}' already landed from an earlier pack — re-run with --overwrite-reserved to permit.`,
+    reason: reason ?? defaultCrossPackCollisionReason(slug),
   };
 }
 
@@ -670,17 +674,21 @@ function workflowCountForPlan(plan: PaiPackImportPlan): number {
 }
 
 async function sizeBytesForPlan(plan: PaiPackImportPlan): Promise<number> {
-  let total = 0;
-  for (const file of plan.files) {
-    if (file.origin !== "source") continue;
-    try {
-      total += (await stat(file.source)).size;
-    } catch {
-      // Resolution metadata is advisory; a raced source deletion will
-      // be handled by the actual import path. Keep the file writable.
-    }
-  }
-  return total;
+  const sourceFiles = plan.files.filter((file) => file.origin === "source");
+  const sizes = await runBoundedConcurrent(
+    sourceFiles,
+    async (file) => {
+      try {
+        return (await stat(file.source)).size;
+      } catch {
+        // Resolution metadata is advisory; a raced source deletion will
+        // be handled by the actual import path. Keep the file writable.
+        return 0;
+      }
+    },
+    16,
+  );
+  return sizes.reduce((total, size) => total + size, 0);
 }
 
 async function collectCollisionGroups(

--- a/test/pai-migration-issue-114.test.ts
+++ b/test/pai-migration-issue-114.test.ts
@@ -57,7 +57,7 @@ test("#114 AC-1: --emit-resolution writes collision metadata", async () => {
 
     const body = await readFile(resolution, "utf8");
     expect(body).toContain("collisions:");
-    expect(body).toContain("browser:");
+    expect(body).toContain("\"browser\":");
     expect(body).toContain(`pick: "${browserPack}"`);
     expect(body).toContain(`source: "${browserPack}"`);
     expect(body).toContain(`source: "${utilitiesPack}"`);

--- a/test/pai-migration-issue-114.test.ts
+++ b/test/pai-migration-issue-114.test.ts
@@ -142,6 +142,16 @@ test("#114 review: preamble metadata before collisions is ignored", async () => 
   });
 });
 
+test("#114 review: non-empty resolution without collisions block refuses loud", async () => {
+  await withCollisionFixture(async ({ homeDir, packsDir }) => {
+    const resolution = join(homeDir, "bad-resolution.yaml");
+    await writeFile(resolution, "metadata:\n  generatedBy: test\n", "utf8");
+
+    await expect(migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true, resolutionPath: resolution }))
+      .rejects.toThrow("missing a collisions block");
+  });
+});
+
 test("#114 AC-5: no resolution preserves first-wins behavior", async () => {
   await withCollisionFixture(async ({ homeDir, packsDir, browserPack }) => {
     const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true });

--- a/test/pai-migration-issue-114.test.ts
+++ b/test/pai-migration-issue-114.test.ts
@@ -38,6 +38,12 @@ async function withCollisionFixture<T>(
   });
 }
 
+async function rewriteResolutionPick(resolution: string, pick: string | null): Promise<void> {
+  let body = await readFile(resolution, "utf8");
+  body = body.replace(/^    pick: .+$/m, pick === null ? "    pick: null" : `    pick: "${pick}"`);
+  await writeFile(resolution, body, "utf8");
+}
+
 test("#114 AC-1: --emit-resolution writes collision metadata", async () => {
   await withCollisionFixture(async ({ homeDir, packsDir, browserPack, utilitiesPack }) => {
     const resolution = join(homeDir, "migration-resolve.yaml");
@@ -64,9 +70,7 @@ test("#114 AC-2: --resolution pick selects the later collision winner", async ()
   await withCollisionFixture(async ({ homeDir, packsDir, utilitiesPack }) => {
     const resolution = join(homeDir, "migration-resolve.yaml");
     await planPaiMigration({ homeDir, paiPacksDir: packsDir, skipMemory: true, emitResolutionPath: resolution });
-    let body = await readFile(resolution, "utf8");
-    body = body.replace(/^    pick: .+$/m, `    pick: "${utilitiesPack}"`);
-    await writeFile(resolution, body, "utf8");
+    await rewriteResolutionPick(resolution, utilitiesPack);
 
     const result = await migratePai({
       homeDir,
@@ -91,9 +95,7 @@ test("#114 AC-3: pick null skips every collision option", async () => {
   await withCollisionFixture(async ({ homeDir, packsDir }) => {
     const resolution = join(homeDir, "migration-resolve.yaml");
     await planPaiMigration({ homeDir, paiPacksDir: packsDir, skipMemory: true, emitResolutionPath: resolution });
-    let body = await readFile(resolution, "utf8");
-    body = body.replace(/^    pick: .+$/m, "    pick: null");
-    await writeFile(resolution, body, "utf8");
+    await rewriteResolutionPick(resolution, null);
 
     const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true, resolutionPath: resolution });
 
@@ -142,9 +144,7 @@ test("#114 AC-6: CLI emits and consumes resolution files", async () => {
       "--emit-resolution",
       resolution,
     ]);
-    let body = await readFile(resolution, "utf8");
-    body = body.replace(/^    pick: .+$/m, `    pick: "${utilitiesPack}"`);
-    await writeFile(resolution, body, "utf8");
+    await rewriteResolutionPick(resolution, utilitiesPack);
 
     const output = await runSomaCli([
       "migrate",
@@ -168,9 +168,7 @@ test("#114 review: emit and consume refuse the same resolution path", async () =
   await withCollisionFixture(async ({ homeDir, packsDir, utilitiesPack }) => {
     const resolution = join(homeDir, "migration-resolve.yaml");
     await planPaiMigration({ homeDir, paiPacksDir: packsDir, skipMemory: true, emitResolutionPath: resolution });
-    let body = await readFile(resolution, "utf8");
-    body = body.replace(/^    pick: .+$/m, `    pick: "${utilitiesPack}"`);
-    await writeFile(resolution, body, "utf8");
+    await rewriteResolutionPick(resolution, utilitiesPack);
 
     await expect(migratePai({
       homeDir,
@@ -182,4 +180,24 @@ test("#114 review: emit and consume refuse the same resolution path", async () =
 
     expect(await readFile(resolution, "utf8")).toContain(`pick: "${utilitiesPack}"`);
   });
+});
+
+test("#114 review: emitted quoted paths preserve hash-looking text", async () => {
+  await withSharedTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    const browserPack = join(packsDir, "Browser");
+    await writeFlatPack(browserPack, "Browser");
+    const utilitiesPack = await writeNestedPack(packsDir, "Utilities", ["Browser"]);
+    const resolution = join(homeDir, "migration-resolve.yaml");
+
+    await planPaiMigration({ homeDir, paiPacksDir: packsDir, skipMemory: true, emitResolutionPath: resolution });
+    await rewriteResolutionPick(resolution, utilitiesPack);
+
+    const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true, resolutionPath: resolution });
+    const importedBrowser = result.packOutcomes.find((outcome) =>
+      outcome.outcome === "imported" && outcome.skillName === "browser"
+    );
+    expect(importedBrowser?.paiPackDir).toBe(utilitiesPack);
+  }, "soma-114- # hash-path-");
 });

--- a/test/pai-migration-issue-114.test.ts
+++ b/test/pai-migration-issue-114.test.ts
@@ -126,6 +126,22 @@ test("#114 review: invalid resolution collision keys refuse loud", async () => {
   });
 });
 
+test("#114 review: preamble metadata before collisions is ignored", async () => {
+  await withCollisionFixture(async ({ homeDir, packsDir, utilitiesPack }) => {
+    const resolution = join(homeDir, "migration-resolve.yaml");
+    await planPaiMigration({ homeDir, paiPacksDir: packsDir, skipMemory: true, emitResolutionPath: resolution });
+    await rewriteResolutionPick(resolution, utilitiesPack);
+    const body = await readFile(resolution, "utf8");
+    await writeFile(resolution, `  metadata:\n    pick: null\n${body}`, "utf8");
+
+    const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true, resolutionPath: resolution });
+    const importedBrowser = result.packOutcomes.find((outcome) =>
+      outcome.outcome === "imported" && outcome.skillName === "browser"
+    );
+    expect(importedBrowser?.paiPackDir).toBe(utilitiesPack);
+  });
+});
+
 test("#114 AC-5: no resolution preserves first-wins behavior", async () => {
   await withCollisionFixture(async ({ homeDir, packsDir, browserPack }) => {
     const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true });

--- a/test/pai-migration-issue-114.test.ts
+++ b/test/pai-migration-issue-114.test.ts
@@ -227,3 +227,25 @@ test("#114 review: emitted quoted paths preserve hash-looking text", async () =>
     expect(importedBrowser?.paiPackDir).toBe(utilitiesPack);
   }, "soma-114- # hash-path-");
 });
+
+test("#114 review: single-quoted YAML picks preserve doubled apostrophes", async () => {
+  await withSharedTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    const browserPack = join(packsDir, "Browser");
+    await writeFlatPack(browserPack, "Browser");
+    const utilitiesPack = await writeNestedPack(packsDir, "Utilities", ["Browser"]);
+    const resolution = join(homeDir, "migration-resolve.yaml");
+
+    await planPaiMigration({ homeDir, paiPacksDir: packsDir, skipMemory: true, emitResolutionPath: resolution });
+    let body = await readFile(resolution, "utf8");
+    body = body.replace(/^    pick: .+$/m, `    pick: '${utilitiesPack.replaceAll("'", "''")}'`);
+    await writeFile(resolution, body, "utf8");
+
+    const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true, resolutionPath: resolution });
+    const importedBrowser = result.packOutcomes.find((outcome) =>
+      outcome.outcome === "imported" && outcome.skillName === "browser"
+    );
+    expect(importedBrowser?.paiPackDir).toBe(utilitiesPack);
+  }, "soma-114-John's-path-");
+});

--- a/test/pai-migration-issue-114.test.ts
+++ b/test/pai-migration-issue-114.test.ts
@@ -116,6 +116,16 @@ test("#114 AC-4: unknown resolution collisions refuse loud", async () => {
   });
 });
 
+test("#114 review: invalid resolution collision keys refuse loud", async () => {
+  await withCollisionFixture(async ({ homeDir, packsDir }) => {
+    const resolution = join(homeDir, "bad-resolution.yaml");
+    await writeFile(resolution, "collisions:\n  browser_v2:\n    pick: null\n", "utf8");
+
+    await expect(migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true, resolutionPath: resolution }))
+      .rejects.toThrow("invalid collision key 'browser_v2'");
+  });
+});
+
 test("#114 AC-5: no resolution preserves first-wins behavior", async () => {
   await withCollisionFixture(async ({ homeDir, packsDir, browserPack }) => {
     const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true });

--- a/test/pai-migration-issue-114.test.ts
+++ b/test/pai-migration-issue-114.test.ts
@@ -163,3 +163,23 @@ test("#114 AC-6: CLI emits and consumes resolution files", async () => {
     expect(output).toContain("Resolution file picked");
   });
 });
+
+test("#114 review: emit and consume refuse the same resolution path", async () => {
+  await withCollisionFixture(async ({ homeDir, packsDir, utilitiesPack }) => {
+    const resolution = join(homeDir, "migration-resolve.yaml");
+    await planPaiMigration({ homeDir, paiPacksDir: packsDir, skipMemory: true, emitResolutionPath: resolution });
+    let body = await readFile(resolution, "utf8");
+    body = body.replace(/^    pick: .+$/m, `    pick: "${utilitiesPack}"`);
+    await writeFile(resolution, body, "utf8");
+
+    await expect(migratePai({
+      homeDir,
+      paiPacksDir: packsDir,
+      skipMemory: true,
+      emitResolutionPath: resolution,
+      resolutionPath: resolution,
+    })).rejects.toThrow("--emit-resolution and --resolution must use different files");
+
+    expect(await readFile(resolution, "utf8")).toContain(`pick: "${utilitiesPack}"`);
+  });
+});

--- a/test/pai-migration-issue-114.test.ts
+++ b/test/pai-migration-issue-114.test.ts
@@ -259,3 +259,23 @@ test("#114 review: single-quoted YAML picks preserve doubled apostrophes", async
     expect(importedBrowser?.paiPackDir).toBe(utilitiesPack);
   }, "soma-114-John's-path-");
 });
+
+test("#114 review: quoted picks allow comments and reject trailing tokens", async () => {
+  await withCollisionFixture(async ({ homeDir, packsDir, utilitiesPack }) => {
+    const resolution = join(homeDir, "migration-resolve.yaml");
+    await planPaiMigration({ homeDir, paiPacksDir: packsDir, skipMemory: true, emitResolutionPath: resolution });
+    let body = await readFile(resolution, "utf8");
+    body = body.replace(/^    pick: .+$/m, `    pick: "${utilitiesPack}" # choose nested`);
+    await writeFile(resolution, body, "utf8");
+    const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true, resolutionPath: resolution });
+    const importedBrowser = result.packOutcomes.find((outcome) =>
+      outcome.outcome === "imported" && outcome.skillName === "browser"
+    );
+    expect(importedBrowser?.paiPackDir).toBe(utilitiesPack);
+
+    body = body.replace(" # choose nested", " unexpected");
+    await writeFile(resolution, body, "utf8");
+    await expect(migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true, resolutionPath: resolution }))
+      .rejects.toThrow("invalid quoted scalar trailing content");
+  });
+});

--- a/test/pai-migration-issue-114.test.ts
+++ b/test/pai-migration-issue-114.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Issue 114 — plan-resolve-apply flow for PAI pack name collisions.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { migratePai, planPaiMigration } from "../src/pai-migration";
+import { runSomaCli } from "../src/cli";
+import {
+  withTempHome as withSharedTempHome,
+  writePaiIdentityFixture as writeIdentityFixture,
+} from "./fixtures/pai-migration-fixtures";
+import { writeFlatPack, writeNestedPackShell, writeNestedSkill } from "./fixtures/pai-pack-fixtures";
+
+const withTempHome = <T>(fn: (homeDir: string) => Promise<T>): Promise<T> =>
+  withSharedTempHome(fn, "soma-114-");
+
+async function writeNestedPack(packsDir: string, packName: string, skills: string[]): Promise<string> {
+  const packDir = join(packsDir, packName);
+  await mkdir(packDir, { recursive: true });
+  await writeNestedPackShell(packDir, packName);
+  for (const skill of skills) {
+    await writeNestedSkill(packDir, skill);
+  }
+  return packDir;
+}
+
+async function withCollisionFixture<T>(
+  fn: (ctx: { homeDir: string; packsDir: string; browserPack: string; utilitiesPack: string }) => Promise<T>,
+): Promise<T> {
+  return withTempHome(async (homeDir) => {
+    await writeIdentityFixture(homeDir);
+    const packsDir = join(homeDir, "Packs");
+    const browserPack = join(packsDir, "Browser");
+    await writeFlatPack(browserPack, "Browser");
+    const utilitiesPack = await writeNestedPack(packsDir, "Utilities", ["Browser"]);
+    return fn({ homeDir, packsDir, browserPack, utilitiesPack });
+  });
+}
+
+test("#114 AC-1: --emit-resolution writes collision metadata", async () => {
+  await withCollisionFixture(async ({ homeDir, packsDir, browserPack, utilitiesPack }) => {
+    const resolution = join(homeDir, "migration-resolve.yaml");
+
+    await planPaiMigration({
+      homeDir,
+      paiPacksDir: packsDir,
+      skipMemory: true,
+      emitResolutionPath: resolution,
+    });
+
+    const body = await readFile(resolution, "utf8");
+    expect(body).toContain("collisions:");
+    expect(body).toContain("browser:");
+    expect(body).toContain(`pick: "${browserPack}"`);
+    expect(body).toContain(`source: "${browserPack}"`);
+    expect(body).toContain(`source: "${utilitiesPack}"`);
+    expect(body).toContain("workflows:");
+    expect(body).toContain("sizeBytes:");
+  });
+});
+
+test("#114 AC-2: --resolution pick selects the later collision winner", async () => {
+  await withCollisionFixture(async ({ homeDir, packsDir, utilitiesPack }) => {
+    const resolution = join(homeDir, "migration-resolve.yaml");
+    await planPaiMigration({ homeDir, paiPacksDir: packsDir, skipMemory: true, emitResolutionPath: resolution });
+    let body = await readFile(resolution, "utf8");
+    body = body.replace(/^    pick: .+$/m, `    pick: "${utilitiesPack}"`);
+    await writeFile(resolution, body, "utf8");
+
+    const result = await migratePai({
+      homeDir,
+      paiPacksDir: packsDir,
+      skipMemory: true,
+      resolutionPath: resolution,
+    });
+
+    const importedBrowser = result.packOutcomes.find((outcome) =>
+      outcome.outcome === "imported" && outcome.skillName === "browser"
+    );
+    expect(importedBrowser?.paiPackDir).toBe(utilitiesPack);
+    expect(result.packOutcomes.some((outcome) =>
+      outcome.outcome === "refused-name-collision" &&
+      outcome.skillName === "browser" &&
+      outcome.reason?.includes("Resolution file picked")
+    )).toBe(true);
+  });
+});
+
+test("#114 AC-3: pick null skips every collision option", async () => {
+  await withCollisionFixture(async ({ homeDir, packsDir }) => {
+    const resolution = join(homeDir, "migration-resolve.yaml");
+    await planPaiMigration({ homeDir, paiPacksDir: packsDir, skipMemory: true, emitResolutionPath: resolution });
+    let body = await readFile(resolution, "utf8");
+    body = body.replace(/^    pick: .+$/m, "    pick: null");
+    await writeFile(resolution, body, "utf8");
+
+    const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true, resolutionPath: resolution });
+
+    expect(result.packs.some((pack) => pack.skillName === "browser")).toBe(false);
+    expect(result.packOutcomes.filter((outcome) =>
+      outcome.outcome === "refused-name-collision" && outcome.skillName === "browser"
+    )).toHaveLength(2);
+  });
+});
+
+test("#114 AC-4: unknown resolution collisions refuse loud", async () => {
+  await withCollisionFixture(async ({ homeDir, packsDir }) => {
+    const resolution = join(homeDir, "bad-resolution.yaml");
+    await writeFile(resolution, "collisions:\n  not-current:\n    pick: null\n", "utf8");
+
+    await expect(migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true, resolutionPath: resolution }))
+      .rejects.toThrow("unknown collision 'not-current'");
+  });
+});
+
+test("#114 AC-5: no resolution preserves first-wins behavior", async () => {
+  await withCollisionFixture(async ({ homeDir, packsDir, browserPack }) => {
+    const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true });
+
+    const importedBrowser = result.packOutcomes.find((outcome) =>
+      outcome.outcome === "imported" && outcome.skillName === "browser"
+    );
+    expect(importedBrowser?.paiPackDir).toBe(browserPack);
+    expect(result.packOutcomes.some((outcome) =>
+      outcome.outcome === "refused-name-collision" && outcome.skillName === "browser"
+    )).toBe(true);
+  });
+});
+
+test("#114 AC-6: CLI emits and consumes resolution files", async () => {
+  await withCollisionFixture(async ({ homeDir, packsDir, utilitiesPack }) => {
+    const resolution = join(homeDir, "migration-resolve.yaml");
+    await runSomaCli([
+      "migrate",
+      "pai",
+      "--home-dir",
+      homeDir,
+      "--pai-packs-dir",
+      packsDir,
+      "--skip-memory",
+      "--emit-resolution",
+      resolution,
+    ]);
+    let body = await readFile(resolution, "utf8");
+    body = body.replace(/^    pick: .+$/m, `    pick: "${utilitiesPack}"`);
+    await writeFile(resolution, body, "utf8");
+
+    const output = await runSomaCli([
+      "migrate",
+      "pai",
+      "--apply",
+      "--home-dir",
+      homeDir,
+      "--pai-packs-dir",
+      packsDir,
+      "--skip-memory",
+      "--resolution",
+      resolution,
+    ]);
+
+    expect(output).toContain("soma migrate pai — applied");
+    expect(output).toContain("Resolution file picked");
+  });
+});

--- a/test/pai-migration-issue-114.test.ts
+++ b/test/pai-migration-issue-114.test.ts
@@ -152,6 +152,16 @@ test("#114 review: non-empty resolution without collisions block refuses loud", 
   });
 });
 
+test("#114 review: empty resolution files refuse loud", async () => {
+  await withCollisionFixture(async ({ homeDir, packsDir }) => {
+    const resolution = join(homeDir, "empty-resolution.yaml");
+    await writeFile(resolution, "", "utf8");
+
+    await expect(migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true, resolutionPath: resolution }))
+      .rejects.toThrow("missing a collisions block");
+  });
+});
+
 test("#114 AC-5: no resolution preserves first-wins behavior", async () => {
   await withCollisionFixture(async ({ homeDir, packsDir, browserPack }) => {
     const result = await migratePai({ homeDir, paiPacksDir: packsDir, skipMemory: true });


### PR DESCRIPTION
Fixes #114.

## Summary

- add `--emit-resolution <path>` to write duplicate PAI pack collision metadata
- add `--resolution <path>` to consume edited picks during plan/apply
- support `pick: null` or commented-out picks to skip all options for a collision
- refuse stale resolution files with unknown collisions or picks outside the current option set
- preserve the existing first-wins behavior when no resolution file is provided
- document the non-interactive resolve flow

## Verification

- `bun test test/pai-migration-issue-114.test.ts --timeout 120000`
- `bun test test/pai-migration-issue-114.test.ts test/pai-migration-issue-105.test.ts test/pai-pack-importer-issue-108-r2.test.ts --timeout 120000`
- `bunx tsc --noEmit`
- `bun run check-release-privacy`
- `bun test --timeout 120000`
