### PR TITLE
Fix #214: add Soma event metrics

### DIFF
--- a/src/tools/learning/metrics.ts
+++ b/src/tools/learning/metrics.ts
@@ -59,7 +59,7 @@ async function countJsonlLines(path: string): Promise<number> {
 
 export async function getSomaCounts(options: LearningToolOptions = {}): Promise<SomaCounts> {
   const paths = pathsForLearningOptions(options);
-  const [skills, workflows, signals, files, work, research, ratings] = await Promise.all([
+  const [skills, workflows, signals, files, work, research, ratings, events] = await Promise.all([
     countSkills(paths.skills()),
     countWorkflowFiles(paths.skills()),
     countFilesRecursive(paths.learning(), (file) => file.endsWith(".md")),
@@ -67,6 +67,7 @@ export async function getSomaCounts(options: LearningToolOptions = {}): Promise<
     countDirectDirectories(paths.work()),
     countFilesRecursive(paths.resolve("memory", "RESEARCH"), (file) => file.endsWith(".md") || file.endsWith(".json")),
     countJsonlLines(paths.ratings()),
+    countJsonlLines(paths.events()),
   ]);
   return {
     skills,
@@ -76,6 +77,7 @@ export async function getSomaCounts(options: LearningToolOptions = {}): Promise<
     work,
     research,
     ratings,
+    events,
   };
 }
 

--- a/src/tools/learning/types.ts
+++ b/src/tools/learning/types.ts
@@ -113,6 +113,7 @@ export interface SomaCounts {
   work: number;
   research: number;
   ratings: number;
+  events: number;
 }
 
 export interface SessionProgressRecord {
@@ -121,9 +122,9 @@ export interface SessionProgressRecord {
   updated: string;
   status: "active" | "completed" | "blocked";
   objectives: string[];
-  decisions: Array<{ text: string; timestamp: string }>;
-  work_completed: Array<{ text: string; timestamp: string }>;
-  blockers: Array<{ text: string; timestamp: string }>;
+  decisions: { text: string; timestamp: string }[];
+  work_completed: { text: string; timestamp: string }[];
+  blockers: { text: string; timestamp: string }[];
   handoff_notes: string[];
   next_steps: string[];
 }

--- a/test/learning-tools.test.ts
+++ b/test/learning-tools.test.ts
@@ -476,6 +476,11 @@ test("metrics and session progress CLIs operate on Soma paths", async () => {
 
 test("metrics CLI treats missing Soma paths as zero and avoids Claude settings", async () => {
   await withTempHome(async (homeDir) => {
+    await mkdir(join(homeDir, ".claude/PAI/Skills/legacy/Workflows"), { recursive: true });
+    await writeFile(join(homeDir, ".claude/settings.json"), JSON.stringify({ hooks: ["legacy"] }), "utf8");
+    await writeFile(join(homeDir, ".claude/PAI/Skills/legacy/SKILL.md"), "# Legacy Claude Skill\n", "utf8");
+    await writeFile(join(homeDir, ".claude/PAI/Skills/legacy/Workflows/run.md"), "# Legacy Workflow\n", "utf8");
+
     const output = JSON.parse(await runSomaCli(["metrics", "--home-dir", homeDir])) as Record<string, number>;
     expect(output).toEqual({
       skills: 0,
@@ -498,9 +503,5 @@ test("metrics CLI treats missing Soma paths as zero and avoids Claude settings",
       "events_count=0",
       "",
     ].join("\n"));
-
-    const metricsSource = await readFile("src/tools/learning/metrics.ts", "utf8");
-    expect(metricsSource).not.toContain(".claude/settings.json");
-    expect(metricsSource).not.toContain(".claude/PAI");
   });
 });

--- a/test/learning-tools.test.ts
+++ b/test/learning-tools.test.ts
@@ -446,12 +446,23 @@ test("metrics and session progress CLIs operate on Soma paths", async () => {
     await mkdir(join(somaHome, "memory/LEARNING/SIGNALS"), { recursive: true });
     await writeFile(join(somaHome, "memory/LEARNING/SIGNALS/ratings.jsonl"), "{}\n{}\n", "utf8");
     await mkdir(join(somaHome, "memory/WORK/example"), { recursive: true });
+    await mkdir(join(somaHome, "memory/STATE"), { recursive: true });
+    await writeFile(join(somaHome, "memory/STATE/events.jsonl"), "{}\n{}\n", "utf8");
 
     const counts = await getSomaCounts({ homeDir });
     expect(counts.skills).toBe(1);
     expect(counts.workflows).toBe(1);
     expect(counts.ratings).toBe(2);
-    expect(JSON.parse(await runSomaCli(["metrics", "--home-dir", homeDir]))).toMatchObject({ skills: 1, workflows: 1, ratings: 2 });
+    expect(counts.events).toBe(2);
+    expect(JSON.parse(await runSomaCli(["metrics", "--home-dir", homeDir]))).toMatchObject({
+      skills: 1,
+      workflows: 1,
+      ratings: 2,
+      work: 1,
+      events: 2,
+    });
+    expect(await runSomaCli(["metrics", "--single", "events", "--home-dir", homeDir])).toBe("2\n");
+    expect(await runSomaCli(["metrics", "--shell", "--home-dir", homeDir])).toContain("events_count=2\n");
 
     await runSomaCli(["session", "create", "proj", "ship feature", "--home-dir", homeDir]);
     await runSomaCli(["session", "decision", "proj", "Use native Soma paths", "--home-dir", homeDir]);
@@ -460,5 +471,36 @@ test("metrics and session progress CLIs operate on Soma paths", async () => {
     const resume = await resumeSessionProgress("proj", { homeDir });
     expect(resume).toContain("Use native Soma paths");
     expect(resume).toContain("Implemented core module");
+  });
+});
+
+test("metrics CLI treats missing Soma paths as zero and avoids Claude settings", async () => {
+  await withTempHome(async (homeDir) => {
+    const output = JSON.parse(await runSomaCli(["metrics", "--home-dir", homeDir])) as Record<string, number>;
+    expect(output).toEqual({
+      skills: 0,
+      workflows: 0,
+      signals: 0,
+      files: 0,
+      work: 0,
+      research: 0,
+      ratings: 0,
+      events: 0,
+    });
+    expect(await runSomaCli(["metrics", "--shell", "--home-dir", homeDir])).toBe([
+      "skills_count=0",
+      "workflows_count=0",
+      "signals_count=0",
+      "files_count=0",
+      "work_count=0",
+      "research_count=0",
+      "ratings_count=0",
+      "events_count=0",
+      "",
+    ].join("\n"));
+
+    const metricsSource = await readFile("src/tools/learning/metrics.ts", "utf8");
+    expect(metricsSource).not.toContain(".claude/settings.json");
+    expect(metricsSource).not.toContain(".claude/PAI");
   });
 });


### PR DESCRIPTION
Closes #214

## Summary

- Adds `events` to the Soma metrics contract, counted from `memory/STATE/events.jsonl`.
- Extends metrics tests for JSON output, `--single events`, shell output, missing-path zero counts, and no legacy Claude settings paths.
- Cleans touched learning-tool type declarations so focused ESLint passes.

## Verification

- `bun test test/learning-tools.test.ts`
- `bun test`
- `bun run typecheck`
- `bunx eslint src/tools/learning/metrics.ts src/tools/learning/types.ts test/learning-tools.test.ts`

Note: full `bun run lint` still has unrelated repo baseline failures; the changed files pass focused ESLint.
