### PR TITLE
Extract substrate lifecycle CLI command module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,4 @@
 import { readSync } from "node:fs";
-import { cursorWorkspaceSubstrateHome } from "./adapters/cursor";
 import {
   checkSomaPolicyBatch,
   checkSomaPolicy,
@@ -15,27 +14,13 @@ import {
   type PaiMigrationPlan,
   type PaiMigrationResult,
   installSomaForClaudeCode,
-  installSomaForCodex,
-  installSomaForCursor,
-  installSomaForPiDev,
   planSomaForClaudeCodeInstall,
-  planSomaForCursorInstall,
   uninstallSomaForClaudeCode,
-  uninstallSomaForCursor,
   type UninstallClaudeCodeOptions,
-  type UninstallClaudeCodeResult,
-  type UninstallCursorResult,
-  buildClaudeCodeHomeProjection,
-  buildCodexHomeProjection,
-  buildCursorHomeProjection,
-  buildPiDevHomeProjection,
-  loadSomaHome,
   planAlgorithmImport,
   planPaiDocsImport,
   planPaiImport,
   planPaiPackImport,
-  planSomaForCodexInstall,
-  planSomaForPiDevInstall,
   promoteAlgorithmRunMemory,
   runSomaLifecycleAlgorithmUpdated,
   runSomaLifecycleSessionEnd,
@@ -61,10 +46,7 @@ import type {
   PaiDocsImportOptions,
   PaiDocsImportPlan,
   PaiDocsImportResult,
-  ProjectionInput,
   SomaInstallOptions,
-  SomaInstallPlan,
-  SomaInstallResult,
   SomaDoctorDiagnosis,
   SomaInitPlan,
   SomaOnboardingOptions,
@@ -95,6 +77,28 @@ import {
   runAlgorithmCli,
   type ParsedAlgorithmArgs,
 } from "./cli/algorithm";
+import { SomaCliError } from "./cli/errors";
+import {
+  SUBSTRATE_LIFECYCLE_COMMAND_HELP,
+  formatClaudeUninstallResult,
+  formatInstallResult,
+  formatPlan,
+  parseDaemonArgs,
+  parseExportArgs,
+  parseInstallArgs,
+  parseOnboardingSubstrate,
+  parseReprojectArgs,
+  parseUninstallArgs,
+  parseUpgradeArgs,
+  runSubstrateLifecycleCli,
+  type ParsedDaemonArgs,
+  type ParsedExportArgs,
+  type ParsedInstallArgs,
+  type ParsedReprojectArgs,
+  type ParsedSubstrateLifecycleArgs,
+  type ParsedUninstallArgs,
+  type ParsedUpgradeArgs,
+} from "./cli/substrate-lifecycle";
 // #115 — `soma migrate claude-skills` (Phase 1). Module-internal, not
 // re-exported from the package barrel, same pattern as
 // `pai-memory-migrator.ts` (#90 Sage r2 Architecture finding — the
@@ -134,21 +138,10 @@ import { RELATIONSHIP_REFLECT_USAGE, runRelationshipCli } from "./tools/relation
 import { runWisdomCli } from "./tools/wisdom/cli";
 import { applySomaInit, diagnoseSomaDoctor, planSomaInit } from "./onboarding";
 
-/**
- * Typed CLI error carrying an exit code distinct from the default 1.
- * Used by `soma isa` (#36) to surface system errors (2) vs user errors (1)
- * vs success (0) per the established CLI convention.
- */
-export class SomaCliError extends Error {
-  readonly exitCode: 1 | 2;
-  constructor(message: string, exitCode: 1 | 2) {
-    super(message);
-    this.name = "SomaCliError";
-    this.exitCode = exitCode;
-  }
-}
 import { isSomaResultEventKind } from "./result-capture";
 import { SOMA_RESULT_EVENT_KINDS } from "./types";
+
+export { SomaCliError } from "./cli/errors";
 
 /**
  * #106 — single-source helper for emitting the
@@ -166,48 +159,6 @@ function warnDeprecatedSubstrateFlag(): void {
   process.stderr.write(
     "Warning: --include-substrate-specific is deprecated; use --include-unrecognized.\n",
   );
-}
-
-type InstallSubstrate = "codex" | "pi-dev" | "claude-code" | "cursor";
-
-interface ParsedInstallArgs {
-  command: "install";
-  substrate: InstallSubstrate;
-  apply: boolean;
-  workspace: boolean;
-  options: SomaInstallOptions;
-}
-
-interface ParsedUninstallArgs {
-  command: "uninstall";
-  substrate: InstallSubstrate;
-  workspace: boolean;
-  options: SomaInstallOptions & UninstallClaudeCodeOptions;
-}
-
-interface ParsedReprojectArgs {
-  command: "reproject";
-  substrate: InstallSubstrate;
-  workspace: boolean;
-  options: SomaInstallOptions;
-}
-
-interface ParsedUpgradeArgs {
-  command: "upgrade";
-  substrate: InstallSubstrate;
-  workspace: boolean;
-  options: SomaInstallOptions;
-}
-
-interface ParsedExportArgs {
-  command: "export";
-  substrate: InstallSubstrate;
-  out?: string;
-  options: SomaInstallOptions;
-}
-
-interface ParsedDaemonArgs {
-  command: "daemon";
 }
 
 interface ParsedInitArgs {
@@ -477,36 +428,12 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
   lifecycle: {
     usage: "Usage: soma lifecycle <session-start|algorithm-updated|session-end> [--home-dir <dir>] [--soma-home <dir>] [--substrate <id>] [--session-id <id>]",
   },
-  install: {
-    usage: "Usage: soma install <codex|pi-dev|claude-code|cursor> [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-    subcommands: {
-      codex: "Usage: soma install codex [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      "pi-dev": "Usage: soma install pi-dev [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      "claude-code": "Usage: soma install claude-code [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      cursor: "Usage: soma install cursor [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-    },
-  },
-  uninstall: {
-    usage: "Usage: soma uninstall <codex|pi-dev|claude-code|cursor> [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-    subcommands: {
-      codex: "Usage: soma uninstall codex [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      "pi-dev": "Usage: soma uninstall pi-dev [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      "claude-code": "Usage: soma uninstall claude-code [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      cursor: "Usage: soma uninstall cursor [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-    },
-  },
-  reproject: {
-    usage: "Usage: soma reproject <codex|pi-dev|claude-code|cursor> [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-  },
-  upgrade: {
-    usage: "Usage: soma upgrade <codex|pi-dev|claude-code|cursor> [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-  },
-  export: {
-    usage: "Usage: soma export <codex|pi-dev|claude-code|cursor> [--out <dir>] [--home-dir <dir>] [--soma-home <dir>]",
-  },
-  daemon: {
-    usage: "Usage: soma daemon  (not yet implemented — placeholder reserves the runtime mode)",
-  },
+  install: SUBSTRATE_LIFECYCLE_COMMAND_HELP.install,
+  uninstall: SUBSTRATE_LIFECYCLE_COMMAND_HELP.uninstall,
+  reproject: SUBSTRATE_LIFECYCLE_COMMAND_HELP.reproject,
+  upgrade: SUBSTRATE_LIFECYCLE_COMMAND_HELP.upgrade,
+  export: SUBSTRATE_LIFECYCLE_COMMAND_HELP.export,
+  daemon: SUBSTRATE_LIFECYCLE_COMMAND_HELP.daemon,
   init: {
     usage: INIT_USAGE,
   },
@@ -553,176 +480,6 @@ function readOption(args: string[], index: number, name: string): string {
 function commandUsage(command: string, action?: string): string {
   const commandHelp = COMMAND_HELP[command] as { usage: string; subcommands?: Record<string, string> } | undefined;
   return (action ? commandHelp?.subcommands?.[action] : undefined) ?? commandHelp?.usage ?? `Usage: soma ${command} ...`;
-}
-
-const INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code", "cursor"] as const satisfies readonly InstallSubstrate[];
-
-function isInstallSubstrate(value: string | undefined): value is InstallSubstrate {
-  return value !== undefined && (INSTALL_SUBSTRATES as readonly string[]).includes(value);
-}
-
-function parseOnboardingSubstrate(value: string): InstallSubstrate {
-  if (isInstallSubstrate(value)) return value;
-  throw new Error("--substrate must be one of codex, pi-dev, claude-code, or cursor.");
-}
-
-function workspaceSubstrateHome(substrate: InstallSubstrate): string {
-  // CONTEXT.md Runtime modes: workspace projection lives at
-  // `./.{codex,pi,claude}/soma` — a soma-scoped subdir so it doesn't
-  // collide with substrate-native workspace files the principal may
-  // already have for that repo.
-  if (substrate === "cursor") return cursorWorkspaceSubstrateHome();
-  const folder = substrate === "pi-dev" ? ".pi" : substrate === "claude-code" ? ".claude" : ".codex";
-  return resolveJoin(process.cwd(), folder, "soma");
-}
-
-function resolveJoin(...parts: string[]): string {
-  // Local helper to keep the cli surface free of an extra import.
-  return parts.join("/").replace(/\/+/g, "/");
-}
-
-// Shared option parser used by install/uninstall/reproject/upgrade.
-// All four verbs accept the same workspace + path triplet; this
-// keeps the workspace-default fallback in one place (Sage r1
-// maintainability finding on #54).
-function parseSubstrateLifecycleOptions(
-  substrate: InstallSubstrate,
-  rest: string[],
-  extra: (arg: string, index: number) => boolean,
-): { workspace: boolean; options: SomaInstallOptions } {
-  const options: SomaInstallOptions = {};
-  let workspace = false;
-  let substrateHomeExplicit = false;
-
-  for (let index = 0; index < rest.length; index += 1) {
-    const arg = rest[index];
-
-    switch (arg) {
-      case "--workspace":
-        workspace = true;
-        continue;
-      case "--home-dir":
-        options.homeDir = readOption(rest, index, arg);
-        index += 1;
-        continue;
-      case "--soma-home":
-        options.somaHome = readOption(rest, index, arg);
-        index += 1;
-        continue;
-      case "--substrate-home":
-        options.substrateHome = readOption(rest, index, arg);
-        substrateHomeExplicit = true;
-        index += 1;
-        continue;
-    }
-
-    if (extra(arg, index)) continue;
-
-    throw new Error(`Unknown option: ${arg}`);
-  }
-
-  if (workspace && !substrateHomeExplicit) {
-    options.substrateHome = workspaceSubstrateHome(substrate);
-  }
-
-  return { workspace, options };
-}
-
-function parseInstallArgs(args: string[]): ParsedInstallArgs {
-  const [command, substrate, ...rest] = args;
-
-  if (command !== "install" || !isInstallSubstrate(substrate)) {
-    throw new Error(commandUsage("install"));
-  }
-
-  let apply = false;
-  // The install verb layers --dry-run / --apply on top of the
-  // shared substrate-lifecycle option set. The `extra` callback
-  // hands those two flags to the shared parser so it can recognize
-  // them without claiming the other options.
-  const { workspace, options } = parseSubstrateLifecycleOptions(substrate, rest, (arg) => {
-    switch (arg) {
-      case "--dry-run":
-        apply = false;
-        return true;
-      case "--apply":
-        apply = true;
-        return true;
-    }
-    return false;
-  });
-
-  return { command, substrate, apply, workspace, options };
-}
-
-function parseLifecycleVerbArgs<T extends "uninstall" | "reproject" | "upgrade">(
-  verb: T,
-  args: string[],
-): { substrate: InstallSubstrate; workspace: boolean; options: SomaInstallOptions } {
-  const [command, substrate, ...rest] = args;
-
-  if (command !== verb || !isInstallSubstrate(substrate)) {
-    throw new Error(commandUsage(verb));
-  }
-
-  const { workspace, options } = parseSubstrateLifecycleOptions(substrate, rest, () => false);
-  return { substrate, workspace, options };
-}
-
-function parseUninstallArgs(args: string[]): ParsedUninstallArgs {
-  const { substrate, workspace, options } = parseLifecycleVerbArgs("uninstall", args);
-  return { command: "uninstall", substrate, workspace, options };
-}
-
-function parseReprojectArgs(args: string[]): ParsedReprojectArgs {
-  const { substrate, workspace, options } = parseLifecycleVerbArgs("reproject", args);
-  return { command: "reproject", substrate, workspace, options };
-}
-
-function parseUpgradeArgs(args: string[]): ParsedUpgradeArgs {
-  const { substrate, workspace, options } = parseLifecycleVerbArgs("upgrade", args);
-  return { command: "upgrade", substrate, workspace, options };
-}
-
-function parseExportArgs(args: string[]): ParsedExportArgs {
-  const [command, substrate, ...rest] = args;
-
-  if (command !== "export" || !isInstallSubstrate(substrate)) {
-    throw new Error(commandUsage("export"));
-  }
-
-  const options: SomaInstallOptions = {};
-  let out: string | undefined;
-
-  for (let index = 0; index < rest.length; index += 1) {
-    const arg = rest[index];
-
-    switch (arg) {
-      case "--out":
-        out = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--home-dir":
-        options.homeDir = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--soma-home":
-        options.somaHome = readOption(rest, index, arg);
-        index += 1;
-        break;
-      default:
-        throw new Error(`Unknown option: ${arg}`);
-    }
-  }
-
-  return { command: "export", substrate, out, options };
-}
-
-function parseDaemonArgs(args: string[]): ParsedDaemonArgs {
-  if (args[0] !== "daemon" || args.length > 1) {
-    throw new Error(commandUsage("daemon"));
-  }
-  return { command: "daemon" };
 }
 
 function parseImportArgs(args: string[]): ParsedImportArgs {
@@ -1444,6 +1201,17 @@ function parseArgs(args: string[]): ParsedArgs {
   throw new Error(renderUnknownCommand(args[0]));
 }
 
+function isSubstrateLifecycleArgs(parsed: ParsedArgs): parsed is ParsedSubstrateLifecycleArgs {
+  return (
+    parsed.command === "install" ||
+    parsed.command === "uninstall" ||
+    parsed.command === "reproject" ||
+    parsed.command === "upgrade" ||
+    parsed.command === "export" ||
+    parsed.command === "daemon"
+  );
+}
+
 function parseOnboardingOptions(rest: string[]): SomaOnboardingOptions {
   const options: SomaOnboardingOptions = {};
   for (let index = 0; index < rest.length; index += 1) {
@@ -1899,40 +1667,6 @@ function readLimitedFeedbackStdin(): string {
   return Buffer.concat(chunks).toString("utf8");
 }
 
-function formatPlan(plan: SomaInstallPlan): string {
-  return [
-    "Soma install plan",
-    `substrate: ${plan.substrate}`,
-    `mode: ${plan.apply ? "apply" : "dry-run"}`,
-    `somaHome: ${plan.somaHome}`,
-    `substrateHome: ${plan.substrateHome}`,
-    "",
-    "Soma directories:",
-    ...plan.somaDirectories.map((path) => `- ${path}`),
-    "",
-    "Soma files:",
-    ...plan.somaFiles.map((path) => `- ${path}`),
-    "",
-    "Substrate files:",
-    ...plan.substrateFiles.map((path) => `- ${path}`),
-  ].join("\n");
-}
-
-function formatInstallResult(result: SomaInstallResult): string {
-  return [
-    "Soma install applied",
-    `substrate: ${result.substrate}`,
-    `somaHome: ${result.somaHome.somaHome}`,
-    `substrateHome: ${result.substrateHome.rootDir}`,
-    "",
-    "Soma files:",
-    ...result.somaHome.files.map((path) => `- ${path}`),
-    "",
-    "Substrate files:",
-    ...result.substrateHome.files.map((path) => `- ${path}`),
-  ].join("\n");
-}
-
 function formatSomaInitPlan(plan: SomaInitPlan): string {
   return [
     `soma init — ${plan.mode === "apply" ? "apply plan" : "plan (dry-run; pass --yes to execute)"}`,
@@ -1986,48 +1720,6 @@ function formatSomaDoctorDiagnosis(diagnosis: SomaDoctorDiagnosis): string {
     "",
     "Findings:",
     ...diagnosis.findings.map((finding) => `- ${finding.id}: ${finding.message}\n  action: ${finding.action}`),
-    "",
-  ].join("\n");
-}
-
-function formatClaudeUninstallResult(result: UninstallClaudeCodeResult): string {
-  if (result.removed.length === 0) {
-    return [
-      "soma adopt claude — uninstall",
-      "",
-      `Substrate home: ${result.substrateHome}`,
-      "Nothing to remove — Soma was not installed at this substrate home.",
-      "",
-    ].join("\n");
-  }
-  return [
-    "soma adopt claude — uninstall",
-    "",
-    `Substrate home: ${result.substrateHome}`,
-    "",
-    "Removed:",
-    ...result.removed.map((p) => `  - ${p}`),
-    "",
-  ].join("\n");
-}
-
-function formatCursorUninstallResult(result: UninstallCursorResult): string {
-  if (result.removed.length === 0) {
-    return [
-      "soma uninstall cursor",
-      "",
-      `Substrate home: ${result.substrateHome}`,
-      "Nothing to remove — Soma was not installed at this substrate home.",
-      "",
-    ].join("\n");
-  }
-  return [
-    "soma uninstall cursor",
-    "",
-    `Substrate home: ${result.substrateHome}`,
-    "",
-    "Removed:",
-    ...result.removed.map((p) => `  - ${p}`),
     "",
   ].join("\n");
 }
@@ -3237,195 +2929,11 @@ export async function runSomaCli(args: string[]): Promise<string> {
     return formatInstallResult(await installSomaForClaudeCode(parsed.options));
   }
 
-  if (parsed.command === "daemon") {
-    // Reserved CLI surface — `daemon` mode (long-lived Myelin
-    // subscriber) is not yet implemented. The verb exists so that
-    // CONTEXT.md's "Runtime modes" table maps onto the CLI surface
-    // one-to-one (#54 AC). Implementation lands in a follow-up
-    // issue.
-    throw new SomaCliError("soma daemon is not yet implemented (placeholder reserves the runtime mode).", 1);
+  if (isSubstrateLifecycleArgs(parsed)) {
+    return runSubstrateLifecycleCli(parsed);
   }
 
-  if (parsed.command === "export") {
-    return formatExportResult(await runExport(parsed));
-  }
-
-  if (parsed.command === "uninstall") {
-    return runUninstall(parsed);
-  }
-
-  if (parsed.command === "reproject" || parsed.command === "upgrade") {
-    // Both verbs reuse the install code path: reproject re-emits the
-    // projection; upgrade is reproject + future migration work
-    // (#54: migration content is a follow-up). They always apply —
-    // unlike `install`, the principal opted into the verb explicitly.
-    return formatInstallResult(await runInstall(parsed.substrate, parsed.options));
-  }
-
-  if (parsed.command !== "install") {
-    throw new Error(`Unhandled command: ${parsed.command}`);
-  }
-
-  if (!parsed.apply) {
-    return formatPlan(planInstall(parsed.substrate, parsed.options));
-  }
-
-  return formatInstallResult(await runInstall(parsed.substrate, parsed.options));
-}
-
-function planInstall(substrate: InstallSubstrate, options: SomaInstallOptions): SomaInstallPlan {
-  switch (substrate) {
-    case "codex":
-      return planSomaForCodexInstall(options);
-    case "pi-dev":
-      return planSomaForPiDevInstall(options);
-    case "claude-code":
-      return planSomaForClaudeCodeInstall(options);
-    case "cursor":
-      return planSomaForCursorInstall(options);
-  }
-}
-
-async function runInstall(substrate: InstallSubstrate, options: SomaInstallOptions): Promise<SomaInstallResult> {
-  switch (substrate) {
-    case "codex":
-      return installSomaForCodex(options);
-    case "pi-dev":
-      return installSomaForPiDev(options);
-    case "claude-code":
-      return installSomaForClaudeCode(options);
-    case "cursor":
-      return installSomaForCursor(options);
-  }
-}
-
-async function runUninstall(parsed: ParsedUninstallArgs): Promise<string> {
-  if (parsed.substrate === "claude-code") {
-    return formatClaudeUninstallResult(await uninstallSomaForClaudeCode(parsed.options));
-  }
-  if (parsed.substrate === "cursor") {
-    return formatCursorUninstallResult(await uninstallSomaForCursor(parsed.options));
-  }
-  // Codex and Pi.dev uninstallers are not yet implemented. The CLI
-  // surface is reserved so CONTEXT.md's "Lifecycle verbs" table maps
-  // one-to-one (#54 AC); functional removal lands in a follow-up.
-  throw new SomaCliError(
-    `soma uninstall ${parsed.substrate} is not yet implemented (claude-code and cursor are currently the functional uninstallers; codex and pi-dev removal land in a follow-up).`,
-    1,
-  );
-}
-
-async function runExport(parsed: ParsedExportArgs): Promise<{ files: { path: string; content: string }[]; out?: string }> {
-  const projection = await buildExportProjection(parsed.substrate, parsed.options);
-  if (!parsed.out) {
-    return { files: projection };
-  }
-  const outRoot = resolveAbsolute(parsed.out);
-  // Compute realpath(--out) once per export run instead of per file
-  // (sage r2 performance finding on #54). The symlink guard inside
-  // `writeProjectionExportFile` reuses this cached value.
-  const { mkdir, realpath } = await import("node:fs/promises");
-  await mkdir(outRoot, { recursive: true });
-  const realOutRoot = await realpath(outRoot);
-  // Parallel writes — independent files, order preserved by mapping
-  // over the original projection array (sage r1 performance finding
-  // on #54).
-  const written = await Promise.all(
-    projection.map(async (file) => {
-      const absolute = await writeProjectionExportFile(outRoot, realOutRoot, file.path, file.content);
-      return { path: absolute, content: file.content };
-    }),
-  );
-  return { files: written, out: outRoot };
-}
-
-async function buildExportProjection(
-  substrate: InstallSubstrate,
-  options: SomaInstallOptions,
-): Promise<{ path: string; content: string }[]> {
-  const projectionInput = await loadSomaHome(options.somaHome ?? defaultSomaHomePath(options.homeDir));
-  const projectionOptions = {
-    homeDir: options.homeDir,
-    somaHome: options.somaHome,
-    substrateHome: options.substrateHome,
-  };
-  const files = projectionFilesFor(substrate, projectionInput, projectionOptions);
-  return files.map((f) => ({ path: f.path, content: f.content }));
-}
-
-function projectionFilesFor(
-  substrate: InstallSubstrate,
-  input: ProjectionInput,
-  options: { homeDir?: string; somaHome?: string; substrateHome?: string },
-): readonly { path: string; content: string }[] {
-  switch (substrate) {
-    case "codex":
-      return buildCodexHomeProjection(input, options).bundle.files;
-    case "pi-dev":
-      return buildPiDevHomeProjection(input, options).bundle.files;
-    case "claude-code":
-      return buildClaudeCodeHomeProjection(input, options).bundle.files;
-    case "cursor":
-      return buildCursorHomeProjection(input, options).bundle.files;
-  }
-}
-
-function defaultSomaHomePath(homeDir?: string): string {
-  const base = homeDir ?? process.env.HOME ?? process.cwd();
-  return resolveJoin(base, ".soma");
-}
-
-function resolveAbsolute(path: string): string {
-  return path.startsWith("/") ? path : resolveJoin(process.cwd(), path);
-}
-
-async function writeProjectionExportFile(
-  outRoot: string,
-  realOutRoot: string,
-  relativePath: string,
-  content: string,
-): Promise<string> {
-  const { mkdir, realpath, writeFile } = await import("node:fs/promises");
-  const path = await import("node:path");
-  // Lexical guard: reject paths that try to escape --out via
-  // absolute paths or `..` segments before we touch the disk.
-  const safeRelative = relativePath.replace(/^[/\\]+/, "");
-  const absolute = path.resolve(outRoot, safeRelative);
-  const resolvedOutRoot = path.resolve(outRoot);
-  if (absolute !== resolvedOutRoot && !absolute.startsWith(resolvedOutRoot + path.sep)) {
-    throw new SomaCliError(`soma export refused to write outside --out (path: ${relativePath}).`, 2);
-  }
-  // Symlink guard (sage r1 security finding on #54): after mkdir,
-  // resolve the real path of the parent directory and verify it is
-  // still under --out's real path. A symlink such as
-  // `<out>/rules -> ~/.ssh` would let writeFile land outside --out
-  // even though the lexical check passed. `realOutRoot` is computed
-  // once by `runExport` (sage r2 performance finding).
-  const parent = path.dirname(absolute);
-  await mkdir(parent, { recursive: true });
-  const realParent = await realpath(parent);
-  if (realParent !== realOutRoot && !realParent.startsWith(realOutRoot + path.sep)) {
-    throw new SomaCliError(
-      `soma export refused to follow a symlink that escapes --out (path: ${relativePath}).`,
-      2,
-    );
-  }
-  await writeFile(absolute, content, "utf8");
-  return absolute;
-}
-
-function formatExportResult(result: { files: { path: string; content: string }[]; out?: string }): string {
-  if (result.out) {
-    return [
-      "Soma export applied",
-      `out: ${result.out}`,
-      "",
-      "Files:",
-      ...result.files.map((f) => `- ${f.path}`),
-    ].join("\n");
-  }
-  // No --out → emit JSON to stdout for downstream tools / diffing.
-  return JSON.stringify(result.files, null, 2);
+  throw new Error("Unhandled command.");
 }
 
 if (import.meta.main) {

--- a/src/cli/errors.ts
+++ b/src/cli/errors.ts
@@ -1,0 +1,14 @@
+/**
+ * Typed CLI error carrying an exit code distinct from the default 1.
+ * Used by command modules to surface system errors (2) vs user errors (1)
+ * vs success (0) per the established CLI convention.
+ */
+export class SomaCliError extends Error {
+  readonly exitCode: 1 | 2;
+
+  constructor(message: string, exitCode: 1 | 2) {
+    super(message);
+    this.name = "SomaCliError";
+    this.exitCode = exitCode;
+  }
+}

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -80,27 +80,34 @@ export type ParsedSubstrateLifecycleArgs =
 
 export const INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code", "cursor"] as const satisfies readonly InstallSubstrate[];
 
+const substrateList = INSTALL_SUBSTRATES.join("|");
+const installOptions = "[--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
+const uninstallOptions = "[--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
+
+function lifecycleUsage(command: string, target: string, options: string): string {
+  return `Usage: soma ${command} ${target} ${options}`;
+}
+
+function lifecycleSubcommandUsage(command: string, options: string): Record<InstallSubstrate, string> {
+  return Object.fromEntries(
+    INSTALL_SUBSTRATES.map((substrate) => [
+      substrate,
+      lifecycleUsage(command, substrate, options),
+    ]),
+  ) as Record<InstallSubstrate, string>;
+}
+
 export const SUBSTRATE_LIFECYCLE_COMMAND_HELP: Record<
   "install" | "uninstall" | "reproject" | "upgrade" | "export" | "daemon",
   { usage: string; subcommands?: Record<string, string> }
 > = {
   install: {
-    usage: "Usage: soma install <codex|pi-dev|claude-code|cursor> [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-    subcommands: {
-      codex: "Usage: soma install codex [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      "pi-dev": "Usage: soma install pi-dev [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      "claude-code": "Usage: soma install claude-code [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      cursor: "Usage: soma install cursor [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-    },
+    usage: lifecycleUsage("install", `<${substrateList}>`, installOptions),
+    subcommands: lifecycleSubcommandUsage("install", installOptions),
   },
   uninstall: {
-    usage: "Usage: soma uninstall <codex|pi-dev|claude-code|cursor> [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-    subcommands: {
-      codex: "Usage: soma uninstall codex [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      "pi-dev": "Usage: soma uninstall pi-dev [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      "claude-code": "Usage: soma uninstall claude-code [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-      cursor: "Usage: soma uninstall cursor [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
-    },
+    usage: lifecycleUsage("uninstall", `<${substrateList}>`, uninstallOptions),
+    subcommands: lifecycleSubcommandUsage("uninstall", uninstallOptions),
   },
   reproject: {
     usage: "Usage: soma reproject <codex|pi-dev|claude-code|cursor> [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -97,6 +97,34 @@ function lifecycleSubcommandUsage(command: string, options: string): Record<Inst
   ) as Record<InstallSubstrate, string>;
 }
 
+type ProjectionOptions = { homeDir?: string; somaHome?: string; substrateHome?: string };
+type ProjectionFile = { path: string; content: string };
+type UninstallResult = { substrateHome: string; removed: string[] };
+
+const installPlanners: Record<InstallSubstrate, (options: SomaInstallOptions) => SomaInstallPlan> = {
+  codex: planSomaForCodexInstall,
+  "pi-dev": planSomaForPiDevInstall,
+  "claude-code": planSomaForClaudeCodeInstall,
+  cursor: planSomaForCursorInstall,
+};
+
+const installers: Record<InstallSubstrate, (options: SomaInstallOptions) => Promise<SomaInstallResult>> = {
+  codex: installSomaForCodex,
+  "pi-dev": installSomaForPiDev,
+  "claude-code": installSomaForClaudeCode,
+  cursor: installSomaForCursor,
+};
+
+const projectionBuilders: Record<
+  InstallSubstrate,
+  (input: ProjectionInput, options: ProjectionOptions) => readonly ProjectionFile[]
+> = {
+  codex: (input, options) => buildCodexHomeProjection(input, options).bundle.files,
+  "pi-dev": (input, options) => buildPiDevHomeProjection(input, options).bundle.files,
+  "claude-code": (input, options) => buildClaudeCodeHomeProjection(input, options).bundle.files,
+  cursor: (input, options) => buildCursorHomeProjection(input, options).bundle.files,
+};
+
 export const SUBSTRATE_LIFECYCLE_COMMAND_HELP: Record<
   "install" | "uninstall" | "reproject" | "upgrade" | "export" | "daemon",
   { usage: string; subcommands?: Record<string, string> }
@@ -325,29 +353,11 @@ export async function runSubstrateLifecycleCli(parsed: ParsedSubstrateLifecycleA
 }
 
 function planInstall(substrate: InstallSubstrate, options: SomaInstallOptions): SomaInstallPlan {
-  switch (substrate) {
-    case "codex":
-      return planSomaForCodexInstall(options);
-    case "pi-dev":
-      return planSomaForPiDevInstall(options);
-    case "claude-code":
-      return planSomaForClaudeCodeInstall(options);
-    case "cursor":
-      return planSomaForCursorInstall(options);
-  }
+  return installPlanners[substrate](options);
 }
 
 async function runInstall(substrate: InstallSubstrate, options: SomaInstallOptions): Promise<SomaInstallResult> {
-  switch (substrate) {
-    case "codex":
-      return installSomaForCodex(options);
-    case "pi-dev":
-      return installSomaForPiDev(options);
-    case "claude-code":
-      return installSomaForClaudeCode(options);
-    case "cursor":
-      return installSomaForCursor(options);
-  }
+  return installers[substrate](options);
 }
 
 async function runUninstall(parsed: ParsedUninstallArgs): Promise<string> {
@@ -407,18 +417,9 @@ async function buildExportProjection(
 function projectionFilesFor(
   substrate: InstallSubstrate,
   input: ProjectionInput,
-  options: { homeDir?: string; somaHome?: string; substrateHome?: string },
-): readonly { path: string; content: string }[] {
-  switch (substrate) {
-    case "codex":
-      return buildCodexHomeProjection(input, options).bundle.files;
-    case "pi-dev":
-      return buildPiDevHomeProjection(input, options).bundle.files;
-    case "claude-code":
-      return buildClaudeCodeHomeProjection(input, options).bundle.files;
-    case "cursor":
-      return buildCursorHomeProjection(input, options).bundle.files;
-  }
+  options: ProjectionOptions,
+): readonly ProjectionFile[] {
+  return projectionBuilders[substrate](input, options);
 }
 
 function defaultSomaHomePath(homeDir?: string): string {
@@ -514,30 +515,17 @@ export function formatInstallResult(result: SomaInstallResult): string {
 }
 
 export function formatClaudeUninstallResult(result: UninstallClaudeCodeResult): string {
-  if (result.removed.length === 0) {
-    return [
-      "soma adopt claude — uninstall",
-      "",
-      `Substrate home: ${result.substrateHome}`,
-      "Nothing to remove — Soma was not installed at this substrate home.",
-      "",
-    ].join("\n");
-  }
-  return [
-    "soma adopt claude — uninstall",
-    "",
-    `Substrate home: ${result.substrateHome}`,
-    "",
-    "Removed:",
-    ...result.removed.map((p) => `  - ${p}`),
-    "",
-  ].join("\n");
+  return formatUninstallResult("soma adopt claude — uninstall", result);
 }
 
 function formatCursorUninstallResult(result: UninstallCursorResult): string {
+  return formatUninstallResult("soma uninstall cursor", result);
+}
+
+function formatUninstallResult(title: string, result: UninstallResult): string {
   if (result.removed.length === 0) {
     return [
-      "soma uninstall cursor",
+      title,
       "",
       `Substrate home: ${result.substrateHome}`,
       "Nothing to remove — Soma was not installed at this substrate home.",
@@ -545,7 +533,7 @@ function formatCursorUninstallResult(result: UninstallCursorResult): string {
     ].join("\n");
   }
   return [
-    "soma uninstall cursor",
+    title,
     "",
     `Substrate home: ${result.substrateHome}`,
     "",

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -1,0 +1,549 @@
+import { cursorWorkspaceSubstrateHome } from "../adapters/cursor";
+import {
+  buildClaudeCodeHomeProjection,
+  buildCodexHomeProjection,
+  buildCursorHomeProjection,
+  buildPiDevHomeProjection,
+  installSomaForClaudeCode,
+  installSomaForCodex,
+  installSomaForCursor,
+  installSomaForPiDev,
+  loadSomaHome,
+  planSomaForClaudeCodeInstall,
+  planSomaForCodexInstall,
+  planSomaForCursorInstall,
+  planSomaForPiDevInstall,
+  uninstallSomaForClaudeCode,
+  uninstallSomaForCursor,
+  type UninstallClaudeCodeOptions,
+  type UninstallClaudeCodeResult,
+  type UninstallCursorResult,
+} from "../index";
+import type {
+  ProjectionInput,
+  SomaInstallOptions,
+  SomaInstallPlan,
+  SomaInstallResult,
+  SubstrateId,
+} from "../types";
+import { SomaCliError } from "./errors";
+
+export type InstallSubstrate = Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor">;
+
+export interface ParsedInstallArgs {
+  command: "install";
+  substrate: InstallSubstrate;
+  apply: boolean;
+  workspace: boolean;
+  options: SomaInstallOptions;
+}
+
+export interface ParsedUninstallArgs {
+  command: "uninstall";
+  substrate: InstallSubstrate;
+  workspace: boolean;
+  options: SomaInstallOptions & UninstallClaudeCodeOptions;
+}
+
+export interface ParsedReprojectArgs {
+  command: "reproject";
+  substrate: InstallSubstrate;
+  workspace: boolean;
+  options: SomaInstallOptions;
+}
+
+export interface ParsedUpgradeArgs {
+  command: "upgrade";
+  substrate: InstallSubstrate;
+  workspace: boolean;
+  options: SomaInstallOptions;
+}
+
+export interface ParsedExportArgs {
+  command: "export";
+  substrate: InstallSubstrate;
+  out?: string;
+  options: SomaInstallOptions;
+}
+
+export interface ParsedDaemonArgs {
+  command: "daemon";
+}
+
+export type ParsedSubstrateLifecycleArgs =
+  | ParsedInstallArgs
+  | ParsedUninstallArgs
+  | ParsedReprojectArgs
+  | ParsedUpgradeArgs
+  | ParsedExportArgs
+  | ParsedDaemonArgs;
+
+export const INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code", "cursor"] as const satisfies readonly InstallSubstrate[];
+
+export const SUBSTRATE_LIFECYCLE_COMMAND_HELP: Record<
+  "install" | "uninstall" | "reproject" | "upgrade" | "export" | "daemon",
+  { usage: string; subcommands?: Record<string, string> }
+> = {
+  install: {
+    usage: "Usage: soma install <codex|pi-dev|claude-code|cursor> [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+    subcommands: {
+      codex: "Usage: soma install codex [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+      "pi-dev": "Usage: soma install pi-dev [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+      "claude-code": "Usage: soma install claude-code [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+      cursor: "Usage: soma install cursor [--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+    },
+  },
+  uninstall: {
+    usage: "Usage: soma uninstall <codex|pi-dev|claude-code|cursor> [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+    subcommands: {
+      codex: "Usage: soma uninstall codex [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+      "pi-dev": "Usage: soma uninstall pi-dev [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+      "claude-code": "Usage: soma uninstall claude-code [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+      cursor: "Usage: soma uninstall cursor [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+    },
+  },
+  reproject: {
+    usage: "Usage: soma reproject <codex|pi-dev|claude-code|cursor> [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+  },
+  upgrade: {
+    usage: "Usage: soma upgrade <codex|pi-dev|claude-code|cursor> [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]",
+  },
+  export: {
+    usage: "Usage: soma export <codex|pi-dev|claude-code|cursor> [--out <dir>] [--home-dir <dir>] [--soma-home <dir>]",
+  },
+  daemon: {
+    usage: "Usage: soma daemon  (not yet implemented - placeholder reserves the runtime mode)",
+  },
+};
+
+function readOption(args: string[], index: number, name: string): string {
+  const value = args[index + 1];
+
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value.`);
+  }
+
+  return value;
+}
+
+export function isInstallSubstrate(value: string | undefined): value is InstallSubstrate {
+  return value !== undefined && (INSTALL_SUBSTRATES as readonly string[]).includes(value);
+}
+
+export function parseOnboardingSubstrate(value: string): InstallSubstrate {
+  if (isInstallSubstrate(value)) return value;
+  throw new Error("--substrate must be one of codex, pi-dev, claude-code, or cursor.");
+}
+
+function commandUsage(command: keyof typeof SUBSTRATE_LIFECYCLE_COMMAND_HELP): string {
+  return SUBSTRATE_LIFECYCLE_COMMAND_HELP[command].usage;
+}
+
+function workspaceSubstrateHome(substrate: InstallSubstrate): string {
+  // CONTEXT.md Runtime modes: workspace projection lives at
+  // `./.{codex,pi,claude}/soma` — a soma-scoped subdir so it doesn't
+  // collide with substrate-native workspace files the principal may
+  // already have for that repo.
+  if (substrate === "cursor") return cursorWorkspaceSubstrateHome();
+  const folder = substrate === "pi-dev" ? ".pi" : substrate === "claude-code" ? ".claude" : ".codex";
+  return resolveJoin(process.cwd(), folder, "soma");
+}
+
+function resolveJoin(...parts: string[]): string {
+  return parts.join("/").replace(/\/+/g, "/");
+}
+
+function parseSubstrateLifecycleOptions(
+  substrate: InstallSubstrate,
+  rest: string[],
+  extra: (arg: string, index: number) => boolean,
+): { workspace: boolean; options: SomaInstallOptions } {
+  const options: SomaInstallOptions = {};
+  let workspace = false;
+  let substrateHomeExplicit = false;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+
+    switch (arg) {
+      case "--workspace":
+        workspace = true;
+        continue;
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        continue;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        continue;
+      case "--substrate-home":
+        options.substrateHome = readOption(rest, index, arg);
+        substrateHomeExplicit = true;
+        index += 1;
+        continue;
+    }
+
+    if (extra(arg, index)) continue;
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (workspace && !substrateHomeExplicit) {
+    options.substrateHome = workspaceSubstrateHome(substrate);
+  }
+
+  return { workspace, options };
+}
+
+export function parseInstallArgs(args: string[]): ParsedInstallArgs {
+  const [command, substrate, ...rest] = args;
+
+  if (command !== "install" || !isInstallSubstrate(substrate)) {
+    throw new Error(commandUsage("install"));
+  }
+
+  let apply = false;
+  const { workspace, options } = parseSubstrateLifecycleOptions(substrate, rest, (arg) => {
+    switch (arg) {
+      case "--dry-run":
+        apply = false;
+        return true;
+      case "--apply":
+        apply = true;
+        return true;
+    }
+    return false;
+  });
+
+  return { command, substrate, apply, workspace, options };
+}
+
+function parseLifecycleVerbArgs(
+  verb: "uninstall" | "reproject" | "upgrade",
+  args: string[],
+): { substrate: InstallSubstrate; workspace: boolean; options: SomaInstallOptions } {
+  const [command, substrate, ...rest] = args;
+
+  if (command !== verb || !isInstallSubstrate(substrate)) {
+    throw new Error(commandUsage(verb));
+  }
+
+  const { workspace, options } = parseSubstrateLifecycleOptions(substrate, rest, () => false);
+  return { substrate, workspace, options };
+}
+
+export function parseUninstallArgs(args: string[]): ParsedUninstallArgs {
+  const { substrate, workspace, options } = parseLifecycleVerbArgs("uninstall", args);
+  return { command: "uninstall", substrate, workspace, options };
+}
+
+export function parseReprojectArgs(args: string[]): ParsedReprojectArgs {
+  const { substrate, workspace, options } = parseLifecycleVerbArgs("reproject", args);
+  return { command: "reproject", substrate, workspace, options };
+}
+
+export function parseUpgradeArgs(args: string[]): ParsedUpgradeArgs {
+  const { substrate, workspace, options } = parseLifecycleVerbArgs("upgrade", args);
+  return { command: "upgrade", substrate, workspace, options };
+}
+
+export function parseExportArgs(args: string[]): ParsedExportArgs {
+  const [command, substrate, ...rest] = args;
+
+  if (command !== "export" || !isInstallSubstrate(substrate)) {
+    throw new Error(commandUsage("export"));
+  }
+
+  const options: SomaInstallOptions = {};
+  let out: string | undefined;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+
+    switch (arg) {
+      case "--out":
+        out = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return { command, substrate, out, options };
+}
+
+export function parseDaemonArgs(args: string[]): ParsedDaemonArgs {
+  if (args[0] !== "daemon" || args.length > 1) {
+    throw new Error(commandUsage("daemon"));
+  }
+  return { command: "daemon" };
+}
+
+export async function runSubstrateLifecycleCli(parsed: ParsedSubstrateLifecycleArgs): Promise<string> {
+  if (parsed.command === "daemon") {
+    throw new SomaCliError("soma daemon is not yet implemented (placeholder reserves the runtime mode).", 1);
+  }
+
+  if (parsed.command === "export") {
+    return formatExportResult(await runExport(parsed));
+  }
+
+  if (parsed.command === "uninstall") {
+    return runUninstall(parsed);
+  }
+
+  if (parsed.command === "reproject" || parsed.command === "upgrade") {
+    // Both verbs reuse the install code path: reproject re-emits the
+    // projection; upgrade is reproject + future migration work
+    // (#54: migration content is a follow-up). They always apply —
+    // unlike `install`, the principal opted into the verb explicitly.
+    return formatInstallResult(await runInstall(parsed.substrate, parsed.options));
+  }
+
+  if (!parsed.apply) {
+    return formatPlan(planInstall(parsed.substrate, parsed.options));
+  }
+
+  return formatInstallResult(await runInstall(parsed.substrate, parsed.options));
+}
+
+function planInstall(substrate: InstallSubstrate, options: SomaInstallOptions): SomaInstallPlan {
+  switch (substrate) {
+    case "codex":
+      return planSomaForCodexInstall(options);
+    case "pi-dev":
+      return planSomaForPiDevInstall(options);
+    case "claude-code":
+      return planSomaForClaudeCodeInstall(options);
+    case "cursor":
+      return planSomaForCursorInstall(options);
+  }
+}
+
+async function runInstall(substrate: InstallSubstrate, options: SomaInstallOptions): Promise<SomaInstallResult> {
+  switch (substrate) {
+    case "codex":
+      return installSomaForCodex(options);
+    case "pi-dev":
+      return installSomaForPiDev(options);
+    case "claude-code":
+      return installSomaForClaudeCode(options);
+    case "cursor":
+      return installSomaForCursor(options);
+  }
+}
+
+async function runUninstall(parsed: ParsedUninstallArgs): Promise<string> {
+  if (parsed.substrate === "claude-code") {
+    return formatClaudeUninstallResult(await uninstallSomaForClaudeCode(parsed.options));
+  }
+  if (parsed.substrate === "cursor") {
+    return formatCursorUninstallResult(await uninstallSomaForCursor(parsed.options));
+  }
+  // Codex and Pi.dev uninstallers are not yet implemented. The CLI
+  // surface is reserved so CONTEXT.md's "Lifecycle verbs" table maps
+  // one-to-one (#54 AC); functional removal lands in a follow-up.
+  throw new SomaCliError(
+    `soma uninstall ${parsed.substrate} is not yet implemented (claude-code and cursor are currently the functional uninstallers; codex and pi-dev removal land in a follow-up).`,
+    1,
+  );
+}
+
+async function runExport(parsed: ParsedExportArgs): Promise<{ files: { path: string; content: string }[]; out?: string }> {
+  const projection = await buildExportProjection(parsed.substrate, parsed.options);
+  if (!parsed.out) {
+    return { files: projection };
+  }
+  const outRoot = resolveAbsolute(parsed.out);
+  // Compute realpath(--out) once per export run instead of per file
+  // (sage r2 performance finding on #54). The symlink guard inside
+  // `writeProjectionExportFile` reuses this cached value.
+  const { mkdir, realpath } = await import("node:fs/promises");
+  await mkdir(outRoot, { recursive: true });
+  const realOutRoot = await realpath(outRoot);
+  // Parallel writes — independent files, order preserved by mapping
+  // over the original projection array (sage r1 performance finding
+  // on #54).
+  const written = await Promise.all(
+    projection.map(async (file) => {
+      const absolute = await writeProjectionExportFile(outRoot, realOutRoot, file.path, file.content);
+      return { path: absolute, content: file.content };
+    }),
+  );
+  return { files: written, out: outRoot };
+}
+
+async function buildExportProjection(
+  substrate: InstallSubstrate,
+  options: SomaInstallOptions,
+): Promise<{ path: string; content: string }[]> {
+  const projectionInput = await loadSomaHome(options.somaHome ?? defaultSomaHomePath(options.homeDir));
+  const projectionOptions = {
+    homeDir: options.homeDir,
+    somaHome: options.somaHome,
+    substrateHome: options.substrateHome,
+  };
+  const files = projectionFilesFor(substrate, projectionInput, projectionOptions);
+  return files.map((f) => ({ path: f.path, content: f.content }));
+}
+
+function projectionFilesFor(
+  substrate: InstallSubstrate,
+  input: ProjectionInput,
+  options: { homeDir?: string; somaHome?: string; substrateHome?: string },
+): readonly { path: string; content: string }[] {
+  switch (substrate) {
+    case "codex":
+      return buildCodexHomeProjection(input, options).bundle.files;
+    case "pi-dev":
+      return buildPiDevHomeProjection(input, options).bundle.files;
+    case "claude-code":
+      return buildClaudeCodeHomeProjection(input, options).bundle.files;
+    case "cursor":
+      return buildCursorHomeProjection(input, options).bundle.files;
+  }
+}
+
+function defaultSomaHomePath(homeDir?: string): string {
+  const base = homeDir ?? process.env.HOME ?? process.cwd();
+  return resolveJoin(base, ".soma");
+}
+
+function resolveAbsolute(path: string): string {
+  return path.startsWith("/") ? path : resolveJoin(process.cwd(), path);
+}
+
+async function writeProjectionExportFile(
+  outRoot: string,
+  realOutRoot: string,
+  relativePath: string,
+  content: string,
+): Promise<string> {
+  const { mkdir, realpath, writeFile } = await import("node:fs/promises");
+  const path = await import("node:path");
+  // Lexical guard: reject paths that try to escape --out via
+  // absolute paths or `..` segments before we touch the disk.
+  const safeRelative = relativePath.replace(/^[/\\]+/, "");
+  const absolute = path.resolve(outRoot, safeRelative);
+  const resolvedOutRoot = path.resolve(outRoot);
+  if (absolute !== resolvedOutRoot && !absolute.startsWith(resolvedOutRoot + path.sep)) {
+    throw new SomaCliError(`soma export refused to write outside --out (path: ${relativePath}).`, 2);
+  }
+  // Symlink guard (sage r1 security finding on #54): after mkdir,
+  // resolve the real path of the parent directory and verify it is
+  // still under --out's real path. A symlink such as
+  // `<out>/rules -> ~/.ssh` would let writeFile land outside --out
+  // even though the lexical check passed. `realOutRoot` is computed
+  // once by `runExport` (sage r2 performance finding).
+  const parent = path.dirname(absolute);
+  await mkdir(parent, { recursive: true });
+  const realParent = await realpath(parent);
+  if (realParent !== realOutRoot && !realParent.startsWith(realOutRoot + path.sep)) {
+    throw new SomaCliError(
+      `soma export refused to follow a symlink that escapes --out (path: ${relativePath}).`,
+      2,
+    );
+  }
+  await writeFile(absolute, content, "utf8");
+  return absolute;
+}
+
+function formatExportResult(result: { files: { path: string; content: string }[]; out?: string }): string {
+  if (result.out) {
+    return [
+      "Soma export applied",
+      `out: ${result.out}`,
+      "",
+      "Files:",
+      ...result.files.map((f) => `- ${f.path}`),
+    ].join("\n");
+  }
+  // No --out → emit JSON to stdout for downstream tools / diffing.
+  return JSON.stringify(result.files, null, 2);
+}
+
+export function formatPlan(plan: SomaInstallPlan): string {
+  return [
+    "Soma install plan",
+    `substrate: ${plan.substrate}`,
+    `mode: ${plan.apply ? "apply" : "dry-run"}`,
+    `somaHome: ${plan.somaHome}`,
+    `substrateHome: ${plan.substrateHome}`,
+    "",
+    "Soma directories:",
+    ...plan.somaDirectories.map((path) => `- ${path}`),
+    "",
+    "Soma files:",
+    ...plan.somaFiles.map((path) => `- ${path}`),
+    "",
+    "Substrate files:",
+    ...plan.substrateFiles.map((path) => `- ${path}`),
+  ].join("\n");
+}
+
+export function formatInstallResult(result: SomaInstallResult): string {
+  return [
+    "Soma install applied",
+    `substrate: ${result.substrate}`,
+    `somaHome: ${result.somaHome.somaHome}`,
+    `substrateHome: ${result.substrateHome.rootDir}`,
+    "",
+    "Soma files:",
+    ...result.somaHome.files.map((path) => `- ${path}`),
+    "",
+    "Substrate files:",
+    ...result.substrateHome.files.map((path) => `- ${path}`),
+  ].join("\n");
+}
+
+export function formatClaudeUninstallResult(result: UninstallClaudeCodeResult): string {
+  if (result.removed.length === 0) {
+    return [
+      "soma adopt claude — uninstall",
+      "",
+      `Substrate home: ${result.substrateHome}`,
+      "Nothing to remove — Soma was not installed at this substrate home.",
+      "",
+    ].join("\n");
+  }
+  return [
+    "soma adopt claude — uninstall",
+    "",
+    `Substrate home: ${result.substrateHome}`,
+    "",
+    "Removed:",
+    ...result.removed.map((p) => `  - ${p}`),
+    "",
+  ].join("\n");
+}
+
+function formatCursorUninstallResult(result: UninstallCursorResult): string {
+  if (result.removed.length === 0) {
+    return [
+      "soma uninstall cursor",
+      "",
+      `Substrate home: ${result.substrateHome}`,
+      "Nothing to remove — Soma was not installed at this substrate home.",
+      "",
+    ].join("\n");
+  }
+  return [
+    "soma uninstall cursor",
+    "",
+    `Substrate home: ${result.substrateHome}`,
+    "",
+    "Removed:",
+    ...result.removed.map((p) => `  - ${p}`),
+    "",
+  ].join("\n");
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -5,6 +5,10 @@ import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import { runSomaCli } from "../src/cli";
 import { ALGORITHM_ACTIONS } from "../src/cli/algorithm";
+import {
+  INSTALL_SUBSTRATES,
+  SUBSTRATE_LIFECYCLE_COMMAND_HELP,
+} from "../src/cli/substrate-lifecycle";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-cli-"));
@@ -160,6 +164,23 @@ test("algorithm step help only advertises supported statuses", async () => {
 
   expect(output).toContain("--status <open|done|blocked>");
   expect(output).not.toContain("dropped");
+});
+
+test("substrate lifecycle command module keeps substrates and help in sync", async () => {
+  for (const command of ["install", "uninstall"] as const) {
+    const groupHelp = await runSomaCli([command, "--help"]);
+
+    expect(groupHelp).toBe(SUBSTRATE_LIFECYCLE_COMMAND_HELP[command].usage);
+    for (const substrate of INSTALL_SUBSTRATES) {
+      const expected = SUBSTRATE_LIFECYCLE_COMMAND_HELP[command].subcommands?.[substrate];
+      expect(expected).toBeDefined();
+      await expect(runSomaCli([command, substrate, "--help"])).resolves.toBe(expected!);
+    }
+  }
+
+  for (const command of ["reproject", "upgrade", "export", "daemon"] as const) {
+    await expect(runSomaCli([command, "--help"])).resolves.toBe(SUBSTRATE_LIFECYCLE_COMMAND_HELP[command].usage);
+  }
 });
 
 test("cli reports unknown top-level command with suggestion", async () => {


### PR DESCRIPTION
## Summary
- extract install/uninstall/reproject/upgrade/export/daemon parsing, help, execution, and formatting into src/cli/substrate-lifecycle.ts
- move shared SomaCliError into src/cli/errors.ts for command modules
- add CLI help sync coverage for substrate lifecycle command help

Refs #189

## Verification
- bun run typecheck
- bun test test/cli.test.ts
- bun test