### PR TITLE
Move Codex install facts behind adapter spec

### DIFF
--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -111,3 +111,52 @@ Three candidates:
 **Supersedes:** `CONTEXT.md` line 235 ("`migrate`, `republish`, `bump` → `upgrade`") — `migrate` removed from that kill-list; `republish` and `bump` remain killed.
 
 **Discussion:** `/grill-with-docs` session 2026-05-17 (Q8).
+
+## 4. Adapter Install Facts
+
+### DD-4: Adapters own install facts; installer owns lifecycle orchestration
+
+**Status:** Decided (2026-05-22)
+
+**Context:** Soma's install path had substrate-specific facts spread across the
+installer, home projection, active ISA projection paths, private projection
+roots, and adapter modules. Adding or changing a substrate required editing
+multiple unrelated modules, which weakened locality and made install,
+reproject, upgrade, and uninstall behavior harder to compare.
+
+Three candidates surfaced:
+- **(a) Central install registry.** Keep all substrate install facts in one
+  installer-owned module.
+- **(b) Adapter-owned install facts.** Each adapter exports its own install
+  facts; the installer consumes them.
+- **(c) Push full install behavior into adapters.** Each adapter owns planning,
+  projection writing, lifecycle refresh, and uninstall behavior end to end.
+
+**Decision:** **(b)** — adapter-owned install facts with installer-owned
+orchestration.
+
+Adapters own substrate-native facts: default home, projected file paths,
+substrate-specific skill destinations, lifecycle projection paths, validators,
+cleanup hooks, private projection roots, and uninstall targets. The installer
+owns orchestration: bootstrapping Soma home, loading active ISA, running
+lifecycle updates, writing projections, and applying the install, reproject,
+upgrade, and uninstall verbs.
+
+**Rejected:**
+- (a) improves switch locality but keeps substrate-native knowledge far from
+  the adapter code that defines the projection.
+- (c) gives maximum adapter autonomy but makes adapters too deep in the wrong
+  direction: they would own lifecycle and Soma home behavior that is
+  substrate-neutral.
+
+**Implications:**
+- A future substrate should add an adapter-local install spec rather than
+  editing scattered installer tables.
+- Existing public per-substrate projection functions can remain as compatibility
+  and test surface while sharing a generic internal install/projection path.
+- The install spec stays internal until external/custom adapter installation
+  needs a stable public API.
+- Missing uninstall support should be represented explicitly as reserved install
+  spec data, not hidden only in CLI branching.
+
+**Discussion:** `/grill-with-docs` session 2026-05-22.

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -158,6 +158,13 @@ Adapters should be thin. They do not own identity, memory, ISA, skill schemas, o
 policy semantics. They only project those contracts into a substrate's native
 mechanisms, and write back substrate-side events through the writeback gate.
 
+Adapters own their substrate-native install facts: default home, projected file
+paths, substrate-specific skill destinations, lifecycle projection paths,
+validators, cleanup hooks, private projection roots, and uninstall targets. The
+installer owns orchestration: bootstrapping Soma home, loading active ISA,
+running lifecycle updates, writing projections, and applying the install,
+reproject, upgrade, and uninstall verbs.
+
 The first portability proof is documented in
 [portability-proof.md](./portability-proof.md). Memory and policy v0 are
 documented in [memory-policy-v0.md](./memory-policy-v0.md).

--- a/src/adapter-active-isa.ts
+++ b/src/adapter-active-isa.ts
@@ -93,15 +93,3 @@ export function activeIsaBundleFile(
   if (!activeIsa) return [];
   return [{ path: activeIsaProjectionPath(substrate), content: renderActiveIsaFile(activeIsa) }];
 }
-
-/**
- * Per-substrate default home directory name (used by both installer
- * and home-projection modules — kept here so adding a substrate is a
- * one-file change). Sage r1 finding.
- */
-export const DEFAULT_SUBSTRATE_HOMES: Record<"codex" | "pi-dev" | "claude-code" | "cursor", string> = {
-  codex: ".codex",
-  "pi-dev": ".pi",
-  "claude-code": ".claude",
-  cursor: ".",
-};

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -1,3 +1,2 @@
 export { projectCodex, projectCodexHome, codexAdapter } from "./adapter";
 export { configureCodexInstall } from "./config";
-export { codexInstallSpec } from "./install";

--- a/src/adapters/codex/index.ts
+++ b/src/adapters/codex/index.ts
@@ -1,2 +1,3 @@
 export { projectCodex, projectCodexHome, codexAdapter } from "./adapter";
 export { configureCodexInstall } from "./config";
+export { codexInstallSpec } from "./install";

--- a/src/adapters/codex/install.ts
+++ b/src/adapters/codex/install.ts
@@ -1,0 +1,87 @@
+import { homedir } from "node:os";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { configureCodexInstall } from "./config";
+import type { SubstrateInstallSpec } from "../../install-spec";
+import type { SubstrateId } from "../../types";
+
+export const CODEX_HOME_FILES = [
+  "rules/soma.rules",
+  "hooks.json",
+  "hooks/soma-lifecycle.mjs",
+  "hooks/soma-lifecycle.config.json",
+  "hooks/codex-hook-entry.mjs",
+  "hooks/soma-feedback-capture.mjs",
+  "hooks/codex-policy-hook.mjs",
+  "hooks/codex-policy-targets.mjs",
+  "hooks/policy-marker.mjs",
+  "skills/soma/SKILL.md",
+  "skills/the-algorithm/SKILL.md",
+  "memories/soma/profile.md",
+  "memories/soma/startup-context.md",
+  "memories/soma/lifecycle.md",
+  "memories/soma/memory-layout.md",
+  "memories/soma/pai-imports.md",
+  "memories/soma/skills.md",
+  "memories/soma/policy.md",
+  "memories/soma/soma-repo.txt",
+  "AGENTS.md",
+  "config.toml",
+] as const;
+
+export const CODEX_AGENTS_IMPORTS = ["@./skills/the-algorithm/SKILL.md", "@./memories/soma/startup-context.md"] as const;
+
+export function codexProjectionPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
+  if (options.substrate !== undefined && options.substrate !== "codex") return [];
+  const home = resolve(options.homeDir ?? homedir());
+  return [join(home, ".codex", "skills", "soma")].map((path) => resolve(path));
+}
+
+export function codexMemoryPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
+  if (options.substrate !== undefined && options.substrate !== "codex") return [];
+  const home = resolve(options.homeDir ?? homedir());
+  return [join(home, ".codex", "memories")].map((path) => resolve(path));
+}
+
+export async function configureCodexAgentsImport(codexHome: string): Promise<string[]> {
+  const path = join(codexHome, "AGENTS.md");
+  const existing = await readFile(path, "utf8").catch(() => "");
+  const existingLines = new Set(existing.split("\n").map((line) => line.trim()));
+  const missingImports = CODEX_AGENTS_IMPORTS.filter((line) => !existingLines.has(line));
+
+  if (missingImports.length > 0) {
+    const separator = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, `${existing}${separator}${missingImports.join("\n")}\n`, "utf8");
+  }
+
+  return [path];
+}
+
+export const codexInstallSpec: SubstrateInstallSpec<"codex"> = {
+  substrate: "codex",
+  defaultHome: ".codex",
+  homeFiles: CODEX_HOME_FILES,
+  lifecycleProjection: {
+    startupContextPath: "memories/soma/startup-context.md",
+    somaRepoPathPath: "memories/soma/soma-repo.txt",
+  },
+  postProjection: [
+    {
+      name: "codex-agents-import",
+      run: async ({ substrateHome }) => configureCodexAgentsImport(substrateHome),
+    },
+    {
+      name: "codex-config",
+      run: async ({ substrateHome, somaHome }) => [await configureCodexInstall(substrateHome, somaHome)],
+    },
+  ],
+  privateRoots: {
+    projection: codexProjectionPrivateRoots,
+    memory: codexMemoryPrivateRoots,
+  },
+  uninstall: {
+    kind: "reserved",
+    reason: "Codex uninstall is not implemented yet; projection removal needs a follow-up that preserves user-owned AGENTS.md and config.toml content.",
+  },
+};

--- a/src/adapters/codex/install.ts
+++ b/src/adapters/codex/install.ts
@@ -5,6 +5,8 @@ import { configureCodexInstall } from "./config";
 import type { SubstrateInstallSpec } from "../../install-spec";
 import type { SubstrateId } from "../../types";
 
+const CODEX_DEFAULT_HOME = ".codex";
+
 export const CODEX_HOME_FILES = [
   "rules/soma.rules",
   "hooks.json",
@@ -34,13 +36,13 @@ export const CODEX_AGENTS_IMPORTS = ["@./skills/the-algorithm/SKILL.md", "@./mem
 export function codexProjectionPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
   if (options.substrate !== undefined && options.substrate !== "codex") return [];
   const home = resolve(options.homeDir ?? homedir());
-  return [join(home, ".codex", "skills", "soma")].map((path) => resolve(path));
+  return [join(home, CODEX_DEFAULT_HOME, "skills", "soma")].map((path) => resolve(path));
 }
 
 export function codexMemoryPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
   if (options.substrate !== undefined && options.substrate !== "codex") return [];
   const home = resolve(options.homeDir ?? homedir());
-  return [join(home, ".codex", "memories")].map((path) => resolve(path));
+  return [join(home, CODEX_DEFAULT_HOME, "memories")].map((path) => resolve(path));
 }
 
 export async function configureCodexAgentsImport(codexHome: string): Promise<string[]> {
@@ -60,7 +62,7 @@ export async function configureCodexAgentsImport(codexHome: string): Promise<str
 
 export const codexInstallSpec: SubstrateInstallSpec<"codex"> = {
   substrate: "codex",
-  defaultHome: ".codex",
+  defaultHome: CODEX_DEFAULT_HOME,
   homeFiles: CODEX_HOME_FILES,
   lifecycleProjection: {
     startupContextPath: "memories/soma/startup-context.md",

--- a/src/home-projection.ts
+++ b/src/home-projection.ts
@@ -6,8 +6,8 @@ import { CURSOR_RULES_PATH } from "./adapters/cursor";
 import { projectClaudeCodeHome, projectCodexHome, projectCursorHome, projectPiDevHome } from "./adapters";
 import { writeProjection } from "./projection";
 import { defaultSomaRepoPath } from "./repo-path";
-import { DEFAULT_SUBSTRATE_HOMES } from "./adapter-active-isa";
-import type { ProjectionInput, SomaHomeProjection, SomaHomeProjectionOptions, SubstrateId, WrittenProjection } from "./types";
+import { defaultSubstrateHome } from "./install-spec-registry";
+import type { Projection, ProjectionInput, SomaHomeProjection, SomaHomeProjectionOptions, SubstrateId, WrittenProjection } from "./types";
 
 export function resolveHomeProjectionPaths(
   substrate: SubstrateId,
@@ -18,24 +18,33 @@ export function resolveHomeProjectionPaths(
   }
 
   const homeDir = resolve(options.homeDir ?? homedir());
-  const defaultSubstrateHome = DEFAULT_SUBSTRATE_HOMES[substrate];
+  const defaultHome = defaultSubstrateHome(substrate);
 
   return {
     substrate,
     somaHome: resolve(options.somaHome ?? join(homeDir, ".soma")),
-    substrateHome: resolve(options.substrateHome ?? join(homeDir, defaultSubstrateHome)),
+    substrateHome: resolve(options.substrateHome ?? join(homeDir, defaultHome)),
+  };
+}
+
+function buildHomeProjectionFor(
+  substrate: Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor">,
+  options: SomaHomeProjectionOptions,
+  project: (paths: Omit<SomaHomeProjection, "bundle">) => Projection,
+): SomaHomeProjection {
+  const paths = resolveHomeProjectionPaths(substrate, options);
+
+  return {
+    ...paths,
+    bundle: project(paths),
   };
 }
 
 export function buildCodexHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
-  const paths = resolveHomeProjectionPaths("codex", options);
   const homeDir = resolve(options.homeDir ?? homedir());
   const somaRepoPath = resolve(options.somaRepoPath ?? defaultSomaRepoPath());
 
-  return {
-    ...paths,
-    bundle: projectCodexHome(input, paths.somaHome, homeDir, somaRepoPath),
-  };
+  return buildHomeProjectionFor("codex", options, (paths) => projectCodexHome(input, paths.somaHome, homeDir, somaRepoPath));
 }
 
 export async function installCodexHomeProjection(
@@ -47,12 +56,7 @@ export async function installCodexHomeProjection(
 }
 
 export function buildPiDevHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
-  const paths = resolveHomeProjectionPaths("pi-dev", options);
-
-  return {
-    ...paths,
-    bundle: projectPiDevHome(input, paths.somaHome),
-  };
+  return buildHomeProjectionFor("pi-dev", options, (paths) => projectPiDevHome(input, paths.somaHome));
 }
 
 export async function installPiDevHomeProjection(
@@ -72,12 +76,7 @@ export function buildClaudeCodeHomeProjection(
   input: ProjectionInput,
   options: SomaHomeProjectionOptions = {},
 ): SomaHomeProjection {
-  const paths = resolveHomeProjectionPaths("claude-code", options);
-
-  return {
-    ...paths,
-    bundle: projectClaudeCodeHome(input),
-  };
+  return buildHomeProjectionFor("claude-code", options, () => projectClaudeCodeHome(input));
 }
 
 export async function installClaudeCodeHomeProjection(
@@ -89,12 +88,7 @@ export async function installClaudeCodeHomeProjection(
 }
 
 export function buildCursorHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
-  const paths = resolveHomeProjectionPaths("cursor", options);
-
-  return {
-    ...paths,
-    bundle: projectCursorHome(input),
-  };
+  return buildHomeProjectionFor("cursor", options, () => projectCursorHome(input));
 }
 
 export async function installCursorHomeProjection(

--- a/src/install-spec-registry.ts
+++ b/src/install-spec-registry.ts
@@ -1,0 +1,18 @@
+import { codexInstallSpec } from "./adapters/codex/install";
+import type { InstallSubstrate, SubstrateInstallSpec } from "./install-spec";
+
+const LEGACY_DEFAULT_SUBSTRATE_HOMES: Record<InstallSubstrate, string> = {
+  codex: codexInstallSpec.defaultHome,
+  "pi-dev": ".pi",
+  "claude-code": ".claude",
+  cursor: ".",
+};
+
+export function installSpecFor(substrate: InstallSubstrate): SubstrateInstallSpec | undefined {
+  if (substrate === "codex") return codexInstallSpec;
+  return undefined;
+}
+
+export function defaultSubstrateHome(substrate: InstallSubstrate): string {
+  return installSpecFor(substrate)?.defaultHome ?? LEGACY_DEFAULT_SUBSTRATE_HOMES[substrate];
+}

--- a/src/install-spec.ts
+++ b/src/install-spec.ts
@@ -1,0 +1,47 @@
+import type { SubstrateId } from "./types";
+
+export type InstallSubstrate = Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor">;
+
+export interface LifecycleProjectionSpec {
+  startupContextPath: string;
+  somaRepoPathPath?: string;
+}
+
+export interface InstallPostProjectionContext {
+  homeDir?: string;
+  somaHome: string;
+  somaRepoPath: string;
+  substrateHome: string;
+}
+
+export interface InstallPostProjectionStep {
+  name: string;
+  run(context: InstallPostProjectionContext): Promise<string[]>;
+}
+
+export interface ReservedUninstallSpec {
+  kind: "reserved";
+  reason: string;
+}
+
+export interface ImplementedUninstallSpec {
+  kind: "implemented";
+  remove: readonly string[];
+}
+
+export type UninstallSpec = ReservedUninstallSpec | ImplementedUninstallSpec;
+
+export interface PrivateRootSpec {
+  projection?(options?: { homeDir?: string; substrate?: SubstrateId }): string[];
+  memory?(options?: { homeDir?: string; substrate?: SubstrateId }): string[];
+}
+
+export interface SubstrateInstallSpec<S extends InstallSubstrate = InstallSubstrate> {
+  substrate: S;
+  defaultHome: string;
+  homeFiles: readonly string[];
+  lifecycleProjection?: LifecycleProjectionSpec;
+  postProjection?: readonly InstallPostProjectionStep[];
+  privateRoots?: PrivateRootSpec;
+  uninstall: UninstallSpec;
+}

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,7 +1,7 @@
 import { homedir } from "node:os";
 import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import { configureCodexInstall } from "./adapters/codex";
+import { codexInstallSpec } from "./adapters/codex";
 import { CURSOR_HOME_FILE_PATHS } from "./adapters/cursor";
 import {
   PI_DEV_ISA_SKILL_ID,
@@ -22,7 +22,9 @@ import { SOMA_MEMORY_CATEGORIES } from "./memory-readmes";
 import { defaultSomaRepoPath } from "./repo-path";
 import { bootstrapSomaHome } from "./soma-home";
 import { installIsaSkill, installIsaSkillProjection } from "./isa-skill-installer";
-import { DEFAULT_SUBSTRATE_HOMES, loadActiveIsaForBundle } from "./adapter-active-isa";
+import { loadActiveIsaForBundle } from "./adapter-active-isa";
+import { type InstallSubstrate, type LifecycleProjectionSpec, type SubstrateInstallSpec } from "./install-spec";
+import { defaultSubstrateHome, installSpecFor } from "./install-spec-registry";
 import type { ProjectionInput, SomaInstallOptions, SomaInstallPlan, SomaInstallResult } from "./types";
 
 const SOMA_BOOTSTRAP_FILES = [
@@ -45,32 +47,6 @@ const SOMA_BOOTSTRAP_DIRECTORIES = [
   "projections/claude-code",
   "projections/cursor",
 ] as const;
-
-const CODEX_HOME_FILES = [
-  "rules/soma.rules",
-  "hooks.json",
-  "hooks/soma-lifecycle.mjs",
-  "hooks/soma-lifecycle.config.json",
-  "hooks/codex-hook-entry.mjs",
-  "hooks/soma-feedback-capture.mjs",
-  "hooks/codex-policy-hook.mjs",
-  "hooks/codex-policy-targets.mjs",
-  "hooks/policy-marker.mjs",
-  "skills/soma/SKILL.md",
-  "skills/the-algorithm/SKILL.md",
-  "memories/soma/profile.md",
-  "memories/soma/startup-context.md",
-  "memories/soma/lifecycle.md",
-  "memories/soma/memory-layout.md",
-  "memories/soma/pai-imports.md",
-  "memories/soma/skills.md",
-  "memories/soma/policy.md",
-  "memories/soma/soma-repo.txt",
-  "AGENTS.md",
-  "config.toml",
-] as const;
-
-const CODEX_AGENTS_IMPORTS = ["@./skills/the-algorithm/SKILL.md", "@./memories/soma/startup-context.md"] as const;
 
 const PI_DEV_HOME_FILES = [
   "agent/extensions/soma.ts",
@@ -101,17 +77,15 @@ const SKILL_SUBPATHS: Record<Exclude<InstallSubstrate, "pi-dev">, string> = {
   cursor: ".cursor/rules/soma/skills/ISA",
 };
 
-type InstallSubstrate = "codex" | "pi-dev" | "claude-code" | "cursor";
-
 const INSTALL_VALIDATORS: Partial<Record<InstallSubstrate, (substrateRoot: string) => Promise<void>>> = {
   "pi-dev": validatePiDevInstallRuntime,
 };
 
 function resolveInstallHomes(substrate: InstallSubstrate, options: SomaInstallOptions): { somaHome: string; substrateHome: string } {
   const homeDir = options.homeDir;
-  const defaultSubstrateHome = DEFAULT_SUBSTRATE_HOMES[substrate];
+  const defaultHome = defaultSubstrateHome(substrate);
   const somaHome = options.somaHome ?? `${homeDir ?? "~"}/.soma`;
-  const defaultRoot = defaultSubstrateHome === "." ? `${homeDir ?? "~"}` : `${homeDir ?? "~"}/${defaultSubstrateHome}`;
+  const defaultRoot = defaultHome === "." ? `${homeDir ?? "~"}` : `${homeDir ?? "~"}/${defaultHome}`;
   const substrateHome = options.substrateHome ?? defaultRoot;
 
   return {
@@ -159,7 +133,7 @@ function planSomaInstall(
 }
 
 export function planSomaForCodexInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
-  return planSomaInstall("codex", CODEX_HOME_FILES, options);
+  return planSomaInstall(codexInstallSpec.substrate, codexInstallSpec.homeFiles, options);
 }
 
 export function planSomaForPiDevInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
@@ -205,7 +179,7 @@ async function installSomaForSubstrate(
   // baseline tracking via `skillDestinationDir`. AC-5: drift detection
   // inherits installIsaSkill's local-edits-preserved contract.
   const resolvedHomeDir = resolve(options.homeDir ?? homedir());
-  const substrateRoot = resolve(options.substrateHome ?? join(resolvedHomeDir, DEFAULT_SUBSTRATE_HOMES[substrate]));
+  const substrateRoot = resolve(options.substrateHome ?? join(resolvedHomeDir, defaultSubstrateHome(substrate)));
   await INSTALL_VALIDATORS[substrate]?.(substrateRoot);
   await prepareSubstrateSkillDestination(substrate, substrateRoot);
   await installIsaSkillProjection({
@@ -222,26 +196,42 @@ async function installSomaForSubstrate(
     activeIsa: (await loadActiveIsaForBundle({ somaHome: somaHome.somaHome })) ?? undefined,
   };
   const substrateHome = await installHomeProjectionFor(substrate, contextWithActiveIsa, projectionOptions);
-  const configFiles = substrate === "codex" ? [await configureCodexInstall(substrateHome.rootDir, somaHome.somaHome)] : [];
-  const agentsFiles = substrate === "codex" ? [await configureCodexAgentsImport(substrateHome.rootDir)] : [];
-  const lifecycleFiles =
-    substrate === "claude-code" || substrate === "cursor"
-      ? []
-      : await installLifecycleProjection(substrate, substrateHome.rootDir, {
-          homeDir: options.homeDir,
-          somaHome: somaHome.somaHome,
-          somaRepoPath: projectionOptions.somaRepoPath,
-          substrate,
-        });
+  const spec = installSpecFor(substrate);
+  const postProjectionFiles = await runPostProjectionSteps(spec, {
+    homeDir: options.homeDir,
+    somaHome: somaHome.somaHome,
+    somaRepoPath: projectionOptions.somaRepoPath,
+    substrateHome: substrateHome.rootDir,
+  });
+  const lifecycleSpec = spec?.lifecycleProjection ?? legacyLifecycleProjectionSpec(substrate);
+  const lifecycleFiles = lifecycleSpec
+    ? await installLifecycleProjection(lifecycleSpec, substrateHome.rootDir, {
+        homeDir: options.homeDir,
+        somaHome: somaHome.somaHome,
+        somaRepoPath: projectionOptions.somaRepoPath,
+        substrate,
+      })
+    : [];
 
   return {
     substrate,
     somaHome,
     substrateHome: {
       ...substrateHome,
-      files: [...substrateHome.files, ...agentsFiles, ...configFiles, ...lifecycleFiles],
+      files: [...substrateHome.files, ...postProjectionFiles, ...lifecycleFiles],
     },
   };
+}
+
+async function runPostProjectionSteps(
+  spec: SubstrateInstallSpec | undefined,
+  context: { homeDir?: string; somaHome: string; somaRepoPath: string; substrateHome: string },
+): Promise<string[]> {
+  const files: string[] = [];
+  for (const step of spec?.postProjection ?? []) {
+    files.push(...(await step.run(context)));
+  }
+  return files;
 }
 
 async function installHomeProjectionFor(
@@ -261,21 +251,6 @@ async function installHomeProjectionFor(
   }
 }
 
-async function configureCodexAgentsImport(codexHome: string): Promise<string> {
-  const path = join(codexHome, "AGENTS.md");
-  const existing = await readFile(path, "utf8").catch(() => "");
-  const existingLines = new Set(existing.split("\n").map((line) => line.trim()));
-  const missingImports = CODEX_AGENTS_IMPORTS.filter((line) => !existingLines.has(line));
-
-  if (missingImports.length > 0) {
-    const separator = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
-    await mkdir(dirname(path), { recursive: true });
-    await writeFile(path, `${existing}${separator}${missingImports.join("\n")}\n`, "utf8");
-  }
-
-  return path;
-}
-
 async function writeProjectionFile(root: string, relativePath: string, content: string): Promise<string> {
   const path = join(root, relativePath);
 
@@ -285,22 +260,27 @@ async function writeProjectionFile(root: string, relativePath: string, content: 
   return path;
 }
 
+function legacyLifecycleProjectionSpec(substrate: InstallSubstrate): LifecycleProjectionSpec | undefined {
+  if (substrate === "pi-dev") {
+    return {
+      startupContextPath: "agent/soma/startup-context.md",
+      somaRepoPathPath: "agent/soma/soma-repo.txt",
+    };
+  }
+  return undefined;
+}
+
 async function installLifecycleProjection(
-  substrate: Exclude<InstallSubstrate, "claude-code">,
+  lifecycle: LifecycleProjectionSpec,
   substrateHome: string,
-  options: { homeDir?: string; somaHome: string; somaRepoPath: string; substrate: Exclude<InstallSubstrate, "claude-code"> },
+  options: { homeDir?: string; somaHome: string; somaRepoPath: string; substrate: InstallSubstrate },
 ): Promise<string[]> {
   await runSomaLifecycleAlgorithmUpdated(options);
   const startup = await buildSomaStartupContext(options);
-  const relativePath = substrate === "codex" ? "memories/soma/startup-context.md" : "agent/soma/startup-context.md";
-  const files = [await writeProjectionFile(substrateHome, relativePath, startup.context)];
+  const files = [await writeProjectionFile(substrateHome, lifecycle.startupContextPath, startup.context)];
 
-  if (substrate === "codex") {
-    files.push(await writeProjectionFile(substrateHome, "memories/soma/soma-repo.txt", options.somaRepoPath));
-  }
-
-  if (substrate === "pi-dev") {
-    files.push(await writeProjectionFile(substrateHome, "agent/soma/soma-repo.txt", options.somaRepoPath));
+  if (lifecycle.somaRepoPathPath) {
+    files.push(await writeProjectionFile(substrateHome, lifecycle.somaRepoPathPath, options.somaRepoPath));
   }
 
   return files;
@@ -394,7 +374,7 @@ export async function uninstallSomaForClaudeCode(
   options: UninstallClaudeCodeOptions = {},
 ): Promise<UninstallClaudeCodeResult> {
   const resolvedHomeDir = resolve(options.homeDir ?? homedir());
-  const substrateHome = resolve(options.substrateHome ?? join(resolvedHomeDir, DEFAULT_SUBSTRATE_HOMES["claude-code"]));
+  const substrateHome = resolve(options.substrateHome ?? join(resolvedHomeDir, defaultSubstrateHome("claude-code")));
   const targets = [join(substrateHome, "rules/soma"), join(substrateHome, "skills/ISA")];
   const removed = await removeExistingTargets(targets);
   return { substrate: "claude-code", substrateHome, removed };
@@ -404,7 +384,7 @@ export async function uninstallSomaForCursor(
   options: UninstallCursorOptions = {},
 ): Promise<UninstallCursorResult> {
   const resolvedHomeDir = resolve(options.homeDir ?? homedir());
-  const substrateHome = resolve(options.substrateHome ?? join(resolvedHomeDir, DEFAULT_SUBSTRATE_HOMES.cursor));
+  const substrateHome = resolve(options.substrateHome ?? join(resolvedHomeDir, defaultSubstrateHome("cursor")));
   const cursorRulesDir = join(substrateHome, ".cursor/rules/soma");
   const cursorRulesFile = join(substrateHome, ".cursorrules");
   const removed = await removeExistingTargets([cursorRulesDir], async () => {

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,7 +1,7 @@
 import { homedir } from "node:os";
 import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import { codexInstallSpec } from "./adapters/codex";
+import { codexInstallSpec } from "./adapters/codex/install";
 import { CURSOR_HOME_FILE_PATHS } from "./adapters/cursor";
 import {
   PI_DEV_ISA_SKILL_ID,

--- a/src/projection-private-roots.ts
+++ b/src/projection-private-roots.ts
@@ -1,10 +1,11 @@
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { codexInstallSpec } from "./adapters/codex/install";
 import type { SubstrateId } from "./types";
 
 export function somaProjectionPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
   const home = resolve(options.homeDir ?? homedir());
-  const codexRoots = [join(home, ".codex", "skills", "soma")];
+  const codexRoots = codexInstallSpec.privateRoots?.projection?.(options) ?? [];
   const piDevRoots = [join(home, ".pi", "agent", "soma"), join(home, ".pi", "agent", "skills", "soma")];
 
   if (options.substrate === "codex") return codexRoots.map((path) => resolve(path));
@@ -14,8 +15,7 @@ export function somaProjectionPrivateRoots(options: { homeDir?: string; substrat
 }
 
 export function somaMemoryPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
-  const home = resolve(options.homeDir ?? homedir());
-  const codexMemoryRoots = [join(home, ".codex", "memories")];
+  const codexMemoryRoots = codexInstallSpec.privateRoots?.memory?.(options) ?? [];
 
   if (options.substrate === undefined || options.substrate === "codex") return codexMemoryRoots.map((path) => resolve(path));
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -4,11 +4,13 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import { installSomaForCodex, installSomaForPiDev, planSomaForCodexInstall, planSomaForPiDevInstall } from "../src/index";
+import { codexInstallSpec } from "../src/adapters/codex/install";
 import { renderStartupContextSummary } from "../src/adapters/codex/hooks/codex-hook-entry.mjs";
 import {
   SOMA_MEMORY_CATEGORIES,
   SOMA_PAI_BOUND_MEMORY_CATEGORIES,
 } from "../src/memory-readmes";
+import { somaMemoryPrivateRoots, somaProjectionPrivateRoots } from "../src/projection-private-roots";
 
 // #88 — Canonical PAI v5.0.0 memory taxonomy (DD-2). 17 substrate-neutral +
 // 2 PAI-bound = 19. Tests consume the production-exported lists from
@@ -158,12 +160,27 @@ test("codex install dry-run lists every substrate file apply reports", async () 
     const plan = planSomaForCodexInstall({ homeDir });
     const result = await installSomaForCodex({ homeDir });
 
+    expect(plan.substrateHome).toBe(join(homeDir, codexInstallSpec.defaultHome));
+    expect(plan.substrateFiles).toEqual(codexInstallSpec.homeFiles.map((path) => join(homeDir, ".codex", path)));
     expect(plan.substrateFiles).toContain(join(homeDir, ".codex/config.toml"));
     expect(plan.substrateFiles).toContain(join(homeDir, ".codex/memories/soma/soma-repo.txt"));
     expect(plan.substrateFiles).toContain(join(homeDir, ".codex/AGENTS.md"));
     expect(plan.substrateFiles).toContain(join(homeDir, ".codex/skills/the-algorithm/SKILL.md"));
     expect(new Set(plan.substrateFiles)).toEqual(new Set(result.substrateHome.files));
   });
+});
+
+test("codex install spec owns lifecycle and private root facts", () => {
+  const homeDir = "/tmp/soma-install-spec-home";
+
+  expect(codexInstallSpec.lifecycleProjection).toEqual({
+    startupContextPath: "memories/soma/startup-context.md",
+    somaRepoPathPath: "memories/soma/soma-repo.txt",
+  });
+  expect(codexInstallSpec.postProjection?.map((step) => step.name)).toEqual(["codex-agents-import", "codex-config"]);
+  expect(codexInstallSpec.uninstall.kind).toBe("reserved");
+  expect(somaProjectionPrivateRoots({ homeDir, substrate: "codex" })).toEqual([join(homeDir, ".codex/skills/soma")]);
+  expect(somaMemoryPrivateRoots({ homeDir, substrate: "codex" })).toEqual([join(homeDir, ".codex/memories")]);
 });
 
 test("pi.dev install dry-run lists every substrate file apply reports", async () => {


### PR DESCRIPTION
## Summary
- record the adapter-owned install facts decision in substrate adapter docs and DD-4
- add internal install spec types plus a registry for default substrate homes
- move Codex install facts, lifecycle paths, post-projection steps, and private roots into the Codex adapter area
- preserve existing installer/projection behavior through compatibility wrappers and tests

## Verification
- bun run typecheck
- bun test test/install.test.ts test/home-projection.test.ts
- bun test