### PR TITLE
Refactor result CLI command module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,6 @@ import {
   checkSomaPolicyBatch,
   checkSomaPolicy,
   captureSomaFeedback,
-  captureSomaResult,
   installSomaForClaudeCode,
   planSomaForClaudeCodeInstall,
   uninstallSomaForClaudeCode,
@@ -11,7 +10,6 @@ import {
   runSomaLifecycleAlgorithmUpdated,
   runSomaLifecycleSessionEnd,
   runSomaLifecycleSessionStart,
-  searchSomaResults,
 } from "./index";
 import type {
   SomaInstallOptions,
@@ -22,11 +20,6 @@ import type {
   SomaFeedbackCaptureResult,
   SomaLifecycleOptions,
   SomaLifecycleResult,
-  SomaResultCaptureOptions,
-  SomaResultCaptureResult,
-  SomaResultEventKind,
-  SomaResultSearchOptions,
-  SomaResultSearchResult,
   SomaPolicyCheckOptions,
   SomaPolicyCheckResult,
   SomaPolicyBatchTarget,
@@ -81,14 +74,17 @@ import {
   runMemoryCli,
   type ParsedMemoryArgs,
 } from "./cli/memory";
+import {
+  RESULT_COMMAND_HELP,
+  parseResultArgs,
+  runResultCli,
+  type ParsedResultArgs,
+} from "./cli/result";
 import { runInferenceCli } from "./tools/inference/cli";
 import { runLearningCli, runMetricsCli, runOpinionCli, runSessionCli } from "./tools/learning/cli";
 import { RELATIONSHIP_REFLECT_USAGE, runRelationshipCli } from "./tools/relationship/cli";
 import { runWisdomCli } from "./tools/wisdom/cli";
 import { applySomaInit, diagnoseSomaDoctor, planSomaInit } from "./onboarding";
-
-import { isSomaResultEventKind } from "./result-capture";
-import { SOMA_RESULT_EVENT_KINDS } from "./types";
 
 export { SomaCliError } from "./cli/errors";
 
@@ -122,20 +118,6 @@ interface ParsedFeedbackArgs {
   options: SomaFeedbackCaptureOptions;
   readTextFromStdin: boolean;
 }
-
-interface ParsedResultCaptureArgs {
-  command: "result";
-  action: "capture";
-  options: SomaResultCaptureOptions;
-}
-
-interface ParsedResultSearchArgs {
-  command: "result";
-  action: "search";
-  options: SomaResultSearchOptions;
-}
-
-type ParsedResultArgs = ParsedResultCaptureArgs | ParsedResultSearchArgs;
 
 interface ParsedPolicyArgs {
   command: "policy";
@@ -273,14 +255,7 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
       health: "Usage: soma wisdom health [--dry-run] [--home-dir <dir>] [--soma-home <dir>]",
     },
   },
-  result: {
-    usage: "Usage: soma result <capture|search> ...",
-    subcommands: {
-      capture:
-        "Usage: soma result capture --substrate <id> --source <source> --summary <text> [--artifact-path <path>...] [--skill <id>] [--session-id <id>] [--kind <kind>] [--home-dir <dir>] [--soma-home <dir>]",
-      search: "Usage: soma result search --query <text> [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
-    },
-  },
+  result: RESULT_COMMAND_HELP,
   policy: {
     usage: "Usage: soma policy check --action write --destination <path> [--content <text>|--content-env <name>] [--source <path>] [--substrate <id>] [--record <all|deny|none>] [--json]",
     subcommands: {
@@ -440,155 +415,6 @@ function parseFeedbackArgs(args: string[]): ParsedFeedbackArgs {
     action,
     options: parsed.options,
     readTextFromStdin: parsed.readTextFromStdin,
-  };
-}
-
-function parseResultKind(value: string): SomaResultEventKind {
-  if (isSomaResultEventKind(value)) {
-    return value;
-  }
-
-  throw new Error(`Unsupported result kind '${value}'. Expected one of: ${SOMA_RESULT_EVENT_KINDS.join(", ")}.`);
-}
-
-function readResultSharedOption(
-  options: Pick<Partial<SomaResultCaptureOptions & SomaResultSearchOptions>, "homeDir" | "somaHome">,
-  args: string[],
-  index: number,
-  arg: string,
-): number | undefined {
-  switch (arg) {
-    case "--home-dir":
-      options.homeDir = readOption(args, index, arg);
-      return index + 1;
-    case "--soma-home":
-      options.somaHome = readOption(args, index, arg);
-      return index + 1;
-    default:
-      return undefined;
-  }
-}
-
-function parsePositiveIntegerOption(args: string[], index: number, arg: string): number {
-  const raw = readOption(args, index, arg);
-  if (!/^[1-9]\d*$/.test(raw)) {
-    throw new Error(`${arg} must be a positive integer.`);
-  }
-
-  return Number(raw);
-}
-
-function parseResultCaptureArgs(args: string[]): SomaResultCaptureOptions {
-  const options: Partial<SomaResultCaptureOptions> = {};
-  const artifactPaths: string[] = [];
-
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    const sharedOptionIndex = readResultSharedOption(options, args, index, arg);
-    if (sharedOptionIndex !== undefined) {
-      index = sharedOptionIndex;
-      continue;
-    }
-
-    switch (arg) {
-      case "--substrate":
-        options.substrate = parseSubstrate(readOption(args, index, arg));
-        index += 1;
-        break;
-      case "--source":
-        options.source = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--summary":
-        options.summary = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--artifact-path":
-        artifactPaths.push(readOption(args, index, arg));
-        index += 1;
-        break;
-      case "--skill":
-        options.skill = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--session-id":
-        options.sessionId = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--kind":
-        options.kind = parseResultKind(readOption(args, index, arg));
-        index += 1;
-        break;
-      default:
-        throw new Error(`Unknown option: ${arg}`);
-    }
-  }
-
-  const missing: string[] = [];
-  if (!options.substrate) missing.push("--substrate");
-  if (!options.source) missing.push("--source");
-  if (!options.summary) missing.push("--summary");
-  if (missing.length > 0) {
-    throw new Error(`soma result capture is missing required option(s): ${missing.join(", ")}.`);
-  }
-
-  return {
-    ...options,
-    artifactPaths: artifactPaths.length > 0 ? artifactPaths : undefined,
-  } as SomaResultCaptureOptions;
-}
-
-function parseResultSearchArgs(args: string[]): SomaResultSearchOptions {
-  const options: Partial<SomaResultSearchOptions> = {};
-
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    const sharedOptionIndex = readResultSharedOption(options, args, index, arg);
-    if (sharedOptionIndex !== undefined) {
-      index = sharedOptionIndex;
-      continue;
-    }
-
-    switch (arg) {
-      case "--query":
-        options.query = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--limit":
-        options.limit = parsePositiveIntegerOption(args, index, arg);
-        index += 1;
-        break;
-      default:
-        throw new Error(`Unknown option: ${arg}`);
-    }
-  }
-
-  if (!options.query) {
-    throw new Error("soma result search is missing required option: --query.");
-  }
-
-  return options as SomaResultSearchOptions;
-}
-
-function parseResultArgs(args: string[]): ParsedResultArgs {
-  const [command, action, ...rest] = args;
-
-  if (command !== "result" || (action !== "capture" && action !== "search")) {
-    throw new Error(commandUsage("result"));
-  }
-
-  if (action === "capture") {
-    return {
-      command,
-      action,
-      options: parseResultCaptureArgs(rest),
-    };
-  }
-
-  return {
-    command,
-    action,
-    options: parseResultSearchArgs(rest),
   };
 }
 
@@ -1102,50 +928,6 @@ function formatFeedbackCaptureResult(result: SomaFeedbackCaptureResult): string 
     .join("\n");
 }
 
-function formatResultCaptureResult(result: SomaResultCaptureResult): string {
-  return [
-    "Soma result capture",
-    `event: ${result.event.id}`,
-    `kind: ${result.event.kind}`,
-    `somaHome: ${result.somaHome}`,
-    result.event.artifactPaths && result.event.artifactPaths.length > 0
-      ? `artifactPaths: ${result.event.artifactPaths.map((artifactPath) => sanitizeTerminalText(artifactPath)).join(", ")}`
-      : undefined,
-  ]
-    .filter((line) => line !== undefined)
-    .join("\n");
-}
-
-function sanitizeTerminalText(value: string): string {
-  return value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "").replace(/[\x00-\x1F\x7F]/g, " ");
-}
-
-function formatResultSearchResult(result: SomaResultSearchResult): string {
-  return [
-    "Soma result search",
-    `query: ${sanitizeTerminalText(result.query)}`,
-    `somaHome: ${result.somaHome}`,
-    "",
-    "Matches:",
-    ...(result.matches.length > 0
-      ? result.matches.map((match) =>
-          [
-            `- ${match.eventPath}:${match.line}`,
-            `[event ${match.eventId}]`,
-            `[kind ${match.kind}]`,
-            `[score ${match.score}]`,
-            sanitizeTerminalText(match.summary),
-            match.artifactPaths.length > 0
-              ? `(artifacts: ${match.artifactPaths.map((artifactPath) => sanitizeTerminalText(artifactPath)).join(", ")})`
-              : "",
-          ]
-            .filter(Boolean)
-            .join(" "),
-        )
-      : ["- none"]),
-  ].join("\n");
-}
-
 function formatPolicyCheckResult(result: SomaPolicyCheckResult): string {
   return [
     "Soma policy check",
@@ -1277,11 +1059,7 @@ export async function runSomaCli(args: string[]): Promise<string> {
   }
 
   if (parsed.command === "result") {
-    if (parsed.action === "capture") {
-      return formatResultCaptureResult(await captureSomaResult(parsed.options));
-    }
-
-    return formatResultSearchResult(await searchSomaResults(parsed.options));
+    return runResultCli(parsed);
   }
 
   if (parsed.command === "policy") {

--- a/src/cli/result.ts
+++ b/src/cli/result.ts
@@ -1,0 +1,236 @@
+import { captureSomaResult, searchSomaResults } from "../index";
+import { isSomaResultEventKind } from "../result-capture";
+import { SOMA_RESULT_EVENT_KINDS } from "../types";
+import type {
+  SomaResultCaptureOptions,
+  SomaResultCaptureResult,
+  SomaResultEventKind,
+  SomaResultSearchOptions,
+  SomaResultSearchResult,
+} from "../types";
+import { readOption } from "./parse-utils";
+import { parseSubstrate } from "./substrate";
+
+export interface ParsedResultCaptureArgs {
+  command: "result";
+  action: "capture";
+  options: SomaResultCaptureOptions;
+}
+
+export interface ParsedResultSearchArgs {
+  command: "result";
+  action: "search";
+  options: SomaResultSearchOptions;
+}
+
+export type ParsedResultArgs = ParsedResultCaptureArgs | ParsedResultSearchArgs;
+
+export const RESULT_COMMAND_HELP: { usage: string; subcommands: Record<ParsedResultArgs["action"], string> } = {
+  usage: "Usage: soma result <capture|search> ...",
+  subcommands: {
+    capture:
+      "Usage: soma result capture --substrate <id> --source <source> --summary <text> [--artifact-path <path>...] [--skill <id>] [--session-id <id>] [--kind <kind>] [--home-dir <dir>] [--soma-home <dir>]",
+    search: "Usage: soma result search --query <text> [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
+  },
+};
+
+export function parseResultArgs(args: string[]): ParsedResultArgs {
+  const [command, action, ...rest] = args;
+
+  if (command !== "result" || (action !== "capture" && action !== "search")) {
+    throw new Error(RESULT_COMMAND_HELP.usage);
+  }
+
+  if (action === "capture") {
+    return {
+      command,
+      action,
+      options: parseResultCaptureArgs(rest),
+    };
+  }
+
+  return {
+    command,
+    action,
+    options: parseResultSearchArgs(rest),
+  };
+}
+
+function parseResultKind(value: string): SomaResultEventKind {
+  if (isSomaResultEventKind(value)) {
+    return value;
+  }
+
+  throw new Error(`Unsupported result kind '${value}'. Expected one of: ${SOMA_RESULT_EVENT_KINDS.join(", ")}.`);
+}
+
+function readResultSharedOption(
+  options: Pick<Partial<SomaResultCaptureOptions & SomaResultSearchOptions>, "homeDir" | "somaHome">,
+  args: string[],
+  index: number,
+  arg: string,
+): number | undefined {
+  switch (arg) {
+    case "--home-dir":
+      options.homeDir = readOption(args, index, arg);
+      return index + 1;
+    case "--soma-home":
+      options.somaHome = readOption(args, index, arg);
+      return index + 1;
+    default:
+      return undefined;
+  }
+}
+
+function parsePositiveIntegerOption(args: string[], index: number, arg: string): number {
+  const raw = readOption(args, index, arg);
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`${arg} must be a positive integer.`);
+  }
+
+  return Number(raw);
+}
+
+function parseResultCaptureArgs(args: string[]): SomaResultCaptureOptions {
+  const options: Partial<SomaResultCaptureOptions> = {};
+  const artifactPaths: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const sharedOptionIndex = readResultSharedOption(options, args, index, arg);
+    if (sharedOptionIndex !== undefined) {
+      index = sharedOptionIndex;
+      continue;
+    }
+
+    switch (arg) {
+      case "--substrate":
+        options.substrate = parseSubstrate(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--source":
+        options.source = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--summary":
+        options.summary = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--artifact-path":
+        artifactPaths.push(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--skill":
+        options.skill = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--session-id":
+        options.sessionId = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--kind":
+        options.kind = parseResultKind(readOption(args, index, arg));
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  const missing: string[] = [];
+  if (!options.substrate) missing.push("--substrate");
+  if (!options.source) missing.push("--source");
+  if (!options.summary) missing.push("--summary");
+  if (missing.length > 0) {
+    throw new Error(`soma result capture is missing required option(s): ${missing.join(", ")}.`);
+  }
+
+  return {
+    ...options,
+    artifactPaths: artifactPaths.length > 0 ? artifactPaths : undefined,
+  } as SomaResultCaptureOptions;
+}
+
+function parseResultSearchArgs(args: string[]): SomaResultSearchOptions {
+  const options: Partial<SomaResultSearchOptions> = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const sharedOptionIndex = readResultSharedOption(options, args, index, arg);
+    if (sharedOptionIndex !== undefined) {
+      index = sharedOptionIndex;
+      continue;
+    }
+
+    switch (arg) {
+      case "--query":
+        options.query = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--limit":
+        options.limit = parsePositiveIntegerOption(args, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (!options.query) {
+    throw new Error("soma result search is missing required option: --query.");
+  }
+
+  return options as SomaResultSearchOptions;
+}
+
+export async function runResultCli(parsed: ParsedResultArgs): Promise<string> {
+  if (parsed.action === "capture") {
+    return formatResultCaptureResult(await captureSomaResult(parsed.options));
+  }
+
+  return formatResultSearchResult(await searchSomaResults(parsed.options));
+}
+
+function formatResultCaptureResult(result: SomaResultCaptureResult): string {
+  return [
+    "Soma result capture",
+    `event: ${result.event.id}`,
+    `kind: ${result.event.kind}`,
+    `somaHome: ${result.somaHome}`,
+    result.event.artifactPaths && result.event.artifactPaths.length > 0
+      ? `artifactPaths: ${result.event.artifactPaths.map((artifactPath) => sanitizeTerminalText(artifactPath)).join(", ")}`
+      : undefined,
+  ]
+    .filter((line) => line !== undefined)
+    .join("\n");
+}
+
+function sanitizeTerminalText(value: string): string {
+  return value.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "").replace(/[\x00-\x1F\x7F]/g, " ");
+}
+
+function formatResultSearchResult(result: SomaResultSearchResult): string {
+  return [
+    "Soma result search",
+    `query: ${sanitizeTerminalText(result.query)}`,
+    `somaHome: ${result.somaHome}`,
+    "",
+    "Matches:",
+    ...(result.matches.length > 0
+      ? result.matches.map((match) =>
+          [
+            `- ${match.eventPath}:${match.line}`,
+            `[event ${match.eventId}]`,
+            `[kind ${match.kind}]`,
+            `[score ${match.score}]`,
+            sanitizeTerminalText(match.summary),
+            match.artifactPaths.length > 0
+              ? `(artifacts: ${match.artifactPaths.map((artifactPath) => sanitizeTerminalText(artifactPath)).join(", ")})`
+              : "",
+          ]
+            .filter(Boolean)
+            .join(" "),
+        )
+      : ["- none"]),
+  ].join("\n");
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -8,6 +8,7 @@ import { ALGORITHM_ACTIONS } from "../src/cli/algorithm";
 import { IMPORT_COMMAND_HELP } from "../src/cli/import";
 import { MEMORY_COMMAND_HELP } from "../src/cli/memory";
 import { MIGRATE_COMMAND_HELP } from "../src/cli/migrate";
+import { RESULT_COMMAND_HELP } from "../src/cli/result";
 import {
   INSTALL_SUBSTRATES,
   SUBSTRATE_LIFECYCLE_COMMAND_HELP,
@@ -208,6 +209,14 @@ test("memory command module keeps memory actions and help in sync", async () => 
 
   for (const [action, usage] of Object.entries(MEMORY_COMMAND_HELP.subcommands)) {
     await expect(runSomaCli(["memory", action, "--help"])).resolves.toBe(usage);
+  }
+});
+
+test("result command module keeps result actions and help in sync", async () => {
+  await expect(runSomaCli(["result", "--help"])).resolves.toBe(RESULT_COMMAND_HELP.usage);
+
+  for (const [action, usage] of Object.entries(RESULT_COMMAND_HELP.subcommands)) {
+    await expect(runSomaCli(["result", action, "--help"])).resolves.toBe(usage);
   }
 });
 


### PR DESCRIPTION
## Summary
- extract result command help, parsing, execution, and formatting into src/cli/result.ts
- keep root cli as top-level router delegating result execution
- add result help-sync coverage alongside other extracted command modules

Part of #189.

## Verification
- bun run typecheck
- bun test test/cli.test.ts
- bun test
- git diff --check