### PR TITLE
Register migrated PAI skills as Algorithm capabilities

### DIFF
--- a/docs/algorithm-execution-modes.md
+++ b/docs/algorithm-execution-modes.md
@@ -69,7 +69,15 @@ contract:
 - `status`: `selected`, `invoked`, `removed`, or `failed`
 - `invocation`: substrate, contract, target, timestamp, and evidence once used
 
-The initial registry includes PAI-style skill capabilities and inline checks.
+The built-in registry includes inline checks that are always available. When a
+Soma home contains an imported Algorithm capability reference at
+`skills/the-algorithm/references/capabilities.md`, the CLI registers matching
+PAI-style capabilities onto each run before mutating it. `Skill("Name")`
+entries are registered only when the corresponding Soma skill exists in the
+same home; `Agent(...)`, inline, and command entries become agent, inline, or
+command capability definitions. Missing skill targets remain unsupported so the
+selection fails loudly instead of pretending a capability can be invoked.
+
 Adapters can add startup capabilities to the run with
 `registerAlgorithmCapabilityDefinition(run, definition)` or
 `registerAlgorithmCapabilityDefinitions(run, definitions)`. Adapter

--- a/src/algorithm-capabilities.ts
+++ b/src/algorithm-capabilities.ts
@@ -255,7 +255,7 @@ export async function loadSomaHomeAlgorithmCapabilityRegistry(
 
   for (const row of parseMarkdownTableRows(markdown)) {
     const name = stripCapabilityLabel(row[0] ?? "");
-    const phaseCell = row.length >= 5 ? row[1] ?? "" : row[1] ?? "";
+    const phaseCell = row[1] ?? "";
     const triggerCell = row.length >= 5 ? row[2] ?? "" : row[1] ?? "";
     const invokeCell = row.length >= 5 ? row[3] ?? "" : row[2] ?? "";
 

--- a/src/algorithm-capabilities.ts
+++ b/src/algorithm-capabilities.ts
@@ -127,23 +127,28 @@ async function loadAvailableSkillNames(somaHome: string): Promise<Map<string, st
   const entries = await readdir(skillsRoot, { withFileTypes: true }).catch(() => []);
   const names = new Map<string, string>();
 
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
+  const skillMetadata = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) => {
+        const skillRoot = join(skillsRoot, entry.name);
+        const skillMd = await readFile(join(skillRoot, "SKILL.md"), "utf8").catch(() => undefined);
+        return skillMd ? { dirName: entry.name, name: frontmatterValue(skillMd, "name", entry.name) } : undefined;
+      }),
+  );
 
-    const skillRoot = join(skillsRoot, entry.name);
-    const skillMd = await readFile(join(skillRoot, "SKILL.md"), "utf8").catch(() => undefined);
-    if (!skillMd) continue;
+  for (const metadata of skillMetadata) {
+    if (!metadata) continue;
 
-    const name = frontmatterValue(skillMd, "name", entry.name);
-    names.set(normalizeCapabilityKey(name), name);
-    names.set(normalizeCapabilityKey(entry.name), name);
-    names.set(normalizeCapabilityKey(basename(skillRoot)), name);
+    names.set(normalizeCapabilityKey(metadata.name), metadata.name);
+    names.set(normalizeCapabilityKey(metadata.dirName), metadata.name);
+    names.set(normalizeCapabilityKey(basename(metadata.dirName)), metadata.name);
   }
 
   return names;
 }
 
-function parsePhaseCell(value: string): AlgorithmPhase[] {
+function parsePhaseCell(value: string, fallback: AlgorithmPhase[] = ["think"]): AlgorithmPhase[] {
   const normalized = stripMarkdownEmphasis(value).toLowerCase();
   if (normalized === "any") {
     return [...CORE_PHASES];
@@ -157,7 +162,7 @@ function parsePhaseCell(value: string): AlgorithmPhase[] {
     }
   }
 
-  return phases.size > 0 ? Array.from(phases) : ["think"];
+  return phases.size > 0 ? Array.from(phases) : [...fallback];
 }
 
 function parseMarkdownTableRows(markdown: string): string[][] {
@@ -204,8 +209,9 @@ function agentInvocationTarget(value: string, capabilityName: string): string | 
 }
 
 function commandInvocationTarget(value: string): string | undefined {
-  if (value.includes("Bash(")) return stripMarkdownEmphasis(value);
-  if (value.startsWith("bun ")) return value;
+  const stripped = stripMarkdownEmphasis(value);
+  if (stripped.includes("Bash(")) return stripped;
+  if (stripped.startsWith("bun ")) return stripped;
   return undefined;
 }
 
@@ -215,6 +221,22 @@ function inlineInvocationTarget(value: string): string | undefined {
     return stripped;
   }
   return undefined;
+}
+
+function buildCapabilityDefinition(
+  name: string,
+  kind: AlgorithmCapabilityDefinition["kind"],
+  phases: AlgorithmPhase[],
+  triggerSignals: string[],
+  target: string,
+): AlgorithmCapabilityDefinition {
+  return {
+    name,
+    kind,
+    phases,
+    triggerSignals,
+    invoke: { contract: kind, target },
+  };
 }
 
 export async function loadSomaHomeAlgorithmCapabilityRegistry(
@@ -233,13 +255,13 @@ export async function loadSomaHomeAlgorithmCapabilityRegistry(
 
   for (const row of parseMarkdownTableRows(markdown)) {
     const name = stripCapabilityLabel(row[0] ?? "");
-    const phaseCell = row.length >= 5 ? row[1] ?? "" : "plan";
+    const phaseCell = row.length >= 5 ? row[1] ?? "" : row[1] ?? "";
     const triggerCell = row.length >= 5 ? row[2] ?? "" : row[1] ?? "";
     const invokeCell = row.length >= 5 ? row[3] ?? "" : row[2] ?? "";
 
     if (!name) continue;
 
-    const phases = parsePhaseCell(phaseCell);
+    const phases = parsePhaseCell(phaseCell, row.length >= 5 ? ["think"] : ["plan"]);
     const triggerSignals = [stripMarkdownEmphasis(triggerCell)].filter((signal) => signal.length > 0);
     const skillTarget = skillInvocationTarget(invokeCell);
     const agentTarget = agentInvocationTarget(invokeCell, name);
@@ -253,46 +275,22 @@ export async function loadSomaHomeAlgorithmCapabilityRegistry(
         continue;
       }
 
-      definitions.set(name, {
-        name,
-        kind: "skill",
-        phases,
-        triggerSignals,
-        invoke: { contract: "skill", target: availableTarget },
-      });
+      definitions.set(name, buildCapabilityDefinition(name, "skill", phases, triggerSignals, availableTarget));
       continue;
     }
 
     if (agentTarget) {
-      definitions.set(name, {
-        name,
-        kind: "agent",
-        phases,
-        triggerSignals,
-        invoke: { contract: "agent", target: agentTarget },
-      });
+      definitions.set(name, buildCapabilityDefinition(name, "agent", phases, triggerSignals, agentTarget));
       continue;
     }
 
     if (inlineTarget) {
-      definitions.set(name, {
-        name,
-        kind: "inline",
-        phases,
-        triggerSignals,
-        invoke: { contract: "inline", target: inlineTarget },
-      });
+      definitions.set(name, buildCapabilityDefinition(name, "inline", phases, triggerSignals, inlineTarget));
       continue;
     }
 
     if (commandTarget) {
-      definitions.set(name, {
-        name,
-        kind: "command",
-        phases,
-        triggerSignals,
-        invoke: { contract: "command", target: commandTarget },
-      });
+      definitions.set(name, buildCapabilityDefinition(name, "command", phases, triggerSignals, commandTarget));
       continue;
     }
 

--- a/src/algorithm-capabilities.ts
+++ b/src/algorithm-capabilities.ts
@@ -1,3 +1,6 @@
+import { readdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, join, resolve } from "node:path";
 import type {
   AlgorithmCapabilityDefinition,
   AlgorithmCapabilitySelection,
@@ -8,6 +11,8 @@ import type {
   SubstrateId,
 } from "./types";
 import { getRunPhase } from "./algorithm-lifecycle";
+
+const CORE_PHASES: AlgorithmPhase[] = ["observe", "think", "plan", "build", "execute", "verify", "learn"];
 
 const DEFAULT_CAPABILITY_REGISTRY: AlgorithmCapabilityDefinition[] = [
   {
@@ -25,6 +30,16 @@ const DEFAULT_CAPABILITY_REGISTRY: AlgorithmCapabilityDefinition[] = [
     invoke: { contract: "inline", target: "Analyze the work as an ordered sequence before planning." },
   },
 ];
+
+export interface SomaHomeAlgorithmCapabilityOptions {
+  homeDir?: string;
+  somaHome?: string;
+}
+
+export interface SomaHomeAlgorithmCapabilityRegistry {
+  definitions: AlgorithmCapabilityDefinition[];
+  unsupported: string[];
+}
 
 export interface SelectAlgorithmCapabilityInput {
   name: string;
@@ -76,6 +91,231 @@ function cloneCapabilityDefinition(definition: AlgorithmCapabilityDefinition): A
     triggerSignals: [...definition.triggerSignals],
     invoke: { ...definition.invoke },
   };
+}
+
+function resolveSomaHome(options: SomaHomeAlgorithmCapabilityOptions = {}): string {
+  const home = resolve(options.homeDir ?? homedir());
+  return resolve(options.somaHome ?? join(home, ".soma"));
+}
+
+function normalizeCapabilityKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function stripMarkdownEmphasis(value: string): string {
+  return value
+    .replaceAll("**", "")
+    .replaceAll("`", "")
+    .trim();
+}
+
+function stripCapabilityLabel(value: string): string {
+  const label = stripMarkdownEmphasis(value).replace(/\s*\([^)]*\)\s*$/, "").trim();
+  return label === "ISA Skill" ? "ISA" : label;
+}
+
+function frontmatterValue(content: string, key: string, fallback: string): string {
+  const pattern = new RegExp(`^${key}:\\s*(.+)$`, "m");
+  const match = content.match(pattern);
+  if (!match) return fallback;
+  const value = match[1].trim().replace(/^["']|["']$/g, "");
+  return value.length > 0 ? value : fallback;
+}
+
+async function loadAvailableSkillNames(somaHome: string): Promise<Map<string, string>> {
+  const skillsRoot = join(somaHome, "skills");
+  const entries = await readdir(skillsRoot, { withFileTypes: true }).catch(() => []);
+  const names = new Map<string, string>();
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const skillRoot = join(skillsRoot, entry.name);
+    const skillMd = await readFile(join(skillRoot, "SKILL.md"), "utf8").catch(() => undefined);
+    if (!skillMd) continue;
+
+    const name = frontmatterValue(skillMd, "name", entry.name);
+    names.set(normalizeCapabilityKey(name), name);
+    names.set(normalizeCapabilityKey(entry.name), name);
+    names.set(normalizeCapabilityKey(basename(skillRoot)), name);
+  }
+
+  return names;
+}
+
+function parsePhaseCell(value: string): AlgorithmPhase[] {
+  const normalized = stripMarkdownEmphasis(value).toLowerCase();
+  if (normalized === "any") {
+    return [...CORE_PHASES];
+  }
+
+  const phases = new Set<AlgorithmPhase>();
+  const phaseNames: AlgorithmPhase[] = [...CORE_PHASES, "complete"];
+  for (const phase of phaseNames) {
+    if (normalized.includes(phase)) {
+      phases.add(phase);
+    }
+  }
+
+  return phases.size > 0 ? Array.from(phases) : ["think"];
+}
+
+function parseMarkdownTableRows(markdown: string): string[][] {
+  const rows: string[][] = [];
+  let inCapabilityTable = false;
+
+  for (const rawLine of markdown.split("\n")) {
+    const line = rawLine.trim();
+    if (!line.startsWith("|") || !line.endsWith("|")) {
+      inCapabilityTable = false;
+      continue;
+    }
+
+    const cells = line.slice(1, -1).split("|").map((cell) => cell.trim());
+    const first = cells[0]?.toLowerCase() ?? "";
+    if (first === "capability") {
+      inCapabilityTable = true;
+      continue;
+    }
+
+    if (!inCapabilityTable) {
+      continue;
+    }
+
+    if (cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()))) {
+      continue;
+    }
+
+    if (cells.length >= 3) {
+      rows.push(cells);
+    }
+  }
+
+  return rows;
+}
+
+function skillInvocationTarget(value: string): string | undefined {
+  return /Skill\("([^"]+)"/.exec(value)?.[1];
+}
+
+function agentInvocationTarget(value: string, capabilityName: string): string | undefined {
+  const subtype = /subagent_type\s*=\s*"([^"]+)"/.exec(value)?.[1];
+  return subtype ?? (value.includes("Agent(") ? capabilityName : undefined);
+}
+
+function commandInvocationTarget(value: string): string | undefined {
+  if (value.includes("Bash(")) return stripMarkdownEmphasis(value);
+  if (value.startsWith("bun ")) return value;
+  return undefined;
+}
+
+function inlineInvocationTarget(value: string): string | undefined {
+  const stripped = stripMarkdownEmphasis(value);
+  if (stripped.includes("inline doctrine") || stripped.includes("no external tool")) {
+    return stripped;
+  }
+  return undefined;
+}
+
+export async function loadSomaHomeAlgorithmCapabilityRegistry(
+  options: SomaHomeAlgorithmCapabilityOptions = {},
+): Promise<SomaHomeAlgorithmCapabilityRegistry> {
+  const somaHome = resolveSomaHome(options);
+  const referencePath = join(somaHome, "skills", "the-algorithm", "references", "capabilities.md");
+  const markdown = await readFile(referencePath, "utf8").catch(() => "");
+  if (!markdown) {
+    return { definitions: [], unsupported: [] };
+  }
+
+  const availableSkills = await loadAvailableSkillNames(somaHome);
+  const definitions = new Map<string, AlgorithmCapabilityDefinition>();
+  const unsupported = new Set<string>();
+
+  for (const row of parseMarkdownTableRows(markdown)) {
+    const name = stripCapabilityLabel(row[0] ?? "");
+    const phaseCell = row.length >= 5 ? row[1] ?? "" : "plan";
+    const triggerCell = row.length >= 5 ? row[2] ?? "" : row[1] ?? "";
+    const invokeCell = row.length >= 5 ? row[3] ?? "" : row[2] ?? "";
+
+    if (!name) continue;
+
+    const phases = parsePhaseCell(phaseCell);
+    const triggerSignals = [stripMarkdownEmphasis(triggerCell)].filter((signal) => signal.length > 0);
+    const skillTarget = skillInvocationTarget(invokeCell);
+    const agentTarget = agentInvocationTarget(invokeCell, name);
+    const commandTarget = commandInvocationTarget(invokeCell);
+    const inlineTarget = inlineInvocationTarget(invokeCell);
+
+    if (skillTarget) {
+      const availableTarget = availableSkills.get(normalizeCapabilityKey(skillTarget));
+      if (!availableTarget) {
+        unsupported.add(name);
+        continue;
+      }
+
+      definitions.set(name, {
+        name,
+        kind: "skill",
+        phases,
+        triggerSignals,
+        invoke: { contract: "skill", target: availableTarget },
+      });
+      continue;
+    }
+
+    if (agentTarget) {
+      definitions.set(name, {
+        name,
+        kind: "agent",
+        phases,
+        triggerSignals,
+        invoke: { contract: "agent", target: agentTarget },
+      });
+      continue;
+    }
+
+    if (inlineTarget) {
+      definitions.set(name, {
+        name,
+        kind: "inline",
+        phases,
+        triggerSignals,
+        invoke: { contract: "inline", target: inlineTarget },
+      });
+      continue;
+    }
+
+    if (commandTarget) {
+      definitions.set(name, {
+        name,
+        kind: "command",
+        phases,
+        triggerSignals,
+        invoke: { contract: "command", target: commandTarget },
+      });
+      continue;
+    }
+
+    unsupported.add(name);
+  }
+
+  return {
+    definitions: Array.from(definitions.values()).map(cloneCapabilityDefinition),
+    unsupported: Array.from(unsupported).sort(),
+  };
+}
+
+export async function registerSomaHomeAlgorithmCapabilities(
+  run: AlgorithmRun,
+  options: SomaHomeAlgorithmCapabilityOptions = {},
+  timestamp = run.updatedAt,
+): Promise<AlgorithmRun> {
+  const { definitions } = await loadSomaHomeAlgorithmCapabilityRegistry(options);
+  if (definitions.length === 0) {
+    return run;
+  }
+
+  return registerAlgorithmCapabilityDefinitions(run, definitions, timestamp);
 }
 
 export function listAlgorithmCapabilityDefinitions(): AlgorithmCapabilityDefinition[] {
@@ -159,7 +399,8 @@ export function selectAlgorithmCapability(
   const name = input.name.trim();
   const definition = getAlgorithmCapabilityDefinition(name, run);
   const phase = input.phase ?? getRunPhase(run);
-  const reason = input.reason?.trim() || `Selected ${definition.name} for ${phase}.`;
+  const trimmedReason = input.reason?.trim();
+  const reason = trimmedReason && trimmedReason.length > 0 ? trimmedReason : `Selected ${definition.name} for ${phase}.`;
   const selections = run.capabilitySelections ?? [];
   const existingIndex = findSelectionIndex(selections, name);
 

--- a/src/algorithm-capabilities.ts
+++ b/src/algorithm-capabilities.ts
@@ -105,6 +105,7 @@ function normalizeCapabilityKey(value: string): string {
 function stripMarkdownEmphasis(value: string): string {
   return value
     .replaceAll("**", "")
+    .replaceAll("*", "")
     .replaceAll("`", "")
     .trim();
 }

--- a/src/algorithm-capabilities.ts
+++ b/src/algorithm-capabilities.ts
@@ -95,7 +95,7 @@ function cloneCapabilityDefinition(definition: AlgorithmCapabilityDefinition): A
 
 function resolveSomaHome(options: SomaHomeAlgorithmCapabilityOptions = {}): string {
   const home = resolve(options.homeDir ?? homedir());
-  return resolve(options.somaHome ?? join(home, ".soma"));
+  return options.somaHome ? resolve(home, options.somaHome) : join(home, ".soma");
 }
 
 function normalizeCapabilityKey(value: string): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,7 +48,6 @@ import {
   recordAlgorithmChange,
   recordAlgorithmDecision,
   recordAlgorithmLearning,
-  registerSomaHomeAlgorithmCapabilities,
   removeAlgorithmCapabilitySelection,
   runSomaLifecycleAlgorithmUpdated,
   runSomaLifecycleSessionEnd,
@@ -61,6 +60,7 @@ import {
   verifyAlgorithmCriterion,
   writeAlgorithmRun,
 } from "./index";
+import { registerSomaHomeAlgorithmCapabilities } from "./algorithm-capabilities";
 // Sage r2 #99 Architecture: presentation helper imported directly
 // (not re-exported from the package root) so the text-rendering shape
 // stays internal and revisable without an SDK breakage.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3502,16 +3502,20 @@ function requireText(options: AlgorithmCliOptions): string {
 async function updateAndReportAlgorithmRun(
   options: AlgorithmCliOptions,
   update: (run: AlgorithmRun) => AlgorithmRun,
+  registration: { registerCapabilities?: boolean } = {},
 ): Promise<string> {
   const id = requireAlgorithmId(options);
   const { run } = await readAlgorithmRunById(id, {
     homeDir: options.homeDir,
     somaHome: options.somaHome,
   });
-  const registered = await registerSomaHomeAlgorithmCapabilities(run, {
-    homeDir: options.homeDir,
-    somaHome: options.somaHome,
-  });
+  const registered =
+    registration.registerCapabilities === true
+      ? await registerSomaHomeAlgorithmCapabilities(run, {
+          homeDir: options.homeDir,
+          somaHome: options.somaHome,
+        })
+      : run;
   const written = await writeAlgorithmRun(update(registered), {
     homeDir: options.homeDir,
     somaHome: options.somaHome,
@@ -3575,18 +3579,22 @@ async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<string> {
     if (capabilities.length > 1 && options.capabilityReason) {
       throw new Error("--reason can only be used with one --capability at a time.");
     }
-    return updateAndReportAlgorithmRun(options, (run) => {
-      const currentRun = run;
-      return capabilities.reduce(
-        (current, capability) =>
-          selectAlgorithmCapability(current, {
-            name: capability,
-            phase: options.capabilityPhase,
-            reason: options.capabilityReason,
-          }),
-        currentRun,
-      );
-    });
+    return updateAndReportAlgorithmRun(
+      options,
+      (run) => {
+        const currentRun = run;
+        return capabilities.reduce(
+          (current, capability) =>
+            selectAlgorithmCapability(current, {
+              name: capability,
+              phase: options.capabilityPhase,
+              reason: options.capabilityReason,
+            }),
+          currentRun,
+        );
+      },
+      { registerCapabilities: true },
+    );
   }
 
   if (parsed.action === "invoke") {
@@ -3594,12 +3602,15 @@ async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<string> {
     if (!capability || !options.evidence) {
       throw new Error("--capability and --evidence are required.");
     }
-    return updateAndReportAlgorithmRun(options, (run) =>
-      recordAlgorithmCapabilityInvocation(run, {
-        name: capability,
-        substrate: options.substrate,
-        evidence: options.evidence ?? "",
-      }),
+    return updateAndReportAlgorithmRun(
+      options,
+      (run) =>
+        recordAlgorithmCapabilityInvocation(run, {
+          name: capability,
+          substrate: options.substrate,
+          evidence: options.evidence ?? "",
+        }),
+      { registerCapabilities: true },
     );
   }
 
@@ -3656,7 +3667,7 @@ async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<string> {
 
   if (parsed.action === "batch") {
     const operations = options.batchOperations ?? [];
-    return updateAndReportAlgorithmRun(options, (run) => applyAlgorithmBatch(run, operations));
+    return updateAndReportAlgorithmRun(options, (run) => applyAlgorithmBatch(run, operations), { registerCapabilities: true });
   }
 
   return updateAndReportAlgorithmRun(options, (run) => advanceAlgorithmRun(run));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -48,6 +48,7 @@ import {
   recordAlgorithmChange,
   recordAlgorithmDecision,
   recordAlgorithmLearning,
+  registerSomaHomeAlgorithmCapabilities,
   removeAlgorithmCapabilitySelection,
   runSomaLifecycleAlgorithmUpdated,
   runSomaLifecycleSessionEnd,
@@ -57,7 +58,6 @@ import {
   setAlgorithmPlan,
   selectAlgorithmCapability,
   updateAlgorithmPlanStep,
-  updateAlgorithmRunById,
   verifyAlgorithmCriterion,
   writeAlgorithmRun,
 } from "./index";
@@ -3504,7 +3504,18 @@ async function updateAndReportAlgorithmRun(
   update: (run: AlgorithmRun) => AlgorithmRun,
 ): Promise<string> {
   const id = requireAlgorithmId(options);
-  const written = await updateAlgorithmRunById(id, { homeDir: options.homeDir, somaHome: options.somaHome }, update);
+  const { run } = await readAlgorithmRunById(id, {
+    homeDir: options.homeDir,
+    somaHome: options.somaHome,
+  });
+  const registered = await registerSomaHomeAlgorithmCapabilities(run, {
+    homeDir: options.homeDir,
+    somaHome: options.somaHome,
+  });
+  const written = await writeAlgorithmRun(update(registered), {
+    homeDir: options.homeDir,
+    somaHome: options.somaHome,
+  });
 
   await runSomaLifecycleAlgorithmUpdated({
     homeDir: options.homeDir,
@@ -3524,7 +3535,11 @@ async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<string> {
   }
 
   if (parsed.action === "new") {
-    const written = await writeAlgorithmRun(createAlgorithmRun(requireAlgorithmRunInput(options)), {
+    const run = await registerSomaHomeAlgorithmCapabilities(createAlgorithmRun(requireAlgorithmRunInput(options)), {
+      homeDir: options.homeDir,
+      somaHome: options.somaHome,
+    });
+    const written = await writeAlgorithmRun(run, {
       homeDir: options.homeDir,
       somaHome: options.somaHome,
     });
@@ -3560,17 +3575,18 @@ async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<string> {
     if (capabilities.length > 1 && options.capabilityReason) {
       throw new Error("--reason can only be used with one --capability at a time.");
     }
-    return updateAndReportAlgorithmRun(options, (run) =>
-      capabilities.reduce(
+    return updateAndReportAlgorithmRun(options, (run) => {
+      const currentRun = run;
+      return capabilities.reduce(
         (current, capability) =>
           selectAlgorithmCapability(current, {
             name: capability,
             phase: options.capabilityPhase,
             reason: options.capabilityReason,
           }),
-        run,
-      ),
-    );
+        currentRun,
+      );
+    });
   }
 
   if (parsed.action === "invoke") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3670,7 +3670,7 @@ async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<string> {
     return updateAndReportAlgorithmRun(options, (run) => applyAlgorithmBatch(run, operations), { registerCapabilities: true });
   }
 
-  return updateAndReportAlgorithmRun(options, (run) => advanceAlgorithmRun(run));
+  return updateAndReportAlgorithmRun(options, (run) => advanceAlgorithmRun(run), { registerCapabilities: true });
 }
 
 export async function runSomaCli(args: string[]): Promise<string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,12 +142,10 @@ export {
 export {
   assertAlgorithmCapabilitiesSatisfied,
   getAlgorithmCapabilityDefinition,
-  loadSomaHomeAlgorithmCapabilityRegistry,
   listAlgorithmCapabilityDefinitions,
   recordAlgorithmCapabilityInvocation,
   registerAlgorithmCapabilityDefinition,
   registerAlgorithmCapabilityDefinitions,
-  registerSomaHomeAlgorithmCapabilities,
   removeAlgorithmCapabilitySelection,
   selectAlgorithmCapability,
   unresolvedAlgorithmCapabilitySelections,

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,10 +142,12 @@ export {
 export {
   assertAlgorithmCapabilitiesSatisfied,
   getAlgorithmCapabilityDefinition,
+  loadSomaHomeAlgorithmCapabilityRegistry,
   listAlgorithmCapabilityDefinitions,
   recordAlgorithmCapabilityInvocation,
   registerAlgorithmCapabilityDefinition,
   registerAlgorithmCapabilityDefinitions,
+  registerSomaHomeAlgorithmCapabilities,
   removeAlgorithmCapabilitySelection,
   selectAlgorithmCapability,
   unresolvedAlgorithmCapabilitySelections,

--- a/test/algorithm.test.ts
+++ b/test/algorithm.test.ts
@@ -9,7 +9,6 @@ import {
   createAlgorithmRun,
   getCriteria,
   getRunPhase,
-  loadSomaHomeAlgorithmCapabilityRegistry,
   recordAlgorithmCapabilityInvocation,
   registerAlgorithmCapabilityDefinition,
   applyAlgorithmBatch,
@@ -20,6 +19,7 @@ import {
   verifyAlgorithmCriterion,
   writeAlgorithmRun,
 } from "../src/index";
+import { loadSomaHomeAlgorithmCapabilityRegistry } from "../src/algorithm-capabilities";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-algorithm-"));
@@ -55,6 +55,10 @@ async function writeAlgorithmCapabilitiesReference(homeDir: string): Promise<voi
       '| MissingSkill | THINK | Missing target | `Skill("MissingSkill")` | E2+ |',
       '| ReReadCheck | VERIFY->LEARN | Final check | *(inline doctrine step - no external tool)* | E1+ |',
       '| Forge (code producer) | EXECUTE | Code production | `Agent(subagent_type="Forge", prompt="...")` | E3+ |',
+      "",
+      "| Capability | When | Invoke |",
+      "|------------|------|--------|",
+      "| BuildCommand | EXECUTE | `bun run build` |",
       "",
     ].join("\n"),
     "utf8",
@@ -271,6 +275,12 @@ test("loads migrated PAI Algorithm skill capabilities from Soma home", async () 
       name: "ReReadCheck",
       kind: "inline",
       phases: ["verify", "learn"],
+    });
+    expect(registry.definitions.find((definition) => definition.name === "BuildCommand")).toMatchObject({
+      name: "BuildCommand",
+      kind: "command",
+      phases: ["execute"],
+      invoke: { contract: "command", target: "bun run build" },
     });
     expect(registry.definitions.some((definition) => definition.name === "MissingSkill")).toBe(false);
     expect(registry.unsupported).toContain("MissingSkill");

--- a/test/algorithm.test.ts
+++ b/test/algorithm.test.ts
@@ -59,6 +59,7 @@ async function writeAlgorithmCapabilitiesReference(homeDir: string, somaHome = "
       "| Capability | When | Invoke |",
       "|------------|------|--------|",
       "| BuildCommand | EXECUTE | `bun run build` |",
+      "| WrappedBuildCommand | EXECUTE | *bun run wrapped* |",
       "",
     ].join("\n"),
     "utf8",
@@ -281,6 +282,12 @@ test("loads migrated PAI Algorithm skill capabilities from Soma home", async () 
       kind: "command",
       phases: ["execute"],
       invoke: { contract: "command", target: "bun run build" },
+    });
+    expect(registry.definitions.find((definition) => definition.name === "WrappedBuildCommand")).toMatchObject({
+      name: "WrappedBuildCommand",
+      kind: "command",
+      phases: ["execute"],
+      invoke: { contract: "command", target: "bun run wrapped" },
     });
     expect(registry.definitions.some((definition) => definition.name === "MissingSkill")).toBe(false);
     expect(registry.unsupported).toContain("MissingSkill");

--- a/test/algorithm.test.ts
+++ b/test/algorithm.test.ts
@@ -31,8 +31,8 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
   }
 }
 
-async function writeSkill(homeDir: string, slug: string, name: string): Promise<void> {
-  const root = join(homeDir, ".soma", "skills", slug);
+async function writeSkill(homeDir: string, slug: string, name: string, somaHome = ".soma"): Promise<void> {
+  const root = join(homeDir, somaHome, "skills", slug);
   await mkdir(root, { recursive: true });
   await writeFile(
     join(root, "SKILL.md"),
@@ -41,8 +41,8 @@ async function writeSkill(homeDir: string, slug: string, name: string): Promise<
   );
 }
 
-async function writeAlgorithmCapabilitiesReference(homeDir: string): Promise<void> {
-  const root = join(homeDir, ".soma", "skills", "the-algorithm", "references");
+async function writeAlgorithmCapabilitiesReference(homeDir: string, somaHome = ".soma"): Promise<void> {
+  const root = join(homeDir, somaHome, "skills", "the-algorithm", "references");
   await mkdir(root, { recursive: true });
   await writeFile(
     join(root, "capabilities.md"),
@@ -284,6 +284,20 @@ test("loads migrated PAI Algorithm skill capabilities from Soma home", async () 
     });
     expect(registry.definitions.some((definition) => definition.name === "MissingSkill")).toBe(false);
     expect(registry.unsupported).toContain("MissingSkill");
+  });
+});
+
+test("resolves relative Soma home capability paths under homeDir", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeAlgorithmCapabilitiesReference(homeDir, "runtime-soma");
+    await writeSkill(homeDir, "first-principles", "FirstPrinciples", "runtime-soma");
+
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir, somaHome: "runtime-soma" });
+
+    expect(registry.definitions.find((definition) => definition.name === "FirstPrinciples")).toMatchObject({
+      kind: "skill",
+      invoke: { contract: "skill", target: "FirstPrinciples" },
+    });
   });
 });
 

--- a/test/algorithm.test.ts
+++ b/test/algorithm.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
@@ -9,6 +9,7 @@ import {
   createAlgorithmRun,
   getCriteria,
   getRunPhase,
+  loadSomaHomeAlgorithmCapabilityRegistry,
   recordAlgorithmCapabilityInvocation,
   registerAlgorithmCapabilityDefinition,
   applyAlgorithmBatch,
@@ -28,6 +29,36 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
   } finally {
     await rm(homeDir, { recursive: true, force: true });
   }
+}
+
+async function writeSkill(homeDir: string, slug: string, name: string): Promise<void> {
+  const root = join(homeDir, ".soma", "skills", slug);
+  await mkdir(root, { recursive: true });
+  await writeFile(
+    join(root, "SKILL.md"),
+    ["---", `name: ${name}`, `description: ${name} test skill.`, "---", "", `# ${name}`, ""].join("\n"),
+    "utf8",
+  );
+}
+
+async function writeAlgorithmCapabilitiesReference(homeDir: string): Promise<void> {
+  const root = join(homeDir, ".soma", "skills", "the-algorithm", "references");
+  await mkdir(root, { recursive: true });
+  await writeFile(
+    join(root, "capabilities.md"),
+    [
+      "# Algorithm Capabilities Reference",
+      "",
+      "| Capability | Phases | Trigger Signal | Invoke | Typical Cost |",
+      "|------------|--------|----------------|--------|--------------|",
+      '| FirstPrinciples | THINK | Architecture decisions | `Skill("FirstPrinciples")` | E2+ |',
+      '| MissingSkill | THINK | Missing target | `Skill("MissingSkill")` | E2+ |',
+      '| ReReadCheck | VERIFY->LEARN | Final check | *(inline doctrine step - no external tool)* | E1+ |',
+      '| Forge (code producer) | EXECUTE | Code production | `Agent(subagent_type="Forge", prompt="...")` | E3+ |',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
 }
 
 function registerFirstPrinciples(run: ReturnType<typeof createAlgorithmRun>) {
@@ -217,8 +248,37 @@ test("records structured Algorithm capability selections and invocations", () =>
   });
 });
 
+test("loads migrated PAI Algorithm skill capabilities from Soma home", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeAlgorithmCapabilitiesReference(homeDir);
+    await writeSkill(homeDir, "first-principles", "FirstPrinciples");
+
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir });
+
+    expect(registry.definitions.find((definition) => definition.name === "FirstPrinciples")).toMatchObject({
+      name: "FirstPrinciples",
+      kind: "skill",
+      phases: ["think"],
+      invoke: { contract: "skill", target: "FirstPrinciples" },
+    });
+    expect(registry.definitions.find((definition) => definition.name === "Forge")).toMatchObject({
+      name: "Forge",
+      kind: "agent",
+      phases: ["execute"],
+      invoke: { contract: "agent", target: "Forge" },
+    });
+    expect(registry.definitions.find((definition) => definition.name === "ReReadCheck")).toMatchObject({
+      name: "ReReadCheck",
+      kind: "inline",
+      phases: ["verify", "learn"],
+    });
+    expect(registry.definitions.some((definition) => definition.name === "MissingSkill")).toBe(false);
+    expect(registry.unsupported).toContain("MissingSkill");
+  });
+});
+
 test("rejects phantom Algorithm capabilities", () => {
-  let run = createAlgorithmRun({
+  const run = createAlgorithmRun({
     id: "phantom-capability",
     timestamp: "2026-05-21T10:00:00.000Z",
     prompt: "Reject invented capability",

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -15,6 +15,28 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
   }
 }
 
+async function writeAlgorithmCapabilityFixture(homeDir: string): Promise<void> {
+  await mkdir(join(homeDir, ".soma/skills/the-algorithm/references"), { recursive: true });
+  await mkdir(join(homeDir, ".soma/skills/first-principles"), { recursive: true });
+  await writeFile(
+    join(homeDir, ".soma/skills/the-algorithm/references/capabilities.md"),
+    [
+      "# Algorithm Capabilities Reference",
+      "",
+      "| Capability | Phases | Trigger Signal | Invoke | Typical Cost |",
+      "|------------|--------|----------------|--------|--------------|",
+      '| FirstPrinciples | THINK | Architecture decisions | `Skill("FirstPrinciples")` | E2+ |',
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    join(homeDir, ".soma/skills/first-principles/SKILL.md"),
+    ["---", "name: FirstPrinciples", "description: Test first principles skill.", "---", "", "# FirstPrinciples", ""].join("\n"),
+    "utf8",
+  );
+}
+
 test("cli dry-runs codex install without writing files", async () => {
   await withTempHome(async (homeDir) => {
     const output = await runSomaCli(["install", "codex", "--home-dir", homeDir]);
@@ -470,6 +492,66 @@ test("cli batch capability invocation accepts explicit substrate prefix", async 
     ]);
 
     expect(output).toContain("reviewed with explicit substrate");
+  });
+});
+
+test("cli selects migrated PAI skill capabilities from Soma home", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeAlgorithmCapabilityFixture(homeDir);
+    await runSomaCli([
+      "algorithm",
+      "new",
+      "--home-dir",
+      homeDir,
+      "--id",
+      "migrated-skill-capability-run",
+      "--prompt",
+      "Use migrated PAI capability",
+      "--intent",
+      "Select a migrated skill capability.",
+      "--current-state",
+      "FirstPrinciples exists as a migrated Soma skill.",
+      "--goal",
+      "FirstPrinciples can be selected and invoked.",
+      "--criterion",
+      "C1:FirstPrinciples selection works.",
+    ]);
+    await runSomaCli(["algorithm", "advance", "--home-dir", homeDir, "--id", "migrated-skill-capability-run"]);
+
+    const selected = await runSomaCli([
+      "algorithm",
+      "capabilities",
+      "--home-dir",
+      homeDir,
+      "--id",
+      "migrated-skill-capability-run",
+      "--capability",
+      "FirstPrinciples",
+      "--phase",
+      "think",
+      "--reason",
+      "Use the migrated PAI skill.",
+    ]);
+
+    expect(selected).toContain("[selected] FirstPrinciples");
+
+    const invoked = await runSomaCli([
+      "algorithm",
+      "invoke",
+      "--home-dir",
+      homeDir,
+      "--id",
+      "migrated-skill-capability-run",
+      "--capability",
+      "FirstPrinciples",
+      "--evidence",
+      "Deconstructed the registration problem.",
+    ]);
+
+    expect(invoked).toContain("[invoked] FirstPrinciples");
+    await expect(readFile(join(homeDir, ".soma/memory/WORK/algorithm-runs/migrated-skill-capability-run.json"), "utf8")).resolves.toContain(
+      '"target": "FirstPrinciples"',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- load Algorithm capability rows from the migrated Soma home at skills/the-algorithm/references/capabilities.md
- register installed Skill("Name") rows, agent rows, inline rows, and command rows onto Algorithm runs before CLI mutations
- add parser/unit coverage, CLI selection/invocation coverage, and docs for unsupported missing skills

Closes #185.

## Verification
- rtk bun test test/algorithm.test.ts test/cli.test.ts
- rtk bun run typecheck
- rtk bun test
- rtk git diff --check
- live smoke: created/completed issue-185-live-smoke against /Users/fischer/.soma and verified FirstPrinciples persisted under capabilityDefinitions and capabilitySelections

## Notes
- rtk bun run lint still fails on existing unrelated repository lint debt; the #185 parser/test files are clean, while src/cli.ts and src/index.ts have pre-existing file-level lint findings outside this change.