### PR TITLE
Add observability telemetry query surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added observability V0 over `memory/STATE/events.jsonl` with
+  `soma telemetry list`, `soma telemetry stats`, and `soma stats` for local
+  event queries, summaries, malformed-row accounting, and JSON output. ([#151])
 - Added canonical PAI-aligned shared work state for lifecycle writeback and
   learning harvest defaults: `work.json`, `session-names.json`,
   resolver-backed `current-work-<safe-session-token>-<session-id-hash>.json`,
@@ -66,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#139]: https://github.com/the-metafactory/soma/issues/139
 [#144]: https://github.com/the-metafactory/soma/issues/144
 [#148]: https://github.com/the-metafactory/soma/issues/148
+[#151]: https://github.com/the-metafactory/soma/issues/151
 [#154]: https://github.com/the-metafactory/soma/issues/154
 [#159]: https://github.com/the-metafactory/soma/pull/159
 [#160]: https://github.com/the-metafactory/soma/pull/160

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -194,3 +194,16 @@ The V0 lifecycle surface has three events:
 
 Substrates can call these events through the CLI or library. Cortex can later
 subscribe to the same lifecycle surface as bus-visible work state.
+
+## Observability
+
+Observability V0 is a filesystem-native read model over
+`memory/STATE/events.jsonl`. `soma telemetry list` queries recent events and
+`soma telemetry stats` / `soma stats` summarizes event counts, lifecycle
+sessions, writeback failures, Algorithm event phases when present, and skipped
+malformed rows. This gives Soma a local inspection surface without adding a
+database, daemon, dashboard, or Signal dependency.
+
+Signal still owns telemetry systems. Soma emits and summarizes local events;
+future Signal export should consume the same read model. See
+[observability.md](./observability.md).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,52 @@
+# Observability V0
+
+Soma observability starts as a filesystem-native read model over the existing
+append-only event log:
+
+```text
+<soma-home>/memory/STATE/events.jsonl
+```
+
+Each line is a `SomaMemoryEvent`. V0 does not add a database, daemon, dashboard,
+or Signal dependency. It also does not harvest raw transcripts, prompts, or full
+tool payloads.
+
+## CLI
+
+List recent events:
+
+```bash
+soma telemetry list
+soma telemetry list --substrate codex --limit 10
+soma telemetry list --kind lifecycle.session_end --json
+```
+
+Summarize the event log:
+
+```bash
+soma telemetry stats
+soma stats --json
+```
+
+The summary includes:
+
+- total parsed events
+- malformed JSONL rows skipped
+- event counts by substrate
+- event counts by kind
+- lifecycle session starts and ends, including per-substrate counts
+- observed session durations when start/end events share a `metadata.sessionId`
+- Algorithm event counts and phase counts when events carry `metadata.phase`
+- skill event counts and skill-name frequencies when events carry
+  `metadata.skill`, `metadata.skillName`, or `metadata.skillId`
+- writeback/failure event counts
+
+Malformed lines are counted and skipped so one corrupt row does not hide the
+rest of the log.
+
+## Boundary
+
+Soma owns the local event vocabulary and the filesystem-native query surface.
+Signal remains the owner of telemetry systems, dashboards, alerting, and longer
+term observability pipelines. A future Signal export should consume this V0
+read model instead of re-parsing event files independently.

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -175,8 +175,10 @@ The registry stores metadata and artifact pointers. It must not mirror full
 private prompts, results, or raw transcripts by default. Session-end writeback
 also appends a metadata-only `lifecycle.session_end` event to
 `<soma-home>/memory/STATE/events.jsonl` with pointers to the shared state files
-it updated. Full tool activity and tool failure telemetry are separate
-observability work.
+it updated. Soma's V0 observability surface reads the same append-only event
+log through `soma telemetry list`, `soma telemetry stats`, and `soma stats`.
+Full tool activity and tool failure capture remain adapter-specific event
+extensions; Signal remains the telemetry-system owner.
 
 Adapters own their substrate-native install facts: default home, projected file
 paths, substrate-specific skill destinations, lifecycle projection paths,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,13 @@ import {
   type ParsedMemoryArgs,
 } from "./cli/memory";
 import {
+  STATS_COMMAND_HELP,
+  TELEMETRY_COMMAND_HELP,
+  parseTelemetryArgs,
+  runTelemetryCli,
+  type ParsedTelemetryArgs,
+} from "./cli/telemetry";
+import {
   RESULT_COMMAND_HELP,
   parseResultArgs,
   runResultCli,
@@ -108,6 +115,7 @@ type ParsedArgs =
   | ParsedAlgorithmArgs
   | ParsedLifecycleArgs
   | ParsedMemoryArgs
+  | ParsedTelemetryArgs
   | ParsedFeedbackArgs
   | ParsedResultArgs
   | ParsedPolicyArgs
@@ -137,6 +145,8 @@ const TOP_LEVEL_COMMANDS = [
   "reproject",
   "result",
   "session",
+  "stats",
+  "telemetry",
   "uninstall",
   "upgrade",
   "wisdom",
@@ -145,6 +155,8 @@ const TOP_LEVEL_COMMANDS = [
 const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string, string> }> = {
   algorithm: ALGORITHM_COMMAND_HELP,
   memory: MEMORY_COMMAND_HELP,
+  telemetry: TELEMETRY_COMMAND_HELP,
+  stats: STATS_COMMAND_HELP,
   feedback: FEEDBACK_COMMAND_HELP,
   ...TOOL_COMMAND_HELP,
   result: RESULT_COMMAND_HELP,
@@ -199,6 +211,10 @@ function parseArgs(args: string[]): ParsedArgs {
 
   if (args[0] === "memory") {
     return parseMemoryArgs(args);
+  }
+
+  if (args[0] === "telemetry" || args[0] === "stats") {
+    return parseTelemetryArgs(args);
   }
 
   if (args[0] === "feedback") {
@@ -396,6 +412,10 @@ export async function runSomaCli(args: string[]): Promise<string> {
 
   if (parsed.command === "memory") {
     return runMemoryCli(parsed);
+  }
+
+  if (parsed.command === "telemetry" || parsed.command === "stats") {
+    return runTelemetryCli(parsed);
   }
 
   if (parsed.command === "feedback") {

--- a/src/cli/telemetry.ts
+++ b/src/cli/telemetry.ts
@@ -74,16 +74,13 @@ function parseTelemetryListOptions(args: string[]): SomaTelemetryQueryOptions & 
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    const commonIndex = parseTelemetryCommonOption(options, args, index, arg);
+    if (commonIndex !== undefined) {
+      index = commonIndex;
+      continue;
+    }
 
     switch (arg) {
-      case "--home-dir":
-        options.homeDir = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--soma-home":
-        options.somaHome = readOption(args, index, arg);
-        index += 1;
-        break;
       case "--substrate":
         options.substrate = parseSubstrate(readOption(args, index, arg));
         index += 1;
@@ -99,9 +96,6 @@ function parseTelemetryListOptions(args: string[]): SomaTelemetryQueryOptions & 
         }
         index += 1;
         break;
-      case "--json":
-        options.json = true;
-        break;
       default:
         throw new Error(`Unknown option: ${arg}`);
     }
@@ -115,25 +109,37 @@ function parseTelemetryStatsOptions(args: string[]): SomaTelemetrySummaryOptions
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-
-    switch (arg) {
-      case "--home-dir":
-        options.homeDir = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--soma-home":
-        options.somaHome = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--json":
-        options.json = true;
-        break;
-      default:
-        throw new Error(`Unknown option: ${arg}`);
+    const commonIndex = parseTelemetryCommonOption(options, args, index, arg);
+    if (commonIndex !== undefined) {
+      index = commonIndex;
+      continue;
     }
+
+    throw new Error(`Unknown option: ${arg}`);
   }
 
   return options;
+}
+
+function parseTelemetryCommonOption(
+  options: SomaTelemetrySummaryOptions & { json?: boolean },
+  args: string[],
+  index: number,
+  arg: string,
+): number | undefined {
+  switch (arg) {
+    case "--home-dir":
+      options.homeDir = readOption(args, index, arg);
+      return index + 1;
+    case "--soma-home":
+      options.somaHome = readOption(args, index, arg);
+      return index + 1;
+    case "--json":
+      options.json = true;
+      return index;
+    default:
+      return undefined;
+  }
 }
 
 export async function runTelemetryCli(parsed: ParsedTelemetryArgs): Promise<string> {

--- a/src/cli/telemetry.ts
+++ b/src/cli/telemetry.ts
@@ -1,0 +1,218 @@
+import { querySomaTelemetryEvents, summarizeSomaTelemetry } from "../index";
+import type {
+  SomaMemoryEvent,
+  SomaTelemetryQueryOptions,
+  SomaTelemetryQueryResult,
+  SomaTelemetrySummary,
+  SomaTelemetrySummaryOptions,
+} from "../types";
+import { readOption } from "./parse-utils";
+import { parseSubstrate } from "./substrate";
+
+export interface ParsedTelemetryListArgs {
+  command: "telemetry";
+  action: "list";
+  options: SomaTelemetryQueryOptions & { json?: boolean };
+}
+
+export interface ParsedTelemetryStatsArgs {
+  command: "telemetry" | "stats";
+  action: "stats";
+  options: SomaTelemetrySummaryOptions & { json?: boolean };
+}
+
+export type ParsedTelemetryArgs = ParsedTelemetryListArgs | ParsedTelemetryStatsArgs;
+
+const TELEMETRY_LIST_USAGE =
+  "Usage: soma telemetry list [--limit <n>] [--substrate <id>] [--kind <event-kind>] [--json] [--home-dir <dir>] [--soma-home <dir>]";
+const TELEMETRY_STATS_USAGE = "Usage: soma telemetry stats [--json] [--home-dir <dir>] [--soma-home <dir>]";
+
+export const TELEMETRY_COMMAND_HELP: { usage: string; subcommands: Record<"list" | "stats", string> } = {
+  usage: "Usage: soma telemetry <list|stats> ...",
+  subcommands: {
+    list: TELEMETRY_LIST_USAGE,
+    stats: TELEMETRY_STATS_USAGE,
+  },
+};
+
+export const STATS_COMMAND_HELP: { usage: string } = {
+  usage: "Usage: soma stats [--json] [--home-dir <dir>] [--soma-home <dir>]",
+};
+
+export function parseTelemetryArgs(args: string[]): ParsedTelemetryArgs {
+  const [command, action, ...rest] = args;
+
+  if (command === "stats") {
+    return {
+      command,
+      action: "stats",
+      options: parseTelemetryStatsOptions(args.slice(1)),
+    };
+  }
+
+  if (command !== "telemetry" || (action !== "list" && action !== "stats")) {
+    throw new Error(TELEMETRY_COMMAND_HELP.usage);
+  }
+
+  if (action === "list") {
+    return {
+      command,
+      action,
+      options: parseTelemetryListOptions(rest),
+    };
+  }
+
+  return {
+    command,
+    action,
+    options: parseTelemetryStatsOptions(rest),
+  };
+}
+
+function parseTelemetryListOptions(args: string[]): SomaTelemetryQueryOptions & { json?: boolean } {
+  const options: SomaTelemetryQueryOptions & { json?: boolean } = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--substrate":
+        options.substrate = parseSubstrate(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--kind":
+        options.kind = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--limit":
+        options.limit = Number.parseInt(readOption(args, index, arg), 10);
+        if (!Number.isFinite(options.limit) || options.limit < 1) {
+          throw new Error("--limit must be a positive integer.");
+        }
+        index += 1;
+        break;
+      case "--json":
+        options.json = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function parseTelemetryStatsOptions(args: string[]): SomaTelemetrySummaryOptions & { json?: boolean } {
+  const options: SomaTelemetrySummaryOptions & { json?: boolean } = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--json":
+        options.json = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+export async function runTelemetryCli(parsed: ParsedTelemetryArgs): Promise<string> {
+  if (parsed.action === "list") {
+    const result = await querySomaTelemetryEvents(parsed.options);
+    return parsed.options.json === true ? `${JSON.stringify(result, null, 2)}\n` : formatTelemetryList(result);
+  }
+
+  const summary = await summarizeSomaTelemetry(parsed.options);
+  return parsed.options.json === true ? `${JSON.stringify(summary, null, 2)}\n` : formatTelemetryStats(summary);
+}
+
+function formatTelemetryList(result: SomaTelemetryQueryResult): string {
+  return [
+    "Soma telemetry events",
+    `somaHome: ${result.somaHome}`,
+    `eventPath: ${result.eventPath}`,
+    `totalEvents: ${result.totalEvents}`,
+    `skippedMalformedLines: ${result.skippedMalformedLines}`,
+    "",
+    "Events:",
+    ...(result.events.length > 0 ? result.events.map(formatEventLine) : ["- none"]),
+  ].join("\n");
+}
+
+function formatEventLine(event: SomaMemoryEvent): string {
+  return `- ${event.timestamp} ${event.substrate} ${event.kind} ${event.id} - ${event.summary}`;
+}
+
+function formatCountMap(record: Record<string, number> | Partial<Record<string, number>>): string[] {
+  const entries = Object.entries(record).sort(([left], [right]) => left.localeCompare(right));
+  return entries.length > 0 ? entries.map(([key, value]) => `- ${key}: ${value}`) : ["- none"];
+}
+
+function formatTelemetryStats(summary: SomaTelemetrySummary): string {
+  return [
+    "Soma telemetry stats",
+    `somaHome: ${summary.somaHome}`,
+    `eventPath: ${summary.eventPath}`,
+    `totalEvents: ${summary.totalEvents}`,
+    `skippedMalformedLines: ${summary.skippedMalformedLines}`,
+    `firstTimestamp: ${summary.firstTimestamp ?? "n/a"}`,
+    `lastTimestamp: ${summary.lastTimestamp ?? "n/a"}`,
+    "",
+    "Sessions:",
+    `- started: ${summary.sessions.started}`,
+    `- ended: ${summary.sessions.ended}`,
+    `- completedWithDuration: ${summary.sessions.completedWithDuration}`,
+    `- averageDurationMs: ${summary.sessions.averageDurationMs ?? "n/a"}`,
+    ...formatSessionSubstrateStats(summary.sessions.bySubstrate),
+    "",
+    "Skills:",
+    `- events: ${summary.skills.events}`,
+    ...formatCountMap(summary.skills.byName).map((line) => `  ${line}`),
+    "",
+    "Substrates:",
+    ...formatCountMap(summary.bySubstrate),
+    "",
+    "Kinds:",
+    ...formatCountMap(summary.byKind),
+    "",
+    "Algorithm:",
+    `- events: ${summary.algorithm.events}`,
+    ...formatCountMap(summary.algorithm.byPhase).map((line) => `  ${line}`),
+    "",
+    "Writeback:",
+    `- events: ${summary.writeback.events}`,
+    `- failures: ${summary.writeback.failures}`,
+  ].join("\n");
+}
+
+function formatSessionSubstrateStats(stats: SomaTelemetrySummary["sessions"]["bySubstrate"]): string[] {
+  const entries = Object.entries(stats).sort(([left], [right]) => left.localeCompare(right));
+  if (entries.length === 0) return ["- bySubstrate: none"];
+
+  return [
+    "- bySubstrate:",
+    ...entries.map(([substrate, value]) =>
+      `  - ${substrate}: started=${value.started} ended=${value.ended} completedWithDuration=${value.completedWithDuration} averageDurationMs=${value.averageDurationMs ?? "n/a"}`,
+    ),
+  ];
+}

--- a/src/cli/telemetry.ts
+++ b/src/cli/telemetry.ts
@@ -90,10 +90,7 @@ function parseTelemetryListOptions(args: string[]): SomaTelemetryQueryOptions & 
         index += 1;
         break;
       case "--limit":
-        options.limit = Number.parseInt(readOption(args, index, arg), 10);
-        if (!Number.isFinite(options.limit) || options.limit < 1) {
-          throw new Error("--limit must be a positive integer.");
-        }
+        options.limit = parsePositiveInteger(readOption(args, index, arg), "--limit");
         index += 1;
         break;
       default:
@@ -102,6 +99,17 @@ function parseTelemetryListOptions(args: string[]): SomaTelemetryQueryOptions & 
   }
 
   return options;
+}
+
+function parsePositiveInteger(value: string, option: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${option} must be a positive integer.`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(`${option} must be a positive integer.`);
+  }
+  return parsed;
 }
 
 function parseTelemetryStatsOptions(args: string[]): SomaTelemetrySummaryOptions & { json?: boolean } {

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,6 +361,7 @@ export {
 } from "./lifecycle";
 export { captureSomaFeedback, classifySomaFeedback, maybeSomaFeedbackPrompt } from "./feedback";
 export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from "./memory";
+export { querySomaTelemetryEvents, summarizeSomaTelemetry } from "./observability";
 export {
   listSomaWorkRegistryEntries,
   readSomaWorkRegistry,

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,0 +1,284 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { somaMemoryEventsPath } from "./memory";
+import type {
+  AlgorithmPhase,
+  SomaMemoryEvent,
+  SomaTelemetryQueryOptions,
+  SomaTelemetryQueryResult,
+  SomaTelemetrySummary,
+  SomaTelemetrySummaryOptions,
+  SubstrateId,
+} from "./types";
+
+const ALGORITHM_PHASES = new Set<AlgorithmPhase>([
+  "observe",
+  "think",
+  "plan",
+  "build",
+  "execute",
+  "verify",
+  "learn",
+  "complete",
+  "abandoned",
+]);
+
+function resolveSomaHome(options: Pick<SomaTelemetryQueryOptions, "homeDir" | "somaHome"> = {}): string {
+  const home = resolve(options.homeDir ?? homedir());
+  return resolve(options.somaHome ?? join(home, ".soma"));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSomaMemoryEvent(value: unknown): value is SomaMemoryEvent {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.id === "string" &&
+    typeof value.timestamp === "string" &&
+    typeof value.substrate === "string" &&
+    typeof value.kind === "string" &&
+    typeof value.summary === "string"
+  );
+}
+
+async function readTelemetryEvents(somaHome: string): Promise<{
+  eventPath: string;
+  events: SomaMemoryEvent[];
+  skippedMalformedLines: number;
+}> {
+  const eventPath = somaMemoryEventsPath(somaHome);
+  const content = await readFile(eventPath, "utf8").catch((error: unknown) => {
+    if (isRecord(error) && error.code === "ENOENT") return "";
+    throw error;
+  });
+  const events: SomaMemoryEvent[] = [];
+  let skippedMalformedLines = 0;
+
+  for (const line of content.split("\n")) {
+    if (line.trim().length === 0) continue;
+
+    try {
+      const event = JSON.parse(line) as unknown;
+      if (!isSomaMemoryEvent(event)) {
+        skippedMalformedLines += 1;
+        continue;
+      }
+      events.push(event);
+    } catch {
+      skippedMalformedLines += 1;
+    }
+  }
+
+  return { eventPath, events, skippedMalformedLines };
+}
+
+function applyTelemetryFilters(events: SomaMemoryEvent[], options: SomaTelemetryQueryOptions): SomaMemoryEvent[] {
+  return events.filter((event) => {
+    if (options.substrate !== undefined && event.substrate !== options.substrate) return false;
+    if (options.kind !== undefined && event.kind !== options.kind) return false;
+    return true;
+  });
+}
+
+function recentEvents(events: SomaMemoryEvent[], limit: number | undefined): SomaMemoryEvent[] {
+  const boundedLimit = limit ?? 20;
+  if (boundedLimit < 1) {
+    throw new Error("Soma telemetry limit must be a positive integer.");
+  }
+
+  return events.slice(-boundedLimit).reverse();
+}
+
+export async function querySomaTelemetryEvents(options: SomaTelemetryQueryOptions = {}): Promise<SomaTelemetryQueryResult> {
+  const somaHome = resolveSomaHome(options);
+  const read = await readTelemetryEvents(somaHome);
+  const filtered = applyTelemetryFilters(read.events, options);
+
+  return {
+    somaHome,
+    eventPath: read.eventPath,
+    totalEvents: read.events.length,
+    skippedMalformedLines: read.skippedMalformedLines,
+    events: recentEvents(filtered, options.limit),
+  };
+}
+
+function increment<T extends string>(record: Partial<Record<T, number>>, key: T): void {
+  record[key] = (record[key] ?? 0) + 1;
+}
+
+function incrementRecord(record: Record<string, number>, key: string): void {
+  record[key] = (record[key] ?? 0) + 1;
+}
+
+function eventSessionId(event: SomaMemoryEvent): string | undefined {
+  const sessionId = event.metadata?.sessionId;
+  return typeof sessionId === "string" && sessionId.length > 0 ? sessionId : undefined;
+}
+
+function eventPhase(event: SomaMemoryEvent): AlgorithmPhase | undefined {
+  const phase = event.metadata?.phase;
+  if (typeof phase === "string" && ALGORITHM_PHASES.has(phase as AlgorithmPhase)) {
+    return phase as AlgorithmPhase;
+  }
+  return undefined;
+}
+
+function eventSkillName(event: SomaMemoryEvent): string | undefined {
+  const candidates = [
+    event.metadata?.skill,
+    event.metadata?.skillName,
+    event.metadata?.skillId,
+  ];
+  const name = candidates.find((candidate): candidate is string => typeof candidate === "string" && candidate.trim().length > 0);
+  return name?.trim();
+}
+
+function timestampMs(value: string): number | undefined {
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function averageDuration(durations: number[]): number | null {
+  return durations.length > 0
+    ? Math.round(durations.reduce((sum, duration) => sum + duration, 0) / durations.length)
+    : null;
+}
+
+interface MutableSessionStats {
+  started: number;
+  ended: number;
+  durations: number[];
+}
+
+function ensureSessionStats(
+  stats: Partial<Record<SubstrateId, MutableSessionStats>>,
+  substrate: SubstrateId,
+): MutableSessionStats {
+  const existing = stats[substrate];
+  if (existing !== undefined) return existing;
+
+  const created: MutableSessionStats = {
+    started: 0,
+    ended: 0,
+    durations: [],
+  };
+  stats[substrate] = created;
+  return created;
+}
+
+function publicSessionStats(stats: Partial<Record<SubstrateId, MutableSessionStats>>): SomaTelemetrySummary["sessions"]["bySubstrate"] {
+  const result: SomaTelemetrySummary["sessions"]["bySubstrate"] = {};
+  for (const [substrate, value] of Object.entries(stats) as [SubstrateId, MutableSessionStats][]) {
+    result[substrate] = {
+      started: value.started,
+      ended: value.ended,
+      completedWithDuration: value.durations.length,
+      averageDurationMs: averageDuration(value.durations),
+    };
+  }
+  return result;
+}
+
+export async function summarizeSomaTelemetry(options: SomaTelemetrySummaryOptions = {}): Promise<SomaTelemetrySummary> {
+  const somaHome = resolveSomaHome(options);
+  const read = await readTelemetryEvents(somaHome);
+  const bySubstrate: Partial<Record<SubstrateId, number>> = {};
+  const byKind: Record<string, number> = {};
+  const algorithmByPhase: Partial<Record<AlgorithmPhase, number>> = {};
+  const skillByName: Record<string, number> = {};
+  const sessionStarts = new Map<string, number>();
+  const sessionStatsBySubstrate: Partial<Record<SubstrateId, MutableSessionStats>> = {};
+  const durations: number[] = [];
+  let sessionStartCount = 0;
+  let sessionEndCount = 0;
+  let skillEventCount = 0;
+  let algorithmEventCount = 0;
+  let writebackEventCount = 0;
+  let writebackFailureCount = 0;
+
+  for (const event of read.events) {
+    increment(bySubstrate, event.substrate);
+    incrementRecord(byKind, event.kind);
+
+    if (event.kind === "lifecycle.session_start") {
+      sessionStartCount += 1;
+      ensureSessionStats(sessionStatsBySubstrate, event.substrate).started += 1;
+      const sessionId = eventSessionId(event);
+      const startedAt = timestampMs(event.timestamp);
+      if (sessionId !== undefined && startedAt !== undefined) {
+        sessionStarts.set(`${event.substrate}\0${sessionId}`, startedAt);
+      }
+    }
+
+    if (event.kind === "lifecycle.session_end") {
+      sessionEndCount += 1;
+      const substrateStats = ensureSessionStats(sessionStatsBySubstrate, event.substrate);
+      substrateStats.ended += 1;
+      const sessionId = eventSessionId(event);
+      const endedAt = timestampMs(event.timestamp);
+      const startedAt = sessionId === undefined ? undefined : sessionStarts.get(`${event.substrate}\0${sessionId}`);
+      if (startedAt !== undefined && endedAt !== undefined && endedAt >= startedAt) {
+        const duration = endedAt - startedAt;
+        durations.push(duration);
+        substrateStats.durations.push(duration);
+      }
+    }
+
+    const skillName = eventSkillName(event);
+    if (event.kind.includes("skill") || skillName !== undefined) {
+      skillEventCount += 1;
+      if (skillName !== undefined) {
+        incrementRecord(skillByName, skillName);
+      }
+    }
+
+    if (event.kind.includes("algorithm")) {
+      algorithmEventCount += 1;
+      const phase = eventPhase(event);
+      if (phase !== undefined) {
+        increment(algorithmByPhase, phase);
+      }
+    }
+
+    if (event.kind.includes("writeback") || event.kind.endsWith(".failed") || event.kind.includes("registry-write")) {
+      writebackEventCount += 1;
+      if (event.kind.endsWith(".failed") || event.kind.includes("failed")) {
+        writebackFailureCount += 1;
+      }
+    }
+  }
+
+  return {
+    somaHome,
+    eventPath: read.eventPath,
+    totalEvents: read.events.length,
+    skippedMalformedLines: read.skippedMalformedLines,
+    firstTimestamp: read.events[0]?.timestamp,
+    lastTimestamp: read.events.at(-1)?.timestamp,
+    bySubstrate,
+    byKind,
+    sessions: {
+      started: sessionStartCount,
+      ended: sessionEndCount,
+      completedWithDuration: durations.length,
+      averageDurationMs: averageDuration(durations),
+      bySubstrate: publicSessionStats(sessionStatsBySubstrate),
+    },
+    skills: {
+      events: skillEventCount,
+      byName: skillByName,
+    },
+    algorithm: {
+      events: algorithmEventCount,
+      byPhase: algorithmByPhase,
+    },
+    writeback: {
+      events: writebackEventCount,
+      failures: writebackFailureCount,
+    },
+  };
+}

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -243,11 +243,15 @@ function recordSessionEvent(event: SomaMemoryEvent, sessions: SessionAggregation
     substrateStats.ended += 1;
     const sessionId = eventSessionId(event);
     const endedAt = timestampMs(event.timestamp);
-    const startedAt = sessionId === undefined ? undefined : sessions.starts.get(`${event.substrate}\0${sessionId}`);
+    const sessionKey = sessionId === undefined ? undefined : `${event.substrate}\0${sessionId}`;
+    const startedAt = sessionKey === undefined ? undefined : sessions.starts.get(sessionKey);
     if (startedAt !== undefined && endedAt !== undefined && endedAt >= startedAt) {
       const duration = endedAt - startedAt;
       recordDuration(sessions.totalDurations, duration);
       recordDuration(substrateStats.durations, duration);
+      if (sessionKey !== undefined) {
+        sessions.starts.delete(sessionKey);
+      }
     }
   }
 }

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -104,13 +104,18 @@ function matchesTelemetryQuery(event: SomaMemoryEvent, options: SomaTelemetryQue
   return true;
 }
 
+function telemetryLimit(limit: number | undefined): number {
+  const boundedLimit = limit ?? 20;
+  if (!Number.isSafeInteger(boundedLimit) || boundedLimit < 1) {
+    throw new Error("Soma telemetry limit must be a positive integer.");
+  }
+  return boundedLimit;
+}
+
 export async function querySomaTelemetryEvents(options: SomaTelemetryQueryOptions = {}): Promise<SomaTelemetryQueryResult> {
   const somaHome = resolveSomaHome(options);
   const events: SomaMemoryEvent[] = [];
-  const boundedLimit = options.limit ?? 20;
-  if (boundedLimit < 1) {
-    throw new Error("Soma telemetry limit must be a positive integer.");
-  }
+  const boundedLimit = telemetryLimit(options.limit);
   const read = await streamTelemetryEvents(somaHome, (event) => {
     if (!matchesTelemetryQuery(event, options)) return;
     events.push(event);
@@ -164,16 +169,24 @@ function timestampMs(value: string): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
-function averageDuration(durations: number[]): number | null {
-  return durations.length > 0
-    ? Math.round(durations.reduce((sum, duration) => sum + duration, 0) / durations.length)
-    : null;
+interface DurationStats {
+  count: number;
+  totalMs: number;
+}
+
+function recordDuration(stats: DurationStats, durationMs: number): void {
+  stats.count += 1;
+  stats.totalMs += durationMs;
+}
+
+function averageDuration(stats: DurationStats): number | null {
+  return stats.count > 0 ? Math.round(stats.totalMs / stats.count) : null;
 }
 
 interface MutableSessionStats {
   started: number;
   ended: number;
-  durations: number[];
+  durations: DurationStats;
 }
 
 function ensureSessionStats(
@@ -186,7 +199,7 @@ function ensureSessionStats(
   const created: MutableSessionStats = {
     started: 0,
     ended: 0,
-    durations: [],
+    durations: { count: 0, totalMs: 0 },
   };
   stats[substrate] = created;
   return created;
@@ -198,11 +211,71 @@ function publicSessionStats(stats: Partial<Record<SubstrateId, MutableSessionSta
     result[substrate] = {
       started: value.started,
       ended: value.ended,
-      completedWithDuration: value.durations.length,
+      completedWithDuration: value.durations.count,
       averageDurationMs: averageDuration(value.durations),
     };
   }
   return result;
+}
+
+interface SessionAggregationState {
+  starts: Map<string, number>;
+  bySubstrate: Partial<Record<SubstrateId, MutableSessionStats>>;
+  totalDurations: DurationStats;
+  started: number;
+  ended: number;
+}
+
+function recordSessionEvent(event: SomaMemoryEvent, sessions: SessionAggregationState): void {
+  if (event.kind === "lifecycle.session_start") {
+    sessions.started += 1;
+    ensureSessionStats(sessions.bySubstrate, event.substrate).started += 1;
+    const sessionId = eventSessionId(event);
+    const startedAt = timestampMs(event.timestamp);
+    if (sessionId !== undefined && startedAt !== undefined) {
+      sessions.starts.set(`${event.substrate}\0${sessionId}`, startedAt);
+    }
+  }
+
+  if (event.kind === "lifecycle.session_end") {
+    sessions.ended += 1;
+    const substrateStats = ensureSessionStats(sessions.bySubstrate, event.substrate);
+    substrateStats.ended += 1;
+    const sessionId = eventSessionId(event);
+    const endedAt = timestampMs(event.timestamp);
+    const startedAt = sessionId === undefined ? undefined : sessions.starts.get(`${event.substrate}\0${sessionId}`);
+    if (startedAt !== undefined && endedAt !== undefined && endedAt >= startedAt) {
+      const duration = endedAt - startedAt;
+      recordDuration(sessions.totalDurations, duration);
+      recordDuration(substrateStats.durations, duration);
+    }
+  }
+}
+
+function recordSkillEvent(event: SomaMemoryEvent, skillByName: Record<string, number>): boolean {
+  const skillName = eventSkillName(event);
+  if (!event.kind.includes("skill") && skillName === undefined) return false;
+  if (skillName !== undefined) {
+    incrementRecord(skillByName, skillName);
+  }
+  return true;
+}
+
+function recordAlgorithmEvent(event: SomaMemoryEvent, algorithmByPhase: Partial<Record<AlgorithmPhase, number>>): boolean {
+  if (!event.kind.includes("algorithm")) return false;
+  const phase = eventPhase(event);
+  if (phase !== undefined) {
+    increment(algorithmByPhase, phase);
+  }
+  return true;
+}
+
+function isWritebackEvent(event: SomaMemoryEvent): boolean {
+  return event.kind.includes("writeback") || event.kind.endsWith(".failed") || event.kind.includes("registry-write");
+}
+
+function isWritebackFailureEvent(event: SomaMemoryEvent): boolean {
+  return event.kind.endsWith(".failed") || event.kind.includes("failed");
 }
 
 export async function summarizeSomaTelemetry(options: SomaTelemetrySummaryOptions = {}): Promise<SomaTelemetrySummary> {
@@ -211,11 +284,13 @@ export async function summarizeSomaTelemetry(options: SomaTelemetrySummaryOption
   const byKind: Record<string, number> = {};
   const algorithmByPhase: Partial<Record<AlgorithmPhase, number>> = {};
   const skillByName: Record<string, number> = {};
-  const sessionStarts = new Map<string, number>();
-  const sessionStatsBySubstrate: Partial<Record<SubstrateId, MutableSessionStats>> = {};
-  const durations: number[] = [];
-  let sessionStartCount = 0;
-  let sessionEndCount = 0;
+  const sessions: SessionAggregationState = {
+    starts: new Map<string, number>(),
+    bySubstrate: {},
+    totalDurations: { count: 0, totalMs: 0 },
+    started: 0,
+    ended: 0,
+  };
   let skillEventCount = 0;
   let algorithmEventCount = 0;
   let writebackEventCount = 0;
@@ -229,49 +304,16 @@ export async function summarizeSomaTelemetry(options: SomaTelemetrySummaryOption
     increment(bySubstrate, event.substrate);
     incrementRecord(byKind, event.kind);
 
-    if (event.kind === "lifecycle.session_start") {
-      sessionStartCount += 1;
-      ensureSessionStats(sessionStatsBySubstrate, event.substrate).started += 1;
-      const sessionId = eventSessionId(event);
-      const startedAt = timestampMs(event.timestamp);
-      if (sessionId !== undefined && startedAt !== undefined) {
-        sessionStarts.set(`${event.substrate}\0${sessionId}`, startedAt);
-      }
-    }
-
-    if (event.kind === "lifecycle.session_end") {
-      sessionEndCount += 1;
-      const substrateStats = ensureSessionStats(sessionStatsBySubstrate, event.substrate);
-      substrateStats.ended += 1;
-      const sessionId = eventSessionId(event);
-      const endedAt = timestampMs(event.timestamp);
-      const startedAt = sessionId === undefined ? undefined : sessionStarts.get(`${event.substrate}\0${sessionId}`);
-      if (startedAt !== undefined && endedAt !== undefined && endedAt >= startedAt) {
-        const duration = endedAt - startedAt;
-        durations.push(duration);
-        substrateStats.durations.push(duration);
-      }
-    }
-
-    const skillName = eventSkillName(event);
-    if (event.kind.includes("skill") || skillName !== undefined) {
+    recordSessionEvent(event, sessions);
+    if (recordSkillEvent(event, skillByName)) {
       skillEventCount += 1;
-      if (skillName !== undefined) {
-        incrementRecord(skillByName, skillName);
-      }
     }
-
-    if (event.kind.includes("algorithm")) {
+    if (recordAlgorithmEvent(event, algorithmByPhase)) {
       algorithmEventCount += 1;
-      const phase = eventPhase(event);
-      if (phase !== undefined) {
-        increment(algorithmByPhase, phase);
-      }
     }
-
-    if (event.kind.includes("writeback") || event.kind.endsWith(".failed") || event.kind.includes("registry-write")) {
+    if (isWritebackEvent(event)) {
       writebackEventCount += 1;
-      if (event.kind.endsWith(".failed") || event.kind.includes("failed")) {
+      if (isWritebackFailureEvent(event)) {
         writebackFailureCount += 1;
       }
     }
@@ -287,11 +329,11 @@ export async function summarizeSomaTelemetry(options: SomaTelemetrySummaryOption
     bySubstrate,
     byKind,
     sessions: {
-      started: sessionStartCount,
-      ended: sessionEndCount,
-      completedWithDuration: durations.length,
-      averageDurationMs: averageDuration(durations),
-      bySubstrate: publicSessionStats(sessionStatsBySubstrate),
+      started: sessions.started,
+      ended: sessions.ended,
+      completedWithDuration: sessions.totalDurations.count,
+      averageDurationMs: averageDuration(sessions.totalDurations),
+      bySubstrate: publicSessionStats(sessions.bySubstrate),
     },
     skills: {
       events: skillEventCount,

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,6 +1,8 @@
-import { readFile } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { access } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
+import { createInterface } from "node:readline/promises";
 import { somaMemoryEventsPath } from "./memory";
 import type {
   AlgorithmPhase,
@@ -44,65 +46,85 @@ function isSomaMemoryEvent(value: unknown): value is SomaMemoryEvent {
   );
 }
 
-async function readTelemetryEvents(somaHome: string): Promise<{
+function parseTelemetryLine(line: string): SomaMemoryEvent | undefined {
+  try {
+    const event = JSON.parse(line) as unknown;
+    return isSomaMemoryEvent(event) ? event : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function streamTelemetryEvents(
+  somaHome: string,
+  onEvent: (event: SomaMemoryEvent) => void,
+): Promise<{
   eventPath: string;
-  events: SomaMemoryEvent[];
+  totalEvents: number;
   skippedMalformedLines: number;
 }> {
   const eventPath = somaMemoryEventsPath(somaHome);
-  const content = await readFile(eventPath, "utf8").catch((error: unknown) => {
-    if (isRecord(error) && error.code === "ENOENT") return "";
-    throw error;
+  const exists = await access(eventPath).then(
+    () => true,
+    (error: unknown) => {
+      if (isRecord(error) && error.code === "ENOENT") return false;
+      throw error;
+    },
+  );
+  if (!exists) {
+    return { eventPath, totalEvents: 0, skippedMalformedLines: 0 };
+  }
+
+  const lines = createInterface({
+    input: createReadStream(eventPath, { encoding: "utf8" }),
+    crlfDelay: Infinity,
   });
-  const events: SomaMemoryEvent[] = [];
+  let totalEvents = 0;
   let skippedMalformedLines = 0;
 
-  for (const line of content.split("\n")) {
+  for await (const line of lines) {
     if (line.trim().length === 0) continue;
 
-    try {
-      const event = JSON.parse(line) as unknown;
-      if (!isSomaMemoryEvent(event)) {
-        skippedMalformedLines += 1;
-        continue;
-      }
-      events.push(event);
-    } catch {
+    const event = parseTelemetryLine(line);
+    if (event === undefined) {
       skippedMalformedLines += 1;
+      continue;
     }
+
+    totalEvents += 1;
+    onEvent(event);
   }
 
-  return { eventPath, events, skippedMalformedLines };
+  return { eventPath, totalEvents, skippedMalformedLines };
 }
 
-function applyTelemetryFilters(events: SomaMemoryEvent[], options: SomaTelemetryQueryOptions): SomaMemoryEvent[] {
-  return events.filter((event) => {
-    if (options.substrate !== undefined && event.substrate !== options.substrate) return false;
-    if (options.kind !== undefined && event.kind !== options.kind) return false;
-    return true;
-  });
-}
-
-function recentEvents(events: SomaMemoryEvent[], limit: number | undefined): SomaMemoryEvent[] {
-  const boundedLimit = limit ?? 20;
-  if (boundedLimit < 1) {
-    throw new Error("Soma telemetry limit must be a positive integer.");
-  }
-
-  return events.slice(-boundedLimit).reverse();
+function matchesTelemetryQuery(event: SomaMemoryEvent, options: SomaTelemetryQueryOptions): boolean {
+  if (options.substrate !== undefined && event.substrate !== options.substrate) return false;
+  if (options.kind !== undefined && event.kind !== options.kind) return false;
+  return true;
 }
 
 export async function querySomaTelemetryEvents(options: SomaTelemetryQueryOptions = {}): Promise<SomaTelemetryQueryResult> {
   const somaHome = resolveSomaHome(options);
-  const read = await readTelemetryEvents(somaHome);
-  const filtered = applyTelemetryFilters(read.events, options);
+  const events: SomaMemoryEvent[] = [];
+  const boundedLimit = options.limit ?? 20;
+  if (boundedLimit < 1) {
+    throw new Error("Soma telemetry limit must be a positive integer.");
+  }
+  const read = await streamTelemetryEvents(somaHome, (event) => {
+    if (!matchesTelemetryQuery(event, options)) return;
+    events.push(event);
+    if (events.length > boundedLimit) {
+      events.shift();
+    }
+  });
 
   return {
     somaHome,
     eventPath: read.eventPath,
-    totalEvents: read.events.length,
+    totalEvents: read.totalEvents,
     skippedMalformedLines: read.skippedMalformedLines,
-    events: recentEvents(filtered, options.limit),
+    events: events.reverse(),
   };
 }
 
@@ -185,7 +207,6 @@ function publicSessionStats(stats: Partial<Record<SubstrateId, MutableSessionSta
 
 export async function summarizeSomaTelemetry(options: SomaTelemetrySummaryOptions = {}): Promise<SomaTelemetrySummary> {
   const somaHome = resolveSomaHome(options);
-  const read = await readTelemetryEvents(somaHome);
   const bySubstrate: Partial<Record<SubstrateId, number>> = {};
   const byKind: Record<string, number> = {};
   const algorithmByPhase: Partial<Record<AlgorithmPhase, number>> = {};
@@ -199,8 +220,12 @@ export async function summarizeSomaTelemetry(options: SomaTelemetrySummaryOption
   let algorithmEventCount = 0;
   let writebackEventCount = 0;
   let writebackFailureCount = 0;
+  let firstTimestamp: string | undefined;
+  let lastTimestamp: string | undefined;
 
-  for (const event of read.events) {
+  const read = await streamTelemetryEvents(somaHome, (event) => {
+    firstTimestamp ??= event.timestamp;
+    lastTimestamp = event.timestamp;
     increment(bySubstrate, event.substrate);
     incrementRecord(byKind, event.kind);
 
@@ -250,15 +275,15 @@ export async function summarizeSomaTelemetry(options: SomaTelemetrySummaryOption
         writebackFailureCount += 1;
       }
     }
-  }
+  });
 
   return {
     somaHome,
     eventPath: read.eventPath,
-    totalEvents: read.events.length,
+    totalEvents: read.totalEvents,
     skippedMalformedLines: read.skippedMalformedLines,
-    firstTimestamp: read.events[0]?.timestamp,
-    lastTimestamp: read.events.at(-1)?.timestamp,
+    firstTimestamp,
+    lastTimestamp,
     bySubstrate,
     byKind,
     sessions: {

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -116,20 +116,22 @@ export async function querySomaTelemetryEvents(options: SomaTelemetryQueryOption
   const somaHome = resolveSomaHome(options);
   const events: SomaMemoryEvent[] = [];
   const boundedLimit = telemetryLimit(options.limit);
+  let matchedEvents = 0;
   const read = await streamTelemetryEvents(somaHome, (event) => {
     if (!matchesTelemetryQuery(event, options)) return;
-    events.push(event);
-    if (events.length > boundedLimit) {
-      events.shift();
-    }
+    events[matchedEvents % boundedLimit] = event;
+    matchedEvents += 1;
   });
+  const retainedEvents = Math.min(matchedEvents, boundedLimit);
+  const oldestIndex = matchedEvents > boundedLimit ? matchedEvents % boundedLimit : 0;
+  const recentEvents = Array.from({ length: retainedEvents }, (_, offset) => events[(oldestIndex + offset) % boundedLimit]).reverse();
 
   return {
     somaHome,
     eventPath: read.eventPath,
     totalEvents: read.totalEvents,
     skippedMalformedLines: read.skippedMalformedLines,
-    events: events.reverse(),
+    events: recentEvents,
   };
 }
 
@@ -226,8 +228,16 @@ interface SessionAggregationState {
   ended: number;
 }
 
+function isSessionStartEvent(event: SomaMemoryEvent): boolean {
+  return event.kind === "lifecycle.session_start";
+}
+
+function isSessionEndEvent(event: SomaMemoryEvent): boolean {
+  return event.kind === "lifecycle.session_end" || event.kind.startsWith("lifecycle.session_end.");
+}
+
 function recordSessionEvent(event: SomaMemoryEvent, sessions: SessionAggregationState): void {
-  if (event.kind === "lifecycle.session_start") {
+  if (isSessionStartEvent(event)) {
     sessions.started += 1;
     ensureSessionStats(sessions.bySubstrate, event.substrate).started += 1;
     const sessionId = eventSessionId(event);
@@ -237,7 +247,7 @@ function recordSessionEvent(event: SomaMemoryEvent, sessions: SessionAggregation
     }
   }
 
-  if (event.kind === "lifecycle.session_end") {
+  if (isSessionEndEvent(event)) {
     sessions.ended += 1;
     const substrateStats = ensureSessionStats(sessions.bySubstrate, event.substrate);
     substrateStats.ended += 1;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1576,6 +1576,62 @@ export interface SomaMemorySearchResult {
   matches: SomaMemorySearchMatch[];
 }
 
+export interface SomaTelemetryQueryOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate?: SubstrateId;
+  kind?: string;
+  limit?: number;
+}
+
+export interface SomaTelemetryQueryResult {
+  somaHome: string;
+  eventPath: string;
+  totalEvents: number;
+  skippedMalformedLines: number;
+  events: SomaMemoryEvent[];
+}
+
+export interface SomaTelemetrySummaryOptions {
+  homeDir?: string;
+  somaHome?: string;
+}
+
+export interface SomaTelemetrySummary {
+  somaHome: string;
+  eventPath: string;
+  totalEvents: number;
+  skippedMalformedLines: number;
+  firstTimestamp?: string;
+  lastTimestamp?: string;
+  bySubstrate: Partial<Record<SubstrateId, number>>;
+  byKind: Record<string, number>;
+  sessions: {
+    started: number;
+    ended: number;
+    completedWithDuration: number;
+    averageDurationMs: number | null;
+    bySubstrate: Partial<Record<SubstrateId, {
+      started: number;
+      ended: number;
+      completedWithDuration: number;
+      averageDurationMs: number | null;
+    }>>;
+  };
+  skills: {
+    events: number;
+    byName: Record<string, number>;
+  };
+  algorithm: {
+    events: number;
+    byPhase: Partial<Record<AlgorithmPhase, number>>;
+  };
+  writeback: {
+    events: number;
+    failures: number;
+  };
+}
+
 export const SOMA_RESULT_EVENT_KINDS = [
   "result.captured",
   "learning.signal",

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -292,6 +292,12 @@ test("cli lists and summarizes telemetry events", async () => {
   });
 });
 
+test("cli rejects malformed telemetry limits", async () => {
+  await expect(runSomaCli(["telemetry", "list", "--limit", "1x"])).rejects.toThrow("--limit must be a positive integer.");
+  await expect(runSomaCli(["telemetry", "list", "--limit", "1.5"])).rejects.toThrow("--limit must be a positive integer.");
+  await expect(runSomaCli(["telemetry", "list", "--limit", "0"])).rejects.toThrow("--limit must be a positive integer.");
+});
+
 test("lifecycle command module keeps lifecycle events and help in sync", async () => {
   await expect(runSomaCli(["lifecycle", "--help"])).resolves.toBe(LIFECYCLE_COMMAND_HELP.usage);
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -11,9 +11,11 @@ import { LIFECYCLE_COMMAND_HELP } from "../src/cli/lifecycle";
 import { MEMORY_COMMAND_HELP } from "../src/cli/memory";
 import { MIGRATE_COMMAND_HELP } from "../src/cli/migrate";
 import { ONBOARDING_COMMAND_HELP } from "../src/cli/onboarding";
+import { TELEMETRY_COMMAND_HELP } from "../src/cli/telemetry";
 import { POLICY_COMMAND_HELP } from "../src/cli/policy";
 import { RESULT_COMMAND_HELP } from "../src/cli/result";
 import { TOOL_COMMAND_HELP } from "../src/cli/tools";
+import { appendSomaMemoryEvent, bootstrapSomaHome } from "../src/index";
 import {
   INSTALL_SUBSTRATES,
   SUBSTRATE_LIFECYCLE_COMMAND_HELP,
@@ -239,6 +241,55 @@ test("feedback command module keeps feedback actions and help in sync", async ()
   for (const [action, usage] of Object.entries(FEEDBACK_COMMAND_HELP.subcommands)) {
     await expect(runSomaCli(["feedback", action, "--help"])).resolves.toBe(usage);
   }
+});
+
+test("telemetry command module keeps telemetry actions and help in sync", async () => {
+  await expect(runSomaCli(["telemetry", "--help"])).resolves.toBe(TELEMETRY_COMMAND_HELP.usage);
+
+  for (const [action, usage] of Object.entries(TELEMETRY_COMMAND_HELP.subcommands)) {
+    await expect(runSomaCli(["telemetry", action, "--help"])).resolves.toBe(usage);
+  }
+});
+
+test("cli lists and summarizes telemetry events", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-cli-1",
+      timestamp: "2026-05-26T08:00:00.000Z",
+      substrate: "codex",
+      kind: "lifecycle.session_start",
+      summary: "Session started: cli-session",
+      metadata: { sessionId: "cli-session" },
+    });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-cli-2",
+      timestamp: "2026-05-26T08:10:00.000Z",
+      substrate: "codex",
+      kind: "lifecycle.session_end",
+      summary: "Session ended.",
+      metadata: { sessionId: "cli-session" },
+    });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-cli-3",
+      timestamp: "2026-05-26T08:15:00.000Z",
+      substrate: "pi-dev",
+      kind: "feedback.candidate",
+      summary: "Feedback candidate captured.",
+    });
+
+    const list = await runSomaCli(["telemetry", "list", "--home-dir", homeDir, "--substrate", "codex", "--limit", "1"]);
+    expect(list).toContain("Soma telemetry events");
+    expect(list).toContain("evt-cli-2");
+    expect(list).not.toContain("evt-cli-1");
+    expect(list).not.toContain("evt-cli-3");
+
+    const stats = await runSomaCli(["stats", "--home-dir", homeDir, "--json"]);
+    const parsed = JSON.parse(stats) as { totalEvents: number; sessions: { averageDurationMs: number }; bySubstrate: Record<string, number> };
+    expect(parsed.totalEvents).toBe(3);
+    expect(parsed.sessions.averageDurationMs).toBe(10 * 60 * 1000);
+    expect(parsed.bySubstrate.codex).toBe(2);
+  });
 });
 
 test("lifecycle command module keeps lifecycle events and help in sync", async () => {

--- a/test/observability.test.ts
+++ b/test/observability.test.ts
@@ -125,7 +125,7 @@ test("telemetry summary aggregates sessions, kinds, substrates, and durations", 
     expect(summary.byKind["lifecycle.session_start"]).toBe(1);
     expect(summary.sessions).toMatchObject({
       started: 1,
-      ended: 1,
+      ended: 2,
       completedWithDuration: 1,
       averageDurationMs: 20 * 60 * 1000,
       bySubstrate: {
@@ -134,6 +134,12 @@ test("telemetry summary aggregates sessions, kinds, substrates, and durations", 
           ended: 1,
           completedWithDuration: 1,
           averageDurationMs: 20 * 60 * 1000,
+        },
+        "pi-dev": {
+          started: 0,
+          ended: 1,
+          completedWithDuration: 0,
+          averageDurationMs: null,
         },
       },
     });

--- a/test/observability.test.ts
+++ b/test/observability.test.ts
@@ -60,6 +60,20 @@ test("telemetry query filters event log and counts malformed lines", async () =>
   });
 });
 
+test("telemetry query rejects non-integer limits", async () => {
+  await withTempHome(async (homeDir) => {
+    await expect(querySomaTelemetryEvents({ homeDir, limit: Number.NaN })).rejects.toThrow(
+      "Soma telemetry limit must be a positive integer.",
+    );
+    await expect(querySomaTelemetryEvents({ homeDir, limit: Number.POSITIVE_INFINITY })).rejects.toThrow(
+      "Soma telemetry limit must be a positive integer.",
+    );
+    await expect(querySomaTelemetryEvents({ homeDir, limit: 1.5 })).rejects.toThrow(
+      "Soma telemetry limit must be a positive integer.",
+    );
+  });
+});
+
 test("telemetry summary aggregates sessions, kinds, substrates, and durations", async () => {
   await withTempHome(async (homeDir) => {
     const { somaHome } = await bootstrapSomaHome({ homeDir });

--- a/test/observability.test.ts
+++ b/test/observability.test.ts
@@ -142,3 +142,39 @@ test("telemetry summary aggregates sessions, kinds, substrates, and durations", 
     expect(summary.writeback.failures).toBe(1);
   });
 });
+
+test("telemetry summary consumes matched session starts once", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-1",
+      timestamp: "2026-05-26T08:00:00.000Z",
+      substrate: "codex",
+      kind: "lifecycle.session_start",
+      summary: "Session started: s1",
+      metadata: { sessionId: "s1" },
+    });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-2",
+      timestamp: "2026-05-26T08:10:00.000Z",
+      substrate: "codex",
+      kind: "lifecycle.session_end",
+      summary: "Session ended.",
+      metadata: { sessionId: "s1" },
+    });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-3",
+      timestamp: "2026-05-26T08:20:00.000Z",
+      substrate: "codex",
+      kind: "lifecycle.session_end",
+      summary: "Duplicate session end.",
+      metadata: { sessionId: "s1" },
+    });
+
+    const summary = await summarizeSomaTelemetry({ homeDir });
+
+    expect(summary.sessions.ended).toBe(2);
+    expect(summary.sessions.completedWithDuration).toBe(1);
+    expect(summary.sessions.averageDurationMs).toBe(10 * 60 * 1000);
+  });
+});

--- a/test/observability.test.ts
+++ b/test/observability.test.ts
@@ -1,0 +1,130 @@
+import { appendFile, mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { expect, test } from "bun:test";
+import {
+  appendSomaMemoryEvent,
+  bootstrapSomaHome,
+  querySomaTelemetryEvents,
+  summarizeSomaTelemetry,
+} from "../src/index";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-observability-"));
+
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+test("telemetry query filters event log and counts malformed lines", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-1",
+      timestamp: "2026-05-26T08:00:00.000Z",
+      substrate: "codex",
+      kind: "lifecycle.session_start",
+      summary: "Session started: s1",
+      metadata: { sessionId: "s1" },
+    });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-2",
+      timestamp: "2026-05-26T08:10:00.000Z",
+      substrate: "pi-dev",
+      kind: "lifecycle.session_start",
+      summary: "Session started: s2",
+      metadata: { sessionId: "s2" },
+    });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-3",
+      timestamp: "2026-05-26T08:20:00.000Z",
+      substrate: "codex",
+      kind: "lifecycle.session_end",
+      summary: "Session ended.",
+      metadata: { sessionId: "s1" },
+    });
+    await appendFile(join(somaHome, "memory/STATE/events.jsonl"), "{not-json}\n", "utf8");
+
+    const result = await querySomaTelemetryEvents({
+      homeDir,
+      substrate: "codex",
+      limit: 1,
+    });
+
+    expect(result.skippedMalformedLines).toBe(1);
+    expect(result.totalEvents).toBe(3);
+    expect(result.events.map((event) => event.id)).toEqual(["evt-3"]);
+  });
+});
+
+test("telemetry summary aggregates sessions, kinds, substrates, and durations", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-1",
+      timestamp: "2026-05-26T08:00:00.000Z",
+      substrate: "codex",
+      kind: "lifecycle.session_start",
+      summary: "Session started: s1",
+      metadata: { sessionId: "s1" },
+    });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-2",
+      timestamp: "2026-05-26T08:05:00.000Z",
+      substrate: "codex",
+      kind: "lifecycle.algorithm_updated",
+      summary: "Algorithm work index updated.",
+      metadata: { phase: "verify" },
+    });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-3",
+      timestamp: "2026-05-26T08:20:00.000Z",
+      substrate: "codex",
+      kind: "lifecycle.session_end",
+      summary: "Session ended.",
+      metadata: { sessionId: "s1" },
+    });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-4",
+      timestamp: "2026-05-26T09:00:00.000Z",
+      substrate: "pi-dev",
+      kind: "lifecycle.session_end.registry-write-failed",
+      summary: "Session ended; shared work registry writeback failed.",
+      metadata: { sessionId: "s2" },
+    });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-5",
+      timestamp: "2026-05-26T09:05:00.000Z",
+      substrate: "codex",
+      kind: "skill.loaded",
+      summary: "Loaded skill.",
+      metadata: { skillName: "Knowledge" },
+    });
+
+    const summary = await summarizeSomaTelemetry({ homeDir });
+
+    expect(summary.totalEvents).toBe(5);
+    expect(summary.bySubstrate).toEqual({ codex: 4, "pi-dev": 1 });
+    expect(summary.byKind["lifecycle.session_start"]).toBe(1);
+    expect(summary.sessions).toMatchObject({
+      started: 1,
+      ended: 1,
+      completedWithDuration: 1,
+      averageDurationMs: 20 * 60 * 1000,
+      bySubstrate: {
+        codex: {
+          started: 1,
+          ended: 1,
+          completedWithDuration: 1,
+          averageDurationMs: 20 * 60 * 1000,
+        },
+      },
+    });
+    expect(summary.skills).toEqual({ events: 1, byName: { Knowledge: 1 } });
+    expect(summary.algorithm.byPhase).toEqual({ verify: 1 });
+    expect(summary.writeback.failures).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- adds `querySomaTelemetryEvents` and `summarizeSomaTelemetry` over `memory/STATE/events.jsonl`
- adds `soma telemetry list`, `soma telemetry stats`, and top-level `soma stats`
- documents observability V0 and keeps Signal as the telemetry-system owner

Closes #151.

## Verification

- `bun test`
- `bun run typecheck`
- `bunx eslint src/observability.ts src/cli/telemetry.ts test/observability.test.ts test/cli.test.ts`

Note: full `bun run lint` is still red on pre-existing lint debt, including `.worktrees/issue-185-skill-registration` and older source/test files outside this PR.
