### PR TITLE
feat: add policy-gated writeback merges

### DIFF
--- a/docs/writeback-and-policy.md
+++ b/docs/writeback-and-policy.md
@@ -54,7 +54,7 @@ verb):
 This intentionally favors clear failure modes over clever sync. If a projection
 is stale, refresh it from `~/.soma`.
 
-## Writeback V0
+## Writeback V0/V1
 
 The only approved writeback path is:
 
@@ -115,6 +115,30 @@ LEARNING, WISDOM, RELATIONSHIP, KNOWLEDGE, WORK, STATE, and identity.
 Promotion from events into durable stores such as `KNOWLEDGE`, `WORK`, or
 `LEARNING` is a future design decision, not an oversight.
 
+### V1 Gate API
+
+Soma exposes a small trusted writeback gate:
+
+```ts
+applySomaWriteback({
+  somaHome,
+  substrate,
+  operation,
+})
+```
+
+The gate is intentionally narrow. It supports only compartments whose merge
+semantics are deterministic:
+
+- `memory-event` writes append one event to `memory/STATE/events.jsonl`.
+- `isa-log` appends Decisions, Changelog, and Verification entries to the
+  active ISA, or to an explicit slug only when that slug matches the active ISA.
+
+Every supported operation first runs Soma policy against the target path. Direct
+durable writes to stores such as `KNOWLEDGE`, `LEARNING`, `RELATIONSHIP`,
+`WISDOM`, or arbitrary `WORK` files are refused until that store has an
+explicit merge rule.
+
 All substrates append to the same shared file. Ordering is file append order,
 with each event carrying its own timestamp. V0 does not claim total ordering
 across concurrent writers beyond what the filesystem append operation records.
@@ -138,6 +162,7 @@ Each memory store needs its own merge semantics before direct writes are allowed
 | Store | Likely merge strategy |
 | --- | --- |
 | `STATE` | Easy: append-only events, latest cache can be regenerated |
+| `ISA` | Supported for log sections only: append Decisions, Changelog, Verification through `applySomaWriteback` |
 | `LEARNING` | Medium: append candidate, consolidate into lessons explicitly |
 | `WORK` | Hard: task/ISA scoped updates with criteria-level history |
 | `RELATIONSHIP` | Hard: conservative append plus review due privacy/sensitivity |

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,6 +344,7 @@ export {
 } from "./lifecycle";
 export { captureSomaFeedback, classifySomaFeedback, maybeSomaFeedbackPrompt } from "./feedback";
 export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from "./memory";
+export { applySomaWriteback, type SomaWritebackOptions, type SomaWritebackResult } from "./writeback";
 export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { captureSomaResult, isSomaResultEventKind, searchSomaResults } from "./result-capture";
 export { importPaiIdentity, planPaiImport } from "./pai-importer";

--- a/src/writeback.ts
+++ b/src/writeback.ts
@@ -47,6 +47,26 @@ export interface SomaWritebackResult {
   writes: string[];
 }
 
+async function assertWritebackAllowed(options: {
+  somaHome: string;
+  substrate: SubstrateId;
+  destinationPath: string;
+  timestamp?: string;
+  deniedMessage: string;
+}): Promise<void> {
+  const policy = await checkSomaPolicy({
+    somaHome: options.somaHome,
+    substrate: options.substrate,
+    action: "modify",
+    destinationPath: options.destinationPath,
+    record: "deny",
+    timestamp: options.timestamp,
+  });
+  if (policy.decision === "deny") {
+    throw new Error(`${options.deniedMessage}: ${policy.reason}`);
+  }
+}
+
 function assertRelativePath(path: string): void {
   if (path.trim().length === 0 || path.startsWith("/") || path.split(/[\\/]+/u).includes("..")) {
     throw new Error(`Invalid writeback relative path: ${path}`);
@@ -59,17 +79,13 @@ export async function applySomaWriteback(options: SomaWritebackOptions): Promise
   switch (options.operation.kind) {
     case "memory-event": {
       const eventPath = somaMemoryEventsPath(options.somaHome);
-      const policy = await checkSomaPolicy({
+      await assertWritebackAllowed({
         somaHome: options.somaHome,
         substrate,
-        action: "modify",
         destinationPath: eventPath,
-        record: "deny",
         timestamp: options.timestamp,
+        deniedMessage: "Writeback gate denied memory-event write",
       });
-      if (policy.decision === "deny") {
-        throw new Error(`Writeback gate denied memory-event write: ${policy.reason}`);
-      }
 
       await appendSomaMemoryEvent(options.somaHome, {
         ...options.operation.event,
@@ -111,17 +127,13 @@ export async function applySomaWriteback(options: SomaWritebackOptions): Promise
       }
 
       const targetPath = isaPath(options.somaHome, slug);
-      const policy = await checkSomaPolicy({
+      await assertWritebackAllowed({
         somaHome: options.somaHome,
         substrate,
-        action: "modify",
         destinationPath: targetPath,
-        record: "deny",
         timestamp: options.timestamp,
+        deniedMessage: "Writeback gate denied ISA write",
       });
-      if (policy.decision === "deny") {
-        throw new Error(`Writeback gate denied ISA write: ${policy.reason}`);
-      }
 
       const write = await applyIsaUpdate(slug, entries, { somaHome: options.somaHome, timestamp: options.timestamp, substrate });
       await appendSomaMemoryEvent(options.somaHome, {

--- a/src/writeback.ts
+++ b/src/writeback.ts
@@ -1,0 +1,150 @@
+import { join } from "node:path";
+import { applyIsaUpdate, getActiveIsa, isaPath } from "./isa";
+import { appendSomaMemoryEvent, somaMemoryEventsPath } from "./memory";
+import { checkSomaPolicy } from "./policy-audit";
+import type { IsaUpdatePayload, SomaMemoryEventInput, SubstrateId } from "./types";
+
+export type SomaWritebackMergeSemantics = "append-only" | "isa-log-append";
+
+export interface SomaWritebackBaseOptions {
+  somaHome: string;
+  substrate?: SubstrateId;
+  timestamp?: string;
+}
+
+export interface SomaMemoryEventWritebackOperation {
+  kind: "memory-event";
+  event: Omit<SomaMemoryEventInput, "substrate" | "timestamp"> & {
+    substrate?: SubstrateId;
+    timestamp?: string;
+  };
+}
+
+export interface SomaDurableMemoryWritebackOperation {
+  kind: "durable-memory";
+  store: string;
+  relativePath: string;
+  content: string;
+}
+
+export interface SomaIsaLogWritebackOperation {
+  kind: "isa-log";
+  slug?: string;
+  entries: IsaUpdatePayload;
+}
+
+export type SomaWritebackOperation =
+  | SomaMemoryEventWritebackOperation
+  | SomaDurableMemoryWritebackOperation
+  | SomaIsaLogWritebackOperation;
+
+export interface SomaWritebackOptions extends SomaWritebackBaseOptions {
+  operation: SomaWritebackOperation;
+}
+
+export interface SomaWritebackResult {
+  decision: "applied";
+  merge: SomaWritebackMergeSemantics;
+  writes: string[];
+}
+
+function assertRelativePath(path: string): void {
+  if (path.trim().length === 0 || path.startsWith("/") || path.split(/[\\/]+/u).includes("..")) {
+    throw new Error(`Invalid writeback relative path: ${path}`);
+  }
+}
+
+export async function applySomaWriteback(options: SomaWritebackOptions): Promise<SomaWritebackResult> {
+  const substrate = options.substrate ?? "custom";
+
+  switch (options.operation.kind) {
+    case "memory-event": {
+      const eventPath = somaMemoryEventsPath(options.somaHome);
+      const policy = await checkSomaPolicy({
+        somaHome: options.somaHome,
+        substrate,
+        action: "modify",
+        destinationPath: eventPath,
+        record: "deny",
+        timestamp: options.timestamp,
+      });
+      if (policy.decision === "deny") {
+        throw new Error(`Writeback gate denied memory-event write: ${policy.reason}`);
+      }
+
+      await appendSomaMemoryEvent(options.somaHome, {
+        ...options.operation.event,
+        substrate: options.operation.event.substrate ?? substrate,
+        timestamp: options.operation.event.timestamp ?? options.timestamp,
+      });
+
+      return {
+        decision: "applied",
+        merge: "append-only",
+        writes: [eventPath],
+      };
+    }
+    case "isa-log": {
+      const active = await getActiveIsa({ somaHome: options.somaHome });
+      const activeSlug = active?.activeSlug ?? null;
+      const slug = options.operation.slug ?? activeSlug;
+      if (!slug) {
+        throw new Error("ISA writeback requires an active ISA or explicit slug.");
+      }
+      if (options.operation.slug && activeSlug && options.operation.slug !== activeSlug) {
+        await appendSomaMemoryEvent(options.somaHome, {
+          substrate,
+          kind: "writeback.isa_log.refused_scope",
+          summary: `ISA writeback slug '${options.operation.slug}' does not match active ISA '${activeSlug}'.`,
+          timestamp: options.timestamp,
+          metadata: { payloadSlug: options.operation.slug, activeSlug },
+        });
+        throw new Error(`ISA writeback slug '${options.operation.slug}' does not match active ISA '${activeSlug}'.`);
+      }
+
+      const entries = [
+        ...(options.operation.entries.decisions ?? []).map((entry) => ({ section: "decisions" as const, ...entry })),
+        ...(options.operation.entries.changelogEntries ?? []).map((entry) => ({ section: "changelog" as const, ...entry })),
+        ...(options.operation.entries.verificationEntries ?? []).map((entry) => ({ section: "verification" as const, ...entry })),
+      ];
+      if (entries.length === 0) {
+        throw new Error("ISA writeback requires at least one log entry.");
+      }
+
+      const targetPath = isaPath(options.somaHome, slug);
+      const policy = await checkSomaPolicy({
+        somaHome: options.somaHome,
+        substrate,
+        action: "modify",
+        destinationPath: targetPath,
+        record: "deny",
+        timestamp: options.timestamp,
+      });
+      if (policy.decision === "deny") {
+        throw new Error(`Writeback gate denied ISA write: ${policy.reason}`);
+      }
+
+      const write = await applyIsaUpdate(slug, entries, { somaHome: options.somaHome, timestamp: options.timestamp, substrate });
+      await appendSomaMemoryEvent(options.somaHome, {
+        substrate,
+        kind: "writeback.isa_log",
+        summary: `Merged ${entries.length} ISA log entr(ies) into ${slug}.`,
+        timestamp: options.timestamp,
+        artifactPaths: write.path ? [write.path] : [],
+        metadata: { slug, entries: options.operation.entries },
+      });
+
+      return {
+        decision: "applied",
+        merge: "isa-log-append",
+        writes: Array.from(new Set([...(write.path ? [write.path] : []), somaMemoryEventsPath(options.somaHome)])),
+      };
+    }
+    case "durable-memory": {
+      assertRelativePath(options.operation.relativePath);
+      throw new Error(
+        `Unsupported writeback store ${options.operation.store}; direct durable memory writeback requires explicit merge semantics before writing ${join(options.operation.store, options.operation.relativePath)}.`,
+      );
+    }
+  }
+}

--- a/src/writeback.ts
+++ b/src/writeback.ts
@@ -87,11 +87,11 @@ export async function applySomaWriteback(options: SomaWritebackOptions): Promise
     case "isa-log": {
       const active = await getActiveIsa({ somaHome: options.somaHome });
       const activeSlug = active?.activeSlug ?? null;
-      const slug = options.operation.slug ?? activeSlug;
-      if (!slug) {
-        throw new Error("ISA writeback requires an active ISA or explicit slug.");
+      if (!activeSlug) {
+        throw new Error("ISA writeback requires an active ISA.");
       }
-      if (options.operation.slug && activeSlug && options.operation.slug !== activeSlug) {
+      const slug = options.operation.slug ?? activeSlug;
+      if (options.operation.slug && options.operation.slug !== activeSlug) {
         await appendSomaMemoryEvent(options.somaHome, {
           substrate,
           kind: "writeback.isa_log.refused_scope",

--- a/src/writeback.ts
+++ b/src/writeback.ts
@@ -24,7 +24,6 @@ export interface SomaDurableMemoryWritebackOperation {
   kind: "durable-memory";
   store: string;
   relativePath: string;
-  content: string;
 }
 
 export interface SomaIsaLogWritebackOperation {

--- a/test/writeback-gate.test.ts
+++ b/test/writeback-gate.test.ts
@@ -107,4 +107,22 @@ describe("applySomaWriteback", () => {
       }),
     ).rejects.toThrow("does not match active ISA");
   });
+
+  test("#147: refuses explicit ISA writeback when no active ISA is set", async () => {
+    const homeDir = await tempHome();
+    await bootstrapSomaHome({ homeDir });
+    await scaffoldIsa({ homeDir, slug: "demo", goal: "G", effort: "E1" });
+
+    await expect(
+      applySomaWriteback({
+        somaHome: join(homeDir, ".soma"),
+        substrate: "codex",
+        operation: {
+          kind: "isa-log",
+          slug: "demo",
+          entries: { decisions: [{ text: "No active target" }] },
+        },
+      }),
+    ).rejects.toThrow("requires an active ISA");
+  });
 });

--- a/test/writeback-gate.test.ts
+++ b/test/writeback-gate.test.ts
@@ -50,7 +50,6 @@ describe("applySomaWriteback", () => {
           kind: "durable-memory",
           store: "KNOWLEDGE",
           relativePath: "facts/example.md",
-          content: "unreviewed fact",
         },
       }),
     ).rejects.toThrow("Unsupported writeback store KNOWLEDGE");

--- a/test/writeback-gate.test.ts
+++ b/test/writeback-gate.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { mkdir, readFile } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { mkdtemp } from "node:fs/promises";
 import { applySomaWriteback, bootstrapSomaHome, readIsa, scaffoldIsa, setActiveIsa } from "../src/index";
 
 async function tempHome(): Promise<string> {

--- a/test/writeback-gate.test.ts
+++ b/test/writeback-gate.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdtemp } from "node:fs/promises";
+import { applySomaWriteback, bootstrapSomaHome, readIsa, scaffoldIsa, setActiveIsa } from "../src/index";
+
+async function tempHome(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "soma-writeback-"));
+}
+
+describe("applySomaWriteback", () => {
+  test("#147: appends memory events only through the writeback gate", async () => {
+    const homeDir = await tempHome();
+    const somaHome = join(homeDir, ".soma");
+
+    const result = await applySomaWriteback({
+      somaHome,
+      substrate: "codex",
+      timestamp: "2026-05-21T10:00:00.000Z",
+      operation: {
+        kind: "memory-event",
+        event: {
+          kind: "result.captured",
+          summary: "Captured result promoted into writeback inbox.",
+          artifactPaths: ["session/1.jsonl"],
+          metadata: { source: "test" },
+        },
+      },
+    });
+
+    expect(result.decision).toBe("applied");
+    expect(result.merge).toBe("append-only");
+    expect(result.writes).toEqual([join(somaHome, "memory/STATE/events.jsonl")]);
+
+    const events = await readFile(join(somaHome, "memory/STATE/events.jsonl"), "utf8");
+    expect(events).toContain('"kind":"result.captured"');
+    expect(events).toContain('"substrate":"codex"');
+    expect(events).toContain('"source":"test"');
+  });
+
+  test("#147: refuses unsupported durable writeback compartments", async () => {
+    const homeDir = await tempHome();
+
+    await expect(
+      applySomaWriteback({
+        somaHome: join(homeDir, ".soma"),
+        substrate: "codex",
+        operation: {
+          kind: "durable-memory",
+          store: "KNOWLEDGE",
+          relativePath: "facts/example.md",
+          content: "unreviewed fact",
+        },
+      }),
+    ).rejects.toThrow("Unsupported writeback store KNOWLEDGE");
+  });
+
+  test("#147: merges ISA log entries through active-ISA append semantics", async () => {
+    const homeDir = await tempHome();
+    const somaHome = join(homeDir, ".soma");
+    await bootstrapSomaHome({ homeDir });
+    await scaffoldIsa({ homeDir, slug: "demo", goal: "G", effort: "E4", timestamp: "2026-05-21T09:00:00.000Z" });
+    await setActiveIsa("demo", { homeDir });
+
+    const result = await applySomaWriteback({
+      somaHome,
+      substrate: "codex",
+      timestamp: "2026-05-21T10:00:00.000Z",
+      operation: {
+        kind: "isa-log",
+        entries: {
+          decisions: [{ text: "Use append-only ISA writeback" }],
+          changelogEntries: [{ text: "Added writeback merge gate" }],
+          verificationEntries: [{ text: "Gate test passed" }],
+        },
+      },
+    });
+
+    expect(result.decision).toBe("applied");
+    expect(result.merge).toBe("isa-log-append");
+    expect(result.writes.some((path) => path.endsWith("isa/demo.md"))).toBe(true);
+    expect(result.writes.some((path) => path.endsWith("memory/STATE/events.jsonl"))).toBe(true);
+
+    const isa = await readIsa("demo", { homeDir });
+    expect(isa.sections.find((s) => s.name === "Decisions")?.content).toContain("Use append-only ISA writeback");
+    expect(isa.sections.find((s) => s.name === "Changelog")?.content).toContain("Added writeback merge gate");
+    expect(isa.sections.find((s) => s.name === "Verification")?.content).toContain("Gate test passed");
+  });
+
+  test("#147: refuses ISA writeback to a non-active slug", async () => {
+    const homeDir = await tempHome();
+    await bootstrapSomaHome({ homeDir });
+    await scaffoldIsa({ homeDir, slug: "active", goal: "G", effort: "E1" });
+    await scaffoldIsa({ homeDir, slug: "other", goal: "G", effort: "E1" });
+    await setActiveIsa("active", { homeDir });
+
+    await expect(
+      applySomaWriteback({
+        somaHome: join(homeDir, ".soma"),
+        substrate: "codex",
+        operation: {
+          kind: "isa-log",
+          slug: "other",
+          entries: { decisions: [{ text: "Wrong target" }] },
+        },
+      }),
+    ).rejects.toThrow("does not match active ISA");
+  });
+});


### PR DESCRIPTION
Fixes #147.

## Summary

- Adds `applySomaWriteback()` as the trusted, policy-gated writeback entrypoint.
- Supports deterministic merge semantics for:
  - `memory-event`: append-only `memory/STATE/events.jsonl`
  - `isa-log`: append Decisions, Changelog, and Verification entries to the active ISA
- Refuses unsupported durable memory compartments until they have explicit merge rules.
- Documents the V1 gate API and supported merge semantics.

## Verification

- `bun test test/writeback-gate.test.ts test/types.test.ts --timeout 120000`
- `bunx tsc --noEmit`
- `bun run check-release-privacy`
