### PR TITLE
Fix #217: timestamp session progress handoffs

### DIFF
--- a/src/tools/learning/session-progress.ts
+++ b/src/tools/learning/session-progress.ts
@@ -74,14 +74,14 @@ export async function recordSessionBlocker(project: string, text: string, option
 }
 
 export async function recordSessionNextStep(project: string, text: string, options: LearningToolOptions = {}): Promise<SessionProgressRecord> {
-  return updateProgress(project, options, (progress) => {
-    progress.next_steps.push(text);
+  return updateProgress(project, options, (progress, timestamp) => {
+    progress.next_steps.push({ text, timestamp });
   });
 }
 
 export async function recordSessionHandoff(project: string, text: string, options: LearningToolOptions = {}): Promise<SessionProgressRecord> {
-  return updateProgress(project, options, (progress) => {
-    progress.handoff_notes.push(text);
+  return updateProgress(project, options, (progress, timestamp) => {
+    progress.handoff_notes.push({ text, timestamp });
   });
 }
 
@@ -102,6 +102,10 @@ async function updateProgress(
   return progress;
 }
 
+function progressEntryText(entry: string | { text: string }): string {
+  return typeof entry === "string" ? entry : entry.text;
+}
+
 export async function resumeSessionProgress(project: string, options: LearningToolOptions = {}): Promise<string> {
   const progress = await loadProgress(project, options);
   return [
@@ -119,13 +123,13 @@ export async function resumeSessionProgress(project: string, options: LearningTo
     ...(progress.work_completed.slice(-5).map((item) => `- ${item.text}`)),
     "",
     "Blockers:",
-    ...(progress.blockers.filter((item) => item).map((item) => `- ${item.text}`)),
+    ...(progress.blockers.map((item) => `- ${item.text}`)),
     "",
     "Next steps:",
-    ...(progress.next_steps.map((item, index) => `${index + 1}. ${item}`)),
+    ...(progress.next_steps.map((item, index) => `${index + 1}. ${progressEntryText(item)}`)),
     "",
     "Handoff:",
-    ...(progress.handoff_notes.map((item) => `- ${item}`)),
+    ...(progress.handoff_notes.map((item) => `- ${progressEntryText(item)}`)),
     "",
   ].join("\n");
 }

--- a/src/tools/learning/types.ts
+++ b/src/tools/learning/types.ts
@@ -116,15 +116,20 @@ export interface SomaCounts {
   events: number;
 }
 
+export interface SessionProgressEntry {
+  text: string;
+  timestamp: string;
+}
+
 export interface SessionProgressRecord {
   project: string;
   created: string;
   updated: string;
   status: "active" | "completed" | "blocked";
   objectives: string[];
-  decisions: { text: string; timestamp: string }[];
-  work_completed: { text: string; timestamp: string }[];
-  blockers: { text: string; timestamp: string }[];
-  handoff_notes: string[];
-  next_steps: string[];
+  decisions: SessionProgressEntry[];
+  work_completed: SessionProgressEntry[];
+  blockers: SessionProgressEntry[];
+  handoff_notes: SessionProgressEntry[];
+  next_steps: SessionProgressEntry[];
 }

--- a/test/learning-tools.test.ts
+++ b/test/learning-tools.test.ts
@@ -509,6 +509,55 @@ test("metrics and session progress CLIs operate on Soma paths", async () => {
   });
 });
 
+test("session progress CLI persists every command with timestamped resume context", async () => {
+  await withTempHome(async (homeDir, somaHome) => {
+    await mkdir(join(homeDir, ".claude/PAI/progress"), { recursive: true });
+    await writeFile(join(homeDir, ".claude/PAI/progress/launch-progress.json"), JSON.stringify({ project: "legacy" }), "utf8");
+
+    await expect(runSomaCli(["session", "create", "Launch", "ship beta", "write docs", "--home-dir", homeDir]))
+      .resolves.toBe("created session: launch\n");
+    await expect(runSomaCli(["session", "decision", "Launch", "Use Soma state", "--home-dir", homeDir]))
+      .resolves.toBe("recorded decision: launch\n");
+    await expect(runSomaCli(["session", "work", "Launch", "Implemented tracker", "--home-dir", homeDir]))
+      .resolves.toBe("recorded work: launch\n");
+    await expect(runSomaCli(["session", "blocker", "Launch", "Need review", "--home-dir", homeDir]))
+      .resolves.toBe("recorded blocker: launch\n");
+    await expect(runSomaCli(["session", "next", "Launch", "Merge PR", "--home-dir", homeDir]))
+      .resolves.toBe("recorded next step: launch\n");
+    await expect(runSomaCli(["session", "handoff", "Launch", "Reviewer should check state paths", "--home-dir", homeDir]))
+      .resolves.toBe("recorded handoff: launch\n");
+    await expect(runSomaCli(["session", "complete", "Launch", "--home-dir", homeDir]))
+      .resolves.toBe("completed session: launch\n");
+
+    const progressPath = join(somaHome, "memory/STATE/progress/launch-progress.json");
+    const progress = JSON.parse(await readFile(progressPath, "utf8")) as {
+      status: string;
+      objectives: string[];
+      decisions: { text: string; timestamp: string }[];
+      work_completed: { text: string; timestamp: string }[];
+      blockers: { text: string; timestamp: string }[];
+      next_steps: { text: string; timestamp: string }[];
+      handoff_notes: { text: string; timestamp: string }[];
+    };
+
+    expect(progress.status).toBe("completed");
+    expect(progress.objectives).toEqual(["ship beta", "write docs"]);
+    expect(progress.decisions[0]).toMatchObject({ text: "Use Soma state", timestamp: expect.stringContaining("T") });
+    expect(progress.work_completed[0]).toMatchObject({ text: "Implemented tracker", timestamp: expect.stringContaining("T") });
+    expect(progress.blockers[0]).toMatchObject({ text: "Need review", timestamp: expect.stringContaining("T") });
+    expect(progress.next_steps[0]).toMatchObject({ text: "Merge PR", timestamp: expect.stringContaining("T") });
+    expect(progress.handoff_notes[0]).toMatchObject({ text: "Reviewer should check state paths", timestamp: expect.stringContaining("T") });
+
+    const resume = await runSomaCli(["session", "resume", "Launch", "--home-dir", homeDir]);
+    expect(resume).toContain("SESSION RESUME: launch");
+    expect(resume).toContain("Use Soma state");
+    expect(resume).toContain("Merge PR");
+    expect(resume).toContain("Reviewer should check state paths");
+    expect(resume).not.toContain(".claude");
+    expect(await runSomaCli(["session", "list", "--home-dir", homeDir])).toContain("launch completed ");
+  });
+});
+
 test("metrics CLI treats missing Soma paths as zero and avoids Claude settings", async () => {
   await withTempHome(async (homeDir) => {
     await mkdir(join(homeDir, ".claude/PAI/Skills/legacy/Workflows"), { recursive: true });


### PR DESCRIPTION
Closes #217

## Summary

- Adds CLI coverage for every `soma session` progress command.
- Stores `next` and `handoff` entries with timestamps, matching decisions/work/blockers.
- Keeps resume rendering compatible with existing string-shaped progress notes.
- Verifies progress records live under `memory/STATE/progress/` and ignore legacy `.claude/PAI` fixtures.

## Verification

- `bun test test/learning-tools.test.ts`
- `bun test`
- `bun run typecheck`
- `bunx eslint src/tools/learning/session-progress.ts src/tools/learning/types.ts test/learning-tools.test.ts`

Note: full `bun run lint` still has unrelated repo baseline failures; the changed files pass focused ESLint.
