### PR TITLE
Refactor import CLI command module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,18 +4,10 @@ import {
   checkSomaPolicy,
   captureSomaFeedback,
   captureSomaResult,
-  importAlgorithm,
-  importPaiDocs,
-  importPaiIdentity,
-  importPaiPack,
   installSomaForClaudeCode,
   planSomaForClaudeCodeInstall,
   uninstallSomaForClaudeCode,
   type UninstallClaudeCodeOptions,
-  planAlgorithmImport,
-  planPaiDocsImport,
-  planPaiImport,
-  planPaiPackImport,
   promoteAlgorithmRunMemory,
   runSomaLifecycleAlgorithmUpdated,
   runSomaLifecycleSessionEnd,
@@ -24,18 +16,6 @@ import {
   searchSomaResults,
 } from "./index";
 import type {
-  AlgorithmImportOptions,
-  AlgorithmImportPlan,
-  AlgorithmImportResult,
-  PaiImportOptions,
-  PaiImportPlan,
-  PaiImportResult,
-  PaiPackImportOptions,
-  PaiPackImportPlan,
-  PaiPackImportResult,
-  PaiDocsImportOptions,
-  PaiDocsImportPlan,
-  PaiDocsImportResult,
   SomaInstallOptions,
   SomaDoctorDiagnosis,
   SomaInitPlan,
@@ -60,7 +40,6 @@ import type {
 } from "./types";
 import { SOMA_FEEDBACK_STDIN_MAX_BYTES } from "./feedback-contract";
 import { ISA_SUBCOMMAND_HELP, ISA_USAGE_HEADER, runIsaCli } from "./cli-isa";
-import { warnDeprecatedSubstrateFlag } from "./cli/deprecated-flags";
 import { readOption } from "./cli/parse-utils";
 import { parseSubstrate } from "./cli/substrate";
 import {
@@ -97,11 +76,12 @@ import {
   runMigrateCli,
   type ParsedMigrateArgs,
 } from "./cli/migrate";
-// CLI formatter for `import pai-docs` needs the same in-scope subtree
-// list the importer iterates. Importing directly from the module
-// keeps the constant a module-internal contract rather than promoting
-// importer policy through the package root surface.
-import { PAI_DOCS_IMPORT_SUBDIRS } from "./pai-docs-importer";
+import {
+  IMPORT_COMMAND_HELP,
+  parseImportArgs,
+  runImportCli,
+  type ParsedImportArgs,
+} from "./cli/import";
 import { runInferenceCli } from "./tools/inference/cli";
 import { runLearningCli, runMetricsCli, runOpinionCli, runSessionCli } from "./tools/learning/cli";
 import { RELATIONSHIP_REFLECT_USAGE, runRelationshipCli } from "./tools/relationship/cli";
@@ -122,13 +102,6 @@ interface ParsedInitArgs {
 interface ParsedDoctorArgs {
   command: "doctor";
   options: SomaOnboardingOptions;
-}
-
-interface ParsedImportArgs {
-  command: "import";
-  source: "pai" | "algorithm" | "pai-pack" | "pai-docs";
-  apply: boolean;
-  options: PaiImportOptions | AlgorithmImportOptions | PaiPackImportOptions | PaiDocsImportOptions;
 }
 
 interface ParsedAdoptArgs {
@@ -351,15 +324,7 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
   doctor: {
     usage: DOCTOR_USAGE,
   },
-  import: {
-    usage: "Usage: soma import <pai|algorithm|pai-pack|pai-docs> ...",
-    subcommands: {
-      pai: "Usage: soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>]",
-      algorithm: "Usage: soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
-      "pai-pack": "Usage: soma import pai-pack [--dry-run] [--apply] [--home-dir <dir>] [--source <dir>] [--soma-home <dir>]",
-      "pai-docs": "Usage: soma import pai-docs [--dry-run] [--apply] [--home-dir <dir>] --pai-source-dir <dir> [--soma-home <dir>]",
-    },
-  },
+  import: IMPORT_COMMAND_HELP,
   migrate: MIGRATE_COMMAND_HELP,
   adopt: {
     usage: ADOPT_CLAUDE_USAGE,
@@ -375,119 +340,6 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
 function commandUsage(command: string, action?: string): string {
   const commandHelp = COMMAND_HELP[command] as { usage: string; subcommands?: Record<string, string> } | undefined;
   return (action ? commandHelp?.subcommands?.[action] : undefined) ?? commandHelp?.usage ?? `Usage: soma ${command} ...`;
-}
-
-function parseImportArgs(args: string[]): ParsedImportArgs {
-  const [command, source, ...rest] = args;
-
-  if (
-    command !== "import" ||
-    (source !== "pai" &&
-      source !== "algorithm" &&
-      source !== "pai-pack" &&
-      source !== "pai-docs")
-  ) {
-    throw new Error(
-      [
-        "Usage:",
-        "  soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>]",
-        "  soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
-        "  soma import pai-pack [--dry-run] [--apply] [--home-dir <dir>] --pai-pack-dir <dir> [--soma-home <dir>] [--skill-name <name>] [--overwrite] [--include-unrecognized]",
-        "  soma import pai-docs [--dry-run] [--apply] [--home-dir <dir>] --pai-source-dir <dir> [--soma-home <dir>]",
-      ].join("\n"),
-    );
-  }
-
-  const options: PaiImportOptions &
-    AlgorithmImportOptions &
-    PaiPackImportOptions &
-    PaiDocsImportOptions = {};
-  let apply = false;
-
-  for (let index = 0; index < rest.length; index += 1) {
-    const arg = rest[index];
-
-    switch (arg) {
-      case "--dry-run":
-        apply = false;
-        break;
-      case "--apply":
-        apply = true;
-        break;
-      case "--home-dir":
-        options.homeDir = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--claude-home":
-        if (source !== "pai") {
-          throw new Error("--claude-home is only valid for soma import pai.");
-        }
-        options.claudeHome = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--pai-algorithm-dir":
-        if (source !== "algorithm") {
-          throw new Error("--pai-algorithm-dir is only valid for soma import algorithm.");
-        }
-        options.paiAlgorithmDir = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--pai-pack-dir":
-        if (source !== "pai-pack") {
-          throw new Error("--pai-pack-dir is only valid for soma import pai-pack.");
-        }
-        options.paiPackDir = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--pai-source-dir":
-        if (source !== "pai-docs") {
-          throw new Error("--pai-source-dir is only valid for soma import pai-docs.");
-        }
-        options.paiSourceDir = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--skill-name":
-        if (source !== "pai-pack") {
-          throw new Error("--skill-name is only valid for soma import pai-pack.");
-        }
-        options.skillName = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--overwrite":
-        if (source !== "pai-pack") {
-          throw new Error("--overwrite is only valid for soma import pai-pack.");
-        }
-        options.overwrite = true;
-        break;
-      case "--include-unrecognized":
-        // #106 — canonical name; legacy flag below is the deprecated alias.
-        if (source !== "pai-pack") {
-          throw new Error("--include-unrecognized is only valid for soma import pai-pack.");
-        }
-        options.includeSubstrateSpecific = true;
-        break;
-      case "--include-substrate-specific":
-        if (source !== "pai-pack") {
-          throw new Error("--include-substrate-specific is only valid for soma import pai-pack.");
-        }
-        warnDeprecatedSubstrateFlag();
-        options.includeSubstrateSpecific = true;
-        break;
-      case "--soma-home":
-        options.somaHome = readOption(rest, index, arg);
-        index += 1;
-        break;
-      default:
-        throw new Error(`Unknown option: ${arg}`);
-    }
-  }
-
-  return {
-    command,
-    source,
-    apply,
-    options,
-  };
 }
 
 function parseMemoryPromotionStore(value: string): SomaMemoryPromotionStore {
@@ -1360,212 +1212,6 @@ function formatSomaDoctorDiagnosis(diagnosis: SomaDoctorDiagnosis): string {
   ].join("\n");
 }
 
-function formatPaiImportPlan(plan: PaiImportPlan): string {
-  const sourceLines =
-    plan.sourceChecks && plan.sourceChecks.length > 0
-      ? plan.sourceChecks.map((check) => `- [${check.present ? "present" : "missing"}] ${check.required ? "required" : "optional"} ${check.path}`)
-      : plan.sourceFiles.map((path) => `- ${path}`);
-
-  return [
-    "Soma PAI import plan",
-    "source: pai",
-    `mode: ${plan.apply ? "apply" : "dry-run"}`,
-    `claudeHome: ${plan.claudeHome}`,
-    `somaHome: ${plan.somaHome}`,
-    "",
-    "Source files:",
-    ...sourceLines,
-    "",
-    "Target files:",
-    ...plan.targetFiles.map((path) => `- ${path}`),
-  ].join("\n");
-}
-
-function formatPaiImportResult(result: PaiImportResult): string {
-  return [
-    "Soma PAI import applied",
-    `claudeHome: ${result.claudeHome}`,
-    `somaHome: ${result.somaHome}`,
-    "",
-    "Files:",
-    ...result.files.map((path) => `- ${path}`),
-  ].join("\n");
-}
-
-function formatAlgorithmImportPlan(plan: AlgorithmImportPlan): string {
-  const sourceLines =
-    plan.sourceChecks && plan.sourceChecks.length > 0
-      ? plan.sourceChecks.map((check) => `- [${check.present ? "present" : "missing"}] ${check.required ? "required" : "optional"} ${check.path}`)
-      : plan.sourceFiles.map((path) => `- ${path}`);
-
-  return [
-    "Soma Algorithm import plan",
-    "source: algorithm",
-    `mode: ${plan.apply ? "apply" : "dry-run"}`,
-    `paiAlgorithmDir: ${plan.paiAlgorithmDir}`,
-    `somaHome: ${plan.somaHome}`,
-    "",
-    "Source files:",
-    ...sourceLines,
-    "",
-    "Target files:",
-    ...plan.targetFiles.map((path) => `- ${path}`),
-  ].join("\n");
-}
-
-function formatAlgorithmImportResult(result: AlgorithmImportResult): string {
-  return [
-    "Soma Algorithm import applied",
-    `paiAlgorithmDir: ${result.paiAlgorithmDir}`,
-    `somaHome: ${result.somaHome}`,
-    "",
-    "Files:",
-    ...result.files.map((path) => `- ${path}`),
-  ].join("\n");
-}
-
-function formatOnePaiPackImportPlan(plan: PaiPackImportPlan): string {
-  const counts = plan.files.reduce<Partial<Record<string, number>>>((acc, file) => {
-    acc[file.classification] = (acc[file.classification] ?? 0) + 1;
-    return acc;
-  }, {});
-
-  const normalizationLines: string[] = [];
-  if (plan.normalization.actions.length > 0 || plan.normalization.warnings.length > 0) {
-    normalizationLines.push("", "Normalization:");
-    if (plan.normalization.actions.length > 0) {
-      normalizationLines.push(`  actions: ${plan.normalization.actions.length}`);
-      for (const action of plan.normalization.actions) {
-        normalizationLines.push(`  - [action] ${action.file}: ${action.kind} — ${action.detail}`);
-      }
-    }
-    if (plan.normalization.warnings.length > 0) {
-      normalizationLines.push(`  warnings: ${plan.normalization.warnings.length}`);
-      for (const warning of plan.normalization.warnings) {
-        normalizationLines.push(`  - [warning] ${warning.file}: ${warning.kind} — ${warning.detail}`);
-      }
-    }
-  } else {
-    normalizationLines.push("", "Normalization: no actions, no warnings");
-  }
-
-  return [
-    "Soma PAI Pack import plan",
-    "source: pai-pack",
-    `mode: ${plan.apply ? "apply" : "dry-run"}`,
-    `paiPackDir: ${plan.paiPackDir}`,
-    `somaHome: ${plan.somaHome}`,
-    `skillName: ${plan.skillName}`,
-    `packName: ${plan.packName}`,
-    `description: ${plan.description}`,
-    "",
-    "Classification:",
-    `- portable: ${counts.portable ?? 0}`,
-    `- template: ${counts.template ?? 0}`,
-    `- source-doc: ${counts["source-doc"] ?? 0}`,
-    `- unrecognized-layout: ${counts["unrecognized-layout"] ?? 0}`,
-    ...normalizationLines,
-    "",
-    "Files:",
-    ...plan.files.map((file) => {
-      const source = file.origin === "source" ? file.source : `generated:${file.generator}`;
-      return `- [${file.classification}] ${source} -> ${file.target}`;
-    }),
-  ].join("\n");
-}
-
-/**
- * #105 — `importPaiPack` / `planPaiPackImport` now return an array
- * (one entry per derived skill). The CLI prints each plan/result in
- * turn separated by a blank line so multi-skill packs surface every
- * derived skill to the principal.
- */
-function formatPaiPackImportPlan(plans: PaiPackImportPlan[]): string {
-  if (plans.length === 0) return "Soma PAI Pack import plan: no derived skills.";
-  if (plans.length === 1) return formatOnePaiPackImportPlan(plans[0]);
-  const header = `Soma PAI Pack import plan: ${plans.length} derived skill(s) — ${plans.map((p) => p.skillName).join(", ")}`;
-  return [header, "", ...plans.map(formatOnePaiPackImportPlan)].join("\n\n");
-}
-
-function formatOnePaiPackImportResult(result: PaiPackImportResult): string {
-  const quotedSomaHome = quoteShellArg(result.somaHome);
-
-  const normalizationLines: string[] = [];
-  if (result.normalization.actions.length > 0 || result.normalization.warnings.length > 0) {
-    normalizationLines.push("", "Normalization applied:");
-    normalizationLines.push(`  actions: ${result.normalization.actions.length}`);
-    normalizationLines.push(`  warnings: ${result.normalization.warnings.length}`);
-  }
-
-  return [
-    "Soma PAI Pack import applied",
-    `paiPackDir: ${result.paiPackDir}`,
-    `somaHome: ${result.somaHome}`,
-    `skillName: ${result.skillName}`,
-    ...normalizationLines,
-    "",
-    "Next step:",
-    "Import makes the skill available in Soma. Refresh the target substrate projection before expecting the skill in that substrate.",
-    `bun run soma install <substrate> --apply --soma-home ${quotedSomaHome}`,
-    "",
-    "Files:",
-    ...result.files.map((path) => `- ${path}`),
-  ].join("\n");
-}
-
-function formatPaiPackImportResult(results: PaiPackImportResult[]): string {
-  if (results.length === 0) return "Soma PAI Pack import applied: no derived skills.";
-  if (results.length === 1) return formatOnePaiPackImportResult(results[0]);
-  const header = `Soma PAI Pack import applied: ${results.length} derived skill(s) — ${results.map((r) => r.skillName).join(", ")}`;
-  return [header, "", ...results.map(formatOnePaiPackImportResult)].join("\n\n");
-}
-
-function formatPaiDocsImportPlan(plan: PaiDocsImportPlan): string {
-  const counts = plan.files.reduce<Partial<Record<string, number>>>((acc, file) => {
-    acc[file.subdir] = (acc[file.subdir] ?? 0) + 1;
-    return acc;
-  }, {});
-
-  return [
-    "Soma PAI docs import plan",
-    "source: pai-docs",
-    `mode: ${plan.apply ? "apply" : "dry-run"}`,
-    `paiSourceDir: ${plan.paiSourceDir}`,
-    `somaHome: ${plan.somaHome}`,
-    `releaseVersion: ${plan.releaseVersion ?? "<unknown>"}`,
-    "",
-    "Counts:",
-    // Drive the counts from the shared subtree constant so adding a
-    // subtree only requires touching `PAI_DOCS_IMPORT_SUBDIRS`.
-    ...PAI_DOCS_IMPORT_SUBDIRS.map((subdir) => `- ${subdir}: ${counts[subdir] ?? 0}`),
-    "",
-    "Files:",
-    ...plan.files.map((file) => `- ${file.relativePath} -> ${file.target}`),
-  ].join("\n");
-}
-
-function formatPaiDocsImportResult(result: PaiDocsImportResult): string {
-  return [
-    "Soma PAI docs import applied",
-    `paiSourceDir: ${result.paiSourceDir}`,
-    `somaHome: ${result.somaHome}`,
-    `releaseVersion: ${result.releaseVersion ?? "<unknown>"}`,
-    `importedAt: ${result.importedAt}`,
-    `writtenCount: ${result.writtenCount}${result.unchanged ? " (idempotent no-op — source SHAs unchanged)" : ""}`,
-    "",
-    "Files:",
-    ...result.files.map((path) => `- ${path}`),
-  ].join("\n");
-}
-
-function quoteShellArg(value: string): string {
-  if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) {
-    return value;
-  }
-
-  return `'${value.replaceAll("'", "'\"'\"'")}'`;
-}
-
 function formatLifecycleResult(result: SomaLifecycleResult): string {
   const lines = [
     "Soma lifecycle event handled",
@@ -1832,43 +1478,7 @@ export async function runSomaCli(args: string[]): Promise<string> {
   }
 
   if (parsed.command === "import") {
-    if (parsed.source === "algorithm") {
-      const options = parsed.options as AlgorithmImportOptions;
-
-      if (!parsed.apply) {
-        return formatAlgorithmImportPlan(planAlgorithmImport(options));
-      }
-
-      return formatAlgorithmImportResult(await importAlgorithm(options));
-    }
-
-    if (parsed.source === "pai-pack") {
-      const options = parsed.options as PaiPackImportOptions;
-
-      if (!parsed.apply) {
-        return formatPaiPackImportPlan(await planPaiPackImport(options));
-      }
-
-      return formatPaiPackImportResult(await importPaiPack(options));
-    }
-
-    if (parsed.source === "pai-docs") {
-      const options = parsed.options as PaiDocsImportOptions;
-
-      if (!parsed.apply) {
-        return formatPaiDocsImportPlan(await planPaiDocsImport(options));
-      }
-
-      return formatPaiDocsImportResult(await importPaiDocs(options));
-    }
-
-    const options = parsed.options as PaiImportOptions;
-
-    if (!parsed.apply) {
-      return formatPaiImportPlan(planPaiImport(options));
-    }
-
-    return formatPaiImportResult(await importPaiIdentity(options));
+    return runImportCli(parsed);
   }
 
   if (parsed.command === "migrate") {

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -1,0 +1,418 @@
+import {
+  importAlgorithm,
+  importPaiDocs,
+  importPaiIdentity,
+  importPaiPack,
+  planAlgorithmImport,
+  planPaiDocsImport,
+  planPaiImport,
+  planPaiPackImport,
+} from "../index";
+import type {
+  AlgorithmImportOptions,
+  AlgorithmImportPlan,
+  AlgorithmImportResult,
+  PaiDocsImportOptions,
+  PaiDocsImportPlan,
+  PaiDocsImportResult,
+  PaiImportOptions,
+  PaiImportPlan,
+  PaiImportResult,
+  PaiPackImportOptions,
+  PaiPackImportPlan,
+  PaiPackImportResult,
+} from "../types";
+import { PAI_DOCS_IMPORT_SUBDIRS } from "../pai-docs-importer";
+import { warnDeprecatedSubstrateFlag } from "./deprecated-flags";
+import { readOption } from "./parse-utils";
+
+export type ImportSource = "pai" | "algorithm" | "pai-pack" | "pai-docs";
+
+export type ParsedImportArgs =
+  | {
+      command: "import";
+      source: "pai";
+      apply: boolean;
+      options: PaiImportOptions;
+    }
+  | {
+      command: "import";
+      source: "algorithm";
+      apply: boolean;
+      options: AlgorithmImportOptions;
+    }
+  | {
+      command: "import";
+      source: "pai-pack";
+      apply: boolean;
+      options: PaiPackImportOptions;
+    }
+  | {
+      command: "import";
+      source: "pai-docs";
+      apply: boolean;
+      options: PaiDocsImportOptions;
+    };
+
+export const IMPORT_COMMAND_HELP: { usage: string; subcommands: Record<ImportSource, string> } = {
+  usage: "Usage: soma import <pai|algorithm|pai-pack|pai-docs> ...",
+  subcommands: {
+    pai: "Usage: soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>]",
+    algorithm: "Usage: soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
+    "pai-pack": "Usage: soma import pai-pack [--dry-run] [--apply] [--home-dir <dir>] --pai-pack-dir <dir> [--soma-home <dir>] [--skill-name <name>] [--overwrite] [--include-unrecognized]",
+    "pai-docs": "Usage: soma import pai-docs [--dry-run] [--apply] [--home-dir <dir>] --pai-source-dir <dir> [--soma-home <dir>]",
+  },
+};
+
+export function parseImportArgs(args: string[]): ParsedImportArgs {
+  const [command, source, ...rest] = args;
+
+  if (command !== "import" || !isImportSource(source)) {
+    throw new Error(
+      [
+        "Usage:",
+        "  soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>]",
+        "  soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
+        "  soma import pai-pack [--dry-run] [--apply] [--home-dir <dir>] --pai-pack-dir <dir> [--soma-home <dir>] [--skill-name <name>] [--overwrite] [--include-unrecognized]",
+        "  soma import pai-docs [--dry-run] [--apply] [--home-dir <dir>] --pai-source-dir <dir> [--soma-home <dir>]",
+      ].join("\n"),
+    );
+  }
+
+  const options: PaiImportOptions &
+    AlgorithmImportOptions &
+    PaiPackImportOptions &
+    PaiDocsImportOptions = {};
+  let apply = false;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+
+    switch (arg) {
+      case "--dry-run":
+        apply = false;
+        break;
+      case "--apply":
+        apply = true;
+        break;
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--claude-home":
+        if (source !== "pai") {
+          throw new Error("--claude-home is only valid for soma import pai.");
+        }
+        options.claudeHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--pai-algorithm-dir":
+        if (source !== "algorithm") {
+          throw new Error("--pai-algorithm-dir is only valid for soma import algorithm.");
+        }
+        options.paiAlgorithmDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--pai-pack-dir":
+        if (source !== "pai-pack") {
+          throw new Error("--pai-pack-dir is only valid for soma import pai-pack.");
+        }
+        options.paiPackDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--pai-source-dir":
+        if (source !== "pai-docs") {
+          throw new Error("--pai-source-dir is only valid for soma import pai-docs.");
+        }
+        options.paiSourceDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--skill-name":
+        if (source !== "pai-pack") {
+          throw new Error("--skill-name is only valid for soma import pai-pack.");
+        }
+        options.skillName = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--overwrite":
+        if (source !== "pai-pack") {
+          throw new Error("--overwrite is only valid for soma import pai-pack.");
+        }
+        options.overwrite = true;
+        break;
+      case "--include-unrecognized":
+        // #106 — canonical name; legacy flag below is the deprecated alias.
+        if (source !== "pai-pack") {
+          throw new Error("--include-unrecognized is only valid for soma import pai-pack.");
+        }
+        options.includeSubstrateSpecific = true;
+        break;
+      case "--include-substrate-specific":
+        if (source !== "pai-pack") {
+          throw new Error("--include-substrate-specific is only valid for soma import pai-pack.");
+        }
+        warnDeprecatedSubstrateFlag();
+        options.includeSubstrateSpecific = true;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (source === "algorithm") {
+    return { command, source, apply, options };
+  }
+  if (source === "pai-pack") {
+    return { command, source, apply, options };
+  }
+  if (source === "pai-docs") {
+    return { command, source, apply, options };
+  }
+  return { command, source, apply, options };
+}
+
+function isImportSource(source: string | undefined): source is ImportSource {
+  return source === "pai" || source === "algorithm" || source === "pai-pack" || source === "pai-docs";
+}
+
+function formatPaiImportPlan(plan: PaiImportPlan): string {
+  const sourceLines =
+    plan.sourceChecks && plan.sourceChecks.length > 0
+      ? plan.sourceChecks.map((check) => `- [${check.present ? "present" : "missing"}] ${check.required ? "required" : "optional"} ${check.path}`)
+      : plan.sourceFiles.map((path) => `- ${path}`);
+
+  return [
+    "Soma PAI import plan",
+    "source: pai",
+    `mode: ${plan.apply ? "apply" : "dry-run"}`,
+    `claudeHome: ${plan.claudeHome}`,
+    `somaHome: ${plan.somaHome}`,
+    "",
+    "Source files:",
+    ...sourceLines,
+    "",
+    "Target files:",
+    ...plan.targetFiles.map((path) => `- ${path}`),
+  ].join("\n");
+}
+
+function formatPaiImportResult(result: PaiImportResult): string {
+  return [
+    "Soma PAI import applied",
+    `claudeHome: ${result.claudeHome}`,
+    `somaHome: ${result.somaHome}`,
+    "",
+    "Files:",
+    ...result.files.map((path) => `- ${path}`),
+  ].join("\n");
+}
+
+function formatAlgorithmImportPlan(plan: AlgorithmImportPlan): string {
+  const sourceLines =
+    plan.sourceChecks && plan.sourceChecks.length > 0
+      ? plan.sourceChecks.map((check) => `- [${check.present ? "present" : "missing"}] ${check.required ? "required" : "optional"} ${check.path}`)
+      : plan.sourceFiles.map((path) => `- ${path}`);
+
+  return [
+    "Soma Algorithm import plan",
+    "source: algorithm",
+    `mode: ${plan.apply ? "apply" : "dry-run"}`,
+    `paiAlgorithmDir: ${plan.paiAlgorithmDir}`,
+    `somaHome: ${plan.somaHome}`,
+    "",
+    "Source files:",
+    ...sourceLines,
+    "",
+    "Target files:",
+    ...plan.targetFiles.map((path) => `- ${path}`),
+  ].join("\n");
+}
+
+function formatAlgorithmImportResult(result: AlgorithmImportResult): string {
+  return [
+    "Soma Algorithm import applied",
+    `paiAlgorithmDir: ${result.paiAlgorithmDir}`,
+    `somaHome: ${result.somaHome}`,
+    "",
+    "Files:",
+    ...result.files.map((path) => `- ${path}`),
+  ].join("\n");
+}
+
+function formatOnePaiPackImportPlan(plan: PaiPackImportPlan): string {
+  const counts = plan.files.reduce<Partial<Record<string, number>>>((acc, file) => {
+    acc[file.classification] = (acc[file.classification] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const normalizationLines: string[] = [];
+  if (plan.normalization.actions.length > 0 || plan.normalization.warnings.length > 0) {
+    normalizationLines.push("", "Normalization:");
+    if (plan.normalization.actions.length > 0) {
+      normalizationLines.push(`  actions: ${plan.normalization.actions.length}`);
+      for (const action of plan.normalization.actions) {
+        normalizationLines.push(`  - [action] ${action.file}: ${action.kind} — ${action.detail}`);
+      }
+    }
+    if (plan.normalization.warnings.length > 0) {
+      normalizationLines.push(`  warnings: ${plan.normalization.warnings.length}`);
+      for (const warning of plan.normalization.warnings) {
+        normalizationLines.push(`  - [warning] ${warning.file}: ${warning.kind} — ${warning.detail}`);
+      }
+    }
+  } else {
+    normalizationLines.push("", "Normalization: no actions, no warnings");
+  }
+
+  return [
+    "Soma PAI Pack import plan",
+    "source: pai-pack",
+    `mode: ${plan.apply ? "apply" : "dry-run"}`,
+    `paiPackDir: ${plan.paiPackDir}`,
+    `somaHome: ${plan.somaHome}`,
+    `skillName: ${plan.skillName}`,
+    `packName: ${plan.packName}`,
+    `description: ${plan.description}`,
+    "",
+    "Classification:",
+    `- portable: ${counts.portable ?? 0}`,
+    `- template: ${counts.template ?? 0}`,
+    `- source-doc: ${counts["source-doc"] ?? 0}`,
+    `- unrecognized-layout: ${counts["unrecognized-layout"] ?? 0}`,
+    ...normalizationLines,
+    "",
+    "Files:",
+    ...plan.files.map((file) => {
+      const source = file.origin === "source" ? file.source : `generated:${file.generator}`;
+      return `- [${file.classification}] ${source} -> ${file.target}`;
+    }),
+  ].join("\n");
+}
+
+/**
+ * #105 — `importPaiPack` / `planPaiPackImport` now return an array
+ * (one entry per derived skill). The CLI prints each plan/result in
+ * turn separated by a blank line so multi-skill packs surface every
+ * derived skill to the principal.
+ */
+function formatPaiPackImportPlan(plans: PaiPackImportPlan[]): string {
+  if (plans.length === 0) return "Soma PAI Pack import plan: no derived skills.";
+  if (plans.length === 1) return formatOnePaiPackImportPlan(plans[0]);
+  const header = `Soma PAI Pack import plan: ${plans.length} derived skill(s) — ${plans.map((p) => p.skillName).join(", ")}`;
+  return [header, "", ...plans.map(formatOnePaiPackImportPlan)].join("\n\n");
+}
+
+function formatOnePaiPackImportResult(result: PaiPackImportResult): string {
+  const quotedSomaHome = quoteShellArg(result.somaHome);
+
+  const normalizationLines: string[] = [];
+  if (result.normalization.actions.length > 0 || result.normalization.warnings.length > 0) {
+    normalizationLines.push("", "Normalization applied:");
+    normalizationLines.push(`  actions: ${result.normalization.actions.length}`);
+    normalizationLines.push(`  warnings: ${result.normalization.warnings.length}`);
+  }
+
+  return [
+    "Soma PAI Pack import applied",
+    `paiPackDir: ${result.paiPackDir}`,
+    `somaHome: ${result.somaHome}`,
+    `skillName: ${result.skillName}`,
+    ...normalizationLines,
+    "",
+    "Next step:",
+    "Import makes the skill available in Soma. Refresh the target substrate projection before expecting the skill in that substrate.",
+    `bun run soma install <substrate> --apply --soma-home ${quotedSomaHome}`,
+    "",
+    "Files:",
+    ...result.files.map((path) => `- ${path}`),
+  ].join("\n");
+}
+
+function formatPaiPackImportResult(results: PaiPackImportResult[]): string {
+  if (results.length === 0) return "Soma PAI Pack import applied: no derived skills.";
+  if (results.length === 1) return formatOnePaiPackImportResult(results[0]);
+  const header = `Soma PAI Pack import applied: ${results.length} derived skill(s) — ${results.map((r) => r.skillName).join(", ")}`;
+  return [header, "", ...results.map(formatOnePaiPackImportResult)].join("\n\n");
+}
+
+function formatPaiDocsImportPlan(plan: PaiDocsImportPlan): string {
+  const counts = plan.files.reduce<Partial<Record<string, number>>>((acc, file) => {
+    acc[file.subdir] = (acc[file.subdir] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  return [
+    "Soma PAI docs import plan",
+    "source: pai-docs",
+    `mode: ${plan.apply ? "apply" : "dry-run"}`,
+    `paiSourceDir: ${plan.paiSourceDir}`,
+    `somaHome: ${plan.somaHome}`,
+    `releaseVersion: ${plan.releaseVersion ?? "<unknown>"}`,
+    "",
+    "Counts:",
+    // Drive the counts from the shared subtree constant so adding a
+    // subtree only requires touching `PAI_DOCS_IMPORT_SUBDIRS`.
+    ...PAI_DOCS_IMPORT_SUBDIRS.map((subdir) => `- ${subdir}: ${counts[subdir] ?? 0}`),
+    "",
+    "Files:",
+    ...plan.files.map((file) => `- ${file.relativePath} -> ${file.target}`),
+  ].join("\n");
+}
+
+function formatPaiDocsImportResult(result: PaiDocsImportResult): string {
+  return [
+    "Soma PAI docs import applied",
+    `paiSourceDir: ${result.paiSourceDir}`,
+    `somaHome: ${result.somaHome}`,
+    `releaseVersion: ${result.releaseVersion ?? "<unknown>"}`,
+    `importedAt: ${result.importedAt}`,
+    `writtenCount: ${result.writtenCount}${result.unchanged ? " (idempotent no-op — source SHAs unchanged)" : ""}`,
+    "",
+    "Files:",
+    ...result.files.map((path) => `- ${path}`),
+  ].join("\n");
+}
+
+function quoteShellArg(value: string): string {
+  if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) {
+    return value;
+  }
+
+  return `'${value.replaceAll("'", "'\"'\"'")}'`;
+}
+
+export async function runImportCli(parsed: ParsedImportArgs): Promise<string> {
+  if (parsed.source === "algorithm") {
+    if (!parsed.apply) {
+      return formatAlgorithmImportPlan(planAlgorithmImport(parsed.options));
+    }
+
+    return formatAlgorithmImportResult(await importAlgorithm(parsed.options));
+  }
+
+  if (parsed.source === "pai-pack") {
+    if (!parsed.apply) {
+      return formatPaiPackImportPlan(await planPaiPackImport(parsed.options));
+    }
+
+    return formatPaiPackImportResult(await importPaiPack(parsed.options));
+  }
+
+  if (parsed.source === "pai-docs") {
+    if (!parsed.apply) {
+      return formatPaiDocsImportPlan(await planPaiDocsImport(parsed.options));
+    }
+
+    return formatPaiDocsImportResult(await importPaiDocs(parsed.options));
+  }
+
+  if (!parsed.apply) {
+    return formatPaiImportPlan(planPaiImport(parsed.options));
+  }
+
+  return formatPaiImportResult(await importPaiIdentity(parsed.options));
+}

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -179,12 +179,13 @@ function isImportSource(source: string | undefined): source is ImportSource {
   return source === "pai" || source === "algorithm" || source === "pai-pack" || source === "pai-docs";
 }
 
-function formatPaiImportPlan(plan: PaiImportPlan): string {
-  const sourceLines =
-    plan.sourceChecks && plan.sourceChecks.length > 0
-      ? plan.sourceChecks.map((check) => `- [${check.present ? "present" : "missing"}] ${check.required ? "required" : "optional"} ${check.path}`)
-      : plan.sourceFiles.map((path) => `- ${path}`);
+function formatImportSourceLines(plan: Pick<PaiImportPlan | AlgorithmImportPlan, "sourceChecks" | "sourceFiles">): string[] {
+  return plan.sourceChecks && plan.sourceChecks.length > 0
+    ? plan.sourceChecks.map((check) => `- [${check.present ? "present" : "missing"}] ${check.required ? "required" : "optional"} ${check.path}`)
+    : plan.sourceFiles.map((path) => `- ${path}`);
+}
 
+function formatPaiImportPlan(plan: PaiImportPlan): string {
   return [
     "Soma PAI import plan",
     "source: pai",
@@ -193,7 +194,7 @@ function formatPaiImportPlan(plan: PaiImportPlan): string {
     `somaHome: ${plan.somaHome}`,
     "",
     "Source files:",
-    ...sourceLines,
+    ...formatImportSourceLines(plan),
     "",
     "Target files:",
     ...plan.targetFiles.map((path) => `- ${path}`),
@@ -212,11 +213,6 @@ function formatPaiImportResult(result: PaiImportResult): string {
 }
 
 function formatAlgorithmImportPlan(plan: AlgorithmImportPlan): string {
-  const sourceLines =
-    plan.sourceChecks && plan.sourceChecks.length > 0
-      ? plan.sourceChecks.map((check) => `- [${check.present ? "present" : "missing"}] ${check.required ? "required" : "optional"} ${check.path}`)
-      : plan.sourceFiles.map((path) => `- ${path}`);
-
   return [
     "Soma Algorithm import plan",
     "source: algorithm",
@@ -225,7 +221,7 @@ function formatAlgorithmImportPlan(plan: AlgorithmImportPlan): string {
     `somaHome: ${plan.somaHome}`,
     "",
     "Source files:",
-    ...sourceLines,
+    ...formatImportSourceLines(plan),
     "",
     "Target files:",
     ...plan.targetFiles.map((path) => `- ${path}`),

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -163,16 +163,7 @@ export function parseImportArgs(args: string[]): ParsedImportArgs {
     }
   }
 
-  if (source === "algorithm") {
-    return { command, source, apply, options };
-  }
-  if (source === "pai-pack") {
-    return { command, source, apply, options };
-  }
-  if (source === "pai-docs") {
-    return { command, source, apply, options };
-  }
-  return { command, source, apply, options };
+  return { command, source, apply, options } as ParsedImportArgs;
 }
 
 function isImportSource(source: string | undefined): source is ImportSource {
@@ -185,13 +176,17 @@ function formatImportSourceLines(plan: Pick<PaiImportPlan | AlgorithmImportPlan,
     : plan.sourceFiles.map((path) => `- ${path}`);
 }
 
-function formatPaiImportPlan(plan: PaiImportPlan): string {
+function formatSimpleImportPlan(
+  title: string,
+  source: ImportSource,
+  dirEntries: string[],
+  plan: Pick<PaiImportPlan | AlgorithmImportPlan, "apply" | "sourceChecks" | "sourceFiles" | "targetFiles">,
+): string {
   return [
-    "Soma PAI import plan",
-    "source: pai",
+    title,
+    `source: ${source}`,
     `mode: ${plan.apply ? "apply" : "dry-run"}`,
-    `claudeHome: ${plan.claudeHome}`,
-    `somaHome: ${plan.somaHome}`,
+    ...dirEntries,
     "",
     "Source files:",
     ...formatImportSourceLines(plan),
@@ -199,6 +194,10 @@ function formatPaiImportPlan(plan: PaiImportPlan): string {
     "Target files:",
     ...plan.targetFiles.map((path) => `- ${path}`),
   ].join("\n");
+}
+
+function formatPaiImportPlan(plan: PaiImportPlan): string {
+  return formatSimpleImportPlan("Soma PAI import plan", "pai", [`claudeHome: ${plan.claudeHome}`, `somaHome: ${plan.somaHome}`], plan);
 }
 
 function formatPaiImportResult(result: PaiImportResult): string {
@@ -213,19 +212,7 @@ function formatPaiImportResult(result: PaiImportResult): string {
 }
 
 function formatAlgorithmImportPlan(plan: AlgorithmImportPlan): string {
-  return [
-    "Soma Algorithm import plan",
-    "source: algorithm",
-    `mode: ${plan.apply ? "apply" : "dry-run"}`,
-    `paiAlgorithmDir: ${plan.paiAlgorithmDir}`,
-    `somaHome: ${plan.somaHome}`,
-    "",
-    "Source files:",
-    ...formatImportSourceLines(plan),
-    "",
-    "Target files:",
-    ...plan.targetFiles.map((path) => `- ${path}`),
-  ].join("\n");
+  return formatSimpleImportPlan("Soma Algorithm import plan", "algorithm", [`paiAlgorithmDir: ${plan.paiAlgorithmDir}`, `somaHome: ${plan.somaHome}`], plan);
 }
 
 function formatAlgorithmImportResult(result: AlgorithmImportResult): string {

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -163,7 +163,16 @@ export function parseImportArgs(args: string[]): ParsedImportArgs {
     }
   }
 
-  return { command, source, apply, options } as ParsedImportArgs;
+  if (source === "algorithm") {
+    return { command, source, apply, options };
+  }
+  if (source === "pai-pack") {
+    return { command, source, apply, options };
+  }
+  if (source === "pai-docs") {
+    return { command, source, apply, options };
+  }
+  return { command, source, apply, options };
 }
 
 function isImportSource(source: string | undefined): source is ImportSource {
@@ -200,15 +209,18 @@ function formatPaiImportPlan(plan: PaiImportPlan): string {
   return formatSimpleImportPlan("Soma PAI import plan", "pai", [`claudeHome: ${plan.claudeHome}`, `somaHome: ${plan.somaHome}`], plan);
 }
 
-function formatPaiImportResult(result: PaiImportResult): string {
+function formatSimpleImportResult(title: string, dirEntries: string[], files: string[]): string {
   return [
-    "Soma PAI import applied",
-    `claudeHome: ${result.claudeHome}`,
-    `somaHome: ${result.somaHome}`,
+    title,
+    ...dirEntries,
     "",
     "Files:",
-    ...result.files.map((path) => `- ${path}`),
+    ...files.map((path) => `- ${path}`),
   ].join("\n");
+}
+
+function formatPaiImportResult(result: PaiImportResult): string {
+  return formatSimpleImportResult("Soma PAI import applied", [`claudeHome: ${result.claudeHome}`, `somaHome: ${result.somaHome}`], result.files);
 }
 
 function formatAlgorithmImportPlan(plan: AlgorithmImportPlan): string {
@@ -216,14 +228,7 @@ function formatAlgorithmImportPlan(plan: AlgorithmImportPlan): string {
 }
 
 function formatAlgorithmImportResult(result: AlgorithmImportResult): string {
-  return [
-    "Soma Algorithm import applied",
-    `paiAlgorithmDir: ${result.paiAlgorithmDir}`,
-    `somaHome: ${result.somaHome}`,
-    "",
-    "Files:",
-    ...result.files.map((path) => `- ${path}`),
-  ].join("\n");
+  return formatSimpleImportResult("Soma Algorithm import applied", [`paiAlgorithmDir: ${result.paiAlgorithmDir}`, `somaHome: ${result.somaHome}`], result.files);
 }
 
 function formatOnePaiPackImportPlan(plan: PaiPackImportPlan): string {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import { runSomaCli } from "../src/cli";
 import { ALGORITHM_ACTIONS } from "../src/cli/algorithm";
+import { IMPORT_COMMAND_HELP } from "../src/cli/import";
 import { MIGRATE_COMMAND_HELP } from "../src/cli/migrate";
 import {
   INSTALL_SUBSTRATES,
@@ -190,6 +191,14 @@ test("migrate command module keeps migration sources and help in sync", async ()
 
   for (const [source, usage] of Object.entries(MIGRATE_COMMAND_HELP.subcommands)) {
     await expect(runSomaCli(["migrate", source, "--help"])).resolves.toBe(usage);
+  }
+});
+
+test("import command module keeps import sources and help in sync", async () => {
+  await expect(runSomaCli(["import", "--help"])).resolves.toBe(IMPORT_COMMAND_HELP.usage);
+
+  for (const [source, usage] of Object.entries(IMPORT_COMMAND_HELP.subcommands)) {
+    await expect(runSomaCli(["import", source, "--help"])).resolves.toBe(usage);
   }
 });
 


### PR DESCRIPTION
## Summary
- extract the import command parser, help table, dispatch, and formatters into src/cli/import.ts
- keep the root CLI as the command router and delegate import execution to the module
- add import help-sync coverage alongside the existing migrate/substrate command guards

Part of #189.

## Verification
- bun run typecheck
- bun test test/cli.test.ts test/algorithm-importer.test.ts test/pai-docs-importer.test.ts test/pai-pack-importer.test.ts test/pai-pack-importer-issue-105.test.ts test/pai-pack-importer-issue-106.test.ts
- bun test
- git diff --check