### PR TITLE
fix: parse block scalar skill descriptions

### DIFF
--- a/src/claude-skills-frontmatter.ts
+++ b/src/claude-skills-frontmatter.ts
@@ -5,9 +5,11 @@
  * bugfix could land in one and miss the other. Holly r1 #117 finding
  * S2 surfaced the duplication.
  *
- * **Scope.** Single-line `key: value` frontmatter only — substrate
- * projection skill bodies follow that convention. No support for
- * folded scalars, block scalars, or anchors.
+ * **Scope.** Minimal frontmatter parsing for the claude-skills
+ * migration path. Supports single-line `key: value` fields plus
+ * `description: |` / `description: >` block scalars. This is not a
+ * general YAML parser; anchors, tags, and nested objects stay out of
+ * scope.
  *
  * **Reach.** The functions here are also safe to use from new code in
  * the same family (Phase 3 verifiers, etc.). Don't reach for these
@@ -31,18 +33,74 @@ export function stripQuotes(value: string): string {
   return value;
 }
 
+export function leadingWhitespaceLength(value: string): number {
+  return value.length - value.trimStart().length;
+}
+
+export function isFrontmatterBlockScalarMarker(value: string): boolean {
+  return /^[|>][+-]?\d*$/.test(value);
+}
+
+export function findFrontmatterBlockScalarEndIndex(lines: string[], startIndex: number, parentIndent: number): number {
+  let endIndex = startIndex;
+  for (let i = startIndex + 1; i < lines.length; i += 1) {
+    const raw = lines[i] ?? "";
+    if (raw.trim().length > 0 && leadingWhitespaceLength(raw) <= parentIndent) {
+      break;
+    }
+    endIndex = i;
+  }
+  return endIndex;
+}
+
+function parseDescriptionBlockScalar(lines: string[], startIndex: number, marker: string, parentIndent: number): string {
+  const blockLines: string[] = [];
+  const endIndex = findFrontmatterBlockScalarEndIndex(lines, startIndex, parentIndent);
+  for (let i = startIndex + 1; i <= endIndex; i += 1) {
+    blockLines.push(lines[i] ?? "");
+  }
+
+  const contentIndent = blockLines
+    .filter((line) => line.trim().length > 0)
+    .reduce<number | null>((min, line) => {
+      const indent = leadingWhitespaceLength(line);
+      return min === null ? indent : Math.min(min, indent);
+    }, null);
+  const dedented = blockLines.map((line) => {
+    if (line.trim().length === 0) return "";
+    return line.slice(contentIndent ?? 0);
+  });
+
+  if (marker.startsWith("|")) {
+    return dedented.join("\n").trimEnd();
+  }
+
+  return dedented
+    .join("\n")
+    .split(/\n{2,}/)
+    .map((paragraph) => paragraph.split(/\n/).map((line) => line.trim()).filter(Boolean).join(" "))
+    .join("\n")
+    .trimEnd();
+}
+
 /**
  * Extract the `description:` field from a frontmatter block, with
- * single-pair outer-quote stripping. Returns `undefined` if no
- * frontmatter or no `description:` line.
+ * single-pair outer-quote stripping for single-line values. Returns
+ * `undefined` if no frontmatter or no `description:` line.
  */
 export function parseDescriptionFromFrontmatter(skillMdContent: string): string | undefined {
   const match = FRONTMATTER_RE.exec(skillMdContent);
   if (!match) return undefined;
-  for (const raw of match[1].split(/\r?\n/)) {
+  const lines = match[1].split(/\r?\n/);
+  for (let i = 0; i < lines.length; i += 1) {
+    const raw = lines[i] ?? "";
     const line = raw.trimEnd();
     if (line.startsWith("description:")) {
-      return stripQuotes(line.slice("description:".length).trim());
+      const value = line.slice("description:".length).trim();
+      if (isFrontmatterBlockScalarMarker(value)) {
+        return parseDescriptionBlockScalar(lines, i, value, leadingWhitespaceLength(raw));
+      }
+      return stripQuotes(value);
     }
   }
   return undefined;

--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -123,7 +123,12 @@ function resolveRewriteDescriptionsAgent(agent: Exclude<RewriteDescriptionsAgent
 // Shared frontmatter helpers — single source of truth for description
 // extraction across the migrator + verifier. See
 // `./claude-skills-frontmatter.ts` for the contract and reach.
-import { FRONTMATTER_RE, parseDescriptionFromFrontmatter as parseSourceDescription } from "./claude-skills-frontmatter";
+import {
+  findFrontmatterBlockScalarEndIndex,
+  FRONTMATTER_RE,
+  isFrontmatterBlockScalarMarker,
+  parseDescriptionFromFrontmatter as parseSourceDescription,
+} from "./claude-skills-frontmatter";
 
 /**
  * Materialize an imported skill as a `SomaSkill`-shaped object so
@@ -1184,19 +1189,23 @@ function spliceFrontmatterDescription(args: {
   const fmBlock = fm[1];
   const lines = fmBlock.split(/\r?\n/);
   let replaced = false;
-  const newLines = lines.map((line: string) => {
+  const newLines: string[] = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i] ?? "";
     if (line.trimStart().startsWith("description:")) {
       replaced = true;
       // Preserve the leading indentation (rare but possible if the
       // skill author indented their frontmatter).
       const indent = /^\s*/.exec(line)?.[0] ?? "";
-      return `${indent}description: ${quoted}`;
+      newLines.push(`${indent}description: ${quoted}`);
+      const value = line.trimStart().slice("description:".length).trim();
+      if (isFrontmatterBlockScalarMarker(value)) {
+        i = findFrontmatterBlockScalarEndIndex(lines, i, indent.length);
+      }
+      continue;
     }
-    return line;
-  });
-  // `replaced` is mutated inside the `.map` closure above; the lint
-  // narrowing can't see it, hence the suppress.
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    newLines.push(line);
+  }
   if (!replaced) {
     // No description line; append one. Substrates require it; the
     // synthesis path means we MUST always end up with a description.

--- a/test/claude-skills-frontmatter.test.ts
+++ b/test/claude-skills-frontmatter.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "bun:test";
+import { parseDescriptionFromFrontmatter } from "../src/claude-skills-frontmatter";
+
+test("parseDescriptionFromFrontmatter reads literal block scalar descriptions", () => {
+  const skillMd = [
+    "---",
+    "name: BlockSkill",
+    "description: |",
+    "  First line.",
+    "  Second line with more detail.",
+    "allowed-tools: Read",
+    "---",
+    "",
+    "# BlockSkill",
+    "",
+  ].join("\n");
+
+  expect(parseDescriptionFromFrontmatter(skillMd)).toBe("First line.\nSecond line with more detail.");
+});
+
+test("parseDescriptionFromFrontmatter reads folded block scalar descriptions", () => {
+  const skillMd = [
+    "---",
+    "name: FoldedSkill",
+    "description: >",
+    "  First line",
+    "  continues here.",
+    "",
+    "  Second paragraph.",
+    "allowed-tools: Read",
+    "---",
+    "",
+    "# FoldedSkill",
+    "",
+  ].join("\n");
+
+  expect(parseDescriptionFromFrontmatter(skillMd)).toBe("First line continues here.\nSecond paragraph.");
+});

--- a/test/claude-skills-migrator.test.ts
+++ b/test/claude-skills-migrator.test.ts
@@ -1062,6 +1062,13 @@ const APIFY_LIKE_DESCRIPTION_1318 = (() => {
   return text.slice(0, 1318);
 })();
 
+const BLOCK_SCALAR_DESCRIPTION_1400 = [
+  APIFY_LIKE_DESCRIPTION_1318.trim(),
+  "This extra block-scalar-only section ensures the expanded YAML description remains above the substrate cap after normal YAML indentation trimming.",
+  "It preserves enough real words to prove the migrator counts actual description text rather than the literal block marker.",
+  "The skill should therefore be refused without rewrite and rewritten when rewrite-descriptions is enabled.",
+].join(" ");
+
 function buildSkillWithFrontmatterDescription(description: string): string {
   // Quote the value so embedded colons / quotes don't break the parser.
   // The migrator's frontmatter helpers handle a single matching outer
@@ -1071,6 +1078,26 @@ function buildSkillWithFrontmatterDescription(description: string): string {
     "---",
     "name: TestSkill",
     `description: "${escaped}"`,
+    "---",
+    "",
+    "# TestSkill",
+    "",
+    "Body content here.",
+    "",
+  ].join("\n");
+}
+
+function buildSkillWithBlockScalarDescription(description: string, marker: "|" | ">" = "|"): string {
+  const wrapped: string[] = [];
+  for (let offset = 0; offset < description.length; offset += 88) {
+    wrapped.push(description.slice(offset, offset + 88).trimEnd());
+  }
+  return [
+    "---",
+    "name: TestSkill",
+    `description: ${marker}`,
+    ...wrapped.map((line) => `  ${line}`),
+    "allowed-tools: Read",
     "---",
     "",
     "# TestSkill",
@@ -1128,6 +1155,27 @@ test("oversize description + agent absent → refused-description-limit, skill n
   });
 });
 
+test("oversize block-scalar description + agent absent → refused using expanded length", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const somaHome = join(home, "soma");
+    await writeFlatSkillsFixture(fromDir, {
+      Confluence: {
+        skillMd: buildSkillWithBlockScalarDescription(BLOCK_SCALAR_DESCRIPTION_1400),
+      },
+    });
+
+    const result = await migrateClaudeSkills({ from: fromDir, somaHome });
+    expect(result.writtenCount).toBe(0);
+    expect(result.refusedDescriptionLimitCount).toBe(1);
+    const outcome = result.outcomes.find((o) => o.sourceName === "Confluence");
+    expect(outcome?.disposition).toBe("refused-description-limit");
+    expect(outcome?.descriptionStatus?.kind).toBe("oversize");
+    expect(outcome?.descriptionStatus?.length).toBeGreaterThan(1024);
+    expect(outcome?.descriptionStatus?.length).not.toBe(1);
+  });
+});
+
 test("missing frontmatter + agent absent → refused-description-limit", async () => {
   await withTempHome(async (home) => {
     const fromDir = join(home, "skills");
@@ -1150,10 +1198,46 @@ test("missing frontmatter + agent absent → refused-description-limit", async (
   });
 });
 
+test("oversize block-scalar description + --rewrite-descriptions auto → rewrites and removes old block body", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "skills");
+    const somaHome = join(home, "soma");
+    await writeFlatSkillsFixture(fromDir, {
+      Confluence: {
+        skillMd: buildSkillWithBlockScalarDescription(BLOCK_SCALAR_DESCRIPTION_1400),
+      },
+    });
+
+    const dispatchStatuses: string[] = [];
+    const result = await migrateClaudeSkills({
+      from: fromDir,
+      somaHome,
+      rewriteDescriptionsAgent: "auto",
+      rewriteDispatchOverride: async (req) => {
+        dispatchStatuses.push(`${req.status.kind}:${req.status.length}`);
+        expect(req.originalDescription).toContain("Scrape social media platforms");
+        return "Confluence skill rewritten under the substrate description cap. USE WHEN importing block scalar frontmatter descriptions.";
+      },
+    });
+
+    expect(dispatchStatuses.length).toBe(1);
+    expect(dispatchStatuses[0]).toMatch(/^oversize:/);
+    expect(result.writtenCount).toBe(1);
+    expect(result.descriptionRewrittenCount).toBe(1);
+    const outcome = result.outcomes.find((o) => o.sourceName === "Confluence");
+    expect(outcome?.descriptionStatus?.length).toBeGreaterThan(1024);
+    const landed = await readFile(join(somaHome, "skills/confluence/SKILL.md"), "utf8");
+    expect(landed).toContain("description: \"Confluence skill rewritten");
+    expect(landed).toContain("allowed-tools: Read");
+    expect(landed).not.toContain("description: |");
+    expect(landed).not.toContain("  Scrape social media platforms");
+  });
+});
+
 test("oversize + --rewrite-descriptions claude (stubbed) → rewrites under cap and imports", async () => {
   await withTempHome(async (home) => {
     const { fromDir, somaHome } = await writeOversizeApifyFixture(home);
-    const dispatchCalls: Array<{ agent: string; status: string; sourceName: string }> = [];
+    const dispatchCalls: { agent: string; status: string; sourceName: string }[] = [];
     const result = await migrateClaudeSkills({
       from: fromDir,
       somaHome,


### PR DESCRIPTION
## Summary

Fixes #205.

- Parse YAML block-scalar skill descriptions (`description: |` and `description: >`) as expanded text during `migrate claude-skills`.
- Treat oversized block-scalar descriptions as over the substrate cap instead of reading the marker as length 1.
- Replace the whole block-scalar body when rewriting descriptions so stale indented description text does not remain in frontmatter.
- Add parser and migrator regression coverage for refused and rewritten block-scalar descriptions.

## Verification

- `bun run typecheck`
- `bun test test/claude-skills-frontmatter.test.ts test/claude-skills-migrator.test.ts test/claude-skills-substrate-verify.test.ts`
- `bunx eslint src/claude-skills-frontmatter.ts test/claude-skills-frontmatter.test.ts test/claude-skills-migrator.test.ts`
- `git diff --check`

## Known unrelated failures

- Full `bun test` currently fails on `test/relationship-tools.test.ts` (`relationship CLI reflects modes`), and that failure reproduces standalone.