### PR TITLE
Align shared work registry state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .worktrees/
 .pi/
 .claude/
+.specflow/

--- a/.specify/app-context.md
+++ b/.specify/app-context.md
@@ -20,7 +20,7 @@ of public templates.
 Soma writes lifecycle events and learning artifacts, and `soma learning harvest`
 can harvest explicit transcript directories. It does not currently write
 PAI-compatible `memory/STATE/work.json`, `memory/STATE/session-names.json`, or
-`memory/STATE/current-work-<session-id>.json`. The learning harvester silently
+resolver-backed `memory/STATE/current-work-<safe-session-token>-<session-id-hash>.json`. The learning harvester silently
 defaults to `memory/STATE/sessions`, which is not a canonical source.
 
 ## Constraints & Requirements

--- a/.specify/app-context.md
+++ b/.specify/app-context.md
@@ -1,0 +1,72 @@
+# App Context: Soma Work Registry Alignment
+
+## Problem Statement
+
+Soma currently has an implicit learning-harvest default at
+`SOMA_HOME/memory/STATE/sessions/*.jsonl`. That path is not produced by current
+PAI or by installed Soma, so it creates a false interoperability contract.
+Soma needs canonical shared session state that aligns with the PAI work registry
+model and remains safe across substrates.
+
+## Users & Stakeholders
+
+The primary users are Soma substrate adapters and agents that need to resume or
+continue work across hosts. Maintainers need deterministic TypeScript contracts,
+CLI-visible behavior, and documentation that keeps private transcript data out
+of public templates.
+
+## Current State
+
+Soma writes lifecycle events and learning artifacts, and `soma learning harvest`
+can harvest explicit transcript directories. It does not currently write
+PAI-compatible `memory/STATE/work.json`, `memory/STATE/session-names.json`, or
+`memory/STATE/current-work-<session-id>.json`. The learning harvester silently
+defaults to `memory/STATE/sessions`, which is not a canonical source.
+
+## Constraints & Requirements
+
+Keep Soma filesystem-native, substrate-portable, and model-provider-neutral.
+Use Bun and TypeScript. Avoid storing full private prompts, results, or raw
+transcripts by default. Raw transcript harvesting must be explicit or
+adapter-policy-gated. Shared state should be minimal, deterministic, and
+compatible with PAI's live work registry concepts.
+
+## User Experience
+
+`soma learning harvest` should no longer imply that a non-existent raw transcript
+directory is the default source. Default behavior should use canonical work
+state when present, and raw transcript harvesting should require `--session-dir`.
+Lifecycle writeback should leave enough metadata for another substrate to see
+active or recently completed work and follow pointers to updated artifacts.
+
+## Edge Cases & Error Handling
+
+Missing work state should produce an empty harvest result rather than create
+fake transcript paths. Malformed registry files should fail with actionable
+errors. Session IDs without names should still produce registry entries with a
+stable fallback name. Event writes should be append-only and should not block
+core work if unrelated optional metadata is absent.
+
+## Success Criteria
+
+Soma documents the canonical work registry, implements PAI-aligned shared state
+files, removes the orphan `STATE/sessions` default, writes a session-end event
+that points to updated shared state, and verifies default behavior through tests.
+
+## Scope
+
+### In Scope
+
+- Canonical Soma work registry and session-name registry files.
+- Lifecycle writeback of minimal work/session metadata.
+- Learning-harvest default behavior that uses work state or requires
+  `--session-dir` for raw transcript harvesting.
+- Minimal observability event linking session-end writeback to state artifacts.
+- Public docs and design decision updates.
+
+### Explicitly Out of Scope
+
+- Full raw transcript mirroring.
+- Full PAI tool activity and tool failure telemetry.
+- Complete observability analytics for all skill usage and algorithm phases.
+- Migration of all imported legacy skill path references.

--- a/.specify/specs/f-1-document-canonical-shared-work-state/docs.md
+++ b/.specify/specs/f-1-document-canonical-shared-work-state/docs.md
@@ -8,7 +8,7 @@ Entry added to `CHANGELOG.md`:
 
 - Added canonical PAI-aligned shared work state for lifecycle writeback and
   learning harvest defaults: `work.json`, `session-names.json`,
-  `current-work-<session-id>.json`, and metadata-only writeback events.
+  resolver-backed current-work pointers, and metadata-only writeback events.
 
 ## User-Facing Changes
 

--- a/.specify/specs/f-1-document-canonical-shared-work-state/docs.md
+++ b/.specify/specs/f-1-document-canonical-shared-work-state/docs.md
@@ -1,0 +1,30 @@
+# Documentation Updates — F-1: Document canonical shared work state
+
+Generated: 2026-05-26
+
+## CHANGELOG
+
+Entry added to `CHANGELOG.md`:
+
+- Added canonical PAI-aligned shared work state for lifecycle writeback and
+  learning harvest defaults: `work.json`, `session-names.json`,
+  `current-work-<session-id>.json`, and metadata-only writeback events.
+
+## User-Facing Changes
+
+### CLI Changes
+
+- `soma learning harvest` now defaults to canonical work registry state.
+- `--session-dir` remains the explicit raw transcript JSONL source.
+
+### Other Changes
+
+- `docs/learning-contracts.md` documents default and explicit harvest sources.
+- `docs/substrate-adapters.md` documents adapter writeback expectations.
+- `CONTEXT.md` and `design/design-decisions.md` record the canonical state
+  vocabulary and decision.
+
+## README Update
+
+No README usage block currently describes learning harvest, so the user-facing
+contract lives in `docs/learning-contracts.md` and `docs/substrate-adapters.md`.

--- a/.specify/specs/f-1-document-canonical-shared-work-state/plan.md
+++ b/.specify/specs/f-1-document-canonical-shared-work-state/plan.md
@@ -1,0 +1,54 @@
+---
+feature: "Document canonical shared work state"
+spec: "./spec.md"
+status: "approved"
+---
+
+# Technical Plan: Document Canonical Shared Work State
+
+## Architecture Overview
+
+Documentation establishes the contract consumed by the later implementation
+features.
+
+```
+CONTEXT.md glossary
+        |
+        v
+design/design-decisions.md DD-5
+        |
+        v
+docs/learning-contracts.md and docs/substrate-adapters.md
+```
+
+## Implementation Strategy
+
+### Phase 1: Glossary
+
+- Define canonical state terms in `CONTEXT.md`.
+
+### Phase 2: Decision Record
+
+- Add a numbered design decision for shared work state.
+
+### Phase 3: User-Facing Docs
+
+- Update learning and substrate adapter docs once implementation confirms exact
+  behavior.
+
+## Risk Assessment
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Docs expose private paths | High | Low | Use `SOMA_HOME` placeholders |
+| Docs overpromise telemetry | Medium | Medium | Keep full observability out of scope |
+
+## Dependencies
+
+- Existing `CONTEXT.md`
+- Existing `design/design-decisions.md`
+
+## Estimated Complexity
+
+- **Modified files:** 4
+- **Test files:** 0 directly; behavior verified by later features

--- a/.specify/specs/f-1-document-canonical-shared-work-state/spec.md
+++ b/.specify/specs/f-1-document-canonical-shared-work-state/spec.md
@@ -11,7 +11,7 @@ created: "2026-05-26"
 
 Soma must document the shared work-state model before code relies on it. The
 canonical state follows the PAI-style work registry: `memory/STATE/work.json`,
-`memory/STATE/session-names.json`, `memory/STATE/current-work-<session-id>.json`,
+`memory/STATE/session-names.json`, resolver-backed current-work pointer files,
 and durable artifacts under `memory/WORK/<slug>/`.
 
 ## User Scenarios

--- a/.specify/specs/f-1-document-canonical-shared-work-state/spec.md
+++ b/.specify/specs/f-1-document-canonical-shared-work-state/spec.md
@@ -1,0 +1,65 @@
+---
+id: "F-1"
+feature: "Document canonical shared work state"
+status: "approved"
+created: "2026-05-26"
+---
+
+# Specification: Document Canonical Shared Work State
+
+## Overview
+
+Soma must document the shared work-state model before code relies on it. The
+canonical state follows the PAI-style work registry: `memory/STATE/work.json`,
+`memory/STATE/session-names.json`, `memory/STATE/current-work-<session-id>.json`,
+and durable artifacts under `memory/WORK/<slug>/`.
+
+## User Scenarios
+
+### Scenario 1: Maintainer Understands Canonical State
+
+**As a** Soma maintainer
+**I want to** see one documented state model
+**So that** adapters do not invent incompatible transcript defaults.
+
+**Acceptance Criteria:**
+- [ ] Docs name the work registry and session-name registry as canonical Soma state.
+- [ ] Docs state that raw transcript sources are substrate-local unless explicit.
+
+### Scenario 2: Adapter Author Avoids Private Transcript Mirroring
+
+**As an** adapter author
+**I want to** know what may be written by default
+**So that** private prompts and results are not mirrored accidentally.
+
+**Acceptance Criteria:**
+- [ ] Docs say full prompt/result storage is out of default scope.
+- [ ] Docs identify policy-gated transcript harvesting as a separate path.
+
+## Functional Requirements
+
+### FR-1: Canonical Registry Terms
+
+Document `work registry`, `session name registry`, `current work pointer`,
+`work artifact`, `raw transcript source`, and `observability event`.
+
+**Validation:** Documentation review and tests that exercise the documented
+paths.
+
+### FR-2: Scope Boundary
+
+Document that minimal writeback observability belongs in this issue while full
+tool telemetry remains separate.
+
+**Validation:** Design decision captures this boundary.
+
+## Non-Functional Requirements
+
+- **Security:** Public docs must use placeholders and generic examples.
+- **Failure Behavior:** Ambiguous path references should be clarified rather
+  than silently retained.
+
+## Out of Scope
+
+- Full observability telemetry.
+- Migration of all imported legacy skill references.

--- a/.specify/specs/f-1-document-canonical-shared-work-state/tasks.md
+++ b/.specify/specs/f-1-document-canonical-shared-work-state/tasks.md
@@ -1,0 +1,30 @@
+---
+feature: "Document canonical shared work state"
+plan: "./plan.md"
+status: "pending"
+total_tasks: 3
+completed: 0
+---
+
+# Tasks: Document Canonical Shared Work State
+
+## Task Groups
+
+### Group 1: Glossary
+
+- [ ] **T-1.1** Add shared state vocabulary
+  - File: `CONTEXT.md`
+  - Description: Define work registry, session-name registry, raw transcript
+    source, and observability event.
+
+### Group 2: Decision Record
+
+- [ ] **T-2.1** Record canonical state decision
+  - File: `design/design-decisions.md`
+  - Description: Capture the decision to canonicalize PAI-style work state.
+
+### Group 3: Public Docs
+
+- [ ] **T-3.1** Update user-facing docs after behavior lands
+  - Files: `docs/learning-contracts.md`, `docs/substrate-adapters.md`
+  - Description: Explain default harvest behavior and lifecycle writeback.

--- a/.specify/specs/f-1-document-canonical-shared-work-state/verify.md
+++ b/.specify/specs/f-1-document-canonical-shared-work-state/verify.md
@@ -1,0 +1,20 @@
+# Verification: Document Canonical Shared Work State
+
+Verified: 2026-05-26
+
+## Evidence
+
+- `bun test test/work-registry.test.ts`
+- `bun test test/learning-tools.test.ts --timeout 20000`
+- `bun test test/lifecycle.test.ts --timeout 20000`
+- `bun test test/cli.test.ts --timeout 20000`
+- `bun test --timeout 30000`
+- `bun run typecheck`
+- `git diff --check`
+
+## Result
+
+All targeted and full-suite verification passed. The implementation writes
+canonical work registry state, defaults learning harvest to registry metadata,
+preserves explicit transcript harvesting, and appends metadata-only lifecycle
+events pointing to updated state artifacts.

--- a/.specify/specs/f-2-canonical-work-registry-filesystem-contract/plan.md
+++ b/.specify/specs/f-2-canonical-work-registry-filesystem-contract/plan.md
@@ -16,7 +16,7 @@ src/work-registry.ts
 
 memory/STATE/work.json
 memory/STATE/session-names.json
-memory/STATE/current-work-<session-id>.json
+memory/STATE/current-work-<safe-session-token>-<session-id-hash>.json
 memory/WORK/<slug>/
 ```
 

--- a/.specify/specs/f-2-canonical-work-registry-filesystem-contract/plan.md
+++ b/.specify/specs/f-2-canonical-work-registry-filesystem-contract/plan.md
@@ -1,0 +1,69 @@
+---
+feature: "Canonical work registry filesystem contract"
+spec: "./spec.md"
+status: "approved"
+---
+
+# Technical Plan: Canonical Work Registry Filesystem Contract
+
+## Architecture Overview
+
+```
+src/work-registry.ts
+  ├─ readWorkRegistry(paths)
+  ├─ upsertWorkRegistryEntry(paths, entry)
+  └─ listWorkRegistryEntries(paths)
+
+memory/STATE/work.json
+memory/STATE/session-names.json
+memory/STATE/current-work-<session-id>.json
+memory/WORK/<slug>/
+```
+
+## Data Model
+
+```typescript
+interface SomaWorkRegistryEntry {
+  sessionUUID: string;
+  sessionName: string;
+  task: string;
+  substrate: string;
+  phase: string;
+  progress: string;
+  started: string;
+  updatedAt: string;
+  artifacts: Record<string, string>;
+}
+```
+
+## Implementation Strategy
+
+### Phase 1: Test Public Helper
+
+- Add a behavior test for writing and reading canonical work state.
+
+### Phase 2: Implement Helper
+
+- Add `src/work-registry.ts` and export it.
+
+### Phase 3: Reuse in Later Features
+
+- Use the helper from learning harvest and lifecycle writeback.
+
+## Risk Assessment
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Diverges from PAI shape | Medium | Medium | Preserve key names used by PAI where safe |
+| Stores too much data | High | Low | Narrow input type to metadata only |
+
+## Dependencies
+
+- `src/soma-home.ts`
+- `src/fs-utils.ts`
+
+## Estimated Complexity
+
+- **New files:** 1
+- **Modified files:** 2
+- **Test files:** 1

--- a/.specify/specs/f-2-canonical-work-registry-filesystem-contract/spec.md
+++ b/.specify/specs/f-2-canonical-work-registry-filesystem-contract/spec.md
@@ -23,7 +23,7 @@ tools update the same files with the same minimal schema.
 **Acceptance Criteria:**
 - [ ] Upsert creates `memory/STATE/work.json`.
 - [ ] Upsert creates `memory/STATE/session-names.json`.
-- [ ] Upsert creates `memory/STATE/current-work-<session-id>.json`.
+- [ ] Upsert creates a resolver-backed current-work pointer under `memory/STATE/`.
 - [ ] No full prompt or result text is required or written.
 
 ### Scenario 2: Tool Reads Shared State

--- a/.specify/specs/f-2-canonical-work-registry-filesystem-contract/spec.md
+++ b/.specify/specs/f-2-canonical-work-registry-filesystem-contract/spec.md
@@ -1,0 +1,62 @@
+---
+id: "F-2"
+feature: "Canonical work registry filesystem contract"
+status: "approved"
+created: "2026-05-26"
+---
+
+# Specification: Canonical Work Registry Filesystem Contract
+
+## Overview
+
+Soma needs deterministic helpers for canonical shared work state so adapters and
+tools update the same files with the same minimal schema.
+
+## User Scenarios
+
+### Scenario 1: Adapter Writes Shared State
+
+**As an** adapter
+**I want to** upsert a session into the work registry
+**So that** another substrate can continue from shared metadata.
+
+**Acceptance Criteria:**
+- [ ] Upsert creates `memory/STATE/work.json`.
+- [ ] Upsert creates `memory/STATE/session-names.json`.
+- [ ] Upsert creates `memory/STATE/current-work-<session-id>.json`.
+- [ ] No full prompt or result text is required or written.
+
+### Scenario 2: Tool Reads Shared State
+
+**As a** Soma tool
+**I want to** read registry entries
+**So that** default behavior can use canonical state.
+
+**Acceptance Criteria:**
+- [ ] Missing registry files read as empty state.
+- [ ] Malformed registry JSON fails with an actionable error.
+
+## Functional Requirements
+
+### FR-1: Registry Schema
+
+Define a minimal `SomaWorkRegistryEntry` with session ID, substrate, task/name,
+phase, progress, started timestamp, updated timestamp, and artifact pointers.
+
+**Validation:** Unit tests call the public helper and inspect returned state.
+
+### FR-2: Atomic Filesystem Writes
+
+Use existing filesystem helpers and stable JSON formatting.
+
+**Validation:** Tests confirm all expected files exist after writeback.
+
+## Non-Functional Requirements
+
+- **Security:** Store metadata and artifact pointers only by default.
+- **Deterministic:** Same input produces stable state paths and JSON shape.
+
+## Out of Scope
+
+- Registry migrations for historical PAI files.
+- Rich tool telemetry.

--- a/.specify/specs/f-2-canonical-work-registry-filesystem-contract/tasks.md
+++ b/.specify/specs/f-2-canonical-work-registry-filesystem-contract/tasks.md
@@ -1,0 +1,35 @@
+---
+feature: "Canonical work registry filesystem contract"
+plan: "./plan.md"
+status: "pending"
+total_tasks: 4
+completed: 0
+---
+
+# Tasks: Canonical Work Registry Filesystem Contract
+
+## Task Groups
+
+### Group 1: Registry Helper
+
+- [ ] **T-1.1** Add registry write/read test [T]
+  - File: `test/work-registry.test.ts`
+  - Description: Prove canonical state files are created and no transcript text
+    is required.
+
+- [ ] **T-1.2** Implement registry helper [T]
+  - File: `src/work-registry.ts`
+  - Description: Add minimal types plus read/upsert/list helpers.
+
+### Group 2: Exports
+
+- [ ] **T-2.1** Export registry API [T]
+  - File: `src/index.ts`
+  - Test: `test/work-registry.test.ts`
+  - Description: Make helpers available to adapters and tools.
+
+### Group 3: Documentation
+
+- [ ] **T-3.1** Link docs to concrete helper behavior
+  - Files: `docs/substrate-adapters.md`
+  - Description: Document the state files produced by the helper.

--- a/.specify/specs/f-2-canonical-work-registry-filesystem-contract/verify.md
+++ b/.specify/specs/f-2-canonical-work-registry-filesystem-contract/verify.md
@@ -11,5 +11,5 @@ Verified: 2026-05-26
 ## Result
 
 The registry helper creates `work.json`, `session-names.json`, and
-`current-work-<session-id>.json`; lists entries through the public API; and does
+resolver-backed current-work pointer files; lists entries through the public API; and does
 not require or store prompt/result transcript text.

--- a/.specify/specs/f-2-canonical-work-registry-filesystem-contract/verify.md
+++ b/.specify/specs/f-2-canonical-work-registry-filesystem-contract/verify.md
@@ -1,0 +1,15 @@
+# Verification: Canonical Work Registry Filesystem Contract
+
+Verified: 2026-05-26
+
+## Evidence
+
+- `bun test test/work-registry.test.ts`
+- `bun test --timeout 30000`
+- `bun run typecheck`
+
+## Result
+
+The registry helper creates `work.json`, `session-names.json`, and
+`current-work-<session-id>.json`; lists entries through the public API; and does
+not require or store prompt/result transcript text.

--- a/.specify/specs/f-3-learning-harvest-uses-canonical-state-by-default/plan.md
+++ b/.specify/specs/f-3-learning-harvest-uses-canonical-state-by-default/plan.md
@@ -1,0 +1,50 @@
+---
+feature: "Learning harvest uses canonical state by default"
+spec: "./spec.md"
+status: "approved"
+---
+
+# Technical Plan: Learning Harvest Uses Canonical State By Default
+
+## Architecture Overview
+
+```
+soma learning harvest
+      |
+      +-- --session-dir present --> transcript JSONL mode
+      |
+      +-- no --session-dir ------> work registry mode
+```
+
+## Implementation Strategy
+
+### Phase 1: Failing Default Test
+
+- Add a test that runs harvest without `sessionDir` and expects work-registry
+  behavior rather than `STATE/sessions`.
+
+### Phase 2: Harvester Branch
+
+- Change `harvestSessions` to branch on explicit `sessionDir`.
+- Add `harvestWorkRegistrySessions` using the registry helper.
+
+### Phase 3: CLI/Docs
+
+- Update CLI help or docs to describe explicit transcript mode.
+
+## Risk Assessment
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Breaks explicit transcript harvest | High | Low | Keep existing explicit session-dir tests |
+| Work registry lacks enough data | Medium | Medium | Emit metadata-only learning candidates |
+
+## Dependencies
+
+- F-2 registry helper
+- `src/tools/learning/session-harvester.ts`
+
+## Estimated Complexity
+
+- **Modified files:** 3
+- **Test files:** 1

--- a/.specify/specs/f-3-learning-harvest-uses-canonical-state-by-default/spec.md
+++ b/.specify/specs/f-3-learning-harvest-uses-canonical-state-by-default/spec.md
@@ -1,0 +1,63 @@
+---
+id: "F-3"
+feature: "Learning harvest uses canonical state by default"
+status: "approved"
+created: "2026-05-26"
+---
+
+# Specification: Learning Harvest Uses Canonical State By Default
+
+## Overview
+
+`soma learning harvest` must stop silently reading from an unproduced raw
+transcript default. Default harvesting should use canonical work state when no
+`--session-dir` is provided. Raw transcript harvesting remains available only
+when a caller passes `--session-dir`.
+
+## User Scenarios
+
+### Scenario 1: Default Harvest Has No Fake Transcript Path
+
+**As a** CLI user
+**I want to** run learning harvest without options
+**So that** Soma uses canonical state or reports no work, not an orphan path.
+
+**Acceptance Criteria:**
+- [ ] Default harvest does not resolve `memory/STATE/sessions`.
+- [ ] Missing work registry yields an empty harvest result.
+
+### Scenario 2: Explicit Raw Transcript Harvest
+
+**As a** user with a policy-approved transcript source
+**I want to** pass `--session-dir`
+**So that** Soma harvests raw transcript JSONL files only when explicit.
+
+**Acceptance Criteria:**
+- [ ] Existing explicit `--session-dir` behavior keeps working.
+- [ ] Docs describe this as explicit raw transcript harvest.
+
+## Functional Requirements
+
+### FR-1: Work-State Default
+
+When no session directory is provided, the harvester reads canonical registry
+entries and produces harvestable session summaries from metadata and artifacts.
+
+**Validation:** Tests cover default behavior without injecting `sessionDir`.
+
+### FR-2: Explicit Transcript Mode
+
+Raw transcript parsing requires a configured session directory.
+
+**Validation:** Existing transcript tests continue passing with explicit
+directories.
+
+## Non-Functional Requirements
+
+- **Security:** No default raw transcript mirroring.
+- **Failure Behavior:** Missing work registry is an empty result, not a thrown
+  missing-directory error.
+
+## Out of Scope
+
+- Summarizing private transcript contents by default.

--- a/.specify/specs/f-3-learning-harvest-uses-canonical-state-by-default/tasks.md
+++ b/.specify/specs/f-3-learning-harvest-uses-canonical-state-by-default/tasks.md
@@ -1,0 +1,34 @@
+---
+feature: "Learning harvest uses canonical state by default"
+plan: "./plan.md"
+status: "pending"
+total_tasks: 4
+completed: 0
+---
+
+# Tasks: Learning Harvest Uses Canonical State By Default
+
+## Task Groups
+
+### Group 1: Default Behavior
+
+- [ ] **T-1.1** Add default harvest test [T]
+  - File: `test/learning-tools.test.ts`
+  - Description: Prove no `--session-dir` uses canonical state, not
+    `STATE/sessions`.
+
+- [ ] **T-1.2** Implement work-state harvest [T]
+  - File: `src/tools/learning/session-harvester.ts`
+  - Description: Branch default mode to registry entries.
+
+### Group 2: Explicit Transcript Mode
+
+- [ ] **T-2.1** Preserve explicit transcript harvest [T]
+  - File: `test/learning-tools.test.ts`
+  - Description: Existing explicit session-dir behavior stays green.
+
+### Group 3: Docs
+
+- [ ] **T-3.1** Document default and explicit modes
+  - File: `docs/learning-contracts.md`
+  - Description: Clarify raw transcripts are explicit/policy-gated.

--- a/.specify/specs/f-3-learning-harvest-uses-canonical-state-by-default/verify.md
+++ b/.specify/specs/f-3-learning-harvest-uses-canonical-state-by-default/verify.md
@@ -1,0 +1,14 @@
+# Verification: Learning Harvest Uses Canonical State By Default
+
+Verified: 2026-05-26
+
+## Evidence
+
+- `bun test test/learning-tools.test.ts --timeout 20000`
+- `bun test test/cli.test.ts --timeout 20000`
+- `bun test --timeout 30000`
+
+## Result
+
+Default harvest now reads canonical work registry entries. Explicit
+`--session-dir` transcript harvesting remains covered and still works.

--- a/.specify/specs/f-4-lifecycle-writeback-updates-shared-work-state/plan.md
+++ b/.specify/specs/f-4-lifecycle-writeback-updates-shared-work-state/plan.md
@@ -1,0 +1,51 @@
+---
+feature: "Lifecycle writeback updates shared work state"
+spec: "./spec.md"
+status: "approved"
+---
+
+# Technical Plan: Lifecycle Writeback Updates Shared Work State
+
+## Architecture Overview
+
+```
+adapter lifecycle hook
+        |
+        v
+core lifecycle/writeback module
+        |
+        v
+work registry helper
+```
+
+## Implementation Strategy
+
+### Phase 1: Locate Lifecycle Writeback
+
+- Reuse existing lifecycle hook entry points rather than adding a new daemon.
+
+### Phase 2: Test Metadata Writeback
+
+- Add a behavior test that invokes lifecycle writeback and reads canonical
+  registry files.
+
+### Phase 3: Wire Helper
+
+- Call the registry helper from the lifecycle writeback path.
+
+## Risk Assessment
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Hook lacks stable session ID | Medium | Medium | Generate a stable fallback when absent |
+| Writes host-specific paths | Medium | Low | Use relative artifact paths |
+
+## Dependencies
+
+- F-2 registry helper
+- Existing lifecycle hook implementation
+
+## Estimated Complexity
+
+- **Modified files:** 2-4
+- **Test files:** 1

--- a/.specify/specs/f-4-lifecycle-writeback-updates-shared-work-state/spec.md
+++ b/.specify/specs/f-4-lifecycle-writeback-updates-shared-work-state/spec.md
@@ -1,0 +1,51 @@
+---
+id: "F-4"
+feature: "Lifecycle writeback updates shared work state"
+status: "approved"
+created: "2026-05-26"
+---
+
+# Specification: Lifecycle Writeback Updates Shared Work State
+
+## Overview
+
+Lifecycle writeback should update canonical work state so another substrate can
+continue from minimal session metadata.
+
+## User Scenarios
+
+### Scenario 1: Session-End Writeback
+
+**As a** lifecycle hook
+**I want to** write session metadata on session end
+**So that** shared state reflects completed work.
+
+**Acceptance Criteria:**
+- [ ] Work registry contains the session ID, session name, substrate, timestamps,
+  phase, progress, and artifact pointers.
+- [ ] Session-name registry maps session ID to a human-readable name.
+- [ ] Current-work pointer exists for the session.
+
+## Functional Requirements
+
+### FR-1: Minimal Metadata
+
+Lifecycle writeback must not require prompt text or result text.
+
+**Validation:** Tests invoke lifecycle writeback with metadata-only input.
+
+### FR-2: Cross-Substrate Shape
+
+Registry entries use stable keys that are compatible with PAI work registry
+expectations.
+
+**Validation:** Tests inspect JSON fields in generated registry files.
+
+## Non-Functional Requirements
+
+- **Security:** No full transcript storage by default.
+- **Portability:** No host-specific behavior in the core helper.
+
+## Out of Scope
+
+- Rich lifecycle analytics.

--- a/.specify/specs/f-4-lifecycle-writeback-updates-shared-work-state/tasks.md
+++ b/.specify/specs/f-4-lifecycle-writeback-updates-shared-work-state/tasks.md
@@ -1,0 +1,27 @@
+---
+feature: "Lifecycle writeback updates shared work state"
+plan: "./plan.md"
+status: "pending"
+total_tasks: 3
+completed: 0
+---
+
+# Tasks: Lifecycle Writeback Updates Shared Work State
+
+## Task Groups
+
+### Group 1: Lifecycle Behavior
+
+- [ ] **T-1.1** Add lifecycle writeback test [T]
+  - File: `test/lifecycle.test.ts`
+  - Description: Prove lifecycle writeback updates canonical registry files.
+
+- [ ] **T-1.2** Wire registry helper into lifecycle writeback [T]
+  - Files: `src/lifecycle.ts`, adapter hook files as needed
+  - Description: Convert lifecycle metadata into registry entries.
+
+### Group 2: Privacy
+
+- [ ] **T-2.1** Assert no full transcript fields are written [T]
+  - File: `test/lifecycle.test.ts`
+  - Description: Guard against prompt/result mirroring by default.

--- a/.specify/specs/f-4-lifecycle-writeback-updates-shared-work-state/verify.md
+++ b/.specify/specs/f-4-lifecycle-writeback-updates-shared-work-state/verify.md
@@ -1,0 +1,14 @@
+# Verification: Lifecycle Writeback Updates Shared Work State
+
+Verified: 2026-05-26
+
+## Evidence
+
+- `bun test test/lifecycle.test.ts --timeout 20000`
+- `bun test --timeout 30000`
+- `bun run typecheck`
+
+## Result
+
+Session-end lifecycle writeback updates shared work registry files when a
+session ID is available and includes those files in the lifecycle result.

--- a/.specify/specs/f-5-writeback-events-point-to-shared-state-artifacts/plan.md
+++ b/.specify/specs/f-5-writeback-events-point-to-shared-state-artifacts/plan.md
@@ -1,0 +1,49 @@
+---
+feature: "Writeback events point to shared state artifacts"
+spec: "./spec.md"
+status: "approved"
+---
+
+# Technical Plan: Writeback Events Point To Shared State Artifacts
+
+## Architecture Overview
+
+```
+lifecycle writeback
+        |
+        +-- registry helper writes state
+        |
+        +-- event append records artifact pointers
+```
+
+## Implementation Strategy
+
+### Phase 1: Failing Event Test
+
+- Extend lifecycle test to assert a metadata-only event is appended.
+
+### Phase 2: Event Append
+
+- Reuse existing event append logic where available.
+- Include relative artifact paths from registry write result.
+
+### Phase 3: Docs
+
+- Document this as minimal writeback observability, not full telemetry.
+
+## Risk Assessment
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Event leaks transcript data | High | Low | Narrow event payload to pointers |
+| Event path shape changes | Low | Medium | Tests assert stable relative paths |
+
+## Dependencies
+
+- F-4 lifecycle writeback
+- Existing `events.jsonl` convention
+
+## Estimated Complexity
+
+- **Modified files:** 2
+- **Test files:** 1

--- a/.specify/specs/f-5-writeback-events-point-to-shared-state-artifacts/spec.md
+++ b/.specify/specs/f-5-writeback-events-point-to-shared-state-artifacts/spec.md
@@ -1,0 +1,51 @@
+---
+id: "F-5"
+feature: "Writeback events point to shared state artifacts"
+status: "approved"
+created: "2026-05-26"
+---
+
+# Specification: Writeback Events Point To Shared State Artifacts
+
+## Overview
+
+Session-end writeback should append a minimal observability event that names the
+state files and artifacts updated during writeback.
+
+## User Scenarios
+
+### Scenario 1: Audit Writeback
+
+**As a** maintainer
+**I want to** inspect the event stream
+**So that** I can see which shared state artifacts were updated.
+
+**Acceptance Criteria:**
+- [ ] Event is appended to `memory/STATE/events.jsonl`.
+- [ ] Event includes type, timestamp, session ID, substrate, and artifact paths.
+- [ ] Event does not contain full prompts or results.
+
+## Functional Requirements
+
+### FR-1: Minimal Event Contract
+
+Define an event type for shared work-state writeback.
+
+**Validation:** Tests read the JSONL event and inspect fields.
+
+### FR-2: Artifact Pointers
+
+The event points to `work.json`, `session-names.json`, current-work pointer, and
+WORK artifact directory when present.
+
+**Validation:** Tests confirm paths are included.
+
+## Non-Functional Requirements
+
+- **Security:** Event is metadata-only.
+- **Reliability:** Event append should be stable JSONL.
+
+## Out of Scope
+
+- Tool activity events.
+- Failure telemetry events.

--- a/.specify/specs/f-5-writeback-events-point-to-shared-state-artifacts/tasks.md
+++ b/.specify/specs/f-5-writeback-events-point-to-shared-state-artifacts/tasks.md
@@ -1,0 +1,27 @@
+---
+feature: "Writeback events point to shared state artifacts"
+plan: "./plan.md"
+status: "pending"
+total_tasks: 3
+completed: 0
+---
+
+# Tasks: Writeback Events Point To Shared State Artifacts
+
+## Task Groups
+
+### Group 1: Event Contract
+
+- [ ] **T-1.1** Add event writeback test [T]
+  - File: `test/lifecycle.test.ts`
+  - Description: Prove session-end writeback appends metadata-only event.
+
+- [ ] **T-1.2** Implement event payload [T]
+  - Files: `src/lifecycle.ts`, registry helper as needed
+  - Description: Append artifact pointers after shared state write.
+
+### Group 2: Documentation
+
+- [ ] **T-2.1** Document minimal observability boundary
+  - Files: `docs/substrate-adapters.md`, `design/design-decisions.md`
+  - Description: Clarify full telemetry remains separate.

--- a/.specify/specs/f-5-writeback-events-point-to-shared-state-artifacts/verify.md
+++ b/.specify/specs/f-5-writeback-events-point-to-shared-state-artifacts/verify.md
@@ -1,0 +1,14 @@
+# Verification: Writeback Events Point To Shared State Artifacts
+
+Verified: 2026-05-26
+
+## Evidence
+
+- `bun test test/lifecycle.test.ts --timeout 20000`
+- `bun test --timeout 30000`
+- `bun run typecheck`
+
+## Result
+
+The `lifecycle.session_end` event includes metadata-only artifact pointers for
+the shared work state files and does not include full prompts or results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added canonical PAI-aligned shared work state for lifecycle writeback and
+  learning harvest defaults: `work.json`, `session-names.json`,
+  `current-work-<session-id>.json`, and metadata-only writeback events. ([#165])
+
 ## [0.6.0] - 2026-05-21
 
 ### Added
@@ -68,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#162]: https://github.com/the-metafactory/soma/pull/162
 [#163]: https://github.com/the-metafactory/soma/pull/163
 [#164]: https://github.com/the-metafactory/soma/pull/164
+[#165]: https://github.com/the-metafactory/soma/issues/165
 [#170]: https://github.com/the-metafactory/soma/issues/170
 [#171]: https://github.com/the-metafactory/soma/issues/171
 [#174]: https://github.com/the-metafactory/soma/issues/174

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added canonical PAI-aligned shared work state for lifecycle writeback and
   learning harvest defaults: `work.json`, `session-names.json`,
-  `current-work-<session-id>.json`, and metadata-only writeback events. ([#165])
+  resolver-backed `current-work-<safe-session-token>-<session-id-hash>.json`,
+  and metadata-only writeback events. ([#165])
 
 ## [0.6.0] - 2026-05-21
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -359,6 +359,42 @@ This makes Soma a closed loop, not a one-way pipe.
 
 ---
 
+## work registry
+
+The canonical Soma state that records active and historical work across substrates.
+
+The work registry is Soma-native. It is not a PAI compatibility shim.
+
+## session name registry
+
+The canonical Soma state that maps substrate session identifiers to human-readable work names.
+
+The session name registry is Soma-native. It is not a PAI compatibility shim.
+
+## raw transcript source
+
+A substrate-local directory or file set containing full session transcripts that Soma may harvest only when explicitly requested or adapter-declared.
+
+Raw transcript sources are not default Soma state.
+
+## observability event
+
+A bounded structured event that records substrate activity for monitoring and continuation without storing full transcripts by default.
+
+### Relationship
+
+- A **work registry** entry may reference one or more substrate sessions.
+- The **session name registry** gives those substrate sessions stable human-readable names.
+- Durable work artifacts belong in the **Memory** compartment, not in substrate-local transcript stores.
+- A **raw transcript source** may feed learning harvest, but only when the principal passes it explicitly or an adapter declares it as a policy-governed source.
+- An **observability event** may point to work registry entries and artifacts, but it is not a transcript.
+
+**Not synonyms:** Do not use `progress registry`, `session registry`, or `transcript registry` for the work registry. Do not use `session map` for the session name registry. Do not use `session directory` to mean raw transcript source unless the content is specifically full substrate transcripts. Do not use `event log` to imply full observability coverage; #165 only needs the minimal writeback event contract.
+
+**Why:** Cross-substrate continuation needs one shared state model. PAI proved the work-registry shape; Soma adopts it as canonical state so Codex, Claude Code, Pi.dev, and Cortex can converge on the same continuation surface.
+
+---
+
 ## eager, indexed, on-demand (loading tiers)
 
 Three adjectives describing how a piece of a [[project|projection]] enters the LLM's [[context]] window at session start.

--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -160,3 +160,52 @@ upgrade, and uninstall verbs.
   spec data, not hidden only in CLI branching.
 
 **Discussion:** `/grill-with-docs` session 2026-05-22.
+
+## 5. Shared Work State
+
+### DD-5: Soma canonicalizes the PAI-style work registry
+
+**Status:** Decided (2026-05-26)
+
+**Context:** Issue #165 exposed a mismatch between Soma learning tools and
+live PAI conventions. `soma learning harvest` had an implicit default
+`memory/STATE/sessions/*.jsonl`, but current PAI v5 uses
+`MEMORY/STATE/work.json`, `MEMORY/STATE/session-names.json`,
+session-scoped `current-work-<session-id>.json`, and durable
+`MEMORY/WORK/<slug>/` artifacts as the continuation surface. PAI v5 no longer
+treats full session transcripts as the primary memory model.
+
+Three candidates surfaced:
+- **(a) Preserve `STATE/sessions` as a Soma-native transcript store.**
+- **(b) Invent a cleaner Soma-only registry and map PAI into it.**
+- **(c) Canonicalize the PAI-style work/session registry in Soma.**
+
+**Decision:** **(c)** — Soma adopts the PAI-style work/session registry as
+canonical Soma state. `memory/STATE/work.json` is the **work registry** and
+`memory/STATE/session-names.json` is the **session name registry**. They are
+not compatibility shims.
+
+Raw transcript sources are explicit, adapter-declared, and policy-governed.
+They are not default Soma state and `soma learning harvest` must not silently
+scan an unproduced transcript directory.
+
+Issue #165 should define the minimal writeback observability event that points
+to updated state and artifacts. Full tool activity/failure observability remains
+separate work, tracked by the observability feature area.
+
+**Rejected:**
+- (a) recreates an older PAI model that v5 intentionally moved away from and
+  risks storing full private prompts/results by default.
+- (b) is theoretically cleaner but creates unnecessary translation work and
+  loses parity with the already-proven PAI continuation model.
+
+**Implications:**
+- Substrate adapters should converge on the same work registry and session name
+  registry instead of inventing per-substrate continuation state.
+- Learning harvest defaults should read canonical work state/artifacts or
+  require an explicit raw transcript source.
+- Session-end writeback should append a bounded observability event that names
+  the state files and artifacts touched.
+- Full transcript mirroring, if added later, needs an explicit policy gate.
+
+**Discussion:** `/grill-with-docs` session 2026-05-26 for issue #165.

--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -183,8 +183,8 @@ Three candidates surfaced:
 **Decision:** **(c)** — Soma adopts the PAI-style work/session registry as
 canonical Soma state. `memory/STATE/work.json` is the **work registry** and
 `memory/STATE/session-names.json` is the **session name registry**. They are
-not compatibility shims. Current-work pointer filenames include a safe session
-token plus a hash suffix; adapters should resolve them through
+not compatibility shims. Current-work pointer filenames include a bounded safe
+session token plus a hash suffix; adapters should resolve them through
 `somaWorkRegistryPaths(..., sessionId).currentWork` rather than constructing
 the filename by hand.
 

--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -171,7 +171,7 @@ upgrade, and uninstall verbs.
 live PAI conventions. `soma learning harvest` had an implicit default
 `memory/STATE/sessions/*.jsonl`, but current PAI v5 uses
 `MEMORY/STATE/work.json`, `MEMORY/STATE/session-names.json`,
-session-scoped `current-work-<session-id>.json`, and durable
+session-scoped current-work pointers, and durable
 `MEMORY/WORK/<slug>/` artifacts as the continuation surface. PAI v5 no longer
 treats full session transcripts as the primary memory model.
 
@@ -183,7 +183,10 @@ Three candidates surfaced:
 **Decision:** **(c)** — Soma adopts the PAI-style work/session registry as
 canonical Soma state. `memory/STATE/work.json` is the **work registry** and
 `memory/STATE/session-names.json` is the **session name registry**. They are
-not compatibility shims.
+not compatibility shims. Current-work pointer filenames include a safe session
+token plus a hash suffix; adapters should resolve them through
+`somaWorkRegistryPaths(..., sessionId).currentWork` rather than constructing
+the filename by hand.
 
 Raw transcript sources are explicit, adapter-declared, and policy-governed.
 They are not default Soma state and `soma learning harvest` must not silently

--- a/docs/learning-contracts.md
+++ b/docs/learning-contracts.md
@@ -2,6 +2,21 @@
 
 Soma learning tools read and write through `createPaths()`. Portable tools must not address `~/.claude/PAI` directly.
 
+## Session Harvest Sources
+
+`soma learning harvest` has two source modes:
+
+- **Default mode:** reads canonical shared work state from
+  `<soma-home>/memory/STATE/work.json` and creates metadata-only learning
+  candidates from registry entries.
+- **Explicit transcript mode:** reads raw transcript JSONL files only when the
+  caller passes `--session-dir <dir>`.
+
+Soma does not treat `<soma-home>/memory/STATE/sessions/*.jsonl` as a default
+source. Raw transcript sources are substrate-local unless an adapter explicitly
+declares and policy-gates them. Default harvest output must not mirror full
+private prompts or results.
+
 ## Ratings JSONL
 
 Path: `<soma-home>/memory/LEARNING/SIGNALS/ratings.jsonl`

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -158,6 +158,21 @@ Adapters should be thin. They do not own identity, memory, ISA, skill schemas, o
 policy semantics. They only project those contracts into a substrate's native
 mechanisms, and write back substrate-side events through the writeback gate.
 
+Shared work state is a core contract, not a substrate convention. Adapters that
+can identify a session should update:
+
+- `<soma-home>/memory/STATE/work.json`
+- `<soma-home>/memory/STATE/session-names.json`
+- `<soma-home>/memory/STATE/current-work-<session-id>.json`
+- `<soma-home>/memory/WORK/<slug>/` artifacts when they produce durable work
+
+The registry stores metadata and artifact pointers. It must not mirror full
+private prompts, results, or raw transcripts by default. Session-end writeback
+also appends a metadata-only `lifecycle.session_end` event to
+`<soma-home>/memory/STATE/events.jsonl` with pointers to the shared state files
+it updated. Full tool activity and tool failure telemetry are separate
+observability work.
+
 Adapters own their substrate-native install facts: default home, projected file
 paths, substrate-specific skill destinations, lifecycle projection paths,
 validators, cleanup hooks, private projection roots, and uninstall targets. The

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -167,9 +167,9 @@ can identify a session should update:
 - `<soma-home>/memory/WORK/<slug>/` artifacts when they produce durable work
 
 Adapters should treat `somaWorkRegistryPaths(..., sessionId).currentWork` as the
-canonical resolver for the current-work pointer. The hash suffix is part of the
-filesystem contract so distinct raw session IDs that sanitize to the same token
-cannot overwrite each other.
+canonical resolver for the current-work pointer. The safe token is bounded and
+human-readable; the hash suffix is part of the filesystem contract so distinct
+raw session IDs that sanitize to the same token cannot overwrite each other.
 
 The registry stores metadata and artifact pointers. It must not mirror full
 private prompts, results, or raw transcripts by default. Session-end writeback

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -163,8 +163,13 @@ can identify a session should update:
 
 - `<soma-home>/memory/STATE/work.json`
 - `<soma-home>/memory/STATE/session-names.json`
-- `<soma-home>/memory/STATE/current-work-<session-id>.json`
+- `<soma-home>/memory/STATE/current-work-<safe-session-token>-<session-id-hash>.json`
 - `<soma-home>/memory/WORK/<slug>/` artifacts when they produce durable work
+
+Adapters should treat `somaWorkRegistryPaths(..., sessionId).currentWork` as the
+canonical resolver for the current-work pointer. The hash suffix is part of the
+filesystem contract so distinct raw session IDs that sanitize to the same token
+cannot overwrite each other.
 
 The registry stores metadata and artifact pointers. It must not mirror full
 private prompts, results, or raw transcripts by default. Session-end writeback

--- a/features.json
+++ b/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "F-1",
+    "name": "Document canonical shared work state",
+    "description": "Record the decision that Soma canonicalizes the PAI-style work registry and clarify how it relates to raw transcripts, learning artifacts, and observability events.",
+    "dependencies": [],
+    "priority": 1
+  },
+  {
+    "id": "F-2",
+    "name": "Canonical work registry filesystem contract",
+    "description": "Implement deterministic helpers for Soma's canonical work registry, session-name registry, current-work pointer, and WORK artifact paths without storing full private transcripts.",
+    "dependencies": ["F-1"],
+    "priority": 2
+  },
+  {
+    "id": "F-3",
+    "name": "Learning harvest uses canonical state by default",
+    "description": "Replace the orphan raw-transcript default with PAI-aligned work-state harvesting, while requiring --session-dir for raw transcript harvesting.",
+    "dependencies": ["F-1"],
+    "priority": 3
+  },
+  {
+    "id": "F-4",
+    "name": "Lifecycle writeback updates shared work state",
+    "description": "Make lifecycle writeback record minimal work/session metadata in the canonical registries for cross-substrate continuation.",
+    "dependencies": ["F-2"],
+    "priority": 4
+  },
+  {
+    "id": "F-5",
+    "name": "Writeback events point to shared state artifacts",
+    "description": "Append a minimal session-end writeback event that names the shared state files and artifacts updated by lifecycle writeback.",
+    "dependencies": ["F-4"],
+    "priority": 5
+  }
+]

--- a/src/cli/tools.ts
+++ b/src/cli/tools.ts
@@ -27,7 +27,7 @@ export const TOOL_COMMAND_HELP: Record<ParsedToolArgs["command"], { usage: strin
     subcommands: {
       synthesize: "Usage: soma learning synthesize [--week|--month|--all] [--dry-run] [--home-dir <dir>] [--soma-home <dir>]",
       "capture-failure": "Usage: soma learning capture-failure <transcript-path> <rating> <summary> [detailed-context] [--home-dir <dir>] [--soma-home <dir>]",
-      harvest: "Usage: soma learning harvest [--recent <n>|--all|--session <id>] [--session-dir <dir>] [--dry-run] [--home-dir <dir>] [--soma-home <dir>]",
+      harvest: "Usage: soma learning harvest [--recent <n>|--all|--session <id>] [--session-dir <dir>] [--dry-run] [--home-dir <dir>] [--soma-home <dir>] (default: work registry; --session-dir: raw transcript JSONL)",
     },
   },
   opinion: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,6 +361,16 @@ export {
 } from "./lifecycle";
 export { captureSomaFeedback, classifySomaFeedback, maybeSomaFeedbackPrompt } from "./feedback";
 export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from "./memory";
+export {
+  listSomaWorkRegistryEntries,
+  readSomaWorkRegistry,
+  somaWorkRegistryPaths,
+  upsertSomaWorkRegistryEntry,
+  type SomaWorkRegistry,
+  type SomaWorkRegistryEntry,
+  type UpsertSomaWorkRegistryEntryOptions,
+  type UpsertSomaWorkRegistryEntryResult,
+} from "./work-registry";
 export { applySomaWriteback, type SomaWritebackOptions, type SomaWritebackResult } from "./writeback";
 export { promoteAlgorithmRunMemory } from "./memory-promotion";
 export { captureSomaResult, isSomaResultEventKind, searchSomaResults } from "./result-capture";

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -532,6 +532,7 @@ export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions =
     artifactPaths: normalizeLifecycleArtifactPaths(somaHome, [index.path, index.activePath, ...learningFiles, ...registryFiles]),
     metadata: {
       sessionId: options.sessionId,
+      substrate: substrate(options),
     },
   });
 

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,6 +1,6 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { listAlgorithmRunSummaries, listAlgorithmRuns } from "./algorithm-store";
 import { appendSomaMemoryEvent } from "./memory";
 import { loadSomaHome } from "./soma-home";
@@ -437,6 +437,7 @@ async function writeSessionEndWorkRegistry(input: {
 }): Promise<string[]> {
   if (input.options.sessionId === undefined) return [];
 
+  const learningArtifacts = buildSessionEndRegistryArtifacts(input.somaHome, input.learningFiles);
   const registryWrite = await upsertSomaWorkRegistryEntry({
     somaHome: input.somaHome,
     sessionId: input.options.sessionId,
@@ -449,11 +450,28 @@ async function writeSessionEndWorkRegistry(input: {
     artifacts: {
       algorithmWorkIndex: "memory/STATE/algorithm-work-index.json",
       activeAlgorithmRun: "memory/STATE/active-algorithm-run.json",
-      ...Object.fromEntries(input.learningFiles.map((file, index) => [`learning${index + 1}`, file.replace(`${input.somaHome}/`, "")])),
+      ...learningArtifacts,
     },
   });
 
   return registryWrite.files;
+}
+
+export function buildSessionEndRegistryArtifacts(somaHome: string, learningFiles: string[]): Record<string, string> {
+  const root = resolve(somaHome);
+  const artifacts: Record<string, string> = {};
+  let artifactIndex = 1;
+
+  for (const file of learningFiles) {
+    const resolvedFile = resolve(root, file);
+    const artifactPath = relative(root, resolvedFile);
+    if (artifactPath === "" || artifactPath.startsWith("..") || isAbsolute(artifactPath)) continue;
+
+    artifacts[`learning${artifactIndex}`] = artifactPath;
+    artifactIndex += 1;
+  }
+
+  return artifacts;
 }
 
 export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions = {}): Promise<SomaLifecycleResult> {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -445,17 +445,32 @@ async function writeSessionEndWorkRegistry(input: {
     activeAlgorithmRunPath: input.activeAlgorithmRunPath,
     learningFiles: input.learningFiles,
   });
-  const registryWrite = await upsertSomaWorkRegistryEntry({
-    somaHome: input.somaHome,
-    sessionId: input.options.sessionId,
-    sessionName: `session ${input.options.sessionId}`,
-    substrate: substrate(input.options),
-    task: `Session ${input.options.sessionId}`,
-    phase: "complete",
-    progress: "1/1",
-    timestamp: input.timestamp,
-    artifacts,
-  });
+  let registryWrite: Awaited<ReturnType<typeof upsertSomaWorkRegistryEntry>>;
+  try {
+    registryWrite = await upsertSomaWorkRegistryEntry({
+      somaHome: input.somaHome,
+      sessionId: input.options.sessionId,
+      sessionName: `session ${input.options.sessionId}`,
+      substrate: substrate(input.options),
+      task: `Session ${input.options.sessionId}`,
+      phase: "complete",
+      progress: "1/1",
+      timestamp: input.timestamp,
+      artifacts,
+    });
+  } catch {
+    await appendSomaMemoryEvent(input.somaHome, {
+      substrate: substrate(input.options),
+      kind: "lifecycle.session_end.registry-write-failed",
+      summary: "Session ended; shared work registry writeback failed.",
+      timestamp: input.timestamp,
+      metadata: {
+        sessionId: input.options.sessionId,
+        substrate: substrate(input.options),
+      },
+    });
+    return [];
+  }
 
   return registryWrite.files;
 }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -429,31 +429,39 @@ export async function runSomaLifecycleAlgorithmUpdated(options: SomaLifecycleOpt
   };
 }
 
+async function writeSessionEndWorkRegistry(input: {
+  somaHome: string;
+  options: SomaLifecycleOptions;
+  timestamp: string;
+  learningFiles: string[];
+}): Promise<string[]> {
+  if (input.options.sessionId === undefined) return [];
+
+  const registryWrite = await upsertSomaWorkRegistryEntry({
+    somaHome: input.somaHome,
+    sessionId: input.options.sessionId,
+    sessionName: `session ${input.options.sessionId}`,
+    substrate: substrate(input.options),
+    task: `Session ${input.options.sessionId}`,
+    phase: "complete",
+    progress: "1/1",
+    timestamp: input.timestamp,
+    artifacts: {
+      algorithmWorkIndex: "memory/STATE/algorithm-work-index.json",
+      activeAlgorithmRun: "memory/STATE/active-algorithm-run.json",
+      ...Object.fromEntries(input.learningFiles.map((file, index) => [`learning${index + 1}`, file.replace(`${input.somaHome}/`, "")])),
+    },
+  });
+
+  return registryWrite.files;
+}
+
 export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions = {}): Promise<SomaLifecycleResult> {
   const somaHome = resolveSomaHome(options);
   const timestamp = options.timestamp ?? new Date().toISOString();
   const index = await writeAlgorithmWorkIndex({ ...options, somaHome, timestamp });
   const learningFiles = await captureCompletedAlgorithmLearnings({ ...options, somaHome, timestamp });
-  const registryFiles: string[] = [];
-
-  if (options.sessionId !== undefined) {
-    const registryWrite = await upsertSomaWorkRegistryEntry({
-      somaHome,
-      sessionId: options.sessionId,
-      sessionName: `session ${options.sessionId}`,
-      substrate: substrate(options),
-      task: `Session ${options.sessionId}`,
-      phase: "complete",
-      progress: "1/1",
-      timestamp,
-      artifacts: {
-        algorithmWorkIndex: "memory/STATE/algorithm-work-index.json",
-        activeAlgorithmRun: "memory/STATE/active-algorithm-run.json",
-        ...Object.fromEntries(learningFiles.map((file, index) => [`learning${index + 1}`, file.replace(`${somaHome}/`, "")])),
-      },
-    });
-    registryFiles.push(...registryWrite.files);
-  }
+  const registryFiles = await writeSessionEndWorkRegistry({ somaHome, options, timestamp, learningFiles });
 
   // #38 AC-4: If an active ISA is set, run checkCompleteness and emit a
   // warning event when tier gate is unmet. NEVER blocks session end.

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -478,6 +478,11 @@ export function buildSessionEndRegistryArtifacts(input: {
   return normalizeSomaWorkRegistryArtifacts({ somaHome: input.somaHome }, rawArtifacts);
 }
 
+function normalizeLifecycleArtifactPaths(somaHome: string, artifactPaths: string[]): string[] {
+  const artifacts = Object.fromEntries(artifactPaths.map((artifactPath, index) => [`artifact${index + 1}`, artifactPath]));
+  return Object.values(normalizeSomaWorkRegistryArtifacts({ somaHome }, artifacts));
+}
+
 export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions = {}): Promise<SomaLifecycleResult> {
   const somaHome = resolveSomaHome(options);
   const timestamp = options.timestamp ?? new Date().toISOString();
@@ -524,7 +529,7 @@ export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions =
     kind: "lifecycle.session_end",
     summary: `Session ended; captured ${learningFiles.length} Algorithm learning artifact(s).${tierGateNote}`,
     timestamp,
-    artifactPaths: [index.path, index.activePath, ...learningFiles, ...registryFiles],
+    artifactPaths: normalizeLifecycleArtifactPaths(somaHome, [index.path, index.activePath, ...learningFiles, ...registryFiles]),
     metadata: {
       sessionId: options.sessionId,
     },

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -458,7 +458,7 @@ async function writeSessionEndWorkRegistry(input: {
       timestamp: input.timestamp,
       artifacts,
     });
-  } catch {
+  } catch (error: unknown) {
     await appendSomaMemoryEvent(input.somaHome, {
       substrate: substrate(input.options),
       kind: "lifecycle.session_end.registry-write-failed",
@@ -467,6 +467,7 @@ async function writeSessionEndWorkRegistry(input: {
       metadata: {
         sessionId: input.options.sessionId,
         substrate: substrate(input.options),
+        error: lifecycleErrorMessage(error, input.somaHome),
       },
     });
     return [];
@@ -491,6 +492,11 @@ export function buildSessionEndRegistryArtifacts(input: {
   }
 
   return normalizeSomaWorkRegistryArtifacts({ somaHome: input.somaHome }, rawArtifacts);
+}
+
+function lifecycleErrorMessage(error: unknown, somaHome: string): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replaceAll(somaHome, "<soma-home>").slice(0, 300);
 }
 
 function normalizeLifecycleArtifactPaths(somaHome: string, artifactPaths: string[]): string[] {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import { listAlgorithmRunSummaries, listAlgorithmRuns } from "./algorithm-store";
 import { appendSomaMemoryEvent } from "./memory";
 import { loadSomaHome } from "./soma-home";
+import { upsertSomaWorkRegistryEntry } from "./work-registry";
 import { getCriteria, getGoal } from "./isa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
 import {
@@ -433,6 +434,26 @@ export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions =
   const timestamp = options.timestamp ?? new Date().toISOString();
   const index = await writeAlgorithmWorkIndex({ ...options, somaHome, timestamp });
   const learningFiles = await captureCompletedAlgorithmLearnings({ ...options, somaHome, timestamp });
+  const registryFiles: string[] = [];
+
+  if (options.sessionId !== undefined) {
+    const registryWrite = await upsertSomaWorkRegistryEntry({
+      somaHome,
+      sessionId: options.sessionId,
+      sessionName: `session ${options.sessionId}`,
+      substrate: substrate(options),
+      task: `Session ${options.sessionId}`,
+      phase: "complete",
+      progress: "1/1",
+      timestamp,
+      artifacts: {
+        algorithmWorkIndex: "memory/STATE/algorithm-work-index.json",
+        activeAlgorithmRun: "memory/STATE/active-algorithm-run.json",
+        ...Object.fromEntries(learningFiles.map((file, index) => [`learning${index + 1}`, file.replace(`${somaHome}/`, "")])),
+      },
+    });
+    registryFiles.push(...registryWrite.files);
+  }
 
   // #38 AC-4: If an active ISA is set, run checkCompleteness and emit a
   // warning event when tier gate is unmet. NEVER blocks session end.
@@ -466,16 +487,17 @@ export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions =
     kind: "lifecycle.session_end",
     summary: `Session ended; captured ${learningFiles.length} Algorithm learning artifact(s).${tierGateNote}`,
     timestamp,
-    artifactPaths: [index.path, index.activePath, ...learningFiles],
+    artifactPaths: [index.path, index.activePath, ...learningFiles, ...registryFiles],
     metadata: {
       sessionId: options.sessionId,
     },
   });
 
+  const files = [index.path, index.activePath, ...learningFiles, ...registryFiles, join(somaHome, "memory/STATE/events.jsonl")];
   return {
     event: "session_end",
     somaHome,
     timestamp,
-    files: [index.path, index.activePath, ...learningFiles, join(somaHome, "memory/STATE/events.jsonl")],
+    files: Array.from(new Set(files)),
   };
 }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,10 +1,10 @@
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { listAlgorithmRunSummaries, listAlgorithmRuns } from "./algorithm-store";
 import { appendSomaMemoryEvent } from "./memory";
 import { loadSomaHome } from "./soma-home";
-import { upsertSomaWorkRegistryEntry } from "./work-registry";
+import { normalizeSomaWorkRegistryArtifacts, upsertSomaWorkRegistryEntry } from "./work-registry";
 import { getCriteria, getGoal } from "./isa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
 import {
@@ -433,11 +433,18 @@ async function writeSessionEndWorkRegistry(input: {
   somaHome: string;
   options: SomaLifecycleOptions;
   timestamp: string;
+  algorithmWorkIndexPath: string;
+  activeAlgorithmRunPath: string;
   learningFiles: string[];
 }): Promise<string[]> {
   if (input.options.sessionId === undefined) return [];
 
-  const learningArtifacts = buildSessionEndRegistryArtifacts(input.somaHome, input.learningFiles);
+  const artifacts = buildSessionEndRegistryArtifacts({
+    somaHome: input.somaHome,
+    algorithmWorkIndexPath: input.algorithmWorkIndexPath,
+    activeAlgorithmRunPath: input.activeAlgorithmRunPath,
+    learningFiles: input.learningFiles,
+  });
   const registryWrite = await upsertSomaWorkRegistryEntry({
     somaHome: input.somaHome,
     sessionId: input.options.sessionId,
@@ -447,31 +454,28 @@ async function writeSessionEndWorkRegistry(input: {
     phase: "complete",
     progress: "1/1",
     timestamp: input.timestamp,
-    artifacts: {
-      algorithmWorkIndex: "memory/STATE/algorithm-work-index.json",
-      activeAlgorithmRun: "memory/STATE/active-algorithm-run.json",
-      ...learningArtifacts,
-    },
+    artifacts,
   });
 
   return registryWrite.files;
 }
 
-export function buildSessionEndRegistryArtifacts(somaHome: string, learningFiles: string[]): Record<string, string> {
-  const root = resolve(somaHome);
-  const artifacts: Record<string, string> = {};
-  let artifactIndex = 1;
+export function buildSessionEndRegistryArtifacts(input: {
+  somaHome: string;
+  algorithmWorkIndexPath: string;
+  activeAlgorithmRunPath: string;
+  learningFiles: string[];
+}): Record<string, string> {
+  const rawArtifacts: Record<string, string> = {
+    algorithmWorkIndex: input.algorithmWorkIndexPath,
+    activeAlgorithmRun: input.activeAlgorithmRunPath,
+  };
 
-  for (const file of learningFiles) {
-    const resolvedFile = resolve(root, file);
-    const artifactPath = relative(root, resolvedFile);
-    if (artifactPath === "" || artifactPath.startsWith("..") || isAbsolute(artifactPath)) continue;
-
-    artifacts[`learning${artifactIndex}`] = artifactPath;
-    artifactIndex += 1;
+  for (const [index, file] of input.learningFiles.entries()) {
+    rawArtifacts[`learning${index + 1}`] = file;
   }
 
-  return artifacts;
+  return normalizeSomaWorkRegistryArtifacts({ somaHome: input.somaHome }, rawArtifacts);
 }
 
 export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions = {}): Promise<SomaLifecycleResult> {
@@ -479,7 +483,14 @@ export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions =
   const timestamp = options.timestamp ?? new Date().toISOString();
   const index = await writeAlgorithmWorkIndex({ ...options, somaHome, timestamp });
   const learningFiles = await captureCompletedAlgorithmLearnings({ ...options, somaHome, timestamp });
-  const registryFiles = await writeSessionEndWorkRegistry({ somaHome, options, timestamp, learningFiles });
+  const registryFiles = await writeSessionEndWorkRegistry({
+    somaHome,
+    options,
+    timestamp,
+    algorithmWorkIndexPath: index.path,
+    activeAlgorithmRunPath: index.activePath,
+    learningFiles,
+  });
 
   // #38 AC-4: If an active ISA is set, run checkCompleteness and emit a
   // warning event when tier gate is unmet. NEVER blocks session end.

--- a/src/tools/learning/session-harvester.ts
+++ b/src/tools/learning/session-harvester.ts
@@ -51,7 +51,12 @@ export async function discoverSessionFiles(options: HarvestOptions = {}): Promis
     return { path, mtime: (await stat(path)).mtimeMs };
   }));
   const sorted = files.sort((a, b) => b.mtime - a.mtime);
-  if (options.sessionId) return sorted.filter((file) => basename(file.path).includes(options.sessionId!)).map((file) => file.path);
+  if (options.sessionId) {
+    const requested = safeFileToken(options.sessionId);
+    return sorted
+      .filter((file) => safeFileToken(basename(file.path, ".jsonl")) === requested)
+      .map((file) => file.path);
+  }
   if (options.all) return sorted.map((file) => file.path);
   return sorted.slice(0, options.recent ?? 10).map((file) => file.path);
 }

--- a/src/tools/learning/session-harvester.ts
+++ b/src/tools/learning/session-harvester.ts
@@ -2,6 +2,7 @@ import { createReadStream } from "node:fs";
 import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
 import { basename, join } from "node:path";
 import { createInterface } from "node:readline/promises";
+import { listSomaWorkRegistryEntries, type SomaWorkRegistryEntry } from "../../work-registry";
 import { isoTimestamp, pathsForLearningOptions, safeFileToken } from "./paths";
 import { transcriptContentToText } from "./transcript";
 import type { HarvestOptions, HarvestedLearning } from "./types";
@@ -39,7 +40,8 @@ function firstMatch(text: string, patterns: RegExp[]): string | undefined {
 }
 
 export async function discoverSessionFiles(options: HarvestOptions = {}): Promise<string[]> {
-  const sessionDir = options.sessionDir ?? pathsForLearningOptions(options).resolve("memory", "STATE", "sessions");
+  if (options.sessionDir === undefined) return [];
+  const sessionDir = options.sessionDir;
   const entries = await readdir(sessionDir, { withFileTypes: true }).catch((error: unknown) => {
     if (error instanceof Error && "code" in error && error.code === "ENOENT") return [];
     throw error;
@@ -52,6 +54,34 @@ export async function discoverSessionFiles(options: HarvestOptions = {}): Promis
   if (options.sessionId) return sorted.filter((file) => basename(file.path).includes(options.sessionId!)).map((file) => file.path);
   if (options.all) return sorted.map((file) => file.path);
   return sorted.slice(0, options.recent ?? 10).map((file) => file.path);
+}
+
+function learningFromWorkRegistryEntry(entry: SomaWorkRegistryEntry): HarvestedLearning {
+  const artifactList = Object.entries(entry.artifacts)
+    .map(([kind, path]) => `${kind}: ${path}`)
+    .join("\n");
+  return {
+    sessionId: entry.sessionUUID,
+    timestamp: isoTimestamp(entry.updatedAt),
+    category: "ALGORITHM",
+    type: "insight",
+    context: `Shared work state from ${entry.substrate}; phase ${entry.phase}; progress ${entry.progress}.`,
+    content: [
+      `Work registry session: ${entry.task}`,
+      `Session name: ${entry.sessionName}`,
+      artifactList ? `Artifacts:\n${artifactList}` : "Artifacts: none recorded",
+    ].join("\n"),
+    source: "work-registry",
+  };
+}
+
+async function harvestWorkRegistrySessions(options: HarvestOptions): Promise<HarvestedLearning[]> {
+  const entries = await listSomaWorkRegistryEntries(options);
+  const filtered = options.sessionId
+    ? entries.filter((entry) => entry.sessionUUID === options.sessionId || entry.sessionName.includes(options.sessionId!))
+    : entries;
+  const selected = options.all ? filtered : filtered.slice(0, options.recent ?? 10);
+  return selected.map(learningFromWorkRegistryEntry);
 }
 
 export async function harvestSessionFile(sessionPath: string): Promise<HarvestedLearning[]> {
@@ -132,8 +162,9 @@ async function mapLimited<T, U>(items: T[], limit: number, fn: (item: T) => Prom
 }
 
 export async function harvestSessions(options: HarvestOptions = {}): Promise<HarvestedLearning[]> {
-  const files = await discoverSessionFiles(options);
-  const learnings = (await mapLimited(files, HARVEST_CONCURRENCY, harvestSessionFile)).flat();
+  const learnings = options.sessionDir === undefined
+    ? await harvestWorkRegistrySessions(options)
+    : (await mapLimited(await discoverSessionFiles(options), HARVEST_CONCURRENCY, harvestSessionFile)).flat();
   if (options.dryRun) return learnings;
   await mapLimited(learnings, HARVEST_CONCURRENCY, async (learning) => {
     learning.path = await writeLearning(learning, options);

--- a/src/tools/learning/session-harvester.ts
+++ b/src/tools/learning/session-harvester.ts
@@ -54,7 +54,7 @@ export async function discoverSessionFiles(options: HarvestOptions = {}): Promis
   if (options.sessionId) {
     const requested = safeFileToken(options.sessionId);
     return sorted
-      .filter((file) => safeFileToken(basename(file.path, ".jsonl")) === requested)
+      .filter((file) => basename(file.path, ".jsonl") === requested)
       .map((file) => file.path);
   }
   if (options.all) return sorted.map((file) => file.path);

--- a/src/tools/learning/session-harvester.ts
+++ b/src/tools/learning/session-harvester.ts
@@ -78,7 +78,7 @@ function learningFromWorkRegistryEntry(entry: SomaWorkRegistryEntry): HarvestedL
 async function harvestWorkRegistrySessions(options: HarvestOptions): Promise<HarvestedLearning[]> {
   const entries = await listSomaWorkRegistryEntries(options);
   const filtered = options.sessionId
-    ? entries.filter((entry) => entry.sessionUUID === options.sessionId || entry.sessionName.includes(options.sessionId!))
+    ? entries.filter((entry) => entry.sessionUUID === options.sessionId)
     : entries;
   const selected = options.all ? filtered : filtered.slice(0, options.recent ?? 10);
   return selected.map(learningFromWorkRegistryEntry);

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -42,6 +42,20 @@ function safeToken(value: string): string {
   return safe || "unknown";
 }
 
+function uniqueSessionSlug(sessions: Record<string, SomaWorkRegistryEntry>, baseSlug: string, sessionId: string): string {
+  const occupied = sessions[baseSlug];
+  if (occupied === undefined || occupied.sessionUUID === sessionId) return baseSlug;
+
+  const sessionSuffix = safeToken(sessionId);
+  let candidate = `${baseSlug}-${sessionSuffix}`;
+  let counter = 2;
+  while (sessions[candidate] !== undefined && sessions[candidate].sessionUUID !== sessionId) {
+    candidate = `${baseSlug}-${sessionSuffix}-${counter}`;
+    counter += 1;
+  }
+  return candidate;
+}
+
 function workRegistryPath(options: SomaPathsOptions): string {
   return createPaths(options).resolve("memory", "STATE", "work.json");
 }
@@ -90,19 +104,21 @@ export async function upsertSomaWorkRegistryEntry(
 ): Promise<UpsertSomaWorkRegistryEntryResult> {
   const timestamp = options.timestamp ?? new Date().toISOString();
   const sessionName = options.sessionName?.trim() || options.task?.trim() || options.sessionId;
-  const slug = safeToken(options.slug ?? sessionName);
+  const baseSlug = safeToken(options.slug ?? sessionName);
   const registryPath = workRegistryPath(options);
   const namesPath = sessionNamesPath(options);
   const pointerPath = currentWorkPath(options, options.sessionId);
   const registry = await readSomaWorkRegistry(options);
   const names = await readJsonFile<Record<string, string>>(namesPath, {}, "session-name registry");
   const existingSlug = Object.entries(registry.sessions).find(([, entry]) => entry.sessionUUID === options.sessionId)?.[0];
-  const existing = registry.sessions[slug] ?? (existingSlug ? registry.sessions[existingSlug] : undefined);
+  const baseEntry = registry.sessions[baseSlug];
+  const existing = baseEntry?.sessionUUID === options.sessionId ? baseEntry : existingSlug ? registry.sessions[existingSlug] : undefined;
   for (const [candidateSlug, candidateEntry] of Object.entries(registry.sessions)) {
-    if (candidateSlug !== slug && candidateEntry.sessionUUID === options.sessionId) {
+    if (candidateEntry.sessionUUID === options.sessionId) {
       delete registry.sessions[candidateSlug];
     }
   }
+  const slug = uniqueSessionSlug(registry.sessions, baseSlug, options.sessionId);
   const artifacts = options.artifacts ?? existing?.artifacts ?? {};
   const entry: SomaWorkRegistryEntry = {
     ...(artifacts.isa ? { isa: artifacts.isa } : {}),

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -44,6 +44,10 @@ function safeToken(value: string): string {
   return safe || "unknown";
 }
 
+function safeFilenameToken(value: string): string {
+  return safeToken(value).slice(0, 64);
+}
+
 function shortHash(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 12);
 }
@@ -133,7 +137,7 @@ function sessionNamesPath(options: SomaPathsOptions): string {
 }
 
 function currentWorkPath(options: SomaPathsOptions, sessionId: string): string {
-  return createPaths(options).resolve("memory", "STATE", `current-work-${safeToken(sessionId)}-${shortHash(sessionId)}.json`);
+  return createPaths(options).resolve("memory", "STATE", `current-work-${safeFilenameToken(sessionId)}-${shortHash(sessionId)}.json`);
 }
 
 async function writeJson(path: string, value: unknown): Promise<void> {

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { createPaths, type SomaPathsOptions } from "./paths";
 
 export interface SomaWorkRegistryEntry {
@@ -40,6 +40,16 @@ export interface UpsertSomaWorkRegistryEntryResult {
 function safeToken(value: string): string {
   const safe = value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
   return safe || "unknown";
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function malformedJsonError(label: string, path: string, detail: string): Error {
+  return new Error(`Malformed ${label} JSON at ${path}: ${detail}`);
 }
 
 function uniqueSessionSlug(sessions: Record<string, SomaWorkRegistryEntry>, baseSlug: string, sessionId: string): string {
@@ -128,9 +138,70 @@ async function readJsonFile<T>(path: string, fallback: T, label: string): Promis
   }
 }
 
+function validateRegistrySessions(path: string, value: unknown): Record<string, SomaWorkRegistryEntry> {
+  if (!isPlainRecord(value)) {
+    throw malformedJsonError("work registry", path, "sessions must be an object");
+  }
+
+  for (const [slug, entry] of Object.entries(value)) {
+    if (!isPlainRecord(entry)) {
+      throw malformedJsonError("work registry", path, `session entry ${slug} must be an object`);
+    }
+  }
+
+  return value as Record<string, SomaWorkRegistryEntry>;
+}
+
+async function readSessionNames(path: string): Promise<Record<string, string>> {
+  const parsed = await readJsonFile<unknown>(path, {}, "session-name registry");
+  if (!isPlainRecord(parsed)) {
+    throw malformedJsonError("session-name registry", path, "root must be an object");
+  }
+
+  for (const [sessionId, sessionName] of Object.entries(parsed)) {
+    if (typeof sessionName !== "string") {
+      throw malformedJsonError("session-name registry", path, `session name ${sessionId} must be a string`);
+    }
+  }
+
+  return parsed as Record<string, string>;
+}
+
+export function normalizeSomaWorkRegistryArtifacts(
+  options: SomaPathsOptions,
+  artifacts: Record<string, string>,
+): Record<string, string> {
+  const root = resolve(createPaths(options).root());
+  const normalized: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(artifacts)) {
+    if (typeof value !== "string") {
+      throw new Error(`Artifact pointer ${key} must be a string`);
+    }
+
+    const resolvedArtifact = isAbsolute(value) ? resolve(value) : resolve(root, value);
+    const artifactPath = relative(root, resolvedArtifact).replaceAll("\\", "/");
+    if (artifactPath === "" || artifactPath.startsWith("../") || artifactPath === ".." || isAbsolute(artifactPath)) {
+      throw new Error(`Artifact pointer ${key} escapes Soma home: ${value}`);
+    }
+    if (!artifactPath.startsWith("memory/")) {
+      throw new Error(`Artifact pointer ${key} must stay under memory/: ${value}`);
+    }
+
+    normalized[key] = artifactPath;
+  }
+
+  return normalized;
+}
+
 export async function readSomaWorkRegistry(options: SomaPathsOptions = {}): Promise<SomaWorkRegistry> {
-  const registry = await readJsonFile<Partial<SomaWorkRegistry>>(workRegistryPath(options), { sessions: {} }, "work registry");
-  return { sessions: registry.sessions ?? {} };
+  const path = workRegistryPath(options);
+  const registry = await readJsonFile<unknown>(path, { sessions: {} }, "work registry");
+  if (!isPlainRecord(registry)) {
+    throw malformedJsonError("work registry", path, "root must be an object");
+  }
+
+  return { sessions: validateRegistrySessions(path, registry.sessions ?? {}) };
 }
 
 export async function listSomaWorkRegistryEntries(options: SomaPathsOptions = {}): Promise<SomaWorkRegistryEntry[]> {
@@ -148,12 +219,18 @@ export async function upsertSomaWorkRegistryEntry(
   const namesPath = sessionNamesPath(options);
   const pointerPath = currentWorkPath(options, options.sessionId);
   const registry = await readSomaWorkRegistry(options);
-  const names = await readJsonFile<Record<string, string>>(namesPath, {}, "session-name registry");
+  const names = await readSessionNames(namesPath);
   const existing = findExistingSession(registry.sessions, options.sessionId, baseSlug);
 
   removeSessionEntries(registry.sessions, options.sessionId);
   const slug = uniqueSessionSlug(registry.sessions, baseSlug, options.sessionId);
-  const entry = buildRegistryEntry(options, sessionName, timestamp, existing);
+  const rawArtifacts = options.artifacts ?? existing?.artifacts ?? {};
+  const entry = buildRegistryEntry(
+    { ...options, artifacts: normalizeSomaWorkRegistryArtifacts(options, rawArtifacts) },
+    sessionName,
+    timestamp,
+    existing,
+  );
 
   registry.sessions[slug] = entry;
   names[options.sessionId] = sessionName;

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -96,7 +96,13 @@ export async function upsertSomaWorkRegistryEntry(
   const pointerPath = currentWorkPath(options, options.sessionId);
   const registry = await readSomaWorkRegistry(options);
   const names = await readJsonFile<Record<string, string>>(namesPath, {}, "session-name registry");
-  const existing = registry.sessions[slug];
+  const existingSlug = Object.entries(registry.sessions).find(([, entry]) => entry.sessionUUID === options.sessionId)?.[0];
+  const existing = registry.sessions[slug] ?? (existingSlug ? registry.sessions[existingSlug] : undefined);
+  for (const [candidateSlug, candidateEntry] of Object.entries(registry.sessions)) {
+    if (candidateSlug !== slug && candidateEntry.sessionUUID === options.sessionId) {
+      delete registry.sessions[candidateSlug];
+    }
+  }
   const artifacts = options.artifacts ?? existing?.artifacts ?? {};
   const entry: SomaWorkRegistryEntry = {
     ...(artifacts.isa ? { isa: artifacts.isa } : {}),

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -1,0 +1,141 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { createPaths, type SomaPathsOptions } from "./paths";
+
+export interface SomaWorkRegistryEntry {
+  isa?: string;
+  task: string;
+  sessionName: string;
+  sessionUUID: string;
+  substrate: string;
+  phase: string;
+  progress: string;
+  started: string;
+  updatedAt: string;
+  artifacts: Record<string, string>;
+}
+
+export interface SomaWorkRegistry {
+  sessions: Record<string, SomaWorkRegistryEntry>;
+}
+
+export interface UpsertSomaWorkRegistryEntryOptions extends SomaPathsOptions {
+  slug?: string;
+  sessionId: string;
+  sessionName?: string;
+  substrate: string;
+  task?: string;
+  phase?: string;
+  progress?: string;
+  timestamp?: string;
+  artifacts?: Record<string, string>;
+}
+
+export interface UpsertSomaWorkRegistryEntryResult {
+  slug: string;
+  entry: SomaWorkRegistryEntry;
+  files: string[];
+}
+
+function safeToken(value: string): string {
+  const safe = value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return safe || "unknown";
+}
+
+function workRegistryPath(options: SomaPathsOptions): string {
+  return createPaths(options).resolve("memory", "STATE", "work.json");
+}
+
+function sessionNamesPath(options: SomaPathsOptions): string {
+  return createPaths(options).resolve("memory", "STATE", "session-names.json");
+}
+
+function currentWorkPath(options: SomaPathsOptions, sessionId: string): string {
+  return createPaths(options).resolve("memory", "STATE", `current-work-${safeToken(sessionId)}.json`);
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+  await rename(tmp, path);
+}
+
+async function readJsonFile<T>(path: string, fallback: T, label: string): Promise<T> {
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as T;
+  } catch (error: unknown) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return fallback;
+    }
+    if (error instanceof SyntaxError) {
+      throw new Error(`Malformed ${label} JSON at ${path}: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+export async function readSomaWorkRegistry(options: SomaPathsOptions = {}): Promise<SomaWorkRegistry> {
+  const registry = await readJsonFile<Partial<SomaWorkRegistry>>(workRegistryPath(options), { sessions: {} }, "work registry");
+  return { sessions: registry.sessions ?? {} };
+}
+
+export async function listSomaWorkRegistryEntries(options: SomaPathsOptions = {}): Promise<SomaWorkRegistryEntry[]> {
+  const registry = await readSomaWorkRegistry(options);
+  return Object.values(registry.sessions).sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+}
+
+export async function upsertSomaWorkRegistryEntry(
+  options: UpsertSomaWorkRegistryEntryOptions,
+): Promise<UpsertSomaWorkRegistryEntryResult> {
+  const timestamp = options.timestamp ?? new Date().toISOString();
+  const sessionName = options.sessionName?.trim() || options.task?.trim() || options.sessionId;
+  const slug = safeToken(options.slug ?? sessionName);
+  const registryPath = workRegistryPath(options);
+  const namesPath = sessionNamesPath(options);
+  const pointerPath = currentWorkPath(options, options.sessionId);
+  const registry = await readSomaWorkRegistry(options);
+  const names = await readJsonFile<Record<string, string>>(namesPath, {}, "session-name registry");
+  const existing = registry.sessions[slug];
+  const artifacts = options.artifacts ?? existing?.artifacts ?? {};
+  const entry: SomaWorkRegistryEntry = {
+    ...(artifacts.isa ? { isa: artifacts.isa } : {}),
+    task: options.task?.trim() || existing?.task || sessionName,
+    sessionName,
+    sessionUUID: options.sessionId,
+    substrate: options.substrate,
+    phase: options.phase ?? existing?.phase ?? "native",
+    progress: options.progress ?? existing?.progress ?? "0/0",
+    started: existing?.started ?? timestamp,
+    updatedAt: timestamp,
+    artifacts,
+  };
+
+  registry.sessions[slug] = entry;
+  names[options.sessionId] = sessionName;
+
+  await writeJson(registryPath, registry);
+  await writeJson(namesPath, names);
+  await writeJson(pointerPath, { slug, ...entry });
+
+  return {
+    slug,
+    entry,
+    files: [registryPath, namesPath, pointerPath],
+  };
+}
+
+export function somaWorkRegistryPaths(options: SomaPathsOptions = {}, sessionId?: string): {
+  work: string;
+  sessionNames: string;
+  currentWork?: string;
+  workRoot: string;
+} {
+  const paths = createPaths(options);
+  return {
+    work: workRegistryPath(options),
+    sessionNames: sessionNamesPath(options),
+    currentWork: sessionId ? currentWorkPath(options, sessionId) : undefined,
+    workRoot: join(paths.root(), "memory", "WORK"),
+  };
+}

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -242,7 +242,7 @@ export async function readSomaWorkRegistry(options: SomaPathsOptions = {}): Prom
     throw malformedJsonError("work registry", path, "root must be an object");
   }
 
-  return { sessions: validateRegistrySessions(path, registry.sessions ?? {}) };
+  return { sessions: validateRegistrySessions(path, registry.sessions === undefined ? {} : registry.sessions) };
 }
 
 export async function listSomaWorkRegistryEntries(options: SomaPathsOptions = {}): Promise<SomaWorkRegistryEntry[]> {

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -58,6 +58,19 @@ function malformedJsonError(label: string, path: string, detail: string): Error 
   return new Error(`Malformed ${label} JSON at ${path}: ${detail}`);
 }
 
+function createRecord<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
+}
+
+function setRecordValue<T>(record: Record<string, T>, key: string, value: T): void {
+  Object.defineProperty(record, key, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
+}
+
 function uniqueSessionSlug(sessions: Record<string, SomaWorkRegistryEntry>, baseSlug: string, sessionId: string): string {
   const occupied = sessions[baseSlug];
   if (occupied === undefined || occupied.sessionUUID === sessionId) return baseSlug;
@@ -213,12 +226,12 @@ function validateRegistrySessions(path: string, value: unknown): Record<string, 
     throw malformedJsonError("work registry", path, "sessions must be an object");
   }
 
-  const sessions: Record<string, SomaWorkRegistryEntry> = {};
+  const sessions = createRecord<SomaWorkRegistryEntry>();
   for (const [slug, entry] of Object.entries(value)) {
     if (!isPlainRecord(entry)) {
       throw malformedJsonError("work registry", path, `session entry ${slug} must be an object`);
     }
-    sessions[slug] = validateRegistryEntry(path, slug, entry);
+    setRecordValue(sessions, slug, validateRegistryEntry(path, slug, entry));
   }
 
   return sessions;
@@ -236,7 +249,12 @@ async function readSessionNames(path: string): Promise<Record<string, string>> {
     }
   }
 
-  return parsed as Record<string, string>;
+  const names = createRecord<string>();
+  for (const [sessionId, sessionName] of Object.entries(parsed)) {
+    setRecordValue(names, sessionId, sessionName);
+  }
+
+  return names;
 }
 
 export function normalizeSomaWorkRegistryArtifacts(
@@ -244,7 +262,7 @@ export function normalizeSomaWorkRegistryArtifacts(
   artifacts: Record<string, string>,
 ): Record<string, string> {
   const root = resolve(createPaths(options).root());
-  const normalized: Record<string, string> = {};
+  const normalized = createRecord<string>();
 
   for (const [key, value] of Object.entries(artifacts)) {
     if (typeof value !== "string") {
@@ -260,7 +278,7 @@ export function normalizeSomaWorkRegistryArtifacts(
       throw new Error(`Artifact pointer ${key} must stay under memory/: ${value}`);
     }
 
-    normalized[key] = artifactPath;
+    setRecordValue(normalized, key, artifactPath);
   }
 
   return normalized;
@@ -310,8 +328,8 @@ async function upsertSomaWorkRegistryEntryLocked(
     existing,
   );
 
-  registry.sessions[slug] = entry;
-  names[options.sessionId] = sessionName;
+  setRecordValue(registry.sessions, slug, entry);
+  setRecordValue(names, options.sessionId, sessionName);
 
   await writeJson(registryPath, registry);
   await writeJson(namesPath, names);

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -56,6 +56,45 @@ function uniqueSessionSlug(sessions: Record<string, SomaWorkRegistryEntry>, base
   return candidate;
 }
 
+function findExistingSession(
+  sessions: Record<string, SomaWorkRegistryEntry>,
+  sessionId: string,
+  baseSlug: string,
+): SomaWorkRegistryEntry | undefined {
+  const baseEntry = sessions[baseSlug];
+  if (baseEntry?.sessionUUID === sessionId) return baseEntry;
+  return Object.values(sessions).find((entry) => entry.sessionUUID === sessionId);
+}
+
+function removeSessionEntries(sessions: Record<string, SomaWorkRegistryEntry>, sessionId: string): void {
+  for (const [candidateSlug, candidateEntry] of Object.entries(sessions)) {
+    if (candidateEntry.sessionUUID === sessionId) {
+      delete sessions[candidateSlug];
+    }
+  }
+}
+
+function buildRegistryEntry(
+  options: UpsertSomaWorkRegistryEntryOptions,
+  sessionName: string,
+  timestamp: string,
+  existing?: SomaWorkRegistryEntry,
+): SomaWorkRegistryEntry {
+  const artifacts = options.artifacts ?? existing?.artifacts ?? {};
+  return {
+    ...(artifacts.isa ? { isa: artifacts.isa } : {}),
+    task: options.task?.trim() || existing?.task || sessionName,
+    sessionName,
+    sessionUUID: options.sessionId,
+    substrate: options.substrate,
+    phase: options.phase ?? existing?.phase ?? "native",
+    progress: options.progress ?? existing?.progress ?? "0/0",
+    started: existing?.started ?? timestamp,
+    updatedAt: timestamp,
+    artifacts,
+  };
+}
+
 function workRegistryPath(options: SomaPathsOptions): string {
   return createPaths(options).resolve("memory", "STATE", "work.json");
 }
@@ -110,28 +149,11 @@ export async function upsertSomaWorkRegistryEntry(
   const pointerPath = currentWorkPath(options, options.sessionId);
   const registry = await readSomaWorkRegistry(options);
   const names = await readJsonFile<Record<string, string>>(namesPath, {}, "session-name registry");
-  const existingSlug = Object.entries(registry.sessions).find(([, entry]) => entry.sessionUUID === options.sessionId)?.[0];
-  const baseEntry = registry.sessions[baseSlug];
-  const existing = baseEntry?.sessionUUID === options.sessionId ? baseEntry : existingSlug ? registry.sessions[existingSlug] : undefined;
-  for (const [candidateSlug, candidateEntry] of Object.entries(registry.sessions)) {
-    if (candidateEntry.sessionUUID === options.sessionId) {
-      delete registry.sessions[candidateSlug];
-    }
-  }
+  const existing = findExistingSession(registry.sessions, options.sessionId, baseSlug);
+
+  removeSessionEntries(registry.sessions, options.sessionId);
   const slug = uniqueSessionSlug(registry.sessions, baseSlug, options.sessionId);
-  const artifacts = options.artifacts ?? existing?.artifacts ?? {};
-  const entry: SomaWorkRegistryEntry = {
-    ...(artifacts.isa ? { isa: artifacts.isa } : {}),
-    task: options.task?.trim() || existing?.task || sessionName,
-    sessionName,
-    sessionUUID: options.sessionId,
-    substrate: options.substrate,
-    phase: options.phase ?? existing?.phase ?? "native",
-    progress: options.progress ?? existing?.progress ?? "0/0",
-    started: existing?.started ?? timestamp,
-    updatedAt: timestamp,
-    artifacts,
-  };
+  const entry = buildRegistryEntry(options, sessionName, timestamp, existing);
 
   registry.sessions[slug] = entry;
   names[options.sessionId] = sessionName;

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -1,5 +1,7 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import { createPaths, type SomaPathsOptions } from "./paths";
 
 export interface SomaWorkRegistryEntry {
@@ -40,6 +42,10 @@ export interface UpsertSomaWorkRegistryEntryResult {
 function safeToken(value: string): string {
   const safe = value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
   return safe || "unknown";
+}
+
+function shortHash(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 12);
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -114,14 +120,39 @@ function sessionNamesPath(options: SomaPathsOptions): string {
 }
 
 function currentWorkPath(options: SomaPathsOptions, sessionId: string): string {
-  return createPaths(options).resolve("memory", "STATE", `current-work-${safeToken(sessionId)}.json`);
+  return createPaths(options).resolve("memory", "STATE", `current-work-${safeToken(sessionId)}-${shortHash(sessionId)}.json`);
 }
 
 async function writeJson(path: string, value: unknown): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
-  const tmp = `${path}.tmp`;
+  const tmp = `${path}.${process.pid}.${shortHash(`${path}:${Date.now()}:${Math.random()}`)}.tmp`;
   await writeFile(tmp, `${JSON.stringify(value, null, 2)}\n`, "utf8");
   await rename(tmp, path);
+}
+
+async function withRegistryFileLock<T>(registryPath: string, fn: () => Promise<T>): Promise<T> {
+  await mkdir(dirname(registryPath), { recursive: true });
+  const lockPath = `${registryPath}.lock`;
+  const started = Date.now();
+
+  while (true) {
+    try {
+      await mkdir(lockPath);
+      break;
+    } catch (error: unknown) {
+      if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
+      if (Date.now() - started > 30_000) {
+        throw new Error(`Timed out waiting for work registry lock at ${lockPath}`);
+      }
+      await sleep(10);
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    await rm(lockPath, { recursive: true, force: true });
+  }
 }
 
 async function readJsonFile<T>(path: string, fallback: T, label: string): Promise<T> {
@@ -251,6 +282,12 @@ export async function listSomaWorkRegistryEntries(options: SomaPathsOptions = {}
 }
 
 export async function upsertSomaWorkRegistryEntry(
+  options: UpsertSomaWorkRegistryEntryOptions,
+): Promise<UpsertSomaWorkRegistryEntryResult> {
+  return withRegistryFileLock(workRegistryPath(options), () => upsertSomaWorkRegistryEntryLocked(options));
+}
+
+async function upsertSomaWorkRegistryEntryLocked(
   options: UpsertSomaWorkRegistryEntryOptions,
 ): Promise<UpsertSomaWorkRegistryEntryResult> {
   const timestamp = options.timestamp ?? new Date().toISOString();

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -138,18 +138,59 @@ async function readJsonFile<T>(path: string, fallback: T, label: string): Promis
   }
 }
 
+function requireStringField(entry: Record<string, unknown>, path: string, slug: string, field: keyof SomaWorkRegistryEntry): string {
+  const value = entry[field];
+  if (typeof value !== "string") {
+    throw malformedJsonError("work registry", path, `session entry ${slug}.${field} must be a string`);
+  }
+  return value;
+}
+
+function validateRegistryEntry(path: string, slug: string, entry: Record<string, unknown>): SomaWorkRegistryEntry {
+  const artifacts = entry.artifacts;
+  if (!isPlainRecord(artifacts)) {
+    throw malformedJsonError("work registry", path, `session entry ${slug}.artifacts must be an object`);
+  }
+
+  for (const [artifactKey, artifactPath] of Object.entries(artifacts)) {
+    if (typeof artifactPath !== "string") {
+      throw malformedJsonError("work registry", path, `session entry ${slug}.artifacts.${artifactKey} must be a string`);
+    }
+  }
+
+  const isa = entry.isa;
+  if (isa !== undefined && typeof isa !== "string") {
+    throw malformedJsonError("work registry", path, `session entry ${slug}.isa must be a string`);
+  }
+
+  return {
+    ...(isa !== undefined ? { isa } : {}),
+    task: requireStringField(entry, path, slug, "task"),
+    sessionName: requireStringField(entry, path, slug, "sessionName"),
+    sessionUUID: requireStringField(entry, path, slug, "sessionUUID"),
+    substrate: requireStringField(entry, path, slug, "substrate"),
+    phase: requireStringField(entry, path, slug, "phase"),
+    progress: requireStringField(entry, path, slug, "progress"),
+    started: requireStringField(entry, path, slug, "started"),
+    updatedAt: requireStringField(entry, path, slug, "updatedAt"),
+    artifacts: artifacts as Record<string, string>,
+  };
+}
+
 function validateRegistrySessions(path: string, value: unknown): Record<string, SomaWorkRegistryEntry> {
   if (!isPlainRecord(value)) {
     throw malformedJsonError("work registry", path, "sessions must be an object");
   }
 
+  const sessions: Record<string, SomaWorkRegistryEntry> = {};
   for (const [slug, entry] of Object.entries(value)) {
     if (!isPlainRecord(entry)) {
       throw malformedJsonError("work registry", path, `session entry ${slug} must be an object`);
     }
+    sessions[slug] = validateRegistryEntry(path, slug, entry);
   }
 
-  return value as Record<string, SomaWorkRegistryEntry>;
+  return sessions;
 }
 
 async function readSessionNames(path: string): Promise<Record<string, string>> {

--- a/test/learning-tools.test.ts
+++ b/test/learning-tools.test.ts
@@ -156,6 +156,28 @@ test("session harvester extracts learnings from recent session transcripts", asy
   });
 });
 
+test("session harvester explicit transcript filter matches exact session ids", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionDir = join(homeDir, "sessions");
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, "alpha.jsonl"), [
+      JSON.stringify({ type: "user", timestamp: "2026-05-19T12:00:00Z", message: { content: "Actually, I meant keep the smaller implementation." } }),
+    ].join("\n"), "utf8");
+    await writeFile(join(sessionDir, "beta-alpha.jsonl"), [
+      JSON.stringify({ type: "user", timestamp: "2026-05-19T12:01:00Z", message: { content: "Actually, I meant this should not be harvested." } }),
+    ].join("\n"), "utf8");
+
+    const learnings = await harvestSessions({
+      homeDir,
+      sessionDir,
+      sessionId: "alpha",
+      dryRun: true,
+    });
+
+    expect(learnings.map((learning) => learning.sessionId)).toEqual(["alpha"]);
+  });
+});
+
 test("session harvester defaults to canonical work registry state", async () => {
   await withTempHome(async (homeDir, somaHome) => {
     await upsertSomaWorkRegistryEntry({

--- a/test/learning-tools.test.ts
+++ b/test/learning-tools.test.ts
@@ -178,6 +178,25 @@ test("session harvester explicit transcript filter matches exact session ids", a
   });
 });
 
+test("session harvester explicit transcript filter matches sanitized raw ids", async () => {
+  await withTempHome(async (homeDir) => {
+    const sessionDir = join(homeDir, "sessions");
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, "a-b.jsonl"), [
+      JSON.stringify({ type: "user", timestamp: "2026-05-19T12:00:00Z", message: { content: "Actually, I meant keep the smaller implementation." } }),
+    ].join("\n"), "utf8");
+
+    const learnings = await harvestSessions({
+      homeDir,
+      sessionDir,
+      sessionId: "a/b",
+      dryRun: true,
+    });
+
+    expect(learnings.map((learning) => learning.sessionId)).toEqual(["a-b"]);
+  });
+});
+
 test("session harvester defaults to canonical work registry state", async () => {
   await withTempHome(async (homeDir, somaHome) => {
     await upsertSomaWorkRegistryEntry({

--- a/test/learning-tools.test.ts
+++ b/test/learning-tools.test.ts
@@ -189,6 +189,32 @@ test("session harvester defaults to canonical work registry state", async () => 
   });
 });
 
+test("session harvester work-registry filter matches exact session ids only", async () => {
+  await withTempHome(async (homeDir) => {
+    await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "alpha",
+      sessionName: "target session",
+      substrate: "codex",
+      task: "Target work",
+      timestamp: "2026-05-26T10:00:00.000Z",
+    });
+    await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "beta",
+      sessionName: "alpha adjacent session",
+      substrate: "codex",
+      task: "Unrelated work",
+      timestamp: "2026-05-26T10:01:00.000Z",
+    });
+
+    const learnings = await harvestSessions({ homeDir, sessionId: "alpha" });
+
+    expect(learnings.map((learning) => learning.sessionId)).toEqual(["alpha"]);
+    expect(learnings[0]?.content).toContain("Target work");
+  });
+});
+
 test("learning CLI rejects invalid ratings and harvester rejects unsafe timestamps", async () => {
   await withTempHome(async (homeDir, somaHome) => {
     const transcript = join(homeDir, "transcript.jsonl");

--- a/test/learning-tools.test.ts
+++ b/test/learning-tools.test.ts
@@ -10,6 +10,7 @@ import {
   harvestSessions,
   resumeSessionProgress,
   synthesizeLearningPatterns,
+  upsertSomaWorkRegistryEntry,
   type InferenceBackend,
   type InferenceRequest,
 } from "../src";
@@ -152,6 +153,39 @@ test("session harvester extracts learnings from recent session transcripts", asy
     expect(learnings.some((learning) => learning.type === "correction")).toBe(true);
     expect(learnings.some((learning) => learning.path?.includes("memory/LEARNING/ALGORITHM/2026-05"))).toBe(true);
     await expect(readFile(join(somaHome, "memory/LEARNING/ALGORITHM/2026-05/2026-05-191200_correction_abc123.md"), "utf8")).resolves.toContain("Actually");
+  });
+});
+
+test("session harvester defaults to canonical work registry state", async () => {
+  await withTempHome(async (homeDir, somaHome) => {
+    await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "session-2",
+      sessionName: "align shared work state",
+      substrate: "codex",
+      task: "Align shared session state",
+      phase: "complete",
+      progress: "1/1",
+      timestamp: "2026-05-26T10:00:00.000Z",
+      artifacts: {
+        isa: "memory/WORK/align-shared-work-state/ISA.md",
+      },
+    });
+
+    const learnings = await harvestSessions({ homeDir });
+
+    expect(learnings).toEqual([
+      expect.objectContaining({
+        sessionId: "session-2",
+        timestamp: "2026-05-26T10:00:00.000Z",
+        type: "insight",
+        category: "ALGORITHM",
+        source: "work-registry",
+      }),
+    ]);
+    expect(learnings[0]?.content).toContain("Align shared session state");
+    expect(learnings[0]?.path).toContain("memory/LEARNING/ALGORITHM/2026-05");
+    await expect(readFile(join(somaHome, "memory/LEARNING/ALGORITHM/2026-05/2026-05-261000_insight_session-.md"), "utf8")).resolves.toContain("Align shared session state");
   });
 });
 

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -239,7 +239,9 @@ test("session-end continues when work registry writeback fails", async () => {
       .map((line) => JSON.parse(line));
 
     expect(end.files).not.toContain(workPath);
-    expect(events.some((event) => event.kind === "lifecycle.session_end.registry-write-failed")).toBe(true);
+    const failed = events.find((event) => event.kind === "lifecycle.session_end.registry-write-failed");
+    expect(failed?.metadata.error).toContain("sessions must be an object");
+    expect(failed?.metadata.error).not.toContain(homeDir);
     expect(events.some((event) => event.kind === "lifecycle.session_end")).toBe(true);
   });
 });

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -170,3 +170,41 @@ test("lifecycle CLI-facing handlers append events and include context", async ()
     expect(events).toContain("lifecycle.session_end");
   });
 });
+
+test("session-end writes shared work registry state and metadata-only event", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+
+    const end = await runSomaLifecycleSessionEnd({
+      homeDir,
+      substrate: "codex",
+      sessionId: "session-3",
+      timestamp: "2026-05-26T10:30:00.000Z",
+    });
+
+    const workPath = join(homeDir, ".soma/memory/STATE/work.json");
+    const namesPath = join(homeDir, ".soma/memory/STATE/session-names.json");
+    const currentPath = join(homeDir, ".soma/memory/STATE/current-work-session-3.json");
+    const events = (await readFile(join(homeDir, ".soma/memory/STATE/events.jsonl"), "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const sessionEnd = events.find((event) => event.kind === "lifecycle.session_end");
+    const work = JSON.parse(await readFile(workPath, "utf8"));
+    const names = JSON.parse(await readFile(namesPath, "utf8"));
+
+    expect(end.files).toContain(workPath);
+    expect(end.files).toContain(namesPath);
+    expect(end.files).toContain(currentPath);
+    expect(names).toEqual({ "session-3": "session session-3" });
+    expect(work.sessions["session-session-3"]).toMatchObject({
+      sessionUUID: "session-3",
+      sessionName: "session session-3",
+      substrate: "codex",
+      phase: "complete",
+    });
+    expect(sessionEnd.artifactPaths).toEqual(expect.arrayContaining([workPath, namesPath, currentPath]));
+    expect(JSON.stringify(sessionEnd)).not.toContain("prompt");
+    expect(JSON.stringify(sessionEnd)).not.toContain("result");
+  });
+});

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -212,6 +212,7 @@ test("session-end writes shared work registry state and metadata-only event", as
       ]),
     );
     expect(JSON.stringify(sessionEnd.artifactPaths)).not.toContain(homeDir);
+    expect(sessionEnd.metadata).toMatchObject({ sessionId: "session-3", substrate: "codex" });
     expect(JSON.stringify(sessionEnd)).not.toContain("prompt");
     expect(JSON.stringify(sessionEnd)).not.toContain("result");
   });

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -204,7 +204,14 @@ test("session-end writes shared work registry state and metadata-only event", as
       substrate: "codex",
       phase: "complete",
     });
-    expect(sessionEnd.artifactPaths).toEqual(expect.arrayContaining([workPath, namesPath, currentPath]));
+    expect(sessionEnd.artifactPaths).toEqual(
+      expect.arrayContaining([
+        "memory/STATE/work.json",
+        "memory/STATE/session-names.json",
+        "memory/STATE/current-work-session-3.json",
+      ]),
+    );
+    expect(JSON.stringify(sessionEnd.artifactPaths)).not.toContain(homeDir);
     expect(JSON.stringify(sessionEnd)).not.toContain("prompt");
     expect(JSON.stringify(sessionEnd)).not.toContain("result");
   });

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { expect, test } from "bun:test";
 import { buildSessionEndRegistryArtifacts } from "../src/lifecycle";
 import {
@@ -17,6 +17,7 @@ import {
   runSomaLifecycleSessionEnd,
   runSomaLifecycleSessionStart,
   setAlgorithmPlan,
+  somaWorkRegistryPaths,
   updateAlgorithmPlanStep,
   verifyAlgorithmCriterion,
   writeAlgorithmRun,
@@ -185,7 +186,8 @@ test("session-end writes shared work registry state and metadata-only event", as
 
     const workPath = join(homeDir, ".soma/memory/STATE/work.json");
     const namesPath = join(homeDir, ".soma/memory/STATE/session-names.json");
-    const currentPath = join(homeDir, ".soma/memory/STATE/current-work-session-3.json");
+    const currentPath = somaWorkRegistryPaths({ homeDir }, "session-3").currentWork!;
+    const currentArtifactPath = relative(join(homeDir, ".soma"), currentPath);
     const events = (await readFile(join(homeDir, ".soma/memory/STATE/events.jsonl"), "utf8"))
       .trim()
       .split("\n")
@@ -208,7 +210,7 @@ test("session-end writes shared work registry state and metadata-only event", as
       expect.arrayContaining([
         "memory/STATE/work.json",
         "memory/STATE/session-names.json",
-        "memory/STATE/current-work-session-3.json",
+        currentArtifactPath,
       ]),
     );
     expect(JSON.stringify(sessionEnd.artifactPaths)).not.toContain(homeDir);

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -212,16 +212,31 @@ test("session-end writes shared work registry state and metadata-only event", as
 
 test("session-end registry artifact pointers stay relative to Soma home", () => {
   const somaHome = join(tmpdir(), "soma-artifact-home", ".soma");
-  const artifacts = buildSessionEndRegistryArtifacts(somaHome, [
-    join(somaHome, "memory/LEARNING/ALGORITHM/complete-run.md"),
-    "memory/LEARNING/ALGORITHM/relative-run.md",
-    join(somaHome, "../outside.md"),
-  ]);
+  const artifacts = buildSessionEndRegistryArtifacts({
+    somaHome,
+    algorithmWorkIndexPath: join(somaHome, "memory/STATE/algorithm-work-index.json"),
+    activeAlgorithmRunPath: join(somaHome, "memory/STATE/active-algorithm-run.json"),
+    learningFiles: [join(somaHome, "memory/LEARNING/ALGORITHM/complete-run.md"), "memory/LEARNING/ALGORITHM/relative-run.md"],
+  });
 
   expect(artifacts).toEqual({
+    activeAlgorithmRun: "memory/STATE/active-algorithm-run.json",
+    algorithmWorkIndex: "memory/STATE/algorithm-work-index.json",
     learning1: "memory/LEARNING/ALGORITHM/complete-run.md",
     learning2: "memory/LEARNING/ALGORITHM/relative-run.md",
   });
   expect(JSON.stringify(artifacts)).not.toContain(somaHome);
-  expect(JSON.stringify(artifacts)).not.toContain("outside.md");
+});
+
+test("session-end registry artifact pointers reject escaped paths", () => {
+  const somaHome = join(tmpdir(), "soma-artifact-home", ".soma");
+
+  expect(() =>
+    buildSessionEndRegistryArtifacts({
+      somaHome,
+      algorithmWorkIndexPath: join(somaHome, "memory/STATE/algorithm-work-index.json"),
+      activeAlgorithmRunPath: join(somaHome, "memory/STATE/active-algorithm-run.json"),
+      learningFiles: [join(somaHome, "../outside.md")],
+    }),
+  ).toThrow("escapes Soma home");
 });

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
+import { buildSessionEndRegistryArtifacts } from "../src/lifecycle";
 import {
   addAlgorithmCapabilities,
   advanceAlgorithmRun,
@@ -207,4 +208,20 @@ test("session-end writes shared work registry state and metadata-only event", as
     expect(JSON.stringify(sessionEnd)).not.toContain("prompt");
     expect(JSON.stringify(sessionEnd)).not.toContain("result");
   });
+});
+
+test("session-end registry artifact pointers stay relative to Soma home", () => {
+  const somaHome = join(tmpdir(), "soma-artifact-home", ".soma");
+  const artifacts = buildSessionEndRegistryArtifacts(somaHome, [
+    join(somaHome, "memory/LEARNING/ALGORITHM/complete-run.md"),
+    "memory/LEARNING/ALGORITHM/relative-run.md",
+    join(somaHome, "../outside.md"),
+  ]);
+
+  expect(artifacts).toEqual({
+    learning1: "memory/LEARNING/ALGORITHM/complete-run.md",
+    learning2: "memory/LEARNING/ALGORITHM/relative-run.md",
+  });
+  expect(JSON.stringify(artifacts)).not.toContain(somaHome);
+  expect(JSON.stringify(artifacts)).not.toContain("outside.md");
 });

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import { expect, test } from "bun:test";
@@ -217,6 +217,30 @@ test("session-end writes shared work registry state and metadata-only event", as
     expect(sessionEnd.metadata).toMatchObject({ sessionId: "session-3", substrate: "codex" });
     expect(JSON.stringify(sessionEnd)).not.toContain("prompt");
     expect(JSON.stringify(sessionEnd)).not.toContain("result");
+  });
+});
+
+test("session-end continues when work registry writeback fails", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    const workPath = join(homeDir, ".soma/memory/STATE/work.json");
+    await writeFile(workPath, "{\"sessions\":null}\n", "utf8");
+
+    const end = await runSomaLifecycleSessionEnd({
+      homeDir,
+      substrate: "codex",
+      sessionId: "session-bad-registry",
+      timestamp: "2026-05-26T10:31:00.000Z",
+    });
+
+    const events = (await readFile(join(homeDir, ".soma/memory/STATE/events.jsonl"), "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+
+    expect(end.files).not.toContain(workPath);
+    expect(events.some((event) => event.kind === "lifecycle.session_end.registry-write-failed")).toBe(true);
+    expect(events.some((event) => event.kind === "lifecycle.session_end")).toBe(true);
   });
 });
 

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -90,3 +90,26 @@ test("work registry upsert replaces stale slug for the same session", async () =
     ]);
   });
 });
+
+test("work registry upsert disambiguates equal names for different sessions", async () => {
+  await withTempHome(async (homeDir) => {
+    await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "session-1",
+      sessionName: "shared name",
+      substrate: "codex",
+    });
+    await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "session-2",
+      sessionName: "shared name",
+      substrate: "pi-dev",
+    });
+
+    const work = JSON.parse(await readFile(join(homeDir, ".soma/memory/STATE/work.json"), "utf8"));
+
+    expect(Object.keys(work.sessions).sort()).toEqual(["shared-name", "shared-name-session-2"]);
+    expect(work.sessions["shared-name"]).toMatchObject({ sessionUUID: "session-1", substrate: "codex" });
+    expect(work.sessions["shared-name-session-2"]).toMatchObject({ sessionUUID: "session-2", substrate: "pi-dev" });
+  });
+});

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -133,6 +133,34 @@ test("work registry rejects malformed object shapes", async () => {
   });
 });
 
+test("work registry rejects malformed entry fields", async () => {
+  await withTempHome(async (homeDir) => {
+    const stateDir = join(homeDir, ".soma/memory/STATE");
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(
+      join(stateDir, "work.json"),
+      `${JSON.stringify({
+        sessions: {
+          bad: {
+            task: "Bad registry",
+            sessionName: "bad",
+            sessionUUID: "session-bad",
+            substrate: "codex",
+            phase: "complete",
+            progress: "1/1",
+            started: "2026-05-26T10:00:00.000Z",
+            updatedAt: 123,
+            artifacts: {},
+          },
+        },
+      })}\n`,
+      "utf8",
+    );
+
+    await expect(listSomaWorkRegistryEntries({ homeDir })).rejects.toThrow("session entry bad.updatedAt must be a string");
+  });
+});
+
 test("work registry normalizes artifact pointers and rejects leaks", async () => {
   await withTempHome(async (homeDir) => {
     await upsertSomaWorkRegistryEntry({

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import {
+  listSomaWorkRegistryEntries,
+  upsertSomaWorkRegistryEntry,
+} from "../src";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-work-registry-"));
+
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+test("work registry helper writes PAI-aligned shared state without transcripts", async () => {
+  await withTempHome(async (homeDir) => {
+    const result = await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "session-1",
+      sessionName: "ship work registry",
+      substrate: "codex",
+      task: "Align shared session state",
+      phase: "complete",
+      progress: "1/1",
+      timestamp: "2026-05-26T10:00:00.000Z",
+      artifacts: {
+        isa: "memory/WORK/ship-work-registry/ISA.md",
+      },
+    });
+
+    const workPath = join(homeDir, ".soma/memory/STATE/work.json");
+    const namesPath = join(homeDir, ".soma/memory/STATE/session-names.json");
+    const currentPath = join(homeDir, ".soma/memory/STATE/current-work-session-1.json");
+
+    expect(result.files).toEqual([workPath, namesPath, currentPath]);
+    const work = JSON.parse(await readFile(workPath, "utf8"));
+    const names = JSON.parse(await readFile(namesPath, "utf8"));
+    const current = JSON.parse(await readFile(currentPath, "utf8"));
+
+    expect(Object.keys(work.sessions)).toEqual(["ship-work-registry"]);
+    expect(work.sessions["ship-work-registry"]).toMatchObject({
+      sessionUUID: "session-1",
+      sessionName: "ship work registry",
+      substrate: "codex",
+      task: "Align shared session state",
+      phase: "complete",
+      progress: "1/1",
+      artifacts: {
+        isa: "memory/WORK/ship-work-registry/ISA.md",
+      },
+    });
+    expect(names).toEqual({ "session-1": "ship work registry" });
+    expect(current).toMatchObject({ slug: "ship-work-registry", sessionUUID: "session-1" });
+
+    const serialized = JSON.stringify(work);
+    expect(serialized).not.toContain("prompt");
+    expect(serialized).not.toContain("result");
+
+    await expect(listSomaWorkRegistryEntries({ homeDir })).resolves.toEqual([
+      expect.objectContaining({ sessionUUID: "session-1", sessionName: "ship work registry" }),
+    ]);
+  });
+});

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -83,8 +83,10 @@ test("work registry upsert replaces stale slug for the same session", async () =
     });
 
     const work = JSON.parse(await readFile(join(homeDir, ".soma/memory/STATE/work.json"), "utf8"));
+    const current = JSON.parse(await readFile(join(homeDir, ".soma/memory/STATE/current-work-session-1.json"), "utf8"));
 
     expect(Object.keys(work.sessions)).toEqual(["renamed-session"]);
+    expect(current).toMatchObject({ slug: "renamed-session", sessionUUID: "session-1" });
     await expect(listSomaWorkRegistryEntries({ homeDir })).resolves.toEqual([
       expect.objectContaining({ sessionUUID: "session-1", sessionName: "renamed session" }),
     ]);

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { expect, test } from "bun:test";
 import {
   listSomaWorkRegistryEntries,
+  somaWorkRegistryPaths,
   upsertSomaWorkRegistryEntry,
 } from "../src";
 
@@ -35,7 +36,7 @@ test("work registry helper writes PAI-aligned shared state without transcripts",
 
     const workPath = join(homeDir, ".soma/memory/STATE/work.json");
     const namesPath = join(homeDir, ".soma/memory/STATE/session-names.json");
-    const currentPath = join(homeDir, ".soma/memory/STATE/current-work-session-1.json");
+    const currentPath = somaWorkRegistryPaths({ homeDir }, "session-1").currentWork!;
 
     expect(result.files).toEqual([workPath, namesPath, currentPath]);
     const work = JSON.parse(await readFile(workPath, "utf8"));
@@ -83,7 +84,7 @@ test("work registry upsert replaces stale slug for the same session", async () =
     });
 
     const work = JSON.parse(await readFile(join(homeDir, ".soma/memory/STATE/work.json"), "utf8"));
-    const current = JSON.parse(await readFile(join(homeDir, ".soma/memory/STATE/current-work-session-1.json"), "utf8"));
+    const current = JSON.parse(await readFile(somaWorkRegistryPaths({ homeDir }, "session-1").currentWork!, "utf8"));
 
     expect(Object.keys(work.sessions)).toEqual(["renamed-session"]);
     expect(current).toMatchObject({ slug: "renamed-session", sessionUUID: "session-1" });
@@ -113,6 +114,48 @@ test("work registry upsert disambiguates equal names for different sessions", as
     expect(Object.keys(work.sessions).sort()).toEqual(["shared-name", "shared-name-session-2"]);
     expect(work.sessions["shared-name"]).toMatchObject({ sessionUUID: "session-1", substrate: "codex" });
     expect(work.sessions["shared-name-session-2"]).toMatchObject({ sessionUUID: "session-2", substrate: "pi-dev" });
+  });
+});
+
+test("work registry upserts preserve concurrent sessions", async () => {
+  await withTempHome(async (homeDir) => {
+    await Promise.all(
+      Array.from({ length: 12 }, (_, index) =>
+        upsertSomaWorkRegistryEntry({
+          homeDir,
+          sessionId: `session-${index + 1}`,
+          sessionName: `parallel session ${index + 1}`,
+          substrate: "codex",
+        }),
+      ),
+    );
+
+    const work = JSON.parse(await readFile(join(homeDir, ".soma/memory/STATE/work.json"), "utf8"));
+    expect(Object.keys(work.sessions)).toHaveLength(12);
+  });
+});
+
+test("work registry current-work filenames resist sanitized session id collisions", async () => {
+  await withTempHome(async (homeDir) => {
+    const slash = await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "a/b",
+      sessionName: "slash",
+      substrate: "codex",
+    });
+    const colon = await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "a:b",
+      sessionName: "colon",
+      substrate: "codex",
+    });
+
+    const slashPointerPath = slash.files.find((file) => file.includes("current-work-"))!;
+    const colonPointerPath = colon.files.find((file) => file.includes("current-work-"))!;
+
+    expect(slashPointerPath).not.toBe(colonPointerPath);
+    await expect(readFile(slashPointerPath, "utf8")).resolves.toContain('"sessionUUID": "a/b"');
+    await expect(readFile(colonPointerPath, "utf8")).resolves.toContain('"sessionUUID": "a:b"');
   });
 });
 

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
@@ -113,5 +113,67 @@ test("work registry upsert disambiguates equal names for different sessions", as
     expect(Object.keys(work.sessions).sort()).toEqual(["shared-name", "shared-name-session-2"]);
     expect(work.sessions["shared-name"]).toMatchObject({ sessionUUID: "session-1", substrate: "codex" });
     expect(work.sessions["shared-name-session-2"]).toMatchObject({ sessionUUID: "session-2", substrate: "pi-dev" });
+  });
+});
+
+test("work registry rejects malformed object shapes", async () => {
+  await withTempHome(async (homeDir) => {
+    const stateDir = join(homeDir, ".soma/memory/STATE");
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(join(stateDir, "work.json"), "{\"sessions\":[]}\n", "utf8");
+
+    await expect(
+      upsertSomaWorkRegistryEntry({
+        homeDir,
+        sessionId: "session-1",
+        sessionName: "malformed registry",
+        substrate: "codex",
+      }),
+    ).rejects.toThrow("sessions must be an object");
+  });
+});
+
+test("work registry normalizes artifact pointers and rejects leaks", async () => {
+  await withTempHome(async (homeDir) => {
+    await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "session-1",
+      sessionName: "artifact pointers",
+      substrate: "codex",
+      artifacts: {
+        learning: join(homeDir, ".soma/memory/LEARNING/ALGORITHM/run.md"),
+        state: "memory/STATE/algorithm-work-index.json",
+      },
+    });
+
+    const work = JSON.parse(await readFile(join(homeDir, ".soma/memory/STATE/work.json"), "utf8"));
+    expect(work.sessions["artifact-pointers"].artifacts).toEqual({
+      learning: "memory/LEARNING/ALGORITHM/run.md",
+      state: "memory/STATE/algorithm-work-index.json",
+    });
+
+    await expect(
+      upsertSomaWorkRegistryEntry({
+        homeDir,
+        sessionId: "session-2",
+        sessionName: "leaky artifact",
+        substrate: "codex",
+        artifacts: {
+          leak: join(homeDir, "outside.md"),
+        },
+      }),
+    ).rejects.toThrow("escapes Soma home");
+
+    await expect(
+      upsertSomaWorkRegistryEntry({
+        homeDir,
+        sessionId: "session-3",
+        sessionName: "private artifact",
+        substrate: "codex",
+        artifacts: {
+          profile: "profile.md",
+        },
+      }),
+    ).rejects.toThrow("must stay under memory/");
   });
 });

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -130,6 +130,9 @@ test("work registry rejects malformed object shapes", async () => {
         substrate: "codex",
       }),
     ).rejects.toThrow("sessions must be an object");
+
+    await writeFile(join(stateDir, "work.json"), "{\"sessions\":null}\n", "utf8");
+    await expect(listSomaWorkRegistryEntries({ homeDir })).rejects.toThrow("sessions must be an object");
   });
 });
 

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -159,6 +159,25 @@ test("work registry current-work filenames resist sanitized session id collision
   });
 });
 
+test("work registry persists special session ids as data keys", async () => {
+  await withTempHome(async (homeDir) => {
+    await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "__proto__",
+      sessionName: "__proto__",
+      substrate: "codex",
+    });
+
+    const work = JSON.parse(await readFile(join(homeDir, ".soma/memory/STATE/work.json"), "utf8"));
+    const names = JSON.parse(await readFile(join(homeDir, ".soma/memory/STATE/session-names.json"), "utf8"));
+
+    expect(Object.hasOwn(work.sessions, "__proto__")).toBe(true);
+    expect(Object.hasOwn(names, "__proto__")).toBe(true);
+    expect(work.sessions["__proto__"]).toMatchObject({ sessionUUID: "__proto__" });
+    expect(names["__proto__"]).toBe("__proto__");
+  });
+});
+
 test("work registry rejects malformed object shapes", async () => {
   await withTempHome(async (homeDir) => {
     const stateDir = join(homeDir, ".soma/memory/STATE");

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { expect, test } from "bun:test";
 import {
   listSomaWorkRegistryEntries,
@@ -156,6 +156,20 @@ test("work registry current-work filenames resist sanitized session id collision
     expect(slashPointerPath).not.toBe(colonPointerPath);
     await expect(readFile(slashPointerPath, "utf8")).resolves.toContain('"sessionUUID": "a/b"');
     await expect(readFile(colonPointerPath, "utf8")).resolves.toContain('"sessionUUID": "a:b"');
+  });
+});
+
+test("work registry current-work filenames bound long session ids", async () => {
+  await withTempHome(async (homeDir) => {
+    const result = await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "session-".padEnd(400, "x"),
+      sessionName: "long session",
+      substrate: "codex",
+    });
+
+    const pointerPath = result.files.find((file) => file.includes("current-work-"))!;
+    expect(basename(pointerPath).length).toBeLessThan(120);
   });
 });
 

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -66,3 +66,27 @@ test("work registry helper writes PAI-aligned shared state without transcripts",
     ]);
   });
 });
+
+test("work registry upsert replaces stale slug for the same session", async () => {
+  await withTempHome(async (homeDir) => {
+    await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "session-1",
+      sessionName: "first name",
+      substrate: "codex",
+    });
+    await upsertSomaWorkRegistryEntry({
+      homeDir,
+      sessionId: "session-1",
+      sessionName: "renamed session",
+      substrate: "codex",
+    });
+
+    const work = JSON.parse(await readFile(join(homeDir, ".soma/memory/STATE/work.json"), "utf8"));
+
+    expect(Object.keys(work.sessions)).toEqual(["renamed-session"]);
+    await expect(listSomaWorkRegistryEntries({ homeDir })).resolves.toEqual([
+      expect.objectContaining({ sessionUUID: "session-1", sessionName: "renamed session" }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds SpecFlow spec/plan/task/verification artifacts for #165.
- Adds canonical PAI-aligned work registry helpers for work.json, session-names.json, and current-work-<session-id>.json.
- Changes learning harvest default to work-registry metadata, keeping raw transcript harvesting explicit via --session-dir.
- Makes session-end lifecycle writeback update shared work state and append metadata-only event artifact pointers.

Closes #165.

## Verification

- bun test test/work-registry.test.ts
- bun test test/learning-tools.test.ts --timeout 20000
- bun test test/lifecycle.test.ts --timeout 20000
- bun test test/cli.test.ts --timeout 20000
- bun test --timeout 30000
- bun run typecheck
- git diff --check