### PR TITLE
Bridge skill manifests into Algorithm capabilities

### DIFF
--- a/docs/algorithm-execution-modes.md
+++ b/docs/algorithm-execution-modes.md
@@ -69,14 +69,32 @@ contract:
 - `status`: `selected`, `invoked`, `removed`, or `failed`
 - `invocation`: substrate, contract, target, timestamp, and evidence once used
 
-The built-in registry includes inline checks that are always available. When a
-Soma home contains an imported Algorithm capability reference at
-`skills/the-algorithm/references/capabilities.md`, the CLI registers matching
-PAI-style capabilities onto each run before mutating it. `Skill("Name")`
-entries are registered only when the corresponding Soma skill exists in the
-same home; `Agent(...)`, inline, and command entries become agent, inline, or
-command capability definitions. Missing skill targets remain unsupported so the
-selection fails loudly instead of pretending a capability can be invoked.
+The built-in registry includes inline checks that are always available. Before
+the CLI writes a Soma-home backed run, it registers portable skills as
+run-scoped capability definitions. The preferred source is
+`skills/<skill>/soma-skill.json` with optional `algorithmCapability` metadata:
+
+```json
+{
+  "algorithmCapability": {
+    "kind": "skill",
+    "phases": ["think", "plan"],
+    "triggerSignals": ["assumption", "root cause"]
+  }
+}
+```
+
+When explicit manifest metadata is absent, Soma falls back to the imported
+Algorithm capability reference at
+`skills/the-algorithm/references/capabilities.md`. `Skill("Name")` entries are
+registered only when the corresponding Soma skill exists in the same home;
+`Agent(...)`, inline, and command entries become agent, inline, or command
+capability definitions. Remaining loaded skills receive broad skill-backed
+defaults. Manifest metadata describes when the skill-backed capability is
+relevant; concrete invocation binding remains registry- or adapter-derived.
+Manifest substrate support is honored when the run declares a substrate.
+Missing skill targets remain unsupported so the selection fails loudly instead
+of pretending a capability can be invoked.
 
 Adapters can add startup capabilities to the run with
 `registerAlgorithmCapabilityDefinition(run, definition)` or

--- a/docs/progressive-skill-loading.md
+++ b/docs/progressive-skill-loading.md
@@ -109,6 +109,11 @@ interface SomaSkillManifest {
     description: string;
     substrateSupport: string[];
   }[];
+  algorithmCapability?: {
+    kind: "skill" | "inline" | "agent" | "command" | "adapter";
+    phases: string[];
+    triggerSignals: string[];
+  };
 }
 ```
 
@@ -292,6 +297,10 @@ frontmatter, copied reference files, and safe defaults:
 - `entrypoint`: `SKILL.md`
 - `references`: copied reference files with descriptions when available
 - `tools`: copied portable tools when available
+- `algorithmCapability`: optional run-scoped Algorithm capability metadata when
+  the skill should be selectable inside Algorithm runs. It describes routing
+  signals, not substrate execution bindings; adapters or the registry derive
+  invocation contract and target.
 
 This is distinct from `soma-pack.json`. `soma-pack.json` records import
 provenance and file classification. `soma-skill.json` records runtime routing

--- a/src/algorithm-capabilities.ts
+++ b/src/algorithm-capabilities.ts
@@ -2,17 +2,21 @@ import { readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join, resolve } from "node:path";
 import type {
+  AlgorithmCapabilityContract,
   AlgorithmCapabilityDefinition,
   AlgorithmCapabilitySelection,
   AlgorithmCapabilitySelectionStatus,
   AlgorithmCapabilityInvocation,
+  AlgorithmCapabilityKind,
   AlgorithmPhase,
   AlgorithmRun,
+  SomaSkillManifest,
   SubstrateId,
 } from "./types";
 import { getRunPhase } from "./algorithm-lifecycle";
 
 const CORE_PHASES: AlgorithmPhase[] = ["observe", "think", "plan", "build", "execute", "verify", "learn"];
+const CAPABILITY_INVOKE_KINDS = ["skill", "inline", "agent", "command", "adapter"] as const;
 
 const DEFAULT_CAPABILITY_REGISTRY: AlgorithmCapabilityDefinition[] = [
   {
@@ -34,6 +38,7 @@ const DEFAULT_CAPABILITY_REGISTRY: AlgorithmCapabilityDefinition[] = [
 export interface SomaHomeAlgorithmCapabilityOptions {
   homeDir?: string;
   somaHome?: string;
+  substrate?: SubstrateId;
 }
 
 export interface SomaHomeAlgorithmCapabilityRegistry {
@@ -115,6 +120,22 @@ function stripCapabilityLabel(value: string): string {
   return label === "ISA Skill" ? "ISA" : label;
 }
 
+function nonEmptyStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+}
+
+function hasOwnField(value: unknown, field: string): boolean {
+  return typeof value === "object" && value !== null && Object.prototype.hasOwnProperty.call(value, field);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
 function frontmatterValue(content: string, key: string, fallback: string): string {
   const pattern = new RegExp(`^${key}:\\s*(.+)$`, "m");
   const match = content.match(pattern);
@@ -123,30 +144,84 @@ function frontmatterValue(content: string, key: string, fallback: string): strin
   return value.length > 0 ? value : fallback;
 }
 
-async function loadAvailableSkillNames(somaHome: string): Promise<Map<string, string>> {
-  const skillsRoot = join(somaHome, "skills");
-  const entries = await readdir(skillsRoot, { withFileTypes: true }).catch(() => []);
-  const names = new Map<string, string>();
+function sectionBullets(content: string, heading: string): string[] {
+  const lines = content.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim().toLowerCase() === `## ${heading}`.toLowerCase());
+  if (start === -1) return [];
 
-  const skillMetadata = await Promise.all(
-    entries
-      .filter((entry) => entry.isDirectory())
-      .map(async (entry) => {
-        const skillRoot = join(skillsRoot, entry.name);
-        const skillMd = await readFile(join(skillRoot, "SKILL.md"), "utf8").catch(() => undefined);
-        return skillMd ? { dirName: entry.name, name: frontmatterValue(skillMd, "name", entry.name) } : undefined;
-      }),
-  );
-
-  for (const metadata of skillMetadata) {
-    if (!metadata) continue;
-
-    names.set(normalizeCapabilityKey(metadata.name), metadata.name);
-    names.set(normalizeCapabilityKey(metadata.dirName), metadata.name);
-    names.set(normalizeCapabilityKey(basename(metadata.dirName)), metadata.name);
+  const bullets: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.startsWith("## ")) break;
+    const match = line.match(/^\s*[-*]\s+(.+)$/);
+    if (match) bullets.push(stripMarkdownEmphasis(match[1]));
   }
 
-  return names;
+  return bullets;
+}
+
+interface AvailableSkill {
+  dirName: string;
+  name: string;
+  description: string;
+  triggers: string[];
+  manifest?: SomaSkillManifest;
+}
+
+async function readSomaSkillManifest(skillRoot: string): Promise<SomaSkillManifest | undefined> {
+  const raw = await readFile(join(skillRoot, "soma-skill.json"), "utf8").catch(() => undefined);
+  if (!raw) return undefined;
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<SomaSkillManifest>;
+    if (
+      parsed.schema !== "soma.skill.v1"
+      || typeof parsed.name !== "string"
+    ) {
+      return undefined;
+    }
+
+    return parsed as SomaSkillManifest;
+  } catch {
+    return undefined;
+  }
+}
+
+async function loadAvailableSkills(somaHome: string): Promise<{ skills: AvailableSkill[]; byKey: Map<string, AvailableSkill> }> {
+  const skillsRoot = join(somaHome, "skills");
+  const entries = await readdir(skillsRoot, { withFileTypes: true }).catch(() => []);
+  const byKey = new Map<string, AvailableSkill>();
+
+  const skillCandidates: Array<AvailableSkill | undefined> = await Promise.all(
+    entries
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry): Promise<AvailableSkill | undefined> => {
+        const skillRoot = join(skillsRoot, entry.name);
+        const skillMd = await readFile(join(skillRoot, "SKILL.md"), "utf8").catch(() => undefined);
+        if (!skillMd) return undefined;
+
+        const manifest = await readSomaSkillManifest(skillRoot);
+        const manifestName = typeof manifest?.name === "string" && manifest.name.trim().length > 0
+          ? manifest.name
+          : undefined;
+        const name = manifestName ?? frontmatterValue(skillMd, "name", entry.name);
+        const description = typeof manifest?.description === "string"
+          ? manifest.description
+          : frontmatterValue(skillMd, "description", "");
+        const manifestTriggers = nonEmptyStrings(manifest?.triggers);
+        const triggers = manifestTriggers.length > 0 ? manifestTriggers : sectionBullets(skillMd, "Triggers");
+
+        return { dirName: entry.name, name, description, triggers, manifest };
+      }),
+  );
+  const skills = skillCandidates.filter((skill): skill is AvailableSkill => skill !== undefined);
+
+  for (const skill of skills) {
+    byKey.set(normalizeCapabilityKey(skill.name), skill);
+    byKey.set(normalizeCapabilityKey(skill.dirName), skill);
+    byKey.set(normalizeCapabilityKey(basename(skill.dirName)), skill);
+  }
+
+  return { skills, byKey };
 }
 
 function parsePhaseCell(value: string, fallback: AlgorithmPhase[] = ["think"]): AlgorithmPhase[] {
@@ -230,14 +305,90 @@ function buildCapabilityDefinition(
   phases: AlgorithmPhase[],
   triggerSignals: string[],
   target: string,
+  contract: AlgorithmCapabilityContract = kind,
 ): AlgorithmCapabilityDefinition {
   return {
     name,
     kind,
     phases,
     triggerSignals,
-    invoke: { contract: kind, target },
+    invoke: { contract, target },
   };
+}
+
+function isSubstrateSupported(manifest: SomaSkillManifest | undefined, substrate: SubstrateId | undefined): boolean {
+  if (!manifest || !substrate) return true;
+  if (!Array.isArray(manifest.substrates)) return false;
+  return manifest.substrates.includes(substrate);
+}
+
+function isCapabilityInvokeKind(value: unknown): value is AlgorithmCapabilityContract & AlgorithmCapabilityKind {
+  return typeof value === "string" && CAPABILITY_INVOKE_KINDS.includes(value as (typeof CAPABILITY_INVOKE_KINDS)[number]);
+}
+
+function isCapabilityKind(value: unknown): value is AlgorithmCapabilityKind {
+  return isCapabilityInvokeKind(value);
+}
+
+function isAlgorithmPhase(value: unknown): value is AlgorithmPhase {
+  return value === "observe" || value === "think" || value === "plan" || value === "build" || value === "execute" || value === "verify" || value === "learn" || value === "complete";
+}
+
+function fallbackTriggerSignals(skill: AvailableSkill): string[] {
+  const triggers = skill.triggers.map((trigger) => trigger.trim()).filter((trigger) => trigger.length > 0);
+  if (triggers.length > 0) return triggers;
+
+  const description = skill.description.trim();
+  return description.length > 0 ? [description] : [skill.name];
+}
+
+function skillManifestCapabilityDefinition(skill: AvailableSkill): AlgorithmCapabilityDefinition | undefined {
+  const metadata = isRecord(skill.manifest?.algorithmCapability)
+    ? skill.manifest.algorithmCapability
+    : undefined;
+  const kind = isCapabilityKind(metadata?.kind) ? metadata.kind : "skill";
+  const phases = Array.isArray(metadata?.phases)
+    ? metadata.phases.filter(isAlgorithmPhase)
+    : [];
+  if (hasOwnField(metadata, "phases") && phases.length === 0) {
+    return undefined;
+  }
+  const triggerSignals = nonEmptyStrings(metadata?.triggerSignals);
+
+  return buildCapabilityDefinition(
+    skill.name,
+    kind,
+    phases.length > 0 ? phases : [...CORE_PHASES],
+    triggerSignals.length > 0 ? triggerSignals : fallbackTriggerSignals(skill),
+    skill.name,
+    kind,
+  );
+}
+
+function maybeRegisterSkillCapability(
+  definitions: Map<string, AlgorithmCapabilityDefinition>,
+  unsupported: Set<string>,
+  skill: AvailableSkill,
+  substrate: SubstrateId | undefined,
+  options: { requireManifestCapability: boolean },
+): void {
+  if (definitions.has(skill.name) || unsupported.has(skill.name)) {
+    return;
+  }
+  if (!isSubstrateSupported(skill.manifest, substrate)) {
+    unsupported.add(skill.name);
+    return;
+  }
+  if (options.requireManifestCapability && !isRecord(skill.manifest?.algorithmCapability)) {
+    return;
+  }
+
+  const definition = skillManifestCapabilityDefinition(skill);
+  if (!definition) {
+    unsupported.add(skill.name);
+    return;
+  }
+  definitions.set(definition.name, definition);
 }
 
 export async function loadSomaHomeAlgorithmCapabilityRegistry(
@@ -246,21 +397,22 @@ export async function loadSomaHomeAlgorithmCapabilityRegistry(
   const somaHome = resolveSomaHome(options);
   const referencePath = join(somaHome, "skills", "the-algorithm", "references", "capabilities.md");
   const markdown = await readFile(referencePath, "utf8").catch(() => "");
-  if (!markdown) {
-    return { definitions: [], unsupported: [] };
-  }
-
-  const availableSkills = await loadAvailableSkillNames(somaHome);
+  const availableSkills = await loadAvailableSkills(somaHome);
   const definitions = new Map<string, AlgorithmCapabilityDefinition>();
   const unsupported = new Set<string>();
 
-  for (const row of parseMarkdownTableRows(markdown)) {
+  for (const skill of availableSkills.skills) {
+    maybeRegisterSkillCapability(definitions, unsupported, skill, options.substrate, { requireManifestCapability: true });
+  }
+
+  for (const row of markdown ? parseMarkdownTableRows(markdown) : []) {
     const name = stripCapabilityLabel(row[0] ?? "");
     const phaseCell = row[1] ?? "";
     const triggerCell = row.length >= 5 ? row[2] ?? "" : row[1] ?? "";
     const invokeCell = row.length >= 5 ? row[3] ?? "" : row[2] ?? "";
 
     if (!name) continue;
+    if (definitions.has(name) || unsupported.has(name)) continue;
 
     const phases = parsePhaseCell(phaseCell, row.length >= 5 ? ["think"] : ["plan"]);
     const triggerSignals = [stripMarkdownEmphasis(triggerCell)].filter((signal) => signal.length > 0);
@@ -270,13 +422,17 @@ export async function loadSomaHomeAlgorithmCapabilityRegistry(
     const inlineTarget = inlineInvocationTarget(invokeCell);
 
     if (skillTarget) {
-      const availableTarget = availableSkills.get(normalizeCapabilityKey(skillTarget));
-      if (!availableTarget) {
+      const targetSkill = availableSkills.byKey.get(normalizeCapabilityKey(skillTarget));
+      if (!targetSkill) {
+        unsupported.add(name);
+        continue;
+      }
+      if (!isSubstrateSupported(targetSkill.manifest, options.substrate)) {
         unsupported.add(name);
         continue;
       }
 
-      definitions.set(name, buildCapabilityDefinition(name, "skill", phases, triggerSignals, availableTarget));
+      definitions.set(name, buildCapabilityDefinition(name, "skill", phases, triggerSignals, targetSkill.name));
       continue;
     }
 
@@ -296,6 +452,10 @@ export async function loadSomaHomeAlgorithmCapabilityRegistry(
     }
 
     unsupported.add(name);
+  }
+
+  for (const skill of availableSkills.skills) {
+    maybeRegisterSkillCapability(definitions, unsupported, skill, options.substrate, { requireManifestCapability: false });
   }
 
   return {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1274,6 +1274,7 @@ function parseAlgorithmArgs(args: string[]): ParsedAlgorithmArgs {
 
   if (action === "new") {
     run.id = options.id;
+    run.substrate = options.substrate;
     options.run = run as AlgorithmRunInput;
   }
 
@@ -3514,6 +3515,7 @@ async function updateAndReportAlgorithmRun(
       ? await registerSomaHomeAlgorithmCapabilities(run, {
           homeDir: options.homeDir,
           somaHome: options.somaHome,
+          substrate: run.substrate,
         })
       : run;
   const written = await writeAlgorithmRun(update(registered), {
@@ -3539,9 +3541,11 @@ async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<string> {
   }
 
   if (parsed.action === "new") {
-    const run = await registerSomaHomeAlgorithmCapabilities(createAlgorithmRun(requireAlgorithmRunInput(options)), {
+    const input = requireAlgorithmRunInput(options);
+    const run = await registerSomaHomeAlgorithmCapabilities(createAlgorithmRun(input), {
       homeDir: options.homeDir,
       somaHome: options.somaHome,
+      substrate: input.substrate,
     });
     const written = await writeAlgorithmRun(run, {
       homeDir: options.homeDir,

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,6 +208,12 @@ export interface AlgorithmCapabilityDefinition {
   };
 }
 
+export interface SomaSkillAlgorithmCapabilityManifest {
+  kind?: AlgorithmCapabilityKind;
+  phases?: AlgorithmPhase[];
+  triggerSignals?: string[];
+}
+
 export interface AlgorithmCapabilityInvocation {
   timestamp: string;
   substrate: SubstrateId;
@@ -732,6 +738,7 @@ export interface SomaSkillManifest {
   tools: string[];
   triggers: string[];
   substrates: ("claude-code" | "codex" | "pi-dev" | "cursor" | "cortex" | "custom")[];
+  algorithmCapability?: SomaSkillAlgorithmCapabilityManifest;
 }
 
 export interface PaiPackImportPlan {

--- a/test/algorithm.test.ts
+++ b/test/algorithm.test.ts
@@ -41,6 +41,17 @@ async function writeSkill(homeDir: string, slug: string, name: string, somaHome 
   );
 }
 
+async function writeSkillManifest(
+  homeDir: string,
+  slug: string,
+  manifest: Record<string, unknown>,
+  somaHome = ".soma",
+): Promise<void> {
+  const root = join(homeDir, somaHome, "skills", slug);
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, "soma-skill.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+}
+
 async function writeAlgorithmCapabilitiesReference(homeDir: string, somaHome = ".soma"): Promise<void> {
   const root = join(homeDir, somaHome, "skills", "the-algorithm", "references");
   await mkdir(root, { recursive: true });
@@ -291,6 +302,344 @@ test("loads migrated PAI Algorithm skill capabilities from Soma home", async () 
     });
     expect(registry.definitions.some((definition) => definition.name === "MissingSkill")).toBe(false);
     expect(registry.unsupported).toContain("MissingSkill");
+  });
+});
+
+test("prefers explicit skill manifest Algorithm capability metadata", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeAlgorithmCapabilitiesReference(homeDir);
+    await writeSkill(homeDir, "first-principles", "FirstPrinciples");
+    await writeSkillManifest(homeDir, "first-principles", {
+      schema: "soma.skill.v1",
+      name: "FirstPrinciples",
+      description: "Manifest-backed first principles skill.",
+      source: { kind: "pai-pack", packName: "FirstPrinciples" },
+      entrypoint: "SKILL.md",
+      references: [],
+      workflows: [],
+      tools: [],
+      triggers: ["manifest trigger"],
+      substrates: ["codex", "pi-dev"],
+      algorithmCapability: {
+        kind: "skill",
+        phases: ["verify"],
+        triggerSignals: ["manifest signal"],
+      },
+    });
+
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir, substrate: "codex" });
+
+    expect(registry.definitions.find((definition) => definition.name === "FirstPrinciples")).toMatchObject({
+      name: "FirstPrinciples",
+      kind: "skill",
+      phases: ["verify"],
+      triggerSignals: ["manifest signal"],
+      invoke: { contract: "skill", target: "FirstPrinciples" },
+    });
+  });
+});
+
+test("derives manifest capability contract from kind", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeSkill(homeDir, "delegate", "Delegate");
+    await writeSkillManifest(homeDir, "delegate", {
+      schema: "soma.skill.v1",
+      name: "Delegate",
+      description: "Agent-backed delegation skill.",
+      source: { kind: "pai-pack", packName: "Delegate" },
+      entrypoint: "SKILL.md",
+      references: [],
+      workflows: [],
+      tools: [],
+      triggers: ["delegate"],
+      substrates: ["codex"],
+      algorithmCapability: {
+        kind: "agent",
+        phases: ["execute"],
+        triggerSignals: ["delegate"],
+      },
+    });
+
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir, substrate: "codex" });
+
+    expect(registry.definitions.find((definition) => definition.name === "Delegate")).toMatchObject({
+      name: "Delegate",
+      kind: "agent",
+      phases: ["execute"],
+      invoke: { contract: "agent", target: "Delegate" },
+    });
+  });
+});
+
+test("treats explicitly invalid manifest capability phases as unsupported", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeSkill(homeDir, "bad-phases", "BadPhases");
+    await writeSkillManifest(homeDir, "bad-phases", {
+      schema: "soma.skill.v1",
+      name: "BadPhases",
+      description: "Invalid phase metadata.",
+      source: { kind: "pai-pack", packName: "BadPhases" },
+      entrypoint: "SKILL.md",
+      references: [],
+      workflows: [],
+      tools: [],
+      triggers: ["bad phases"],
+      substrates: ["codex"],
+      algorithmCapability: {
+        kind: "skill",
+        phases: ["verfy"],
+        triggerSignals: ["bad phases"],
+      },
+    });
+
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir, substrate: "codex" });
+
+    expect(registry.definitions.some((definition) => definition.name === "BadPhases")).toBe(false);
+    expect(registry.unsupported).toContain("BadPhases");
+  });
+});
+
+test("falls back to loaded Soma skills when no Algorithm reference exists", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeSkill(homeDir, "context-search", "ContextSearch");
+
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir });
+
+    expect(registry.definitions.find((definition) => definition.name === "ContextSearch")).toMatchObject({
+      name: "ContextSearch",
+      kind: "skill",
+      phases: ["observe", "think", "plan", "build", "execute", "verify", "learn"],
+      invoke: { contract: "skill", target: "ContextSearch" },
+    });
+  });
+});
+
+test("filters manifest-declared Algorithm capabilities by substrate", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeAlgorithmCapabilitiesReference(homeDir);
+    await writeSkill(homeDir, "pi-only", "PiOnly");
+    await writeSkillManifest(homeDir, "pi-only", {
+      schema: "soma.skill.v1",
+      name: "PiOnly",
+      description: "Pi-only skill.",
+      source: { kind: "pai-pack", packName: "PiOnly" },
+      entrypoint: "SKILL.md",
+      references: [],
+      workflows: [],
+      tools: [],
+      triggers: ["pi only"],
+      substrates: ["pi-dev"],
+      algorithmCapability: {
+        kind: "skill",
+        phases: ["think"],
+        triggerSignals: ["pi only"],
+      },
+    });
+
+    const codexRegistry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir, substrate: "codex" });
+    const piRegistry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir, substrate: "pi-dev" });
+
+    expect(codexRegistry.definitions.some((definition) => definition.name === "PiOnly")).toBe(false);
+    expect(codexRegistry.unsupported).toContain("PiOnly");
+    expect(piRegistry.definitions.find((definition) => definition.name === "PiOnly")).toMatchObject({
+      name: "PiOnly",
+      phases: ["think"],
+    });
+  });
+});
+
+test("migrated reference rows cannot re-register substrate-unsupported skills", async () => {
+  await withTempHome(async (homeDir) => {
+    const root = join(homeDir, ".soma", "skills", "the-algorithm", "references");
+    await mkdir(root, { recursive: true });
+    await writeFile(
+      join(root, "capabilities.md"),
+      [
+        "# Algorithm Capabilities Reference",
+        "",
+        "| Capability | Phases | Trigger Signal | Invoke | Typical Cost |",
+        "|------------|--------|----------------|--------|--------------|",
+        '| PiOnly | THINK | Pi only | `Skill("PiOnly")` | E2+ |',
+        '| WrapperCapability | THINK | Wraps PiOnly | `Skill("PiOnly")` | E2+ |',
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    await writeSkill(homeDir, "pi-only", "PiOnly");
+    await writeSkillManifest(homeDir, "pi-only", {
+      schema: "soma.skill.v1",
+      name: "PiOnly",
+      description: "Pi-only skill.",
+      source: { kind: "pai-pack", packName: "PiOnly" },
+      entrypoint: "SKILL.md",
+      references: [],
+      workflows: [],
+      tools: [],
+      triggers: ["pi only"],
+      substrates: ["pi-dev"],
+      algorithmCapability: {
+        kind: "skill",
+        phases: ["think"],
+        triggerSignals: ["pi only"],
+      },
+    });
+
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir, substrate: "codex" });
+
+    expect(registry.definitions.some((definition) => definition.name === "PiOnly")).toBe(false);
+    expect(registry.definitions.some((definition) => definition.name === "WrapperCapability")).toBe(false);
+    expect(registry.unsupported).toContain("PiOnly");
+    expect(registry.unsupported).toContain("WrapperCapability");
+  });
+});
+
+test("treats malformed manifest substrate metadata as unsupported without throwing", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeSkill(homeDir, "broken", "BrokenSkill");
+    await writeSkillManifest(homeDir, "broken", {
+      schema: "soma.skill.v1",
+      name: "BrokenSkill",
+      description: "Broken substrate metadata.",
+      source: { kind: "pai-pack", packName: "BrokenSkill" },
+      entrypoint: "SKILL.md",
+      references: [],
+      workflows: [],
+      tools: [],
+      triggers: ["broken"],
+      substrates: "codex",
+      algorithmCapability: {
+        kind: "skill",
+        phases: ["think"],
+        triggerSignals: ["broken"],
+      },
+    });
+
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir, substrate: "codex" });
+
+    expect(registry.definitions.some((definition) => definition.name === "BrokenSkill")).toBe(false);
+    expect(registry.unsupported).toContain("BrokenSkill");
+  });
+});
+
+test("ignores malformed manifest trigger metadata without throwing", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeSkill(homeDir, "broken-triggers", "BrokenTriggers");
+    await writeSkillManifest(homeDir, "broken-triggers", {
+      schema: "soma.skill.v1",
+      name: "BrokenTriggers",
+      description: "Broken trigger metadata.",
+      source: { kind: "pai-pack", packName: "BrokenTriggers" },
+      entrypoint: "SKILL.md",
+      references: [],
+      workflows: [],
+      tools: [],
+      triggers: "not-an-array",
+      substrates: ["codex"],
+      algorithmCapability: {
+        kind: "skill",
+        phases: ["think"],
+        triggerSignals: [123],
+      },
+    });
+
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir, substrate: "codex" });
+
+    expect(registry.definitions.find((definition) => definition.name === "BrokenTriggers")).toMatchObject({
+      name: "BrokenTriggers",
+      phases: ["think"],
+      triggerSignals: ["Broken trigger metadata."],
+      invoke: { contract: "skill", target: "BrokenTriggers" },
+    });
+  });
+});
+
+test("empty manifest names fall back to SKILL name while preserving metadata", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeSkill(homeDir, "empty-name", "FallbackName");
+    await writeSkillManifest(homeDir, "empty-name", {
+      schema: "soma.skill.v1",
+      name: "",
+      description: "Invalid empty manifest name.",
+      source: { kind: "pai-pack", packName: "FallbackName" },
+      entrypoint: "SKILL.md",
+      references: [],
+      workflows: [],
+      tools: [],
+      triggers: ["invalid"],
+      substrates: ["codex"],
+      algorithmCapability: {
+        kind: "skill",
+        phases: ["think"],
+        triggerSignals: ["invalid"],
+      },
+    });
+
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir, substrate: "codex" });
+
+    expect(registry.definitions.find((definition) => definition.name === "FallbackName")).toMatchObject({
+      name: "FallbackName",
+      phases: ["think"],
+      triggerSignals: ["invalid"],
+      invoke: { contract: "skill", target: "FallbackName" },
+    });
+    expect(registry.definitions.some((definition) => definition.name === "")).toBe(false);
+  });
+});
+
+test("empty manifest names still preserve substrate filtering", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeSkill(homeDir, "empty-pi-only", "EmptyPiOnly");
+    await writeSkillManifest(homeDir, "empty-pi-only", {
+      schema: "soma.skill.v1",
+      name: "",
+      description: "Pi-only manifest with invalid name.",
+      source: { kind: "pai-pack", packName: "EmptyPiOnly" },
+      entrypoint: "SKILL.md",
+      references: [],
+      workflows: [],
+      tools: [],
+      triggers: ["pi only"],
+      substrates: ["pi-dev"],
+      algorithmCapability: {
+        kind: "skill",
+        phases: ["think"],
+        triggerSignals: ["pi only"],
+      },
+    });
+
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir, substrate: "codex" });
+
+    expect(registry.definitions.some((definition) => definition.name === "EmptyPiOnly")).toBe(false);
+    expect(registry.unsupported).toContain("EmptyPiOnly");
+  });
+});
+
+test("treats non-object manifest capability metadata as absent", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeSkill(homeDir, "bad-capability-shape", "BadCapabilityShape");
+    await writeSkillManifest(homeDir, "bad-capability-shape", {
+      schema: "soma.skill.v1",
+      name: "BadCapabilityShape",
+      description: "Malformed capability metadata.",
+      source: { kind: "pai-pack", packName: "BadCapabilityShape" },
+      entrypoint: "SKILL.md",
+      references: [],
+      workflows: [],
+      tools: [],
+      triggers: ["fallback trigger"],
+      substrates: ["codex"],
+      algorithmCapability: "bad",
+    });
+
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({ homeDir, substrate: "codex" });
+
+    expect(registry.definitions.find((definition) => definition.name === "BadCapabilityShape")).toMatchObject({
+      name: "BadCapabilityShape",
+      kind: "skill",
+      phases: ["observe", "think", "plan", "build", "execute", "verify", "learn"],
+      triggerSignals: ["fallback trigger"],
+      invoke: { contract: "skill", target: "BadCapabilityShape" },
+    });
   });
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -37,6 +37,36 @@ async function writeAlgorithmCapabilityFixture(homeDir: string): Promise<void> {
   );
 }
 
+async function writeManifestOnlyCapabilityFixture(homeDir: string): Promise<void> {
+  await mkdir(join(homeDir, ".soma/skills/pi-only"), { recursive: true });
+  await writeFile(
+    join(homeDir, ".soma/skills/pi-only/SKILL.md"),
+    ["---", "name: PiOnly", "description: Pi-only test skill.", "---", "", "# PiOnly", ""].join("\n"),
+    "utf8",
+  );
+  await writeFile(
+    join(homeDir, ".soma/skills/pi-only/soma-skill.json"),
+    `${JSON.stringify({
+      schema: "soma.skill.v1",
+      name: "PiOnly",
+      description: "Pi-only test skill.",
+      source: { kind: "pai-pack", packName: "PiOnly" },
+      entrypoint: "SKILL.md",
+      references: [],
+      workflows: [],
+      tools: [],
+      triggers: ["pi only"],
+      substrates: ["pi-dev"],
+      algorithmCapability: {
+        kind: "skill",
+        phases: ["think"],
+        triggerSignals: ["pi only"],
+      },
+    }, null, 2)}\n`,
+    "utf8",
+  );
+}
+
 test("cli dry-runs codex install without writing files", async () => {
   await withTempHome(async (homeDir) => {
     const output = await runSomaCli(["install", "codex", "--home-dir", homeDir]);
@@ -552,6 +582,53 @@ test("cli selects migrated PAI skill capabilities from Soma home", async () => {
     await expect(readFile(join(homeDir, ".soma/memory/WORK/algorithm-runs/migrated-skill-capability-run.json"), "utf8")).resolves.toContain(
       '"target": "FirstPrinciples"',
     );
+  });
+});
+
+test("cli persists algorithm new substrate and filters manifest capabilities", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeManifestOnlyCapabilityFixture(homeDir);
+    await runSomaCli([
+      "algorithm",
+      "new",
+      "--home-dir",
+      homeDir,
+      "--id",
+      "substrate-filter-run",
+      "--substrate",
+      "codex",
+      "--prompt",
+      "Use substrate filtering",
+      "--intent",
+      "Filter skill capabilities by substrate.",
+      "--current-state",
+      "PiOnly declares pi-dev support.",
+      "--goal",
+      "Codex runs do not register PiOnly.",
+      "--criterion",
+      "C1:Substrate filtering works.",
+    ]);
+
+    const raw = await readFile(join(homeDir, ".soma/memory/WORK/algorithm-runs/substrate-filter-run.json"), "utf8");
+    expect(raw).toContain('"substrate": "codex"');
+    expect(raw).not.toContain('"name": "PiOnly"');
+
+    await expect(
+      runSomaCli([
+        "algorithm",
+        "capabilities",
+        "--home-dir",
+        homeDir,
+        "--id",
+        "substrate-filter-run",
+        "--capability",
+        "PiOnly",
+        "--phase",
+        "think",
+        "--reason",
+        "Should be unavailable for Codex.",
+      ]),
+    ).rejects.toThrow("not registered");
   });
 });
 


### PR DESCRIPTION
## Summary

- add optional `algorithmCapability` metadata to `soma-skill.json`
- prefer manifest-backed capability definitions, then fall back to the migrated Algorithm capability table, then broad loaded-skill defaults
- persist `--substrate` on `algorithm new` and use it when refreshing capability definitions
- document the manifest-backed bridge and add registry/CLI coverage

Closes #187.

## Verification

- `bunx tsc --noEmit`
- `bun test test/algorithm.test.ts test/cli.test.ts`
- `bun test`
