### PR TITLE
Refactor install facts into adapter specs

### DIFF
--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -1,5 +1,4 @@
-import { resolve } from "node:path";
-import type { SubstrateInstallSpec } from "../../install-spec";
+import { isaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
 import { CLAUDE_CODE_RULES_FILES } from "../claude-code";
 
 export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
@@ -7,7 +6,7 @@ export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
   defaultHome: ".claude",
   homeFiles: CLAUDE_CODE_RULES_FILES,
   isaSkillProjection: {
-    destinationDir: (substrateHome) => resolve(substrateHome, "skills/ISA"),
+    destinationDir: isaSkillUnder(),
   },
   uninstall: {
     kind: "implemented",

--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -1,0 +1,16 @@
+import { resolve } from "node:path";
+import type { SubstrateInstallSpec } from "../../install-spec";
+import { CLAUDE_CODE_RULES_FILES } from "../claude-code";
+
+export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
+  substrate: "claude-code",
+  defaultHome: ".claude",
+  homeFiles: CLAUDE_CODE_RULES_FILES,
+  isaSkillProjection: {
+    destinationDir: (substrateHome) => resolve(substrateHome, "skills/ISA"),
+  },
+  uninstall: {
+    kind: "implemented",
+    remove: ["rules/soma", "skills/ISA"],
+  },
+};

--- a/src/adapters/codex/install.ts
+++ b/src/adapters/codex/install.ts
@@ -64,6 +64,9 @@ export const codexInstallSpec: SubstrateInstallSpec<"codex"> = {
   substrate: "codex",
   defaultHome: CODEX_DEFAULT_HOME,
   homeFiles: CODEX_HOME_FILES,
+  isaSkillProjection: {
+    destinationDir: (substrateHome) => resolve(substrateHome, "skills/ISA"),
+  },
   lifecycleProjection: {
     startupContextPath: "memories/soma/startup-context.md",
     somaRepoPathPath: "memories/soma/soma-repo.txt",

--- a/src/adapters/codex/install.ts
+++ b/src/adapters/codex/install.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { configureCodexInstall } from "./config";
-import type { SubstrateInstallSpec } from "../../install-spec";
+import { isaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
 import type { SubstrateId } from "../../types";
 
 const CODEX_DEFAULT_HOME = ".codex";
@@ -65,7 +65,7 @@ export const codexInstallSpec: SubstrateInstallSpec<"codex"> = {
   defaultHome: CODEX_DEFAULT_HOME,
   homeFiles: CODEX_HOME_FILES,
   isaSkillProjection: {
-    destinationDir: (substrateHome) => resolve(substrateHome, "skills/ISA"),
+    destinationDir: isaSkillUnder(),
   },
   lifecycleProjection: {
     startupContextPath: "memories/soma/startup-context.md",

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -4,6 +4,8 @@ import { activeIsaBundleFile } from "../adapter-active-isa";
 import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "./shared";
 
 export const CURSOR_RULES_PATH = ".cursorrules";
+export const CURSOR_RULES_BLOCK_BEGIN = "<!-- SOMA_CURSOR_BEGIN -->";
+export const CURSOR_RULES_BLOCK_END = "<!-- SOMA_CURSOR_END -->";
 export const CURSOR_RULES_README_PATH = ".cursor/rules/soma/README.md";
 export const CURSOR_CONTEXT_PATH = ".cursor/rules/soma/CONTEXT.md";
 export const CURSOR_PROFILE_PATH = ".cursor/rules/soma/PROFILE.md";

--- a/src/adapters/cursor/install.ts
+++ b/src/adapters/cursor/install.ts
@@ -1,0 +1,67 @@
+import { readFile, rm, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import type { SubstrateInstallSpec } from "../../install-spec";
+import { CURSOR_HOME_FILE_PATHS, CURSOR_RULES_BLOCK_BEGIN, CURSOR_RULES_BLOCK_END, CURSOR_RULES_PATH } from "../cursor";
+
+function isEnoent(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT";
+}
+
+async function shouldRemoveSomaRulesDir(target: string): Promise<boolean> {
+  const markerFile = join(target, "README.md");
+  try {
+    const content = await readFile(markerFile, "utf8");
+    return content.startsWith("# Soma Cursor Projection");
+  } catch (error) {
+    if (isEnoent(error)) return false;
+    throw error;
+  }
+}
+
+async function removeCursorRulesProjection(path: string): Promise<boolean> {
+  let content: string;
+  try {
+    content = await readFile(path, "utf8");
+  } catch (error) {
+    if (isEnoent(error)) return false;
+    throw error;
+  }
+
+  if (content.startsWith("# Soma Cursor Projection")) {
+    await rm(path, { force: true });
+    return true;
+  }
+
+  const start = content.indexOf(CURSOR_RULES_BLOCK_BEGIN);
+  if (start === -1) return false;
+  const end = content.indexOf(CURSOR_RULES_BLOCK_END, start);
+  if (end === -1) return false;
+
+  const before = content.slice(0, start).trimEnd();
+  const after = content.slice(end + CURSOR_RULES_BLOCK_END.length).trimStart();
+  const preserved = [before, after.trimEnd()].filter((part) => part.length > 0).join("\n\n");
+  if (preserved.length === 0) {
+    await rm(path, { force: true });
+    return true;
+  }
+  await writeFile(path, `${preserved}\n`, "utf8");
+  return true;
+}
+
+export const cursorInstallSpec: SubstrateInstallSpec<"cursor"> = {
+  substrate: "cursor",
+  defaultHome: ".",
+  homeFiles: CURSOR_HOME_FILE_PATHS,
+  isaSkillProjection: {
+    destinationDir: (substrateHome) => resolve(substrateHome, ".cursor/rules/soma/skills/ISA"),
+  },
+  uninstall: {
+    kind: "implemented",
+    remove: [".cursor/rules/soma"],
+    shouldRemove: (target) => shouldRemoveSomaRulesDir(target),
+    postRemove: async ({ substrateHome }) => {
+      const cursorRulesFile = join(substrateHome, CURSOR_RULES_PATH);
+      return (await removeCursorRulesProjection(cursorRulesFile)) ? [cursorRulesFile] : [];
+    },
+  },
+};

--- a/src/adapters/cursor/install.ts
+++ b/src/adapters/cursor/install.ts
@@ -1,11 +1,8 @@
 import { readFile, rm, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
+import { isEnoent } from "../../fs-errors";
 import type { SubstrateInstallSpec } from "../../install-spec";
 import { CURSOR_HOME_FILE_PATHS, CURSOR_RULES_BLOCK_BEGIN, CURSOR_RULES_BLOCK_END, CURSOR_RULES_PATH } from "../cursor";
-
-function isEnoent(error: unknown): boolean {
-  return (error as NodeJS.ErrnoException).code === "ENOENT";
-}
 
 async function shouldRemoveSomaRulesDir(target: string): Promise<boolean> {
   const markerFile = join(target, "README.md");

--- a/src/adapters/cursor/install.ts
+++ b/src/adapters/cursor/install.ts
@@ -1,7 +1,7 @@
 import { readFile, rm, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { isEnoent } from "../../fs-errors";
-import type { SubstrateInstallSpec } from "../../install-spec";
+import { isaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
 import { CURSOR_HOME_FILE_PATHS, CURSOR_RULES_BLOCK_BEGIN, CURSOR_RULES_BLOCK_END, CURSOR_RULES_PATH } from "../cursor";
 
 async function shouldRemoveSomaRulesDir(target: string): Promise<boolean> {
@@ -50,7 +50,7 @@ export const cursorInstallSpec: SubstrateInstallSpec<"cursor"> = {
   defaultHome: ".",
   homeFiles: CURSOR_HOME_FILE_PATHS,
   isaSkillProjection: {
-    destinationDir: (substrateHome) => resolve(substrateHome, ".cursor/rules/soma/skills/ISA"),
+    destinationDir: isaSkillUnder(".cursor/rules/soma"),
   },
   uninstall: {
     kind: "implemented",

--- a/src/adapters/cursor/install.ts
+++ b/src/adapters/cursor/install.ts
@@ -4,7 +4,7 @@ import type { SubstrateInstallSpec } from "../../install-spec";
 import { CURSOR_HOME_FILE_PATHS, CURSOR_RULES_BLOCK_BEGIN, CURSOR_RULES_BLOCK_END, CURSOR_RULES_PATH } from "../cursor";
 
 function isEnoent(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT";
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
 }
 
 async function shouldRemoveSomaRulesDir(target: string): Promise<boolean> {

--- a/src/adapters/pi-dev/install.ts
+++ b/src/adapters/pi-dev/install.ts
@@ -33,7 +33,7 @@ function piDevProjectionPrivateRoots(options: { homeDir?: string; substrate?: Su
   return [
     join(home, PI_DEV_DEFAULT_HOME, "agent", "soma"),
     join(home, PI_DEV_DEFAULT_HOME, "agent", "skills", "soma"),
-  ].map((path) => resolve(path));
+  ];
 }
 
 export const piDevInstallSpec: SubstrateInstallSpec<"pi-dev"> = {

--- a/src/adapters/pi-dev/install.ts
+++ b/src/adapters/pi-dev/install.ts
@@ -1,0 +1,60 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import type { SubstrateInstallSpec } from "../../install-spec";
+import type { SubstrateId } from "../../types";
+import {
+  PI_DEV_ISA_SKILL_ID,
+  piDevIsaSkillDestinationDir,
+  removeLegacyPiDevIsaSkillProjection,
+} from "./skill-projection";
+import { validatePiDevInstallRuntime } from "./version";
+
+const PI_DEV_DEFAULT_HOME = ".pi";
+
+export const PI_DEV_HOME_FILES = [
+  "agent/extensions/soma.ts",
+  "agent/extensions/soma-path-guard.ts",
+  "agent/extensions/soma-algorithm.ts",
+  "agent/soma/context.md",
+  "agent/soma/profile.md",
+  "agent/soma/startup-context.md",
+  "agent/soma/memory-layout.md",
+  "agent/soma/pai-imports.md",
+  "agent/soma/tools.md",
+  "agent/soma/skills.md",
+  "agent/soma/policy.md",
+  "agent/soma/soma-repo.txt",
+  "agent/skills/soma/SKILL.md",
+] as const;
+
+function piDevProjectionPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
+  if (options.substrate !== undefined && options.substrate !== "pi-dev") return [];
+  const home = resolve(options.homeDir ?? homedir());
+  return [
+    join(home, PI_DEV_DEFAULT_HOME, "agent", "soma"),
+    join(home, PI_DEV_DEFAULT_HOME, "agent", "skills", "soma"),
+  ].map((path) => resolve(path));
+}
+
+export const piDevInstallSpec: SubstrateInstallSpec<"pi-dev"> = {
+  substrate: "pi-dev",
+  defaultHome: PI_DEV_DEFAULT_HOME,
+  homeFiles: PI_DEV_HOME_FILES,
+  isaSkillProjection: {
+    destinationDir: piDevIsaSkillDestinationDir,
+    skillNameOverride: PI_DEV_ISA_SKILL_ID,
+    prepare: removeLegacyPiDevIsaSkillProjection,
+  },
+  validator: validatePiDevInstallRuntime,
+  lifecycleProjection: {
+    startupContextPath: "agent/soma/startup-context.md",
+    somaRepoPathPath: "agent/soma/soma-repo.txt",
+  },
+  privateRoots: {
+    projection: piDevProjectionPrivateRoots,
+  },
+  uninstall: {
+    kind: "reserved",
+    reason: "Pi.dev uninstall is not implemented yet; extension and skill removal need a follow-up that preserves user-owned Pi.dev agent files.",
+  },
+};

--- a/src/fs-errors.ts
+++ b/src/fs-errors.ts
@@ -1,3 +1,3 @@
 export function isEnoent(error: unknown): boolean {
-  return (error as NodeJS.ErrnoException).code === "ENOENT";
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT";
 }

--- a/src/fs-errors.ts
+++ b/src/fs-errors.ts
@@ -1,0 +1,3 @@
+export function isEnoent(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}

--- a/src/home-projection.ts
+++ b/src/home-projection.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { dirname } from "node:path";
-import { CURSOR_RULES_PATH } from "./adapters/cursor";
+import { CURSOR_RULES_BLOCK_BEGIN, CURSOR_RULES_BLOCK_END, CURSOR_RULES_PATH } from "./adapters/cursor";
 import { projectClaudeCodeHome, projectCodexHome, projectCursorHome, projectPiDevHome } from "./adapters";
 import { writeProjection } from "./projection";
 import { defaultSomaRepoPath } from "./repo-path";
@@ -113,8 +113,7 @@ export async function installCursorHomeProjection(
   return written;
 }
 
-export const CURSOR_RULES_BLOCK_BEGIN = "<!-- SOMA_CURSOR_BEGIN -->";
-export const CURSOR_RULES_BLOCK_END = "<!-- SOMA_CURSOR_END -->";
+export { CURSOR_RULES_BLOCK_BEGIN, CURSOR_RULES_BLOCK_END };
 
 function renderCursorRulesBlock(content: string): string {
   return `${CURSOR_RULES_BLOCK_BEGIN}\n${content.trimEnd()}\n${CURSOR_RULES_BLOCK_END}`;

--- a/src/install-spec-registry.ts
+++ b/src/install-spec-registry.ts
@@ -1,18 +1,24 @@
 import { codexInstallSpec } from "./adapters/codex/install";
+import { claudeCodeInstallSpec } from "./adapters/claude-code/install";
+import { cursorInstallSpec } from "./adapters/cursor/install";
+import { piDevInstallSpec } from "./adapters/pi-dev/install";
 import type { InstallSubstrate, SubstrateInstallSpec } from "./install-spec";
 
-const LEGACY_DEFAULT_SUBSTRATE_HOMES: Record<InstallSubstrate, string> = {
-  codex: codexInstallSpec.defaultHome,
-  "pi-dev": ".pi",
-  "claude-code": ".claude",
-  cursor: ".",
-};
+const INSTALL_SPECS = {
+  codex: codexInstallSpec,
+  "pi-dev": piDevInstallSpec,
+  "claude-code": claudeCodeInstallSpec,
+  cursor: cursorInstallSpec,
+} satisfies Record<InstallSubstrate, SubstrateInstallSpec>;
 
-export function installSpecFor(substrate: InstallSubstrate): SubstrateInstallSpec | undefined {
-  if (substrate === "codex") return codexInstallSpec;
-  return undefined;
+export function installSpecFor<S extends InstallSubstrate>(substrate: S): SubstrateInstallSpec<S> {
+  return INSTALL_SPECS[substrate] as SubstrateInstallSpec<S>;
+}
+
+export function allInstallSpecs(): readonly SubstrateInstallSpec[] {
+  return Object.values(INSTALL_SPECS);
 }
 
 export function defaultSubstrateHome(substrate: InstallSubstrate): string {
-  return installSpecFor(substrate)?.defaultHome ?? LEGACY_DEFAULT_SUBSTRATE_HOMES[substrate];
+  return installSpecFor(substrate).defaultHome;
 }

--- a/src/install-spec-registry.ts
+++ b/src/install-spec-registry.ts
@@ -19,6 +19,10 @@ export function allInstallSpecs(): readonly SubstrateInstallSpec[] {
   return Object.values(INSTALL_SPECS);
 }
 
+export function isRegisteredInstallSubstrate(value: string | undefined): value is InstallSubstrate {
+  return value !== undefined && Object.prototype.hasOwnProperty.call(INSTALL_SPECS, value);
+}
+
 export function defaultSubstrateHome(substrate: InstallSubstrate): string {
   return installSpecFor(substrate).defaultHome;
 }

--- a/src/install-spec-registry.ts
+++ b/src/install-spec-registry.ts
@@ -4,15 +4,17 @@ import { cursorInstallSpec } from "./adapters/cursor/install";
 import { piDevInstallSpec } from "./adapters/pi-dev/install";
 import type { InstallSubstrate, SubstrateInstallSpec } from "./install-spec";
 
+type InstallSpecRegistry = { [S in InstallSubstrate]: SubstrateInstallSpec<S> };
+
 const INSTALL_SPECS = {
   codex: codexInstallSpec,
   "pi-dev": piDevInstallSpec,
   "claude-code": claudeCodeInstallSpec,
   cursor: cursorInstallSpec,
-} satisfies Record<InstallSubstrate, SubstrateInstallSpec>;
+} satisfies InstallSpecRegistry;
 
-export function installSpecFor<S extends InstallSubstrate>(substrate: S): SubstrateInstallSpec<S> {
-  return INSTALL_SPECS[substrate] as SubstrateInstallSpec<S>;
+export function installSpecFor<S extends InstallSubstrate>(substrate: S): InstallSpecRegistry[S] {
+  return INSTALL_SPECS[substrate];
 }
 
 export function allInstallSpecs(): readonly SubstrateInstallSpec[] {

--- a/src/install-spec.ts
+++ b/src/install-spec.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import type { SubstrateId } from "./types";
 
 export type InstallSubstrate = Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor">;
@@ -23,6 +24,10 @@ export interface IsaSkillProjectionSpec {
   destinationDir(substrateHome: string): string;
   skillNameOverride?: string;
   prepare?(substrateHome: string): Promise<void>;
+}
+
+export function isaSkillUnder(...pathSegments: string[]): (substrateHome: string) => string {
+  return (substrateHome) => resolve(substrateHome, ...pathSegments, "skills/ISA");
 }
 
 export type InstallValidator = (substrateRoot: string) => Promise<void>;

--- a/src/install-spec.ts
+++ b/src/install-spec.ts
@@ -19,6 +19,19 @@ export interface InstallPostProjectionStep {
   run(context: InstallPostProjectionContext): Promise<string[]>;
 }
 
+export interface IsaSkillProjectionSpec {
+  destinationDir(substrateHome: string): string;
+  skillNameOverride?: string;
+  prepare?(substrateHome: string): Promise<void>;
+}
+
+export type InstallValidator = (substrateRoot: string) => Promise<void>;
+
+export interface UninstallContext {
+  homeDir?: string;
+  substrateHome: string;
+}
+
 export interface ReservedUninstallSpec {
   kind: "reserved";
   reason: string;
@@ -27,6 +40,8 @@ export interface ReservedUninstallSpec {
 export interface ImplementedUninstallSpec {
   kind: "implemented";
   remove: readonly string[];
+  shouldRemove?(target: string, context: UninstallContext): Promise<boolean>;
+  postRemove?(context: UninstallContext): Promise<string[]>;
 }
 
 export type UninstallSpec = ReservedUninstallSpec | ImplementedUninstallSpec;
@@ -40,6 +55,8 @@ export interface SubstrateInstallSpec<S extends InstallSubstrate = InstallSubstr
   substrate: S;
   defaultHome: string;
   homeFiles: readonly string[];
+  isaSkillProjection: IsaSkillProjectionSpec;
+  validator?: InstallValidator;
   lifecycleProjection?: LifecycleProjectionSpec;
   postProjection?: readonly InstallPostProjectionStep[];
   privateRoots?: PrivateRootSpec;

--- a/src/install.ts
+++ b/src/install.ts
@@ -13,6 +13,7 @@ import { defaultSomaRepoPath } from "./repo-path";
 import { bootstrapSomaHome } from "./soma-home";
 import { installIsaSkillProjection } from "./isa-skill-installer";
 import { loadActiveIsaForBundle } from "./adapter-active-isa";
+import { isEnoent } from "./fs-errors";
 import {
   type ImplementedUninstallSpec,
   type InstallSubstrate,
@@ -286,10 +287,6 @@ type ImplementedUninstallResult<S extends ImplementedUninstallSubstrate> = {
   substrateHome: string;
   removed: string[];
 };
-
-function isEnoent(error: unknown): boolean {
-  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT";
-}
 
 async function removeExistingTargets(
   targets: readonly string[],

--- a/src/install.ts
+++ b/src/install.ts
@@ -61,11 +61,11 @@ function resolveInstallHomes(substrate: InstallSubstrate, options: SomaInstallOp
 // `src/bun-probe.ts` for the discovery + remediation logic.
 import { requireBunInPath } from "./bun-probe";
 
-function planSomaInstall(
+export function planSomaInstall(
   substrate: InstallSubstrate,
-  substrateFiles: readonly string[],
   options: SomaInstallOptions = {},
 ): SomaInstallPlan {
+  const spec = installSpecFor(substrate);
   const homes = resolveInstallHomes(substrate, options);
 
   return {
@@ -75,28 +75,24 @@ function planSomaInstall(
     substrateHome: homes.substrateHome,
     somaDirectories: SOMA_BOOTSTRAP_DIRECTORIES.map((path) => `${homes.somaHome}/${path}`),
     somaFiles: SOMA_BOOTSTRAP_FILES.map((path) => `${homes.somaHome}/${path}`),
-    substrateFiles: substrateFiles.map((path) => `${homes.substrateHome}/${path}`),
+    substrateFiles: spec.homeFiles.map((path) => `${homes.substrateHome}/${path}`),
   };
 }
 
 export function planSomaForCodexInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
-  const spec = installSpecFor("codex");
-  return planSomaInstall(spec.substrate, spec.homeFiles, options);
+  return planSomaInstall("codex", options);
 }
 
 export function planSomaForPiDevInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
-  const spec = installSpecFor("pi-dev");
-  return planSomaInstall(spec.substrate, spec.homeFiles, options);
+  return planSomaInstall("pi-dev", options);
 }
 
 export function planSomaForClaudeCodeInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
-  const spec = installSpecFor("claude-code");
-  return planSomaInstall(spec.substrate, spec.homeFiles, options);
+  return planSomaInstall("claude-code", options);
 }
 
 export function planSomaForCursorInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
-  const spec = installSpecFor("cursor");
-  return planSomaInstall(spec.substrate, spec.homeFiles, options);
+  return planSomaInstall("cursor", options);
 }
 
 async function installSomaForSubstrate(
@@ -283,6 +279,14 @@ export interface UninstallCursorResult {
   removed: string[];
 }
 
+type ImplementedUninstallSubstrate = "claude-code" | "cursor";
+type ImplementedUninstallOptions = { homeDir?: string; substrateHome?: string };
+type ImplementedUninstallResult<S extends ImplementedUninstallSubstrate> = {
+  substrate: S;
+  substrateHome: string;
+  removed: string[];
+};
+
 function isEnoent(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT";
 }
@@ -321,22 +325,25 @@ async function runImplementedUninstall(
   return removed;
 }
 
+async function uninstallSomaForSubstrate<S extends ImplementedUninstallSubstrate>(
+  substrate: S,
+  options: ImplementedUninstallOptions = {},
+): Promise<ImplementedUninstallResult<S>> {
+  const resolvedHomeDir = resolve(options.homeDir ?? homedir());
+  const substrateHome = resolve(options.substrateHome ?? join(resolvedHomeDir, defaultSubstrateHome(substrate)));
+  const spec = installSpecFor(substrate).uninstall;
+  const removed = spec.kind === "implemented" ? await runImplementedUninstall(spec, { homeDir: options.homeDir, substrateHome }) : [];
+  return { substrate, substrateHome, removed };
+}
+
 export async function uninstallSomaForClaudeCode(
   options: UninstallClaudeCodeOptions = {},
 ): Promise<UninstallClaudeCodeResult> {
-  const resolvedHomeDir = resolve(options.homeDir ?? homedir());
-  const substrateHome = resolve(options.substrateHome ?? join(resolvedHomeDir, defaultSubstrateHome("claude-code")));
-  const spec = installSpecFor("claude-code").uninstall;
-  const removed = spec.kind === "implemented" ? await runImplementedUninstall(spec, { homeDir: options.homeDir, substrateHome }) : [];
-  return { substrate: "claude-code", substrateHome, removed };
+  return uninstallSomaForSubstrate("claude-code", options);
 }
 
 export async function uninstallSomaForCursor(
   options: UninstallCursorOptions = {},
 ): Promise<UninstallCursorResult> {
-  const resolvedHomeDir = resolve(options.homeDir ?? homedir());
-  const substrateHome = resolve(options.substrateHome ?? join(resolvedHomeDir, defaultSubstrateHome("cursor")));
-  const spec = installSpecFor("cursor").uninstall;
-  const removed = spec.kind === "implemented" ? await runImplementedUninstall(spec, { homeDir: options.homeDir, substrateHome }) : [];
-  return { substrate: "cursor", substrateHome, removed };
+  return uninstallSomaForSubstrate("cursor", options);
 }

--- a/src/install.ts
+++ b/src/install.ts
@@ -1,17 +1,7 @@
 import { homedir } from "node:os";
-import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import { codexInstallSpec } from "./adapters/codex/install";
-import { CURSOR_HOME_FILE_PATHS } from "./adapters/cursor";
 import {
-  PI_DEV_ISA_SKILL_ID,
-  piDevIsaSkillDestinationDir,
-  removeLegacyPiDevIsaSkillProjection,
-} from "./adapters/pi-dev/skill-projection";
-import { validatePiDevInstallRuntime } from "./adapters/pi-dev/version";
-import {
-  CURSOR_RULES_BLOCK_BEGIN,
-  CURSOR_RULES_BLOCK_END,
   installClaudeCodeHomeProjection,
   installCodexHomeProjection,
   installCursorHomeProjection,
@@ -21,9 +11,15 @@ import { buildSomaStartupContext, runSomaLifecycleAlgorithmUpdated } from "./lif
 import { SOMA_MEMORY_CATEGORIES } from "./memory-readmes";
 import { defaultSomaRepoPath } from "./repo-path";
 import { bootstrapSomaHome } from "./soma-home";
-import { installIsaSkill, installIsaSkillProjection } from "./isa-skill-installer";
+import { installIsaSkillProjection } from "./isa-skill-installer";
 import { loadActiveIsaForBundle } from "./adapter-active-isa";
-import { type InstallSubstrate, type LifecycleProjectionSpec, type SubstrateInstallSpec } from "./install-spec";
+import {
+  type ImplementedUninstallSpec,
+  type InstallSubstrate,
+  type LifecycleProjectionSpec,
+  type SubstrateInstallSpec,
+  type UninstallContext,
+} from "./install-spec";
 import { defaultSubstrateHome, installSpecFor } from "./install-spec-registry";
 import type { ProjectionInput, SomaInstallOptions, SomaInstallPlan, SomaInstallResult } from "./types";
 
@@ -48,39 +44,6 @@ const SOMA_BOOTSTRAP_DIRECTORIES = [
   "projections/cursor",
 ] as const;
 
-const PI_DEV_HOME_FILES = [
-  "agent/extensions/soma.ts",
-  "agent/extensions/soma-path-guard.ts",
-  // #43 minimal-correct slice — Algorithm phase renderer extension.
-  "agent/extensions/soma-algorithm.ts",
-  "agent/soma/context.md",
-  "agent/soma/profile.md",
-  "agent/soma/startup-context.md",
-  "agent/soma/memory-layout.md",
-  "agent/soma/pai-imports.md",
-  "agent/soma/tools.md",
-  "agent/soma/skills.md",
-  "agent/soma/policy.md",
-  "agent/soma/soma-repo.txt",
-  "agent/skills/soma/SKILL.md",
-] as const;
-
-// Claude Code home files written by the full #29 installer
-// (`.claude/rules/soma/`-pivot per soma#64). Sourced from the adapter
-// so the planner and writer can't drift (sage r1 finding).
-import { CLAUDE_CODE_RULES_FILES } from "./adapters/claude-code";
-const CLAUDE_CODE_HOME_FILES = CLAUDE_CODE_RULES_FILES;
-
-const SKILL_SUBPATHS: Record<Exclude<InstallSubstrate, "pi-dev">, string> = {
-  codex: "skills/ISA",
-  "claude-code": "skills/ISA",
-  cursor: ".cursor/rules/soma/skills/ISA",
-};
-
-const INSTALL_VALIDATORS: Partial<Record<InstallSubstrate, (substrateRoot: string) => Promise<void>>> = {
-  "pi-dev": validatePiDevInstallRuntime,
-};
-
 function resolveInstallHomes(substrate: InstallSubstrate, options: SomaInstallOptions): { somaHome: string; substrateHome: string } {
   const homeDir = options.homeDir;
   const defaultHome = defaultSubstrateHome(substrate);
@@ -92,22 +55,6 @@ function resolveInstallHomes(substrate: InstallSubstrate, options: SomaInstallOp
     somaHome,
     substrateHome,
   };
-}
-
-function resolveSubstrateSkillDir(substrate: InstallSubstrate, substrateHome: string): string {
-  if (substrate === "pi-dev") return piDevIsaSkillDestinationDir(substrateHome);
-  return resolve(substrateHome, SKILL_SUBPATHS[substrate]);
-}
-
-function substrateSkillNameOverride(substrate: InstallSubstrate): string | undefined {
-  if (substrate === "pi-dev") return PI_DEV_ISA_SKILL_ID;
-  return undefined;
-}
-
-async function prepareSubstrateSkillDestination(substrate: InstallSubstrate, substrateHome: string): Promise<void> {
-  if (substrate === "pi-dev") {
-    await removeLegacyPiDevIsaSkillProjection(substrateHome);
-  }
 }
 
 // soma#73 pre-flight is shared with the codex adapter — see
@@ -133,25 +80,30 @@ function planSomaInstall(
 }
 
 export function planSomaForCodexInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
-  return planSomaInstall(codexInstallSpec.substrate, codexInstallSpec.homeFiles, options);
+  const spec = installSpecFor("codex");
+  return planSomaInstall(spec.substrate, spec.homeFiles, options);
 }
 
 export function planSomaForPiDevInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
-  return planSomaInstall("pi-dev", PI_DEV_HOME_FILES, options);
+  const spec = installSpecFor("pi-dev");
+  return planSomaInstall(spec.substrate, spec.homeFiles, options);
 }
 
 export function planSomaForClaudeCodeInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
-  return planSomaInstall("claude-code", CLAUDE_CODE_HOME_FILES, options);
+  const spec = installSpecFor("claude-code");
+  return planSomaInstall(spec.substrate, spec.homeFiles, options);
 }
 
 export function planSomaForCursorInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
-  return planSomaInstall("cursor", CURSOR_HOME_FILE_PATHS, options);
+  const spec = installSpecFor("cursor");
+  return planSomaInstall(spec.substrate, spec.homeFiles, options);
 }
 
 async function installSomaForSubstrate(
   substrate: InstallSubstrate,
   options: SomaInstallOptions = {},
 ): Promise<SomaInstallResult> {
+  const spec = installSpecFor(substrate);
   // soma#73 pre-flight: every soma substrate hook now runs under Bun
   // (#!/usr/bin/env bun shebang). The adopter rejects loud + early
   // when bun is missing rather than producing a half-broken install
@@ -179,15 +131,15 @@ async function installSomaForSubstrate(
   // baseline tracking via `skillDestinationDir`. AC-5: drift detection
   // inherits installIsaSkill's local-edits-preserved contract.
   const resolvedHomeDir = resolve(options.homeDir ?? homedir());
-  const substrateRoot = resolve(options.substrateHome ?? join(resolvedHomeDir, defaultSubstrateHome(substrate)));
-  await INSTALL_VALIDATORS[substrate]?.(substrateRoot);
-  await prepareSubstrateSkillDestination(substrate, substrateRoot);
+  const substrateRoot = resolve(options.substrateHome ?? join(resolvedHomeDir, spec.defaultHome));
+  await spec.validator?.(substrateRoot);
+  await spec.isaSkillProjection.prepare?.(substrateRoot);
   await installIsaSkillProjection({
     homeDir: options.homeDir,
     somaHome: somaHome.somaHome,
     somaRepoPath,
-    skillDestinationDir: resolveSubstrateSkillDir(substrate, substrateRoot),
-    skillNameOverride: substrateSkillNameOverride(substrate),
+    skillDestinationDir: spec.isaSkillProjection.destinationDir(substrateRoot),
+    skillNameOverride: spec.isaSkillProjection.skillNameOverride,
   });
   // Populate the projection input with the active ISA so each
   // substrate writes its `active-isa.md` file (#37 AC-1/AC-2).
@@ -196,14 +148,13 @@ async function installSomaForSubstrate(
     activeIsa: (await loadActiveIsaForBundle({ somaHome: somaHome.somaHome })) ?? undefined,
   };
   const substrateHome = await installHomeProjectionFor(substrate, contextWithActiveIsa, projectionOptions);
-  const spec = installSpecFor(substrate);
   const postProjectionFiles = await runPostProjectionSteps(spec, {
     homeDir: options.homeDir,
     somaHome: somaHome.somaHome,
     somaRepoPath: projectionOptions.somaRepoPath,
     substrateHome: substrateHome.rootDir,
   });
-  const lifecycleSpec = spec?.lifecycleProjection ?? legacyLifecycleProjectionSpec(substrate);
+  const lifecycleSpec = spec.lifecycleProjection;
   const lifecycleFiles = lifecycleSpec
     ? await installLifecycleProjection(lifecycleSpec, substrateHome.rootDir, {
         homeDir: options.homeDir,
@@ -224,11 +175,11 @@ async function installSomaForSubstrate(
 }
 
 async function runPostProjectionSteps(
-  spec: SubstrateInstallSpec | undefined,
+  spec: SubstrateInstallSpec,
   context: { homeDir?: string; somaHome: string; somaRepoPath: string; substrateHome: string },
 ): Promise<string[]> {
   const files: string[] = [];
-  for (const step of spec?.postProjection ?? []) {
+  for (const step of spec.postProjection ?? []) {
     files.push(...(await step.run(context)));
   }
   return files;
@@ -258,16 +209,6 @@ async function writeProjectionFile(root: string, relativePath: string, content: 
   await writeFile(path, `${content.trimEnd()}\n`, "utf8");
 
   return path;
-}
-
-function legacyLifecycleProjectionSpec(substrate: InstallSubstrate): LifecycleProjectionSpec | undefined {
-  if (substrate === "pi-dev") {
-    return {
-      startupContextPath: "agent/soma/startup-context.md",
-      somaRepoPathPath: "agent/soma/soma-repo.txt",
-    };
-  }
-  return undefined;
 }
 
 async function installLifecycleProjection(
@@ -370,13 +311,23 @@ async function removeExistingTargets(
   return removed;
 }
 
+async function runImplementedUninstall(
+  spec: ImplementedUninstallSpec,
+  context: UninstallContext,
+): Promise<string[]> {
+  const targets = spec.remove.map((target) => resolve(context.substrateHome, target));
+  const removed = await removeExistingTargets(targets, async (target) => spec.shouldRemove?.(target, context) ?? true);
+  removed.push(...(await spec.postRemove?.(context) ?? []));
+  return removed;
+}
+
 export async function uninstallSomaForClaudeCode(
   options: UninstallClaudeCodeOptions = {},
 ): Promise<UninstallClaudeCodeResult> {
   const resolvedHomeDir = resolve(options.homeDir ?? homedir());
   const substrateHome = resolve(options.substrateHome ?? join(resolvedHomeDir, defaultSubstrateHome("claude-code")));
-  const targets = [join(substrateHome, "rules/soma"), join(substrateHome, "skills/ISA")];
-  const removed = await removeExistingTargets(targets);
+  const spec = installSpecFor("claude-code").uninstall;
+  const removed = spec.kind === "implemented" ? await runImplementedUninstall(spec, { homeDir: options.homeDir, substrateHome }) : [];
   return { substrate: "claude-code", substrateHome, removed };
 }
 
@@ -385,50 +336,7 @@ export async function uninstallSomaForCursor(
 ): Promise<UninstallCursorResult> {
   const resolvedHomeDir = resolve(options.homeDir ?? homedir());
   const substrateHome = resolve(options.substrateHome ?? join(resolvedHomeDir, defaultSubstrateHome("cursor")));
-  const cursorRulesDir = join(substrateHome, ".cursor/rules/soma");
-  const cursorRulesFile = join(substrateHome, ".cursorrules");
-  const removed = await removeExistingTargets([cursorRulesDir], async () => {
-    const markerFile = join(cursorRulesDir, "README.md");
-    try {
-      const content = await readFile(markerFile, "utf8");
-      return content.startsWith("# Soma Cursor Projection");
-    } catch (error) {
-      if (isEnoent(error)) return false;
-      throw error;
-    }
-  });
-  if (await removeCursorRulesProjection(cursorRulesFile)) {
-    removed.push(cursorRulesFile);
-  }
+  const spec = installSpecFor("cursor").uninstall;
+  const removed = spec.kind === "implemented" ? await runImplementedUninstall(spec, { homeDir: options.homeDir, substrateHome }) : [];
   return { substrate: "cursor", substrateHome, removed };
-}
-
-async function removeCursorRulesProjection(path: string): Promise<boolean> {
-  let content: string;
-  try {
-    content = await readFile(path, "utf8");
-  } catch (error) {
-    if (isEnoent(error)) return false;
-    throw error;
-  }
-
-  if (content.startsWith("# Soma Cursor Projection")) {
-    await rm(path, { force: true });
-    return true;
-  }
-
-  const start = content.indexOf(CURSOR_RULES_BLOCK_BEGIN);
-  if (start === -1) return false;
-  const end = content.indexOf(CURSOR_RULES_BLOCK_END, start);
-  if (end === -1) return false;
-
-  const before = content.slice(0, start).trimEnd();
-  const after = content.slice(end + CURSOR_RULES_BLOCK_END.length).trimStart();
-  const preserved = [before, after.trimEnd()].filter((part) => part.length > 0).join("\n\n");
-  if (preserved.length === 0) {
-    await rm(path, { force: true });
-    return true;
-  }
-  await writeFile(path, `${preserved}\n`, "utf8");
-  return true;
 }

--- a/src/projection-private-roots.ts
+++ b/src/projection-private-roots.ts
@@ -1,23 +1,20 @@
-import { homedir } from "node:os";
-import { join, resolve } from "node:path";
-import { codexInstallSpec } from "./adapters/codex/install";
+import { resolve } from "node:path";
+import { allInstallSpecs, installSpecFor } from "./install-spec-registry";
+import type { InstallSubstrate } from "./install-spec";
 import type { SubstrateId } from "./types";
 
+const INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code", "cursor"] as const satisfies readonly InstallSubstrate[];
+
+function isInstallSubstrate(substrate: SubstrateId | undefined): substrate is InstallSubstrate {
+  return substrate !== undefined && (INSTALL_SUBSTRATES as readonly string[]).includes(substrate);
+}
+
 export function somaProjectionPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
-  const home = resolve(options.homeDir ?? homedir());
-  const codexRoots = codexInstallSpec.privateRoots?.projection?.(options) ?? [];
-  const piDevRoots = [join(home, ".pi", "agent", "soma"), join(home, ".pi", "agent", "skills", "soma")];
-
-  if (options.substrate === "codex") return codexRoots.map((path) => resolve(path));
-  if (options.substrate === "pi-dev") return piDevRoots.map((path) => resolve(path));
-
-  return [...codexRoots, ...piDevRoots].map((path) => resolve(path));
+  const specs = isInstallSubstrate(options.substrate) ? [installSpecFor(options.substrate)] : allInstallSpecs();
+  return specs.flatMap((spec) => spec.privateRoots?.projection?.(options) ?? []).map((path) => resolve(path));
 }
 
 export function somaMemoryPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
-  const codexMemoryRoots = codexInstallSpec.privateRoots?.memory?.(options) ?? [];
-
-  if (options.substrate === undefined || options.substrate === "codex") return codexMemoryRoots.map((path) => resolve(path));
-
-  return [];
+  const specs = isInstallSubstrate(options.substrate) ? [installSpecFor(options.substrate)] : allInstallSpecs();
+  return specs.flatMap((spec) => spec.privateRoots?.memory?.(options) ?? []).map((path) => resolve(path));
 }

--- a/src/projection-private-roots.ts
+++ b/src/projection-private-roots.ts
@@ -1,20 +1,13 @@
 import { resolve } from "node:path";
-import { allInstallSpecs, installSpecFor } from "./install-spec-registry";
-import type { InstallSubstrate } from "./install-spec";
+import { allInstallSpecs, installSpecFor, isRegisteredInstallSubstrate } from "./install-spec-registry";
 import type { SubstrateId } from "./types";
 
-const INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code", "cursor"] as const satisfies readonly InstallSubstrate[];
-
-function isInstallSubstrate(substrate: SubstrateId | undefined): substrate is InstallSubstrate {
-  return substrate !== undefined && (INSTALL_SUBSTRATES as readonly string[]).includes(substrate);
-}
-
 export function somaProjectionPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
-  const specs = isInstallSubstrate(options.substrate) ? [installSpecFor(options.substrate)] : allInstallSpecs();
+  const specs = isRegisteredInstallSubstrate(options.substrate) ? [installSpecFor(options.substrate)] : allInstallSpecs();
   return specs.flatMap((spec) => spec.privateRoots?.projection?.(options) ?? []).map((path) => resolve(path));
 }
 
 export function somaMemoryPrivateRoots(options: { homeDir?: string; substrate?: SubstrateId } = {}): string[] {
-  const specs = isInstallSubstrate(options.substrate) ? [installSpecFor(options.substrate)] : allInstallSpecs();
+  const specs = isRegisteredInstallSubstrate(options.substrate) ? [installSpecFor(options.substrate)] : allInstallSpecs();
   return specs.flatMap((spec) => spec.privateRoots?.memory?.(options) ?? []).map((path) => resolve(path));
 }

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -11,6 +11,7 @@ import {
   SOMA_PAI_BOUND_MEMORY_CATEGORIES,
 } from "../src/memory-readmes";
 import { somaMemoryPrivateRoots, somaProjectionPrivateRoots } from "../src/projection-private-roots";
+import { allInstallSpecs, installSpecFor } from "../src/install-spec-registry";
 
 // #88 — Canonical PAI v5.0.0 memory taxonomy (DD-2). 17 substrate-neutral +
 // 2 PAI-bound = 19. Tests consume the production-exported lists from
@@ -181,6 +182,47 @@ test("codex install spec owns lifecycle and private root facts", () => {
   expect(codexInstallSpec.uninstall.kind).toBe("reserved");
   expect(somaProjectionPrivateRoots({ homeDir, substrate: "codex" })).toEqual([join(homeDir, ".codex/skills/soma")]);
   expect(somaMemoryPrivateRoots({ homeDir, substrate: "codex" })).toEqual([join(homeDir, ".codex/memories")]);
+});
+
+test("install spec registry has adapter-owned facts for every install substrate", () => {
+  const substrates = ["codex", "pi-dev", "claude-code", "cursor"] as const;
+
+  expect(allInstallSpecs().map((spec) => spec.substrate).sort()).toEqual([...substrates].sort());
+
+  for (const substrate of substrates) {
+    const spec = installSpecFor(substrate);
+    expect(spec.substrate).toBe(substrate);
+    expect(spec.defaultHome.length).toBeGreaterThan(0);
+    expect(spec.homeFiles.length).toBeGreaterThan(0);
+    expect(spec.isaSkillProjection.destinationDir("/tmp/substrate-home")).toContain("/tmp/substrate-home");
+    expect(spec.uninstall.kind).toMatch(/implemented|reserved/);
+  }
+
+  expect(installSpecFor("pi-dev").validator).toBeDefined();
+  expect(installSpecFor("pi-dev").lifecycleProjection).toEqual({
+    startupContextPath: "agent/soma/startup-context.md",
+    somaRepoPathPath: "agent/soma/soma-repo.txt",
+  });
+  expect(installSpecFor("pi-dev").isaSkillProjection.skillNameOverride).toBe("isa");
+  expect(installSpecFor("claude-code").uninstall).toMatchObject({
+    kind: "implemented",
+    remove: ["rules/soma", "skills/ISA"],
+  });
+  expect(installSpecFor("cursor").uninstall.kind).toBe("implemented");
+});
+
+test("projection private roots aggregate adapter specs", () => {
+  const homeDir = "/tmp/soma-install-spec-home";
+
+  expect(somaProjectionPrivateRoots({ homeDir, substrate: "pi-dev" })).toEqual([
+    join(homeDir, ".pi/agent/soma"),
+    join(homeDir, ".pi/agent/skills/soma"),
+  ]);
+  expect(somaProjectionPrivateRoots({ homeDir })).toEqual([
+    join(homeDir, ".codex/skills/soma"),
+    join(homeDir, ".pi/agent/soma"),
+    join(homeDir, ".pi/agent/skills/soma"),
+  ]);
 });
 
 test("pi.dev install dry-run lists every substrate file apply reports", async () => {


### PR DESCRIPTION
## Summary
- make install spec registry total for codex, pi-dev, claude-code, and cursor
- move adapter-owned install facts into per-substrate install specs: home files, ISA skill projection, validators, lifecycle projection, private roots, and uninstall metadata
- simplify install/private-root paths to consume specs instead of local substrate fact tables

## Verification
- bun run typecheck
- bun test test/install.test.ts
- bun test test/claude-code-install.test.ts test/adapter-active-isa.test.ts
- bun test
- git diff --check