### PR TITLE
Fix telemetry session-end counts

### DIFF
--- a/src/observability.ts
+++ b/src/observability.ts
@@ -233,7 +233,7 @@ function isSessionStartEvent(event: SomaMemoryEvent): boolean {
 }
 
 function isSessionEndEvent(event: SomaMemoryEvent): boolean {
-  return event.kind === "lifecycle.session_end" || event.kind.startsWith("lifecycle.session_end.");
+  return event.kind === "lifecycle.session_end";
 }
 
 function recordSessionEvent(event: SomaMemoryEvent, sessions: SessionAggregationState): void {

--- a/test/observability.test.ts
+++ b/test/observability.test.ts
@@ -111,6 +111,14 @@ test("telemetry summary aggregates sessions, kinds, substrates, and durations", 
     });
     await appendSomaMemoryEvent(somaHome, {
       id: "evt-5",
+      timestamp: "2026-05-26T09:01:00.000Z",
+      substrate: "pi-dev",
+      kind: "lifecycle.session_end",
+      summary: "Session ended.",
+      metadata: { sessionId: "s2" },
+    });
+    await appendSomaMemoryEvent(somaHome, {
+      id: "evt-6",
       timestamp: "2026-05-26T09:05:00.000Z",
       substrate: "codex",
       kind: "skill.loaded",
@@ -120,8 +128,8 @@ test("telemetry summary aggregates sessions, kinds, substrates, and durations", 
 
     const summary = await summarizeSomaTelemetry({ homeDir });
 
-    expect(summary.totalEvents).toBe(5);
-    expect(summary.bySubstrate).toEqual({ codex: 4, "pi-dev": 1 });
+    expect(summary.totalEvents).toBe(6);
+    expect(summary.bySubstrate).toEqual({ codex: 4, "pi-dev": 2 });
     expect(summary.byKind["lifecycle.session_start"]).toBe(1);
     expect(summary.sessions).toMatchObject({
       started: 1,


### PR DESCRIPTION
## Summary
- count only canonical lifecycle.session_end events as session ends
- keep lifecycle.session_end.registry-write-failed as writeback/failure telemetry
- extend observability regression to model the actual failure + final session_end sequence

## Verification
- bun test test/observability.test.ts test/cli.test.ts --grep "telemetry|summarizes"
- bunx eslint src/observability.ts test/observability.test.ts
- bun run typecheck
- bun test