### PR TITLE
Fix #220: document FeatureRegistry non-migration

### DIFF
--- a/docs/algorithm-execution-modes.md
+++ b/docs/algorithm-execution-modes.md
@@ -120,14 +120,24 @@ owned by the host substrate.
 
 ## FeatureRegistry
 
-PAI's FeatureRegistry is intentionally not migrated. Soma already has the same
-work-tracking semantics in typed Algorithm structures:
+PAI's FeatureRegistry is not migrated as a standalone Soma tool. No `soma feature-registry`
+command or JSON registry should be added unless a future design decision
+explicitly reverses this rule. Soma already has the same work-tracking
+semantics in typed Algorithm structures:
 
-- Features map to `planSteps[]`.
-- Priority maps to criteria and plan-step order.
-- Status maps to criterion and plan-step status enums.
-- Blockers map to blocked plan steps with evidence.
+- `init`: create an Algorithm run with criteria, then establish the first
+  tracked work items through `setAlgorithmPlan`.
+- `add`: add features as criterion-mapped `planSteps[]`; priority is expressed
+  by criteria and plan-step order.
+- `update`: change feature status through `updateAlgorithmPlanStep`, using
+  `open`, `done`, or `blocked` plus evidence.
+- `verify`: record acceptance through `verifyAlgorithmCriterion` and keep the
+  linked plan step evidence in the same run.
+- `next`: read the next open or blocked `planSteps[]` item from the Algorithm
+  run state instead of maintaining a separate queue.
 
-Adding a second feature tracker would create two sources of truth. If future
-work needs richer feature metadata, extend `planSteps[]` rather than adding a
+This preserves a single source of truth for plan state, criterion status,
+verification evidence, blockers, and handoff context. If future work needs
+richer feature metadata such as explicit dependency edges or owner fields,
+extend `AlgorithmPlanStep` and the Algorithm CLI surface rather than adding a
 parallel registry.

--- a/test/algorithm-execution-modes.test.ts
+++ b/test/algorithm-execution-modes.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import {
   IDEATE_PRESETS,
   OPTIMIZE_PRESETS,
@@ -14,6 +15,9 @@ import {
 } from "../src";
 import type { AlgorithmRun, IdealStateCriterion } from "../src";
 import { loadAlgorithmRun } from "../src/algorithm-store";
+
+const algorithmExecutionModesDocs = readFileSync("docs/algorithm-execution-modes.md", "utf8");
+const normalizedAlgorithmExecutionModesDocs = algorithmExecutionModesDocs.replace(/\s+/g, " ");
 
 function criterion(id: string): IdealStateCriterion {
   return { id, text: `${id} criterion`, status: "open" };
@@ -112,9 +116,9 @@ test("#133 detectPlateau uses plateau counter and consecutive zero-progress iter
     loop: {
       ...zeroProgress.loop,
       iterations: [
-        zeroProgress.loop.iterations[0]!,
+        zeroProgress.loop.iterations[0],
         { iteration: 2, timestamp: "2026-05-19T12:02:00.000Z", progressBefore: "0/3", progressAfter: "1/3" },
-        zeroProgress.loop.iterations[2]!,
+        zeroProgress.loop.iterations[2],
       ],
     },
   };
@@ -139,7 +143,7 @@ test("#133 partitions criteria by ISC domain and load-balances when worker count
   const balanced = partitionCriteriaByDomain(criteria, 2);
   expect(balanced).toHaveLength(2);
   expect(balanced.flatMap((partition) => partition.criteria).map((item) => item.id).sort()).toEqual(criteria.map((item) => item.id).sort());
-  expect(Math.abs(balanced[0]!.criteria.length - balanced[1]!.criteria.length)).toBeLessThanOrEqual(1);
+  expect(Math.abs(balanced[0].criteria.length - balanced[1].criteria.length)).toBeLessThanOrEqual(1);
 });
 
 test("#133 partitions run criteria through the ISA accessor", () => {
@@ -196,4 +200,20 @@ test("#133 notification events are substrate-neutral data contracts", () => {
     plateauCounter: 3,
     threshold: 3,
   });
+});
+
+test("#220 documents FeatureRegistry as an Algorithm plan-state decision", () => {
+  expect(algorithmExecutionModesDocs).toContain("## FeatureRegistry");
+  expect(normalizedAlgorithmExecutionModesDocs).toContain("FeatureRegistry is not migrated as a standalone Soma tool");
+  expect(normalizedAlgorithmExecutionModesDocs).toContain("No `soma feature-registry` command");
+
+  for (const command of ["init", "add", "update", "verify", "next"]) {
+    expect(algorithmExecutionModesDocs).toContain(`\`${command}\``);
+  }
+
+  expect(algorithmExecutionModesDocs).toContain("`planSteps[]`");
+  expect(algorithmExecutionModesDocs).toContain("`setAlgorithmPlan`");
+  expect(algorithmExecutionModesDocs).toContain("`updateAlgorithmPlanStep`");
+  expect(algorithmExecutionModesDocs).toContain("`verifyAlgorithmCriterion`");
+  expect(algorithmExecutionModesDocs).toContain("extend `AlgorithmPlanStep`");
 });


### PR DESCRIPTION
## Summary

- Documents the #220 FeatureRegistry decision as a non-migration outcome.
- Maps the legacy `init`, `add`, `update`, `verify`, and `next` commands onto Algorithm run state.
- Adds a docs contract test so the standalone-registry ban and Algorithm mappings stay visible.

## Verification

- `rtk bun test test/algorithm-execution-modes.test.ts`
- `rtk bun test`
- `rtk bun run typecheck`
- `rtk bunx eslint test/algorithm-execution-modes.test.ts`

Closes #220.
