### PR TITLE
Fix #221: add configurable wisdom synthesis coverage

### DIFF
--- a/src/cli/tools.ts
+++ b/src/cli/tools.ts
@@ -58,8 +58,8 @@ export const TOOL_COMMAND_HELP: Record<ParsedToolArgs["command"], { usage: strin
       list: "Usage: soma wisdom list [--home-dir <dir>] [--soma-home <dir>]",
       update:
         "Usage: soma wisdom update --domain <domain> --type <principle|contextual-rule|prediction|anti-pattern|evolution> --observation <text> [--home-dir <dir>] [--soma-home <dir>]",
-      synthesize: "Usage: soma wisdom synthesize [--dry-run] [--home-dir <dir>] [--soma-home <dir>]",
-      health: "Usage: soma wisdom health [--dry-run] [--home-dir <dir>] [--soma-home <dir>]",
+      synthesize: "Usage: soma wisdom synthesize [--dry-run] [--threshold <0..1>] [--home-dir <dir>] [--soma-home <dir>]",
+      health: "Usage: soma wisdom health [--dry-run] [--threshold <0..1>] [--home-dir <dir>] [--soma-home <dir>]",
     },
   },
 };

--- a/src/tools/wisdom/cli.ts
+++ b/src/tools/wisdom/cli.ts
@@ -1,4 +1,4 @@
-import { classifyDomains, listFrames, synthesizeWisdom, updateFrame } from "./index";
+import { classifyDomains, listFrames, normalizeSimilarityThreshold, synthesizeWisdom, updateFrame } from "./index";
 import type { WisdomObservationType, WisdomToolOptions } from "./types";
 
 function readOption(args: string[], index: number, name: string): string {
@@ -10,8 +10,9 @@ function readOption(args: string[], index: number, name: string): string {
 function readOptionText(args: string[], index: number, name: string): string {
   const values: string[] = [];
   for (let cursor = index + 1; cursor < args.length; cursor += 1) {
-    if (args[cursor]!.startsWith("--")) break;
-    values.push(args[cursor]!);
+    const value = args[cursor];
+    if (value.startsWith("--")) break;
+    values.push(value);
   }
   if (values.length === 0) throw new Error(`${name} requires a value.`);
   return values.join(" ");
@@ -30,8 +31,8 @@ function stripCommon(args: string[]): string[] {
   const stripped: string[] = [];
   for (let index = 0; index < args.length; index += 1) {
     if (args[index] === "--home-dir" || args[index] === "--soma-home") {
-      if (index > 0 && ["--domain", "--type", "--observation"].includes(args[index - 1]!)) {
-        stripped.push(args[index]!);
+      if (index > 0 && ["--domain", "--type", "--observation"].includes(args[index - 1])) {
+        stripped.push(args[index]);
         continue;
       }
       index += 1;
@@ -40,6 +41,14 @@ function stripCommon(args: string[]): string[] {
     stripped.push(args[index]);
   }
   return stripped;
+}
+
+function parseThreshold(args: string[]): number | undefined {
+  const index = args.indexOf("--threshold");
+  if (index === -1) return undefined;
+  const value = readOption(args, index, "--threshold");
+  const parsed = Number(value);
+  return normalizeSimilarityThreshold(parsed, "--threshold");
 }
 
 function parseUpdateArgs(args: string[]): { domain: string; type: WisdomObservationType; observation: string } {
@@ -58,7 +67,7 @@ function parseUpdateArgs(args: string[]): { domain: string; type: WisdomObservat
     }
     if (arg === "--observation") {
       parsed.observation = readOptionText(args, index, "--observation");
-      while (args[index + 1] && !args[index + 1]!.startsWith("--")) index += 1;
+      while (args[index + 1] && !args[index + 1].startsWith("--")) index += 1;
       continue;
     }
     throw new Error(`Unknown wisdom update argument: ${arg}`);
@@ -99,6 +108,7 @@ export async function runWisdomCli(args: string[]): Promise<string> {
       ...options,
       dryRun: local.includes("--dry-run"),
       healthOnly: action === "health",
+      similarityThreshold: parseThreshold(local),
     });
     return [
       `wisdom ${action}: ${result.principles.length} cross-frame principle(s), ${result.health.length} frame(s)`,

--- a/src/tools/wisdom/synthesizer.ts
+++ b/src/tools/wisdom/synthesizer.ts
@@ -63,10 +63,18 @@ export function synthesizeCrossFramePrinciples(frames: WisdomFrame[], threshold 
   const principles: CrossFramePrinciple[] = [];
   for (let leftIndex = 0; leftIndex < frames.length; leftIndex += 1) {
     for (let rightIndex = leftIndex + 1; rightIndex < frames.length; rightIndex += 1) {
-      principles.push(...synthesizeFramePair(frames[leftIndex]!, frames[rightIndex]!, threshold));
+      principles.push(...synthesizeFramePair(frames[leftIndex], frames[rightIndex], threshold));
     }
   }
   return principles.sort((a, b) => b.similarity - a.similarity || a.domains.join(",").localeCompare(b.domains.join(",")));
+}
+
+export function normalizeSimilarityThreshold(value: number | undefined, label = "similarityThreshold"): number {
+  if (value === undefined) return 0.3;
+  if (!Number.isFinite(value) || value < 0 || value > 1) {
+    throw new Error(`${label} must be a number between 0 and 1.`);
+  }
+  return value;
 }
 
 function renderPrinciples(result: WisdomSynthesisResult, now: Date): string {
@@ -94,8 +102,9 @@ ${result.health.map((health) =>
 export async function synthesizeWisdom(options: WisdomToolOptions & { dryRun?: boolean; healthOnly?: boolean } = {}): Promise<WisdomSynthesisResult> {
   const now = options.now ?? new Date();
   const frames = await readAllWisdomFrames(options);
+  const threshold = normalizeSimilarityThreshold(options.similarityThreshold);
   const result: WisdomSynthesisResult = {
-    principles: options.healthOnly ? [] : synthesizeCrossFramePrinciples(frames),
+    principles: options.healthOnly ? [] : synthesizeCrossFramePrinciples(frames, threshold),
     health: frames.map((frame) => assessFrameHealth(frame, now)),
   };
 

--- a/src/tools/wisdom/types.ts
+++ b/src/tools/wisdom/types.ts
@@ -5,6 +5,7 @@ export type FrameHealthStatus = "growing" | "stable" | "stale";
 
 export interface WisdomToolOptions extends SomaPathsOptions {
   now?: Date;
+  similarityThreshold?: number;
 }
 
 export interface WisdomFrameSummary {

--- a/test/wisdom-tools.test.ts
+++ b/test/wisdom-tools.test.ts
@@ -209,6 +209,111 @@ test("wisdom synthesis detects cross-frame principles and health thresholds", as
   });
 });
 
+test("wisdom synthesis supports dry-run previews and configurable similarity thresholds", async () => {
+  await withTempHome(async (homeDir, somaHome) => {
+    await updateFrame({
+      homeDir,
+      domain: "development",
+      type: "principle",
+      observation: "Small review catches integration bugs early",
+      now: new Date("2026-05-19T12:00:00Z"),
+    });
+    await updateFrame({
+      homeDir,
+      domain: "deployment",
+      type: "principle",
+      observation: "Small review catches integration failures early",
+      now: new Date("2026-05-19T12:00:00Z"),
+    });
+
+    const preview = await synthesizeWisdom({
+      homeDir,
+      dryRun: true,
+      similarityThreshold: 0.7,
+      now: new Date("2026-05-20T12:00:00Z"),
+    });
+    expect(preview.principles).toHaveLength(1);
+    expect(preview.principlesPath).toBeUndefined();
+    expect(preview.healthPath).toBeUndefined();
+    await expect(readFile(join(somaHome, "memory/WISDOM/PRINCIPLES/verified.md"), "utf8")).rejects.toThrow();
+    await expect(readFile(join(somaHome, "memory/WISDOM/META/frame-health.md"), "utf8")).rejects.toThrow();
+
+    const strictPreview = await synthesizeWisdom({
+      homeDir,
+      dryRun: true,
+      similarityThreshold: 0.9,
+      now: new Date("2026-05-20T12:00:00Z"),
+    });
+    expect(strictPreview.principles).toHaveLength(0);
+
+    const cliPreview = await runSomaCli([
+      "wisdom",
+      "synthesize",
+      "--dry-run",
+      "--threshold",
+      "0.9",
+      "--home-dir",
+      homeDir,
+    ]);
+    expect(cliPreview).toContain("wisdom synthesize: 0 cross-frame principle(s)");
+
+    await expect(runSomaCli(["wisdom", "synthesize", "--dry-run", "--threshold", "1.1", "--home-dir", homeDir])).rejects.toThrow(
+      "--threshold must be a number between 0 and 1.",
+    );
+  });
+});
+
+test("wisdom synthesis validates library similarity thresholds", async () => {
+  await withTempHome(async (homeDir) => {
+    await expect(synthesizeWisdom({ homeDir, similarityThreshold: Number.NaN })).rejects.toThrow(
+      "similarityThreshold must be a number between 0 and 1.",
+    );
+    await expect(synthesizeWisdom({ homeDir, similarityThreshold: 1.1 })).rejects.toThrow(
+      "similarityThreshold must be a number between 0 and 1.",
+    );
+  });
+});
+
+test("wisdom health reports growing stable and stale frames without writing principles", async () => {
+  await withTempHome(async (homeDir, somaHome) => {
+    for (let index = 0; index < 10; index += 1) {
+      await updateFrame({
+        homeDir,
+        domain: "growing-domain",
+        type: "principle",
+        observation: `Fresh principle ${index}`,
+        now: new Date("2026-05-27T12:00:00Z"),
+      });
+    }
+    await updateFrame({
+      homeDir,
+      domain: "stable-domain",
+      type: "principle",
+      observation: "Moderately recent principle",
+      now: new Date("2026-05-07T12:00:00Z"),
+    });
+    await updateFrame({
+      homeDir,
+      domain: "stale-domain",
+      type: "principle",
+      observation: "Old principle",
+      now: new Date("2026-03-01T12:00:00Z"),
+    });
+
+    const output = await runSomaCli(["wisdom", "health", "--home-dir", homeDir]);
+    expect(output).toContain("wisdom health: 0 cross-frame principle(s), 3 frame(s)");
+    expect(output).toContain(".soma/memory/WISDOM/META/frame-health.md");
+    expect(output).not.toContain(".claude");
+
+    const health = await readFile(join(somaHome, "memory/WISDOM/META/frame-health.md"), "utf8");
+    expect(health).toContain("growing-domain: growing");
+    expect(health).toContain("stable-domain: stable");
+    expect(health).toContain("stale-domain: stale");
+    expect(health).not.toContain(".claude");
+    await expect(readFile(join(somaHome, "memory/WISDOM/PRINCIPLES/verified.md"), "utf8")).rejects.toThrow();
+  });
+});
+
 test("wisdom CLI routes classify, list, update, synthesize, and health", async () => {
   await withTempHome(async (homeDir) => {
     await runSomaCli([


### PR DESCRIPTION
Closes #221

## Summary

- Adds dry-run synthesis coverage proving previews do not write principles or health files.
- Adds configurable similarity threshold support for library and CLI synthesis.
- Covers health-only reporting for growing, stable, and stale frames without writing verified principles.
- Updates CLI usage text for `--threshold`.

## Verification

- `bun test test/wisdom-tools.test.ts`
- `bun test`
- `bun run typecheck`
- `bunx eslint src/tools/wisdom/synthesizer.ts src/tools/wisdom/cli.ts src/tools/wisdom/types.ts src/cli/tools.ts test/wisdom-tools.test.ts`

Note: full `bun run lint` still has unrelated repo baseline failures; the changed files pass focused ESLint.
