### PR TITLE
Refactor onboarding CLI command module

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,18 +1,4 @@
-import {
-  installSomaForClaudeCode,
-  planSomaForClaudeCodeInstall,
-  uninstallSomaForClaudeCode,
-  type UninstallClaudeCodeOptions,
-} from "./index";
-import type {
-  SomaInstallOptions,
-  SomaDoctorDiagnosis,
-  SomaInitPlan,
-  SomaOnboardingOptions,
-} from "./types";
 import { ISA_SUBCOMMAND_HELP, ISA_USAGE_HEADER, runIsaCli } from "./cli-isa";
-import { readOption } from "./cli/parse-utils";
-import { parseSubstrate } from "./cli/substrate";
 import {
   ALGORITHM_COMMAND_HELP,
   parseAlgorithmArgs,
@@ -22,13 +8,9 @@ import {
 import { SomaCliError } from "./cli/errors";
 import {
   SUBSTRATE_LIFECYCLE_COMMAND_HELP,
-  formatClaudeUninstallResult,
-  formatInstallResult,
-  formatPlan,
   parseDaemonArgs,
   parseExportArgs,
   parseInstallArgs,
-  parseOnboardingSubstrate,
   parseReprojectArgs,
   parseUninstallArgs,
   parseUpgradeArgs,
@@ -83,31 +65,20 @@ import {
   runLifecycleCli,
   type ParsedLifecycleArgs,
 } from "./cli/lifecycle";
+import {
+  ONBOARDING_COMMAND_HELP,
+  parseAdoptArgs,
+  parseDoctorArgs,
+  parseInitArgs,
+  runOnboardingCli,
+  type ParsedOnboardingArgs,
+} from "./cli/onboarding";
 import { runInferenceCli } from "./tools/inference/cli";
 import { runLearningCli, runMetricsCli, runOpinionCli, runSessionCli } from "./tools/learning/cli";
 import { RELATIONSHIP_REFLECT_USAGE, runRelationshipCli } from "./tools/relationship/cli";
 import { runWisdomCli } from "./tools/wisdom/cli";
-import { applySomaInit, diagnoseSomaDoctor, planSomaInit } from "./onboarding";
 
 export { SomaCliError } from "./cli/errors";
-
-interface ParsedInitArgs {
-  command: "init";
-  apply: boolean;
-  options: SomaOnboardingOptions;
-}
-
-interface ParsedDoctorArgs {
-  command: "doctor";
-  options: SomaOnboardingOptions;
-}
-
-interface ParsedAdoptArgs {
-  command: "adopt";
-  substrate: "claude";
-  mode: "plan" | "apply" | "uninstall";
-  options: SomaInstallOptions & UninstallClaudeCodeOptions;
-}
 
 interface ParsedHelpArgs {
   command: "help";
@@ -137,11 +108,9 @@ type ParsedArgs =
   | ParsedUpgradeArgs
   | ParsedExportArgs
   | ParsedDaemonArgs
-  | ParsedInitArgs
-  | ParsedDoctorArgs
+  | ParsedOnboardingArgs
   | ParsedImportArgs
   | ParsedMigrateArgs
-  | ParsedAdoptArgs
   | ParsedAlgorithmArgs
   | ParsedLifecycleArgs
   | ParsedMemoryArgs
@@ -180,12 +149,6 @@ const TOP_LEVEL_COMMANDS = [
   "wisdom",
 ] as const;
 
-const ADOPT_CLAUDE_USAGE =
-  "Usage: soma adopt claude [--dry-run] [--apply] [--uninstall] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
-const INIT_USAGE =
-  "Usage: soma init [--dry-run] [--yes] [--home-dir <dir>] [--soma-home <dir>] [--substrate <codex|pi-dev|claude-code|cursor>]";
-const DOCTOR_USAGE =
-  "Usage: soma doctor [--home-dir <dir>] [--soma-home <dir>] [--substrate codex]";
 const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string, string> }> = {
   algorithm: ALGORITHM_COMMAND_HELP,
   memory: MEMORY_COMMAND_HELP,
@@ -241,18 +204,11 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
   upgrade: SUBSTRATE_LIFECYCLE_COMMAND_HELP.upgrade,
   export: SUBSTRATE_LIFECYCLE_COMMAND_HELP.export,
   daemon: SUBSTRATE_LIFECYCLE_COMMAND_HELP.daemon,
-  init: {
-    usage: INIT_USAGE,
-  },
-  doctor: {
-    usage: DOCTOR_USAGE,
-  },
+  init: ONBOARDING_COMMAND_HELP.init,
+  doctor: ONBOARDING_COMMAND_HELP.doctor,
   import: IMPORT_COMMAND_HELP,
   migrate: MIGRATE_COMMAND_HELP,
-  adopt: {
-    usage: ADOPT_CLAUDE_USAGE,
-    subcommands: { claude: ADOPT_CLAUDE_USAGE },
-  },
+  adopt: ONBOARDING_COMMAND_HELP.adopt,
   isa: {
     // Single source of truth lives in `./cli-isa.ts` (Sage round-1 dedup).
     usage: ISA_USAGE_HEADER,
@@ -375,98 +331,6 @@ function isSubstrateLifecycleArgs(parsed: ParsedArgs): parsed is ParsedSubstrate
   );
 }
 
-function parseOnboardingOptions(rest: string[]): SomaOnboardingOptions {
-  const options: SomaOnboardingOptions = {};
-  for (let index = 0; index < rest.length; index += 1) {
-    const arg = rest[index];
-    switch (arg) {
-      case "--home-dir":
-        options.homeDir = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--soma-home":
-        options.somaHome = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--substrate":
-        options.substrate = parseOnboardingSubstrate(readOption(rest, index, arg));
-        index += 1;
-        break;
-      default:
-        throw new Error(`Unknown option: ${arg}`);
-    }
-  }
-  return options;
-}
-
-function parseInitArgs(args: string[]): ParsedInitArgs {
-  const [, ...rest] = args;
-  let apply = false;
-  const optionArgs: string[] = [];
-  for (const arg of rest) {
-    if (arg === "--yes") {
-      apply = true;
-    } else if (arg === "--dry-run") {
-      apply = false;
-    } else {
-      optionArgs.push(arg);
-    }
-  }
-  return { command: "init", apply, options: parseOnboardingOptions(optionArgs) };
-}
-
-function parseDoctorArgs(args: string[]): ParsedDoctorArgs {
-  const [, ...rest] = args;
-  const options = parseOnboardingOptions(rest);
-  if (options.substrate && options.substrate !== "codex") {
-    throw new Error("soma doctor currently supports --substrate codex only.");
-  }
-  return { command: "doctor", options };
-}
-
-function parseAdoptArgs(args: string[]): ParsedAdoptArgs {
-  const [command, substrate, ...rest] = args;
-  if (command !== "adopt" || substrate !== "claude") {
-    throw new Error(commandUsage("adopt", substrate));
-  }
-  const options: SomaInstallOptions & UninstallClaudeCodeOptions = {};
-  let mode: "plan" | "apply" | "uninstall" = "plan";
-  for (let index = 0; index < rest.length; index += 1) {
-    const arg = rest[index];
-    switch (arg) {
-      case "--dry-run":
-        mode = "plan";
-        break;
-      case "--apply":
-        mode = "apply";
-        break;
-      case "--uninstall":
-        mode = "uninstall";
-        break;
-      case "--home-dir":
-        options.homeDir = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--soma-home":
-        options.somaHome = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--substrate-home":
-        options.substrateHome = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--help":
-        // Defensive: parseArgs intercepts --help at the top, but keep
-        // this branch so the parser surfaces usage if called directly
-        // (sage r1 on #72 — blocker bar).
-        throw new Error(ADOPT_CLAUDE_USAGE);
-      default:
-        throw new Error(`Unknown option: ${arg}`);
-    }
-  }
-  return { command: "adopt", substrate: "claude", mode, options };
-}
-
 function helpTopic(args: string[]): string[] {
   const helpIndex = args.indexOf("--help");
   const topicArgs = helpIndex === 0 ? args.slice(1) : args.slice(0, helpIndex);
@@ -553,63 +417,6 @@ function editDistance(left: string, right: string): number {
   return previous[right.length] ?? left.length;
 }
 
-function formatSomaInitPlan(plan: SomaInitPlan): string {
-  return [
-    `soma init — ${plan.mode === "apply" ? "apply plan" : "plan (dry-run; pass --yes to execute)"}`,
-    "",
-    `Home:       ${plan.homeDir}`,
-    `Soma home:  ${plan.somaHome}`,
-    `Substrate:  ${plan.substrate}`,
-    "",
-    "Detected:",
-    `  - PAI install:    ${plan.detected.paiInstall ?? "not found"}`,
-    `  - Claude skills:  ${plan.detected.claudeSkillsDir ?? "not found"}`,
-    `  - CORE_USER:      ${plan.detected.coreUserDir ?? "not found"}`,
-    "",
-    "Soma state:",
-    `  - exists:          ${plan.soma.exists ? "yes" : "no"}`,
-    `  - starter profile: ${plan.soma.starterProfile ? "yes" : "no"}`,
-    `  - skills:          ${plan.soma.skillsPopulated ? "populated" : "empty"}`,
-    `  - Algorithm skill: ${plan.soma.algorithmSkillPresent ? "present" : "missing"}`,
-    "",
-    "Steps:",
-    ...plan.steps.map((step, index) => `${index + 1}. ${step.command}`),
-    "",
-  ].join("\n");
-}
-
-function formatSomaInitApplied(results: { id: string; status: "applied" | "skipped"; detail: string }[]): string {
-  return [
-    "soma init — applied",
-    "",
-    ...results.map((result) => `${result.id}: ${result.status}${result.detail ? ` (${result.detail})` : ""}`),
-    "",
-  ].join("\n");
-}
-
-function formatSomaDoctorDiagnosis(diagnosis: SomaDoctorDiagnosis): string {
-  if (diagnosis.status === "ok") {
-    return [
-      "soma doctor — ok",
-      "",
-      `Home:      ${diagnosis.homeDir}`,
-      `Soma home: ${diagnosis.somaHome}`,
-      "No onboarding drift detected.",
-      "",
-    ].join("\n");
-  }
-  return [
-    "soma doctor — drift detected",
-    "",
-    `Home:      ${diagnosis.homeDir}`,
-    `Soma home: ${diagnosis.somaHome}`,
-    "",
-    "Findings:",
-    ...diagnosis.findings.map((finding) => `- ${finding.id}: ${finding.message}\n  action: ${finding.action}`),
-    "",
-  ].join("\n");
-}
-
 export async function runSomaCli(args: string[]): Promise<string> {
   const parsed = parseArgs(args);
 
@@ -621,15 +428,8 @@ export async function runSomaCli(args: string[]): Promise<string> {
     return runLifecycleCli(parsed);
   }
 
-  if (parsed.command === "doctor") {
-    return formatSomaDoctorDiagnosis(await diagnoseSomaDoctor(parsed.options));
-  }
-
-  if (parsed.command === "init") {
-    if (!parsed.apply) {
-      return formatSomaInitPlan(await planSomaInit(parsed.options));
-    }
-    return formatSomaInitApplied((await applySomaInit(parsed.options)).steps);
+  if (parsed.command === "doctor" || parsed.command === "init" || parsed.command === "adopt") {
+    return runOnboardingCli(parsed);
   }
 
   if (parsed.command === "algorithm") {
@@ -696,16 +496,6 @@ export async function runSomaCli(args: string[]): Promise<string> {
 
   if (parsed.command === "migrate") {
     return runMigrateCli(parsed);
-  }
-
-  if (parsed.command === "adopt") {
-    if (parsed.mode === "uninstall") {
-      return formatClaudeUninstallResult(await uninstallSomaForClaudeCode(parsed.options));
-    }
-    if (parsed.mode === "plan") {
-      return formatPlan(planSomaForClaudeCodeInstall(parsed.options));
-    }
-    return formatInstallResult(await installSomaForClaudeCode(parsed.options));
   }
 
   if (isSubstrateLifecycleArgs(parsed)) {

--- a/src/cli/onboarding.ts
+++ b/src/cli/onboarding.ts
@@ -88,6 +88,12 @@ export function parseAdoptArgs(args: string[]): ParsedAdoptArgs {
   let mode: "plan" | "apply" | "uninstall" = "plan";
   for (let index = 0; index < rest.length; index += 1) {
     const arg = rest[index];
+    const sharedOptionIndex = readCommonDirOption(options, rest, index, arg);
+    if (sharedOptionIndex !== undefined) {
+      index = sharedOptionIndex;
+      continue;
+    }
+
     switch (arg) {
       case "--dry-run":
         mode = "plan";
@@ -97,14 +103,6 @@ export function parseAdoptArgs(args: string[]): ParsedAdoptArgs {
         break;
       case "--uninstall":
         mode = "uninstall";
-        break;
-      case "--home-dir":
-        options.homeDir = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--soma-home":
-        options.somaHome = readOption(rest, index, arg);
-        index += 1;
         break;
       case "--substrate-home":
         options.substrateHome = readOption(rest, index, arg);
@@ -126,15 +124,13 @@ function parseOnboardingOptions(rest: string[]): SomaOnboardingOptions {
   const options: SomaOnboardingOptions = {};
   for (let index = 0; index < rest.length; index += 1) {
     const arg = rest[index];
+    const sharedOptionIndex = readCommonDirOption(options, rest, index, arg);
+    if (sharedOptionIndex !== undefined) {
+      index = sharedOptionIndex;
+      continue;
+    }
+
     switch (arg) {
-      case "--home-dir":
-        options.homeDir = readOption(rest, index, arg);
-        index += 1;
-        break;
-      case "--soma-home":
-        options.somaHome = readOption(rest, index, arg);
-        index += 1;
-        break;
       case "--substrate":
         options.substrate = parseOnboardingSubstrate(readOption(rest, index, arg));
         index += 1;
@@ -144,6 +140,24 @@ function parseOnboardingOptions(rest: string[]): SomaOnboardingOptions {
     }
   }
   return options;
+}
+
+function readCommonDirOption(
+  options: Pick<Partial<SomaInstallOptions & SomaOnboardingOptions>, "homeDir" | "somaHome">,
+  args: string[],
+  index: number,
+  arg: string,
+): number | undefined {
+  switch (arg) {
+    case "--home-dir":
+      options.homeDir = readOption(args, index, arg);
+      return index + 1;
+    case "--soma-home":
+      options.somaHome = readOption(args, index, arg);
+      return index + 1;
+    default:
+      return undefined;
+  }
 }
 
 export async function runOnboardingCli(parsed: ParsedOnboardingArgs): Promise<string> {

--- a/src/cli/onboarding.ts
+++ b/src/cli/onboarding.ts
@@ -1,0 +1,225 @@
+import {
+  installSomaForClaudeCode,
+  planSomaForClaudeCodeInstall,
+  uninstallSomaForClaudeCode,
+  type UninstallClaudeCodeOptions,
+} from "../index";
+import { applySomaInit, diagnoseSomaDoctor, planSomaInit } from "../onboarding";
+import type { SomaDoctorDiagnosis, SomaInitPlan, SomaInstallOptions, SomaOnboardingOptions } from "../types";
+import {
+  formatClaudeUninstallResult,
+  formatInstallResult,
+  formatPlan,
+  parseOnboardingSubstrate,
+} from "./substrate-lifecycle";
+import { readOption } from "./parse-utils";
+
+export interface ParsedInitArgs {
+  command: "init";
+  apply: boolean;
+  options: SomaOnboardingOptions;
+}
+
+export interface ParsedDoctorArgs {
+  command: "doctor";
+  options: SomaOnboardingOptions;
+}
+
+export interface ParsedAdoptArgs {
+  command: "adopt";
+  substrate: "claude";
+  mode: "plan" | "apply" | "uninstall";
+  options: SomaInstallOptions & UninstallClaudeCodeOptions;
+}
+
+export type ParsedOnboardingArgs = ParsedInitArgs | ParsedDoctorArgs | ParsedAdoptArgs;
+
+const ADOPT_CLAUDE_USAGE =
+  "Usage: soma adopt claude [--dry-run] [--apply] [--uninstall] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
+const INIT_USAGE =
+  "Usage: soma init [--dry-run] [--yes] [--home-dir <dir>] [--soma-home <dir>] [--substrate <codex|pi-dev|claude-code|cursor>]";
+const DOCTOR_USAGE =
+  "Usage: soma doctor [--home-dir <dir>] [--soma-home <dir>] [--substrate codex]";
+
+export const ONBOARDING_COMMAND_HELP: Record<ParsedOnboardingArgs["command"], { usage: string; subcommands?: Record<string, string> }> = {
+  init: {
+    usage: INIT_USAGE,
+  },
+  doctor: {
+    usage: DOCTOR_USAGE,
+  },
+  adopt: {
+    usage: ADOPT_CLAUDE_USAGE,
+    subcommands: { claude: ADOPT_CLAUDE_USAGE },
+  },
+};
+
+export function parseInitArgs(args: string[]): ParsedInitArgs {
+  const [, ...rest] = args;
+  let apply = false;
+  const optionArgs: string[] = [];
+  for (const arg of rest) {
+    if (arg === "--yes") {
+      apply = true;
+    } else if (arg === "--dry-run") {
+      apply = false;
+    } else {
+      optionArgs.push(arg);
+    }
+  }
+  return { command: "init", apply, options: parseOnboardingOptions(optionArgs) };
+}
+
+export function parseDoctorArgs(args: string[]): ParsedDoctorArgs {
+  const [, ...rest] = args;
+  const options = parseOnboardingOptions(rest);
+  if (options.substrate && options.substrate !== "codex") {
+    throw new Error("soma doctor currently supports --substrate codex only.");
+  }
+  return { command: "doctor", options };
+}
+
+export function parseAdoptArgs(args: string[]): ParsedAdoptArgs {
+  const [command, substrate, ...rest] = args;
+  if (command !== "adopt" || substrate !== "claude") {
+    throw new Error(ONBOARDING_COMMAND_HELP.adopt.subcommands?.[substrate] ?? ONBOARDING_COMMAND_HELP.adopt.usage);
+  }
+  const options: SomaInstallOptions & UninstallClaudeCodeOptions = {};
+  let mode: "plan" | "apply" | "uninstall" = "plan";
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    switch (arg) {
+      case "--dry-run":
+        mode = "plan";
+        break;
+      case "--apply":
+        mode = "apply";
+        break;
+      case "--uninstall":
+        mode = "uninstall";
+        break;
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--substrate-home":
+        options.substrateHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--help":
+        // Defensive: parseArgs intercepts --help at the top, but keep
+        // this branch so the parser surfaces usage if called directly
+        // (sage r1 on #72 — blocker bar).
+        throw new Error(ADOPT_CLAUDE_USAGE);
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return { command: "adopt", substrate: "claude", mode, options };
+}
+
+function parseOnboardingOptions(rest: string[]): SomaOnboardingOptions {
+  const options: SomaOnboardingOptions = {};
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--substrate":
+        options.substrate = parseOnboardingSubstrate(readOption(rest, index, arg));
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return options;
+}
+
+export async function runOnboardingCli(parsed: ParsedOnboardingArgs): Promise<string> {
+  if (parsed.command === "doctor") {
+    return formatSomaDoctorDiagnosis(await diagnoseSomaDoctor(parsed.options));
+  }
+
+  if (parsed.command === "init") {
+    if (!parsed.apply) {
+      return formatSomaInitPlan(await planSomaInit(parsed.options));
+    }
+    return formatSomaInitApplied((await applySomaInit(parsed.options)).steps);
+  }
+
+  if (parsed.mode === "uninstall") {
+    return formatClaudeUninstallResult(await uninstallSomaForClaudeCode(parsed.options));
+  }
+  if (parsed.mode === "plan") {
+    return formatPlan(planSomaForClaudeCodeInstall(parsed.options));
+  }
+  return formatInstallResult(await installSomaForClaudeCode(parsed.options));
+}
+
+function formatSomaInitPlan(plan: SomaInitPlan): string {
+  return [
+    `soma init — ${plan.mode === "apply" ? "apply plan" : "plan (dry-run; pass --yes to execute)"}`,
+    "",
+    `Home:       ${plan.homeDir}`,
+    `Soma home:  ${plan.somaHome}`,
+    `Substrate:  ${plan.substrate}`,
+    "",
+    "Detected:",
+    `  - PAI install:    ${plan.detected.paiInstall ?? "not found"}`,
+    `  - Claude skills:  ${plan.detected.claudeSkillsDir ?? "not found"}`,
+    `  - CORE_USER:      ${plan.detected.coreUserDir ?? "not found"}`,
+    "",
+    "Soma state:",
+    `  - exists:          ${plan.soma.exists ? "yes" : "no"}`,
+    `  - starter profile: ${plan.soma.starterProfile ? "yes" : "no"}`,
+    `  - skills:          ${plan.soma.skillsPopulated ? "populated" : "empty"}`,
+    `  - Algorithm skill: ${plan.soma.algorithmSkillPresent ? "present" : "missing"}`,
+    "",
+    "Steps:",
+    ...plan.steps.map((step, index) => `${index + 1}. ${step.command}`),
+    "",
+  ].join("\n");
+}
+
+function formatSomaInitApplied(results: { id: string; status: "applied" | "skipped"; detail: string }[]): string {
+  return [
+    "soma init — applied",
+    "",
+    ...results.map((result) => `${result.id}: ${result.status}${result.detail ? ` (${result.detail})` : ""}`),
+    "",
+  ].join("\n");
+}
+
+function formatSomaDoctorDiagnosis(diagnosis: SomaDoctorDiagnosis): string {
+  if (diagnosis.status === "ok") {
+    return [
+      "soma doctor — ok",
+      "",
+      `Home:      ${diagnosis.homeDir}`,
+      `Soma home: ${diagnosis.somaHome}`,
+      "No onboarding drift detected.",
+      "",
+    ].join("\n");
+  }
+  return [
+    "soma doctor — drift detected",
+    "",
+    `Home:      ${diagnosis.homeDir}`,
+    `Soma home: ${diagnosis.somaHome}`,
+    "",
+    "Findings:",
+    ...diagnosis.findings.map((finding) => `- ${finding.id}: ${finding.message}\n  action: ${finding.action}`),
+    "",
+  ].join("\n");
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -10,6 +10,7 @@ import { IMPORT_COMMAND_HELP } from "../src/cli/import";
 import { LIFECYCLE_COMMAND_HELP } from "../src/cli/lifecycle";
 import { MEMORY_COMMAND_HELP } from "../src/cli/memory";
 import { MIGRATE_COMMAND_HELP } from "../src/cli/migrate";
+import { ONBOARDING_COMMAND_HELP } from "../src/cli/onboarding";
 import { POLICY_COMMAND_HELP } from "../src/cli/policy";
 import { RESULT_COMMAND_HELP } from "../src/cli/result";
 import {
@@ -244,6 +245,16 @@ test("lifecycle command module keeps lifecycle events and help in sync", async (
 
   for (const [event, usage] of Object.entries(LIFECYCLE_COMMAND_HELP.subcommands)) {
     await expect(runSomaCli(["lifecycle", event, "--help"])).resolves.toBe(usage);
+  }
+});
+
+test("onboarding command module keeps onboarding commands and help in sync", async () => {
+  for (const [command, help] of Object.entries(ONBOARDING_COMMAND_HELP)) {
+    await expect(runSomaCli([command, "--help"])).resolves.toBe(help.usage);
+
+    for (const [action, usage] of Object.entries(help.subcommands ?? {})) {
+      await expect(runSomaCli([command, action, "--help"])).resolves.toBe(usage);
+    }
   }
 });
 


### PR DESCRIPTION
## Summary
- extract init, doctor, and adopt claude help, parsing, execution, and formatting into src/cli/onboarding.ts
- keep root cli as top-level router delegating onboarding execution
- add onboarding help-sync coverage alongside other extracted command modules

Part of #189.

## Verification
- bun run typecheck
- bun test test/cli.test.ts test/onboarding-doctor.test.ts
- bun test test/policy-path-guard.test.ts -t "cli supports --action delete"
- bun test
- git diff --check