### PR TITLE
Refactor ISA skill for Codex-friendly loading

### DIFF
--- a/docs/codex-friendly-skills.md
+++ b/docs/codex-friendly-skills.md
@@ -18,6 +18,17 @@ The 120-line limit is intentionally simple. It catches the failure mode that
 hurts Codex most: a selected skill pasting a long manual into context before the
 task-local repo evidence has been read.
 
+Rare exceptions are allowed only when the extra entrypoint material is needed
+before routing. Record the exception in `SKILL.md` frontmatter:
+
+```yaml
+codex-entrypoint-max-lines: 160
+codex-entrypoint-exception: "Why this skill needs more pre-routing material."
+```
+
+Waived entrypoints are still capped at 240 lines by the repository test. Prefer
+splitting to references before using a waiver.
+
 ## Entrypoint Shape
 
 Use this structure unless a skill has a strong reason to differ:

--- a/docs/codex-friendly-skills.md
+++ b/docs/codex-friendly-skills.md
@@ -16,7 +16,8 @@ manual.
 
 The 120-line limit is intentionally simple. It catches the failure mode that
 hurts Codex most: a selected skill pasting a long manual into context before the
-task-local repo evidence has been read.
+task-local repo evidence has been read. The enforced source for these limits is
+`test/skill-entrypoints.test.ts`; update this document when changing that test.
 
 Rare exceptions are allowed only when the extra entrypoint material is needed
 before routing. Record the exception in `SKILL.md` frontmatter:
@@ -35,7 +36,7 @@ Use this structure unless a skill has a strong reason to differ:
 
 1. Frontmatter with name, description, effort, version, and pack id if relevant.
 2. One short purpose paragraph.
-3. `Codex Fast Path` with the common execution route.
+3. `Fast Path` with the common execution route.
 4. `When To Use` and `Do Not Use` guidance.
 5. Workflow or command routing table.
 6. Critical invariants only.

--- a/docs/codex-friendly-skills.md
+++ b/docs/codex-friendly-skills.md
@@ -1,0 +1,50 @@
+# Codex-Friendly Skill Entrypoints
+
+Soma skills should be discoverable without spending most of a Codex session's
+context on instructions. Treat `SKILL.md` as a compact router, not as the whole
+manual.
+
+## Recommended Budget
+
+- Keep checked-in `SKILL.md` entrypoints at or below 120 lines.
+- Put purpose, trigger guidance, fast path, routing, and reference links in the
+  entrypoint.
+- Move doctrine, examples, detailed tables, command references, and long
+  operational checklists into `references/`, `Workflows/`, `Examples/`, or
+  `Tools/`.
+- Load references only after the entrypoint routes to them.
+
+The 120-line limit is intentionally simple. It catches the failure mode that
+hurts Codex most: a selected skill pasting a long manual into context before the
+task-local repo evidence has been read.
+
+## Entrypoint Shape
+
+Use this structure unless a skill has a strong reason to differ:
+
+1. Frontmatter with name, description, effort, version, and pack id if relevant.
+2. One short purpose paragraph.
+3. `Codex Fast Path` with the common execution route.
+4. `When To Use` and `Do Not Use` guidance.
+5. Workflow or command routing table.
+6. Critical invariants only.
+7. Reference-loading table.
+
+## Current Inventory
+
+The first #172 audit found two checked-in Soma skill entrypoints:
+
+| Entrypoint | Pre-refactor size | Role | Action |
+| --- | ---: | --- | --- |
+| `skill/SKILL.md` | 22 lines | Soma kernel skill | Already compact. |
+| `src/skills/ISA/SKILL.md` | 241 lines | Bundled ISA skill projected into substrates | Refactored into a compact entrypoint plus references. |
+
+The ISA skill was the highest-impact representative target because it is bundled
+with Soma, projected into installed homes, and likely to be invoked inside Codex
+when working through Algorithm/ISA flows.
+
+## Authoring Rule
+
+If adding a new long-form section to a skill, ask whether the model needs it
+before routing. If not, place it behind a named reference and add one line to the
+entrypoint explaining when to load it.

--- a/src/skills/ISA/SKILL.md
+++ b/src/skills/ISA/SKILL.md
@@ -13,7 +13,7 @@ being pursued: a project, feature, library, infrastructure change, work session,
 art piece, or strategic decision. It acts as ideal-state articulation, test
 harness, done condition, verification record, and system of record.
 
-## Codex Fast Path
+## Fast Path
 
 1. Identify the requested ISA workflow from the routing table below.
 2. Load only that workflow file from `Workflows/`.

--- a/src/skills/ISA/SKILL.md
+++ b/src/skills/ISA/SKILL.md
@@ -88,12 +88,5 @@ taxonomy, ID-stability contract, and Algorithm relationship.
 ## Example Selection
 
 Start with `Examples/canonical-isa.md` only when you need the full shape or
-tone. Otherwise choose the closest small reference:
-
-- E1 quick task: `Examples/e1-minimal.md`
-- E2 operational or implementation task: `Examples/e2-backup-verify.md` or
-  `Examples/e2-rotate-credential.md`
-- E3 project or experiential task: `Examples/e3-project.md`,
-  `Examples/e3-essay.md`, or `Examples/e3-help-redesign.md`
-- E4/E5 large system, brand, desktop app, album, or enterprise work: load the
-  matching E4/E5 example only after the workflow needs it.
+tone. Otherwise load `references/examples.md` and choose the closest small
+reference from that single map.

--- a/src/skills/ISA/SKILL.md
+++ b/src/skills/ISA/SKILL.md
@@ -2,240 +2,98 @@
 name: ISA
 description: "Owns the Ideal State Artifact: the commitment-time scaffold for articulating done, deriving ISC criteria, planning features, recording decisions, and verifying work. Use for ideal state, ISA/ISC criteria, project specs, scaffolding, completeness checks, reconciliation, or seeding an ISA from a repo."
 effort: medium
-version: 1.0.2
+version: 1.0.3
 pack-id: pai-isa-v1.0.0
 ---
 
-## 🚨 MANDATORY: Voice Notification (REQUIRED BEFORE ANY ACTION)
+# ISA
 
-**You MUST send this notification BEFORE doing anything else when this skill is invoked.**
+The ISA is the document that articulates "done" for work whose ideal state is
+being pursued: a project, feature, library, infrastructure change, work session,
+art piece, or strategic decision. It acts as ideal-state articulation, test
+harness, done condition, verification record, and system of record.
 
-1. **Send voice notification**:
-   ```bash
-   curl -s -X POST http://localhost:31337/notify \
-     -H "Content-Type: application/json" \
-     -d '{"message": "Running the WORKFLOWNAME workflow in the ISA skill"}' \
-     > /dev/null 2>&1 &
-   ```
+## Codex Fast Path
 
-2. **Output text notification**:
-   ```
-   Running the **WorkflowName** workflow in the **ISA** skill to ACTION...
-   ```
+1. Identify the requested ISA workflow from the routing table below.
+2. Load only that workflow file from `Workflows/`.
+3. Load `references/format.md` only when the task needs section, tier, ISC, or
+   reconciliation rules.
+4. Load `references/examples.md` only when scaffolding or comparing against an
+   exemplar.
+5. Load `references/gotchas.md` before reconcile, tier checks, or any edit that
+   might renumber criteria.
 
-**This is not optional. Execute this curl command immediately upon skill invocation.**
+Do not load the full examples directory by default. Pick the smallest example
+that matches the task tier and domain.
 
-# ISA — Ideal State Artifact
+## When To Use
 
-The ISA is the single document that articulates "done" for any thing whose ideal state we are pursuing — a project, an application, a library, infrastructure, a work session, an art piece, a strategic decision. It serves five identities simultaneously: ideal state articulation, test harness, build verification, done condition, system of record.
+Use when the prompt mentions ideal state, ISA, ISC, ideal state criteria,
+project specification, articulating done, scaffolding an ISA, interviewing for
+an ISA, checking completeness, reconciling an ephemeral feature file back to a
+master ISA, or seeding an ISA from an existing project.
 
-This skill owns the canonical template, the workflows that generate and refine ISAs, and the example library.
-
----
-
-## Routing Details
-
-The ISA is the universal primitive that holds the articulated ideal state of any thing (project, task, application, library, infrastructure, work session) as a hard-to-vary explanation. It drives the build, verifies the build, and records the evolution of understanding.
-
-Five workflows:
-
-- Scaffold: generate a fresh ISA from a prompt at a specified effort tier.
-- Interview: adaptive question-and-answer to fill in or deepen sections.
-- CheckCompleteness: score an existing ISA against the tier completeness gate and report gaps.
-- Reconcile: deterministic merge of an ephemeral feature-file excerpt back into the master ISA, keyed on stable ISC IDs.
-- Seed: bootstrap a draft project ISA from an existing repository's README, code structure, and recent commits.
-
-Examples directory:
-
-- `canonical-isa.md`: showpiece reference, fully populated across all twelve sections.
-- `e1-minimal.md`: 90-second task with Goal and Criteria only.
-- `e3-project.md`: mid-size project with eight sections.
-- `e5-enterprise.md`, `e5-desktop-app.md`, and `e5-album.md`: full applications with all twelve sections plus populated changelog history.
-
-Use when any prompt mentions ideal state, ISA, ISC, ideal state criteria, ideal state artifact, project specification, hill-climb on a task, articulating done, scaffolding an ISA, interviewing for an ISA, checking ISA completeness, reconciling an ephemeral feature file back to a master ISA, or seeding an ISA from an existing project.
-
-Not for creating new skills, running the Algorithm itself, generating non-ISA artifacts, or after-the-fact write-ups like postmortems, decision logs, or engineering journals. Those are retrospective; the ISA is a commitment-time scaffold for ideal state.
-
----
-
-## The Twelve-Section Body (locked v6.2.0)
-
-Every ISA may have up to twelve body sections. The tier completeness gate decides which are required at which effort tier; sections never appear empty. **Order is fixed**.
-
-| # | Section | Purpose | Written At |
-|---|---------|---------|------------|
-| 1 | `## Problem` | What is broken or missing right now that makes the ideal state worth pursuing | OBSERVE |
-| 2 | `## Vision` | What euphoric surprise looks like — experiential intent, 1–5 sentences | OBSERVE |
-| 3 | `## Out of Scope` | Anti-vision — what is *not* included in this ideal state, declared upfront in prose | OBSERVE |
-| 4 | `## Principles` | Substrate-independent truths (Deutsch reach) the work must respect | OBSERVE |
-| 5 | `## Constraints` | Immovable architectural mandates that bound the solution space | OBSERVE |
-| 6 | `## Goal` | The hard-to-vary spine — 1–3 sentences naming verifiable done | OBSERVE |
-| 7 | `## Criteria` | Atomic ISCs (Ideal State Criteria) — one binary tool probe each, including derived `Anti:` ISCs | OBSERVE → EXECUTE |
-| 8 | `## Test Strategy` | Per-ISC verification approach — `isc | type | check | threshold | tool` | OBSERVE/PLAN |
-| 9 | `## Features` | Work breakdown — `name | description | satisfies: [ISC-N…] | depends_on: [feature…] | parallelizable: bool` | PLAN |
-| 10 | `## Decisions` | Timestamped decision log including dead ends; `refined:` prefix for Goal/ISC restructures | any phase |
-| 11 | `## Changelog` | Conjecture / refuted-by / learned / criterion-now entries — Deutsch error-correction trail | LEARN |
-| 12 | `## Verification` | Evidence that each ISC passed — quoted command output, file content, screenshot path | VERIFY |
-
----
-
-## Three-Guardrail Taxonomy (Principles vs Constraints vs Anti-criteria)
-
-Adjacent concepts. Distinguished by **who they bind**.
-
-| Guardrail | Binds | Tone | Example | Lives In |
-|-----------|-------|------|---------|----------|
-| **Principles** | The *thinking* | Aspirational, generalizable | "User-facing systems prioritize responsiveness." | `## Principles` |
-| **Constraints** | The *solution space* | Immovable, non-negotiable | "We do not roll our own cryptography — OAuth via industry-standard libraries only." | `## Constraints` |
-| **Out of Scope** | The *vision* | Declared, explicit, prose | "Mobile native apps are not part of v1." | `## Out of Scope` |
-| **Anti-criteria** | The *test surface* | Granular, testable, yes/no | "Anti: /admin returns 200 in v1 build." | `## Criteria` (with `Anti:` prefix) |
-
-The first three are author-stated (declarative). Anti-criteria are derived — they are how Out of Scope, Constraints, and Principles become probe-able.
-
----
-
-## Tier Completeness Gate (HARD at all tiers)
-
-Mirrors the v6.1.0 thinking-floor non-relaxability. Required sections per tier:
-
-| Tier | Required Sections |
-|------|-------------------|
-| **E1** | Goal, Criteria |
-| **E2** | Problem, Goal, Criteria, Test Strategy |
-| **E3** | Problem, Vision, Out of Scope, Constraints, Goal, Criteria, Features, Test Strategy |
-| **E4** | All twelve sections |
-| **E5** | All twelve + active Interview workflow run before BUILD |
-
-**Project ISA override:** any `<project>/ISA.md` requires E3+ structure regardless of the active task's tier. The project file is the long-lived source of truth; one transient E1 task must not downgrade it.
-
-`CheckCompleteness` workflow enforces this gate. A miss blocks `phase: complete` until the missing sections are filled in.
-
----
+Do not use for creating new skills, running the Algorithm itself, generating
+non-ISA artifacts, postmortems, decision logs, or engineering journals. Those
+are retrospective; the ISA is a commitment-time scaffold.
 
 ## Workflow Routing
 
-Match the verb in the request to a workflow. When ambiguous, default to Scaffold for new ISAs and CheckCompleteness for audits.
+When ambiguous, default to Scaffold for new ISAs and CheckCompleteness for
+audits.
 
-| Verb / Intent | Workflow | File |
-|---------------|----------|------|
-| "scaffold", "create", "generate", "new ISA from this prompt", "extract feature as ephemeral" | **Scaffold** | `Workflows/Scaffold.md` |
-| "interview me", "fill in the ISA", "deepen", "ask me questions" | **Interview** | `Workflows/Interview.md` |
-| "check", "audit", "score this ISA", "is it complete?" | **CheckCompleteness** | `Workflows/CheckCompleteness.md` |
-| "reconcile", "merge feature file back", "ephemeral → master" | **Reconcile** | `Workflows/Reconcile.md` |
-| "seed", "bootstrap from this repo", "draft an ISA from existing code" | **Seed** | `Workflows/Seed.md` |
-| "append decision", "append changelog", "append verification", "record C/R/L entry" | **Append** | `Workflows/Append.md` |
+| Intent | Workflow | Load |
+| --- | --- | --- |
+| scaffold, create, generate, new ISA, extract feature as ephemeral | Scaffold | `Workflows/Scaffold.md` |
+| interview me, fill in, deepen, ask questions | Interview | `Workflows/Interview.md` |
+| check, audit, score, is this complete | CheckCompleteness | `Workflows/CheckCompleteness.md` |
+| reconcile, merge feature file back, ephemeral to master | Reconcile | `Workflows/Reconcile.md` |
+| seed, bootstrap from repo, draft from existing code | Seed | `Workflows/Seed.md` |
+| append decision, append changelog, append verification, record C/R/L | Append | `Workflows/Append.md` |
 
-**When executing a workflow, output this notification directly:**
+When executing a workflow, emit:
 
-```
+```text
 Running the **WorkflowName** workflow in the **ISA** skill to ACTION...
 ```
 
----
+Then follow the selected workflow file. If that workflow includes a substrate
+notification step, execute it when the local substrate supports it; otherwise
+continue with the workflow text notification.
 
-## Gotchas
+## Core Rules
 
-The highest-information-density part of this skill. Each entry captures a non-obvious failure mode that has bitten real ISA work.
+- Stable ISC IDs are sacred. Never renumber criteria after creation.
+- Empty sections are omitted unless the active tier requires them.
+- At least one `Anti:` ISC is required at every tier.
+- Experiential work requires at least one `Antecedent:` ISC.
+- Project ISAs require E3+ structure even when the active task is smaller.
+- Ephemeral feature files are derived views, never sources of truth.
+- Reconcile is deterministic and keyed by ISC ID.
 
-- **ID-stability is the cornerstone of Reconcile — never re-number on edit.** When the Splitting Test produces a finer-grained version of `ISC-7`, preserve `ISC-7` as the parent and add `ISC-7.1`, `ISC-7.2`, etc. Even when an ISC is dropped, leave a tombstone (`- [ ] ISC-N: [DROPPED — see Decisions YYYY-MM-DD]`). Reconcile keys on stable IDs; renumbering breaks ephemeral feature-file merges silently and the failure mode looks like "the worker's checkmarks didn't land in master."
-- **Ephemeral files are derived views, never sources of truth.** Scaffold's `--ephemeral` mode produces a slice of the master ISA at `MEMORY/WORK/{slug}/_ephemeral/<feature>.md`. Workers operate against that slice; Reconcile merges back. Hand-editing master content from an ephemeral file is policy-forbidden — the master is what persists; the ephemeral is what gets archived.
-- **The Changelog format is non-negotiable.** Every entry needs all four pieces (`conjectured`, `refuted by`, `learned`, `criterion now`) in that order. Append refuses to write a partial C/R/L; if any of the four is missing, the entry is a Decision, not a Changelog. The format is what makes the Deutsch error-correction trail auditable across sessions.
-- **Project ISAs upgrade tier to `max(declared, E3)` regardless of the active task's tier.** A `<project>/ISA.md` is the long-lived system of record for a thing with persistent identity. One transient E1 task on the project must NOT downgrade the structural minimum. CheckCompleteness applies this override automatically.
-- **Empty sections never appear.** The twelve-section body is a *capacity*, not a *requirement* at every tier. Sections required-but-empty for the tier are populated; sections not required and not yet written are simply absent from the file. CheckCompleteness distinguishes `present` / `thin` / `missing` / `empty` and only `empty` is acceptable for `Verification` before VERIFY phase.
-- **Anti-criteria are derived from Out of Scope plus regression-prevention concerns.** They are how the prose-guardrails (Out of Scope, Constraints, Principles) become probe-able. At least one is required at every tier; the absence of an anti-criterion at OBSERVE is a hard CheckCompleteness failure.
-- **Antecedents are required when the goal is experiential.** For art, design, content, and anything that has to "land," at least one ISC must use the `Antecedent:` prefix to name a precondition that reliably produces the target experience. Verifiable goals (build, deploy, schema) don't need antecedents; experiential goals always do.
-- **Reconcile is deterministic — there are no conflicts to resolve.** Either an ISC ID exists in master (mechanical merge) or it doesn't (abort with ID-stability violation). If the ephemeral made structural changes (split ISC-7 into ISC-7.1/ISC-7.2), those structural changes belong in master via a separate Edit by the user *before* Reconcile runs.
-- **The format spec wins on contradiction.** `IsaFormat.md` is the file-shape contract. If this skill's prose ever drifts from the format spec, the spec is canonical and the skill updates to match — not the reverse.
+Load `references/format.md` for the twelve-section body, tier gate, guardrail
+taxonomy, ID-stability contract, and Algorithm relationship.
 
----
+## Reference Loading
 
-## Examples
+| Need | Load |
+| --- | --- |
+| Section order, tier requirements, guardrail taxonomy, ID stability | `references/format.md` |
+| Failure modes and non-obvious operational traps | `references/gotchas.md` |
+| Example selection by tier and domain | `references/examples.md` |
+| Canonical full example | `Examples/canonical-isa.md` |
+| Minimal E1 example | `Examples/e1-minimal.md` |
 
-The `Examples/` directory holds twelve reference ISAs spanning the tier (E1–E5) × domain (code / art / design / ops / marketplace / enterprise) matrix. Always start by reading the canonical showpiece before scaffolding a new ISA — copy its section headers, then populate. Pick the example closest to your domain + scale as a template.
+## Example Selection
 
-**Showpiece**
+Start with `Examples/canonical-isa.md` only when you need the full shape or
+tone. Otherwise choose the closest small reference:
 
-| File | Purpose |
-|------|---------|
-| `Examples/canonical-isa.md` | **BeanLine** — peer-to-peer specialty-coffee marketplace. The showpiece reference, fully populated across all twelve sections with real-feeling Decisions and a four-piece C/R/L Changelog. Read this first. |
-
-**Code**
-
-| File | Tier | Purpose |
-|------|------|---------|
-| `Examples/e1-minimal.md` | E1 | Add a `--no-color` flag to a CLI tool. <90s task, Goal + 4 ISCs only. Demonstrates the fast-path floor. |
-| `Examples/e2-backup-verify.md` | E2 | Add SHA-256 verification to a backup CLI's `--verify` mode. Single-domain, 18 ISCs. |
-| `Examples/e3-project.md` | E3 | Build an arxiv metadata extractor CLI. Mid-size project, 12 ISCs, eight sections. |
-| `Examples/e4-api-migration.md` | E4 | Migrate a public API from REST to GraphQL with 6-month backwards-compat. Cross-cutting, 73 ISCs, all twelve sections. |
-| `Examples/e5-desktop-app.md` | E5 | **WattWatch** — open-source desktop app for personal home-energy monitoring. Single-user app pattern, 50 ISCs, populated Changelog. |
-
-**Art (experiential — antecedents required)**
-
-| File | Tier | Purpose |
-|------|------|---------|
-| `Examples/e3-essay.md` | E3 | Write a 1500-word essay on a specific thesis. Experiential goal, antecedent ISCs, post-publish reception probes. |
-| `Examples/e5-album.md` | E5 | **Mariner Frequencies** — produce a 12-track instrumental album over 6 months. Long-form experiential, multi-act Changelog. |
-
-**Design (experiential)**
-
-| File | Tier | Purpose |
-|------|------|---------|
-| `Examples/e3-help-redesign.md` | E3 | Redesign a CLI tool's `--help` output for first-encounter clarity. Antecedents + usability tests. |
-| `Examples/e4-brand-identity.md` | E4 | **Cardinal** — brand identity for a small fintech startup (logo + type + color + voice + first 5 marketing surfaces). 56 ISCs, 6 antecedents. |
-
-**Ops**
-
-| File | Tier | Purpose |
-|------|------|---------|
-| `Examples/e2-rotate-credential.md` | E2 | Rotate a production deploy credential in CI. Demonstrates the ISA primitive applied to ops/runbook work. 16 ISCs. |
-
-**Enterprise**
-
-| File | Tier | Purpose |
-|------|------|---------|
-| `Examples/e5-enterprise.md` | E5 | **Beacon Health Alliance** — multi-region HIPAA-compliant patient portal for a 50-hospital network. Compliance anti-criteria, multi-team parallelizable features, 68 ISCs across all twelve sections. |
-
----
-
-## ID Stability Rule
-
-**ISC IDs never re-number on edit.** When the Splitting Test produces a finer-grained version of `ISC-7`, the original number is preserved as the parent and children become `ISC-7.1`, `ISC-7.2`, etc. Do not collapse the numbering even if the ISC is dropped — leave a tombstone marker so historical references in Decisions, Changelog, and Verification remain valid.
-
-This rule exists because `Reconcile` is keyed on ISC IDs. If IDs renumber across edits, ephemeral feature-file reconciliation breaks silently. The renumbering ban is what makes feature-file workflows safe.
-
----
-
-## Ephemeral Feature Files (Ralph Loop / Maestro pattern)
-
-When a feature is to be worked in an isolated context (Ralph Loop, Maestro, parallel coding-agent instances), the Algorithm invokes:
-
-```
-Skill("ISA", "extract feature <name> as ephemeral file")
-```
-
-`Scaffold` (with `--ephemeral` mode) produces a derived view at `MEMORY/WORK/{slug}/_ephemeral/<feature>.md` containing only the slice relevant to that feature: the Vision and Goal as read-only context, the relevant Constraints, the ISCs in the feature's `satisfies:` list with stable IDs, the matching Test Strategy entries, and an empty Verification section.
-
-A fresh-context agent operates against the ephemeral file alone. At completion, `Reconcile` deterministically merges ISC checkmarks, Verification evidence, Decisions entries, and any new Changelog entries back to master, then archives the ephemeral file under `_ephemeral/.archive/`.
-
-**Ephemeral files are derived views. They are never sources of truth. They are never hand-edited as policy. The master ISA is what persists.**
-
----
-
-## Relationship to the Algorithm
-
-The Algorithm at OBSERVE invokes this skill to scaffold or read an ISA. The skill does not run the Algorithm — it owns the artifact the Algorithm operates on.
-
-- OBSERVE: `Skill("ISA", "scaffold from prompt at tier T")` → returns populated ISA at canonical location.
-- OBSERVE: `Skill("ISA", "check completeness of <path> at tier T")` → pass/fail + gap report.
-- PLAN: `Skill("ISA", "extract feature <name> as ephemeral file")` → ephemeral excerpt.
-- LEARN: `Skill("ISA", "reconcile <ephemeral-path> → <master-path>")` → deterministic merge.
-
-The Algorithm doctrine spec at `~/.claude/PAI/ALGORITHM/v6.2.0.md` (or LATEST) governs invocation cadence. This skill is invocation-agnostic — it works the same whether called by the Algorithm or directly by the user.
-
----
-
-## Format spec cross-reference
-
-The full ISA format spec lives at `~/.claude/PAI/DOCUMENTATION/IsaFormat.md`. This skill implements that spec; if there is ever a contradiction, the format spec wins and this skill is updated to match.
-
-The system-architecture doc — five identities, three-guardrail taxonomy, twelve-section body, six workflows, two homes, subsystem relationships — lives at `~/.claude/PAI/DOCUMENTATION/Isa/IsaSystem.md`. Read that for the conceptual frame; read this file (and `IsaFormat.md`) for the operational contract.
+- E1 quick task: `Examples/e1-minimal.md`
+- E2 operational or implementation task: `Examples/e2-backup-verify.md` or
+  `Examples/e2-rotate-credential.md`
+- E3 project or experiential task: `Examples/e3-project.md`,
+  `Examples/e3-essay.md`, or `Examples/e3-help-redesign.md`
+- E4/E5 large system, brand, desktop app, album, or enterprise work: load the
+  matching E4/E5 example only after the workflow needs it.

--- a/src/skills/ISA/references/examples.md
+++ b/src/skills/ISA/references/examples.md
@@ -1,0 +1,36 @@
+# ISA Examples Reference
+
+Load this reference when choosing an example to scaffold from or compare against.
+Do not load the whole `Examples/` directory by default.
+
+## Showpiece
+
+| File | Purpose |
+| --- | --- |
+| `Examples/canonical-isa.md` | Fully populated all-section reference. Read when you need tone, complete structure, or a high-fidelity template. |
+
+## Code
+
+| File | Tier | Purpose |
+| --- | --- | --- |
+| `Examples/e1-minimal.md` | E1 | Add a `--no-color` flag to a CLI tool. Fast-path floor. |
+| `Examples/e2-backup-verify.md` | E2 | Add SHA-256 verification to a backup CLI. |
+| `Examples/e3-project.md` | E3 | Build an arxiv metadata extractor CLI. |
+| `Examples/e4-api-migration.md` | E4 | Migrate a public API from REST to GraphQL. |
+| `Examples/e5-desktop-app.md` | E5 | Open-source desktop app for home-energy monitoring. |
+
+## Experiential Work
+
+| File | Tier | Purpose |
+| --- | --- | --- |
+| `Examples/e3-essay.md` | E3 | Write a 1500-word essay. Antecedent ISCs and reception probes. |
+| `Examples/e3-help-redesign.md` | E3 | Redesign CLI help output. Antecedents plus usability tests. |
+| `Examples/e4-brand-identity.md` | E4 | Brand identity for a fintech startup. |
+| `Examples/e5-album.md` | E5 | Produce a 12-track instrumental album. |
+
+## Operations And Enterprise
+
+| File | Tier | Purpose |
+| --- | --- | --- |
+| `Examples/e2-rotate-credential.md` | E2 | Rotate a production deploy credential in CI. |
+| `Examples/e5-enterprise.md` | E5 | Multi-region compliant patient portal. |

--- a/src/skills/ISA/references/format.md
+++ b/src/skills/ISA/references/format.md
@@ -1,0 +1,108 @@
+# ISA Format Reference
+
+Load this reference only when the active task needs exact ISA structure, tier
+requirements, guardrail distinctions, ID stability, ephemeral feature behavior,
+or Algorithm integration details.
+
+## Twelve-Section Body
+
+Every ISA may contain up to twelve body sections. The tier completeness gate
+decides which are required. Sections never appear empty. Order is fixed.
+
+| # | Section | Purpose | Written at |
+| --- | --- | --- | --- |
+| 1 | `## Problem` | What is broken or missing right now | OBSERVE |
+| 2 | `## Vision` | What euphoric surprise looks like | OBSERVE |
+| 3 | `## Out of Scope` | What is explicitly not included | OBSERVE |
+| 4 | `## Principles` | Substrate-independent truths the work must respect | OBSERVE |
+| 5 | `## Constraints` | Immovable mandates that bound the solution space | OBSERVE |
+| 6 | `## Goal` | Verifiable done in 1-3 sentences | OBSERVE |
+| 7 | `## Criteria` | Atomic ISCs, including derived `Anti:` ISCs | OBSERVE to EXECUTE |
+| 8 | `## Test Strategy` | Per-ISC verification approach | OBSERVE / PLAN |
+| 9 | `## Features` | Work breakdown tied to ISC IDs | PLAN |
+| 10 | `## Decisions` | Timestamped decisions and dead ends | any phase |
+| 11 | `## Changelog` | Conjecture / refuted-by / learned / criterion-now trail | LEARN |
+| 12 | `## Verification` | Evidence that each ISC passed | VERIFY |
+
+## Guardrail Taxonomy
+
+| Guardrail | Binds | Tone | Lives in |
+| --- | --- | --- | --- |
+| Principles | The thinking | Aspirational and generalizable | `## Principles` |
+| Constraints | The solution space | Immovable and non-negotiable | `## Constraints` |
+| Out of Scope | The vision | Explicit prose boundary | `## Out of Scope` |
+| Anti-criteria | The test surface | Granular yes/no probe | `## Criteria` with `Anti:` |
+
+Principles, Constraints, and Out of Scope are author-stated. Anti-criteria are
+derived from those guardrails so they become probe-able.
+
+## Tier Completeness Gate
+
+| Tier | Required sections |
+| --- | --- |
+| E1 | Goal, Criteria |
+| E2 | Problem, Goal, Criteria, Test Strategy |
+| E3 | Problem, Vision, Out of Scope, Constraints, Goal, Criteria, Features, Test Strategy |
+| E4 | All twelve sections |
+| E5 | All twelve sections plus an active Interview workflow run before BUILD |
+
+Project ISA override: any `<project>/ISA.md` requires E3+ structure regardless
+of the active task tier.
+
+`CheckCompleteness` enforces this gate. A miss blocks `phase: complete` until
+the missing sections are filled in.
+
+## ID Stability
+
+ISC IDs never renumber on edit. If `ISC-7` is split, preserve it as the parent
+and add `ISC-7.1`, `ISC-7.2`, etc. If an ISC is dropped, leave a tombstone:
+
+```markdown
+- [ ] ISC-7: [DROPPED - see Decisions 2026-04-15]
+```
+
+Reconcile is keyed on ISC IDs. Renumbering breaks feature-file merges and
+historical references in Decisions, Changelog, and Verification.
+
+## Ephemeral Feature Files
+
+For isolated feature work, the Algorithm may invoke:
+
+```text
+Skill("ISA", "extract feature <name> as ephemeral file")
+```
+
+`Scaffold` with ephemeral mode writes a derived view at
+`MEMORY/WORK/{slug}/_ephemeral/<feature>.md` containing only:
+
+- Vision and Goal as read-only context
+- relevant Constraints
+- ISCs from the feature's `satisfies:` list, with stable IDs preserved
+- matching Test Strategy entries
+- optional Decisions mentioning those ISC IDs
+- empty Verification section
+
+A fresh-context agent works against the ephemeral file. `Reconcile` then merges
+checkmarks, Verification evidence, Decisions, and Changelog entries back to the
+master ISA and archives the ephemeral file.
+
+Ephemeral files are derived views. They are never sources of truth and should
+not be used to hand-edit the master ISA.
+
+## Relationship To The Algorithm
+
+The Algorithm may use this skill at specific phases, but this skill does not run
+the Algorithm.
+
+| Phase | ISA skill action |
+| --- | --- |
+| OBSERVE | scaffold from prompt at tier T |
+| OBSERVE | check completeness of an ISA at tier T |
+| PLAN | extract feature as ephemeral file |
+| LEARN | reconcile ephemeral path back to master path |
+
+## Format Authority
+
+The canonical format lives in Soma's ISA library and workflow files. If this
+reference ever contradicts the parser, serializer, accessor tests, or workflow
+contracts in this repo, update this reference to match the executable contract.

--- a/src/skills/ISA/references/gotchas.md
+++ b/src/skills/ISA/references/gotchas.md
@@ -1,0 +1,24 @@
+# ISA Gotchas
+
+Load this reference before reconcile, tier checks, or any edit that may change
+criteria structure.
+
+- **ID stability is the cornerstone of Reconcile.** Never renumber on edit. Split
+  by preserving the parent ID and adding child IDs such as `ISC-7.1`.
+- **Ephemeral files are derived views.** Workers operate against the slice;
+  Reconcile merges back. The master ISA remains the durable source of truth.
+- **Changelog entries require all four fields.** Use `conjectured`,
+  `refuted by`, `learned`, and `criterion now` in that order. If one is
+  missing, record a Decision instead.
+- **Project ISAs upgrade to E3+.** A long-lived project ISA must not be
+  structurally downgraded by one small task.
+- **Empty sections do not appear.** Required sections must be populated;
+  non-required sections are omitted until they are meaningful.
+- **Anti-criteria are derived from boundaries.** Out of Scope, Constraints, and
+  Principles should become probe-able `Anti:` ISCs where relevant.
+- **Experiential goals need antecedents.** Art, design, writing, brand, and
+  other "has to land" work needs at least one `Antecedent:` ISC.
+- **Reconcile is deterministic.** Unknown ISC IDs abort. Structural changes such
+  as splitting criteria belong in the master before reconcile runs.
+- **Executable contracts win over prose.** Parser, serializer, accessor, and
+  workflow tests are canonical when prose drifts.

--- a/test/isa-skill-installer.test.ts
+++ b/test/isa-skill-installer.test.ts
@@ -315,6 +315,6 @@ test("ship config: real src/skills/ISA description fits portable metadata limit"
   const description = /^description:\s*"([\s\S]*?)"$/m.exec(content)?.[1];
   expect(description).toBeDefined();
   expect(description!.length).toBeLessThanOrEqual(SOMA_SKILL_DESCRIPTION_MAX_LENGTH);
-  expect(content).toContain("## Codex Fast Path");
+  expect(content).toContain("## Fast Path");
   expect(content).toContain("## Reference Loading");
 });

--- a/test/isa-skill-installer.test.ts
+++ b/test/isa-skill-installer.test.ts
@@ -315,5 +315,6 @@ test("ship config: real src/skills/ISA description fits portable metadata limit"
   const description = /^description:\s*"([\s\S]*?)"$/m.exec(content)?.[1];
   expect(description).toBeDefined();
   expect(description!.length).toBeLessThanOrEqual(SOMA_SKILL_DESCRIPTION_MAX_LENGTH);
-  expect(content).toContain("## Routing Details");
+  expect(content).toContain("## Codex Fast Path");
+  expect(content).toContain("## Reference Loading");
 });

--- a/test/skill-entrypoints.test.ts
+++ b/test/skill-entrypoints.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from "bun:test";
 
 const REPO_ROOT = join(import.meta.dirname, "..");
 const MAX_SKILL_ENTRYPOINT_LINES = 120;
+const MAX_WAIVED_SKILL_ENTRYPOINT_LINES = 240;
 
 function collectSkillEntrypoints(root: string): string[] {
   const results: string[] = [];
@@ -28,6 +29,23 @@ function collectSkillEntrypoints(root: string): string[] {
   return results;
 }
 
+function readEntrypointBudget(text: string): { maxLines: number; exception?: string } {
+  const frontmatter = /^---\n([\s\S]*?)\n---/.exec(text)?.[1] ?? "";
+  const maxLinesRaw = /^codex-entrypoint-max-lines:\s*(\d+)\s*$/m.exec(frontmatter)?.[1];
+  const exception = /^codex-entrypoint-exception:\s*"(.+)"\s*$/m.exec(frontmatter)?.[1];
+
+  if (!maxLinesRaw) {
+    return { maxLines: MAX_SKILL_ENTRYPOINT_LINES };
+  }
+
+  const maxLines = Number(maxLinesRaw);
+  expect(maxLines).toBeGreaterThan(MAX_SKILL_ENTRYPOINT_LINES);
+  expect(maxLines).toBeLessThanOrEqual(MAX_WAIVED_SKILL_ENTRYPOINT_LINES);
+  expect(exception?.length ?? 0).toBeGreaterThanOrEqual(20);
+
+  return { maxLines, exception };
+}
+
 test("checked-in skill entrypoints stay Codex-friendly", () => {
   const skillEntrypoints = [
     join(REPO_ROOT, "skill/SKILL.md"),
@@ -39,10 +57,11 @@ test("checked-in skill entrypoints stay Codex-friendly", () => {
   for (const path of skillEntrypoints) {
     const text = readFileSync(path, "utf8");
     const lines = text.trimEnd().split("\n").length;
+    const budget = readEntrypointBudget(text);
 
     expect(
       lines,
-      `${relative(REPO_ROOT, path)} has ${lines} lines; keep SKILL.md <= ${MAX_SKILL_ENTRYPOINT_LINES} and move details to references/ or Workflows/.`,
-    ).toBeLessThanOrEqual(MAX_SKILL_ENTRYPOINT_LINES);
+      `${relative(REPO_ROOT, path)} has ${lines} lines; keep SKILL.md <= ${budget.maxLines} and move details to references/ or Workflows/.`,
+    ).toBeLessThanOrEqual(budget.maxLines);
   }
 });

--- a/test/skill-entrypoints.test.ts
+++ b/test/skill-entrypoints.test.ts
@@ -3,6 +3,7 @@ import { join, relative } from "node:path";
 import { expect, test } from "bun:test";
 
 const REPO_ROOT = join(import.meta.dirname, "..");
+// Enforced source for the budget documented in docs/codex-friendly-skills.md.
 const MAX_SKILL_ENTRYPOINT_LINES = 120;
 const MAX_WAIVED_SKILL_ENTRYPOINT_LINES = 240;
 

--- a/test/skill-entrypoints.test.ts
+++ b/test/skill-entrypoints.test.ts
@@ -1,0 +1,48 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { expect, test } from "bun:test";
+
+const REPO_ROOT = join(import.meta.dirname, "..");
+const MAX_SKILL_ENTRYPOINT_LINES = 120;
+
+function collectSkillEntrypoints(root: string): string[] {
+  const results: string[] = [];
+
+  function walk(dir: string): void {
+    for (const entry of readdirSync(dir)) {
+      const path = join(dir, entry);
+      const stat = statSync(path);
+
+      if (stat.isDirectory()) {
+        walk(path);
+        continue;
+      }
+
+      if (entry === "SKILL.md") {
+        results.push(path);
+      }
+    }
+  }
+
+  walk(root);
+  return results;
+}
+
+test("checked-in skill entrypoints stay Codex-friendly", () => {
+  const skillEntrypoints = [
+    join(REPO_ROOT, "skill/SKILL.md"),
+    ...collectSkillEntrypoints(join(REPO_ROOT, "src/skills")),
+  ];
+
+  expect(skillEntrypoints.length).toBeGreaterThan(0);
+
+  for (const path of skillEntrypoints) {
+    const text = readFileSync(path, "utf8");
+    const lines = text.trimEnd().split("\n").length;
+
+    expect(
+      lines,
+      `${relative(REPO_ROOT, path)} has ${lines} lines; keep SKILL.md <= ${MAX_SKILL_ENTRYPOINT_LINES} and move details to references/ or Workflows/.`,
+    ).toBeLessThanOrEqual(MAX_SKILL_ENTRYPOINT_LINES);
+  }
+});


### PR DESCRIPTION
## Summary\n\nCloses #172.\n\n- Refactor bundled ISA SKILL.md from a long manual-style entrypoint into a compact 99-line router with a Codex fast path\n- Move stable ISA format, gotchas, and example-selection material into explicit references loaded only when needed\n- Document the repo pattern for Codex-friendly skill entrypoints and record the initial skill-size audit\n- Add a test guard keeping checked-in SKILL.md entrypoints at or below 120 lines\n- Bump bundled ISA skill version from 1.0.2 to 1.0.3\n\n## Verification\n\n- bun test test/skill-entrypoints.test.ts test/isa-skill-installer.test.ts\n- bun scripts/check-skill-version.ts\n- bun run typecheck\n- git diff --check\n- bun test\n