### PR TITLE
Wire Claude Code Soma lifecycle hooks

### DIFF
--- a/docs/default-availability.md
+++ b/docs/default-availability.md
@@ -110,22 +110,21 @@ The first end-to-end install function is `installSomaForCodex`. It bootstraps
 
 ### Claude Code
 
-Initial Soma projection target:
+Current Soma projection target:
 
 ```text
-~/.claude/
-  CLAUDE.md
+<claude-home>/
   settings.json
-  skills/Soma/
-  hooks/soma/
-  agents/soma/
-  commands/soma.md
-  soma/
+  rules/soma/
+  skills/ISA/
+  hooks/soma/soma-claude-code-hook.mjs
+  hooks/soma/soma-claude-code-hook.config.json
 ```
 
-This projection should merge or patch existing user config instead of blindly
-replacing it. PAI's installer warns and backs up because it owns the whole
-Claude home; Soma should be less invasive.
+This projection patches existing user config instead of replacing it. The
+settings patch adds Soma-owned lifecycle/writeback hook entries and leaves
+non-Soma hook entries intact. Uninstall removes only generated Soma files and
+matching Soma hook entries.
 
 ### Pi.dev
 

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -103,6 +103,30 @@ Claude Code skills, sub-agents, commands, principal identity, memory, and
 daemon support are available at every Claude Code startup. Soma should project
 into that shape without making Claude Code the source of truth.
 
+Current home install behavior:
+
+- `soma install claude-code --apply` writes context under
+  `<claude-home>/rules/soma/` and the ISA skill under
+  `<claude-home>/skills/ISA/`.
+- It installs a Soma-owned hook runner at
+  `<claude-home>/hooks/soma/soma-claude-code-hook.mjs` with colocated runtime
+  config.
+- It patches `<claude-home>/settings.json` with Soma-owned hook entries for
+  `SessionStart`, `SessionEnd`, `PostToolUse`, `SubagentStart`, and
+  `SubagentStop`. Re-running install is idempotent and preserves existing
+  user, project, PAI, and non-Soma hook entries.
+- Lifecycle hooks call Soma lifecycle APIs with `--substrate claude-code`.
+  Tool and subagent hooks emit metadata-only events through the Soma writeback
+  gate; they do not mirror full raw transcripts or prompt text.
+- `soma uninstall claude-code` removes only the generated `rules/soma/`
+  projection, `skills/ISA/`, the Soma-owned hook runner/config, and matching
+  Soma hook entries in `settings.json`.
+
+Context projection, PAI Native Mode memory, and Soma shared memory remain
+distinct. Claude Code may keep rich substrate-local PAI artifacts, while Soma
+shared memory records portable lifecycle events, work-registry pointers, and
+policy-gated writeback metadata in `<soma-home>/memory/STATE/events.jsonl`.
+
 ## Cursor
 
 Cursor reads project-level rule files and can use MCP servers for additional

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -205,12 +205,9 @@ const CLAUDE_RULES_CONTENT_BUILDERS: Record<
  * file set in the same order, so a second install with unchanged
  * input writes byte-identical content (AC-4 idempotency).
  *
- * Out of scope for #29 (filed as follow-up):
- *   - Hook scripts (.claude/hooks/soma-*.mjs) + settings.local.json
- *     patching: AC-6/AC-7/AC-8/AC-12 from the original #29 spec.
- *   - CLI command (`soma install claude-code`): AC-9 — depends on
- *     the CLI surface refactor in #30 split.
- *   - Active CLAUDE.md modification: dropped by the #64 pivot.
+ * Hook scripts and settings patching are installed by the Claude Code
+ * install spec postProjection step, not by this pure projection bundle.
+ * Active CLAUDE.md modification remains dropped by the #64 pivot.
  */
 export function projectClaudeCodeHome(input: ProjectionInput): Projection {
   const skeleton = (Object.keys(CLAUDE_RULES_CONTENT_BUILDERS) as (keyof typeof CLAUDE_RULES_CONTENT_BUILDERS)[]).map((path) => ({

--- a/src/adapters/claude-code/hook-runner.mjs
+++ b/src/adapters/claude-code/hook-runner.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env bun
+/* eslint-disable no-undef -- The handler table placeholder is replaced before installation. */
+import { spawn, spawnSync } from "node:child_process";
+import { readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { appendFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+const FLUSH_EVENT = "flush-writeback-queue";
+const HOOK_EVENT_HANDLERS = __SOMA_CLAUDE_HOOK_EVENT_HANDLERS__;
+const MAX_FLUSH_RETRIES = 5;
+const STALE_FLUSH_LOCK_MS = 5 * 60 * 1000;
+
+function hookDir() {
+  return dirname(fileURLToPath(import.meta.url));
+}
+
+function readConfig() {
+  return JSON.parse(readFileSync(join(hookDir(), "soma-claude-code-hook.config.json"), "utf8"));
+}
+
+function readHookInput() {
+  try {
+    const raw = readFileSync(0, "utf8");
+    if (raw.trim().length === 0) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function isErrorCode(error, code) {
+  return error && typeof error === "object" && error.code === code;
+}
+
+function removeIfExists(path) {
+  try {
+    unlinkSync(path);
+  } catch {
+    return undefined;
+  }
+}
+
+function ignoreSpawnError() {
+  return undefined;
+}
+
+function spawnDetached(command, args, cwd, env = {}, onError = ignoreSpawnError) {
+  const child = spawn(command, args, {
+    cwd,
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env, ...env },
+  });
+  child.on("error", onError);
+  child.unref();
+}
+
+function runSomaDetached(config, args, env = {}) {
+  spawnDetached(config.bunPath, args, config.trustedSomaRepo, env);
+}
+
+function runSomaBlocking(config, args) {
+  return spawnSync(config.bunPath, args, {
+    cwd: config.trustedSomaRepo,
+    stdio: "ignore",
+    env: process.env,
+  });
+}
+
+function runHookDetached(config, args, onError = ignoreSpawnError) {
+  spawnDetached(config.bunPath, [fileURLToPath(import.meta.url), ...args], config.trustedSomaRepo, {}, onError);
+}
+
+function sessionId(input) {
+  return typeof input.session_id === "string" && input.session_id.trim().length > 0 ? input.session_id : undefined;
+}
+
+function lifecycle(config, event, input) {
+  const args = ["src/cli.ts", "lifecycle", event, "--soma-home", config.somaHome, "--substrate", "claude-code"];
+  const id = sessionId(input);
+  if (id) args.push("--session-id", id);
+  runSomaDetached(config, args);
+}
+
+function metadata(input, source) {
+  return {
+    sessionId: sessionId(input),
+    source,
+    hookEventName: typeof input.hook_event_name === "string" ? input.hook_event_name : undefined,
+    cwd: typeof input.cwd === "string" ? input.cwd : undefined,
+    toolName: typeof input.tool_name === "string" ? input.tool_name : undefined,
+    agentType: typeof input.agent_type === "string" ? input.agent_type : undefined,
+    agentId: typeof input.agent_id === "string" ? input.agent_id : undefined,
+  };
+}
+
+function artifactPaths(input) {
+  const toolInput = input && typeof input.tool_input === "object" && !Array.isArray(input.tool_input) ? input.tool_input : {};
+  const paths = [];
+  for (const key of ["file_path", "path", "notebook_path"]) {
+    if (typeof toolInput[key] === "string") paths.push(toolInput[key]);
+  }
+  if (Array.isArray(toolInput.edits)) {
+    for (const edit of toolInput.edits) {
+      if (edit && typeof edit === "object" && typeof edit.file_path === "string") paths.push(edit.file_path);
+    }
+  }
+  return Array.from(new Set(paths));
+}
+
+function writebackQueuePath() {
+  return join(hookDir(), "soma-claude-code-writeback-queue.jsonl");
+}
+
+function acquireFlushLock(path) {
+  removeStaleFlushLock(path);
+  try {
+    writeFileSync(path, JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }), { encoding: "utf8", flag: "wx" });
+    return true;
+  } catch (error) {
+    if (isErrorCode(error, "EEXIST")) return false;
+    throw error;
+  }
+}
+
+function removeStaleFlushLock(path) {
+  try {
+    if (Date.now() - statSync(path).mtimeMs > STALE_FLUSH_LOCK_MS) removeIfExists(path);
+  } catch (error) {
+    if (!isErrorCode(error, "ENOENT")) throw error;
+  }
+}
+
+function scheduleWritebackFlush(config) {
+  const lockPath = `${writebackQueuePath()}.lock`;
+  if (!acquireFlushLock(lockPath)) {
+    writeFileSync(`${writebackQueuePath()}.followup`, "1", "utf8");
+    return;
+  }
+  try {
+    runHookDetached(config, [FLUSH_EVENT], () => {
+      removeIfExists(lockPath);
+    });
+  } catch (error) {
+    removeIfExists(lockPath);
+    throw error;
+  }
+}
+
+function consumeFlushFollowup(queuePath) {
+  try {
+    unlinkSync(`${queuePath}.followup`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function queueHasEntries(queuePath) {
+  try {
+    return statSync(queuePath).size > 0;
+  } catch {
+    return false;
+  }
+}
+
+function retryAttemptsPath(queuePath) {
+  return `${queuePath}.attempts`;
+}
+
+function retryCheckpointPath(queuePath) {
+  return `${queuePath}.checkpoint`;
+}
+
+function readRetryAttempts(queuePath) {
+  try {
+    const value = Number.parseInt(readFileSync(retryAttemptsPath(queuePath), "utf8"), 10);
+    return Number.isFinite(value) && value > 0 ? value : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function recordFlushFailure(queuePath) {
+  const attempts = readRetryAttempts(queuePath) + 1;
+  writeFileSync(retryAttemptsPath(queuePath), `${attempts}`, "utf8");
+  return attempts;
+}
+
+function clearFlushFailures(queuePath) {
+  removeIfExists(retryAttemptsPath(queuePath));
+}
+
+function clearRetryCheckpoint(queuePath) {
+  removeIfExists(retryCheckpointPath(queuePath));
+}
+
+function retryDelayMs(attempts) {
+  if (attempts <= 0) return 250;
+  return Math.min(5000, 250 * 2 ** Math.min(attempts - 1, 4));
+}
+
+function claimQueuedWritebacks(queuePath, retryPath) {
+  if (queueHasEntries(retryPath)) return true;
+  return claimFreshQueuedWritebacks(queuePath, retryPath);
+}
+
+function claimFreshQueuedWritebacks(queuePath, retryPath) {
+  removeIfExists(retryPath);
+  clearRetryCheckpoint(queuePath);
+  try {
+    renameSync(queuePath, retryPath);
+    return true;
+  } catch (error) {
+    if (isErrorCode(error, "ENOENT")) return false;
+    throw error;
+  }
+}
+
+function deadLetterQueuedWritebacks(queuePath, retryPath) {
+  if (!queueHasEntries(retryPath)) {
+    removeIfExists(retryPath);
+    clearFlushFailures(queuePath);
+    clearRetryCheckpoint(queuePath);
+    return false;
+  }
+  try {
+    renameSync(retryPath, `${retryPath}.failed.${Date.now()}.${process.pid}`);
+  } catch (error) {
+    if (isErrorCode(error, "ENOENT")) return false;
+    throw error;
+  }
+  clearFlushFailures(queuePath);
+  clearRetryCheckpoint(queuePath);
+  return true;
+}
+
+function shouldRescheduleFlush(queuePath, retryPath, flushFailed, failureAttempts) {
+  if (flushFailed) {
+    if (failureAttempts < MAX_FLUSH_RETRIES) return queueHasEntries(retryPath);
+    deadLetterQueuedWritebacks(queuePath, retryPath);
+    return consumeFlushFollowup(queuePath) || queueHasEntries(queuePath);
+  }
+  return consumeFlushFollowup(queuePath) || queueHasEntries(queuePath) || queueHasEntries(retryPath);
+}
+
+async function flushWritebackQueue(config) {
+  const queuePath = writebackQueuePath();
+  const lockPath = `${queuePath}.lock`;
+  const retryPath = `${queuePath}.retry`;
+  let result = { flushFailed: false, failureAttempts: 0 };
+  try {
+    result = await runFlushAttempt(config, { queuePath, retryPath });
+  } finally {
+    removeIfExists(lockPath);
+    const reschedule = shouldRescheduleFlush(queuePath, retryPath, result.flushFailed, result.failureAttempts);
+    if (reschedule) scheduleWritebackFlush(config);
+  }
+}
+
+async function runFlushAttempt(config, paths) {
+  let flushFailed = false;
+  let failureAttempts = 0;
+  await delay(retryDelayMs(readRetryAttempts(paths.queuePath)));
+  if (!claimQueuedWritebacks(paths.queuePath, paths.retryPath)) return { flushFailed, failureAttempts };
+  try {
+    flushFailed = true;
+    const result = runSomaBlocking(config, ["src/cli.ts", "writeback", "events", "--soma-home", config.somaHome, "--queue-file", paths.retryPath, "--checkpoint-file", retryCheckpointPath(paths.queuePath), "--substrate", "claude-code"]);
+    flushFailed = Boolean(result.error || result.status !== 0);
+  } finally {
+    if (flushFailed) failureAttempts = recordFlushFailure(paths.queuePath);
+    else clearFlushFailures(paths.queuePath);
+  }
+  return { flushFailed, failureAttempts };
+}
+
+async function writeback(config, input, kind, summary, source) {
+  const artifacts = artifactPaths(input);
+  const event = {
+    substrate: "claude-code",
+    kind,
+    summary,
+    artifactPaths: artifacts.length > 0 ? artifacts : undefined,
+    metadata: metadata(input, source),
+  };
+  await appendFile(writebackQueuePath(), `${JSON.stringify(event)}\n`, "utf8");
+  scheduleWritebackFlush(config);
+}
+
+async function main() {
+  const config = readConfig();
+  const event = process.argv[2];
+  if (event === FLUSH_EVENT) {
+    await flushWritebackQueue(config);
+    return;
+  }
+  const input = readHookInput();
+  const handler = HOOK_EVENT_HANDLERS[event];
+  if (!handler) return;
+  if (handler.kind === "lifecycle") lifecycle(config, handler.lifecycleEvent, input);
+  else if (handler.kind === "writeback") await writeback(config, input, handler.eventKind, handler.eventSummary, handler.source);
+}
+
+main().catch(() => {
+  // Fail soft: Soma observability must never block normal Claude Code use.
+});

--- a/src/adapters/claude-code/hooks.ts
+++ b/src/adapters/claude-code/hooks.ts
@@ -1,0 +1,276 @@
+import { readFileSync } from "node:fs";
+import { chmod, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { resolveBunExecutable } from "../../bun-probe";
+import { isEnoent } from "../../fs-errors";
+
+export const SOMA_CLAUDE_HOOK_RELATIVE_PATH = "hooks/soma/soma-claude-code-hook.mjs";
+export const SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH = "hooks/soma/soma-claude-code-hook.config.json";
+const SOMA_CLAUDE_SETTINGS_RELATIVE_PATH = "settings.json";
+
+const SOMA_CLAUDE_HOOK_EVENTS = [
+  {
+    event: "SessionStart",
+    commandEvent: "session-start",
+    summary: "Start Soma lifecycle session",
+    runner: { kind: "lifecycle", lifecycleEvent: "session-start" },
+  },
+  {
+    event: "SessionEnd",
+    commandEvent: "session-end",
+    summary: "End Soma lifecycle session",
+    runner: { kind: "lifecycle", lifecycleEvent: "session-end" },
+  },
+  {
+    event: "PostToolUse",
+    commandEvent: "writeback-tool",
+    matcher: "Write|Edit|MultiEdit|NotebookEdit",
+    summary: "Write Soma tool metadata",
+    runner: {
+      kind: "writeback",
+      eventKind: "writeback.claude_code.tool",
+      eventSummary: "Claude Code tool activity metadata captured.",
+      source: "PostToolUse",
+    },
+  },
+  {
+    event: "SubagentStart",
+    commandEvent: "writeback-subagent-start",
+    summary: "Write Soma subagent start metadata",
+    runner: {
+      kind: "writeback",
+      eventKind: "writeback.claude_code.subagent_start",
+      eventSummary: "Claude Code subagent start metadata captured.",
+      source: "SubagentStart",
+    },
+  },
+  {
+    event: "SubagentStop",
+    commandEvent: "writeback-subagent-stop",
+    summary: "Write Soma subagent stop metadata",
+    runner: {
+      kind: "writeback",
+      eventKind: "writeback.claude_code.subagent_stop",
+      eventSummary: "Claude Code subagent stop metadata captured.",
+      source: "SubagentStop",
+    },
+  },
+] as const;
+
+type JsonObject = Record<string, unknown>;
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function legacySomaClaudeHookCommand(substrateHome: string, commandEvent: string): string {
+  return `${shellQuote(resolve(substrateHome, SOMA_CLAUDE_HOOK_RELATIVE_PATH))} ${commandEvent}`;
+}
+
+function somaClaudeHookCommand(substrateHome: string, bunPath: string, commandEvent: string): string {
+  return `${shellQuote(bunPath)} ${shellQuote(resolve(substrateHome, SOMA_CLAUDE_HOOK_RELATIVE_PATH))} ${commandEvent}`;
+}
+
+function isObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseJsonObject(content: string, path: string): JsonObject {
+  if (content.trim().length === 0) return {};
+  const parsed: unknown = JSON.parse(content);
+  if (!isObject(parsed)) {
+    throw new Error(`Claude Code settings must be a JSON object: ${path}`);
+  }
+  return parsed;
+}
+
+async function readSettingsWithRaw(path: string): Promise<{ before: string; settings: JsonObject }> {
+  const before = await readFile(path, "utf8").catch((error: unknown) => {
+    if (isEnoent(error)) return "";
+    throw error;
+  });
+  return { before, settings: parseJsonObject(before, path) };
+}
+
+function somaHookCommands(substrateHome: string, bunPath: string): Set<string> {
+  return new Set(
+    SOMA_CLAUDE_HOOK_EVENTS.flatMap((event) => [
+      somaClaudeHookCommand(substrateHome, bunPath, event.commandEvent),
+      legacySomaClaudeHookCommand(substrateHome, event.commandEvent),
+    ]),
+  );
+}
+
+function somaHookEntry(substrateHome: string, bunPath: string, commandEvent: string): JsonObject {
+  return {
+    type: "command",
+    command: somaClaudeHookCommand(substrateHome, bunPath, commandEvent),
+    timeout: 30,
+  };
+}
+
+function appendSomaHookGroup(settings: JsonObject, input: (typeof SOMA_CLAUDE_HOOK_EVENTS)[number], substrateHome: string, bunPath: string): boolean {
+  const hooks = isObject(settings.hooks) ? settings.hooks : {};
+  const eventGroups = Array.isArray(hooks[input.event]) ? hooks[input.event] as unknown[] : [];
+  const knownCommands = somaHookCommands(substrateHome, bunPath);
+
+  for (const group of eventGroups) {
+    if (!isObject(group) || !Array.isArray(group.hooks)) continue;
+    if (group.hooks.some((hook) => isObject(hook) && typeof hook.command === "string" && knownCommands.has(hook.command))) {
+      settings.hooks = hooks;
+      return false;
+    }
+  }
+
+  eventGroups.push({
+    description: `Soma: ${input.summary}`,
+    ...("matcher" in input ? { matcher: input.matcher } : {}),
+    hooks: [somaHookEntry(substrateHome, bunPath, input.commandEvent)],
+  });
+  hooks[input.event] = eventGroups;
+  settings.hooks = hooks;
+  return true;
+}
+
+function removeSomaHooksFromSettings(settings: JsonObject, substrateHome: string, bunPath: string): boolean {
+  if (!isObject(settings.hooks)) return false;
+  const commands = somaHookCommands(substrateHome, bunPath);
+  const nextHooksByEvent: JsonObject = {};
+  let changed = false;
+
+  for (const [event, groups] of Object.entries(settings.hooks)) {
+    if (!Array.isArray(groups)) {
+      nextHooksByEvent[event] = groups;
+      continue;
+    }
+    const nextGroups: unknown[] = [];
+    for (const group of groups) {
+      const result = removeSomaCommandsFromGroup(group, commands);
+      changed = result.changed || changed;
+      if (result.group) nextGroups.push(result.group);
+    }
+    if (nextGroups.length > 0) {
+      nextHooksByEvent[event] = nextGroups;
+    }
+  }
+
+  if (Object.keys(nextHooksByEvent).length === 0) {
+    delete settings.hooks;
+  } else {
+    settings.hooks = nextHooksByEvent;
+  }
+  return changed;
+}
+
+function removeSomaCommandsFromGroup(group: unknown, commands: Set<string>): { group?: unknown; changed: boolean } {
+  if (!isObject(group) || !Array.isArray(group.hooks)) {
+    return { group, changed: false };
+  }
+  const nextHooks = group.hooks.filter((hook) => !(isObject(hook) && typeof hook.command === "string" && commands.has(hook.command)));
+  if (nextHooks.length === group.hooks.length) {
+    return { group, changed: false };
+  }
+  if (nextHooks.length === 0) {
+    return { changed: true };
+  }
+  return { group: { ...group, hooks: nextHooks }, changed: true };
+}
+
+async function writeJsonIfChanged(path: string, value: JsonObject, before?: string): Promise<string[]> {
+  const next = `${JSON.stringify(value, null, 2)}\n`;
+  if (before === next) return [];
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, next, "utf8");
+  return [path];
+}
+
+export async function patchClaudeCodeSomaHookSettings(substrateHome: string, bunPath = resolveBunExecutable()): Promise<string[]> {
+  const settingsPath = resolve(substrateHome, SOMA_CLAUDE_SETTINGS_RELATIVE_PATH);
+  const { before, settings } = await readSettingsWithRaw(settingsPath);
+  let changed = false;
+  for (const event of SOMA_CLAUDE_HOOK_EVENTS) {
+    changed = appendSomaHookGroup(settings, event, substrateHome, bunPath) || changed;
+  }
+  if (!changed && before.trim().length > 0) return [];
+  return writeJsonIfChanged(settingsPath, settings, before);
+}
+
+export async function unpatchClaudeCodeSomaHookSettings(substrateHome: string, bunPath = resolveBunExecutable()): Promise<string[]> {
+  const settingsPath = resolve(substrateHome, SOMA_CLAUDE_SETTINGS_RELATIVE_PATH);
+  const { before, settings } = await readSettingsWithRaw(settingsPath);
+  if (before.trim().length === 0) return [];
+  if (!removeSomaHooksFromSettings(settings, substrateHome, bunPath)) return [];
+  return writeJsonIfChanged(settingsPath, settings, before);
+}
+
+export async function installClaudeCodeSomaHooks(context: {
+  somaHome: string;
+  somaRepoPath: string;
+  substrateHome: string;
+}): Promise<string[]> {
+  const hookPath = resolve(context.substrateHome, SOMA_CLAUDE_HOOK_RELATIVE_PATH);
+  const configPath = resolve(context.substrateHome, SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH);
+  const bunPath = resolveBunExecutable();
+  const config = {
+    somaHome: context.somaHome,
+    trustedSomaRepo: context.somaRepoPath,
+    bunPath,
+  };
+
+  await mkdir(dirname(hookPath), { recursive: true });
+  await writeFile(hookPath, renderClaudeCodeSomaHook(), { encoding: "utf8", mode: 0o755 });
+  await chmod(hookPath, 0o755);
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  const settingsFiles = await patchClaudeCodeSomaHookSettings(context.substrateHome, bunPath);
+  return [hookPath, configPath, ...settingsFiles];
+}
+
+export async function removeClaudeCodeSomaHookFiles(substrateHome: string): Promise<string[]> {
+  const removed: string[] = [];
+  const installedBunPath = await readInstalledClaudeCodeHookBunPath(substrateHome);
+  for (const relativePath of [SOMA_CLAUDE_HOOK_RELATIVE_PATH, SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH]) {
+    const target = resolve(substrateHome, relativePath);
+    const exists = await stat(target).then(
+      () => true,
+      (error: unknown) => {
+        if (isEnoent(error)) return false;
+        throw error;
+      },
+    );
+    if (!exists) continue;
+    await rm(target, { force: true }).then(
+      () => removed.push(target),
+      (error: unknown) => {
+        if (!isEnoent(error)) throw error;
+      },
+    );
+  }
+  removed.push(...(await unpatchClaudeCodeSomaHookSettings(substrateHome, installedBunPath)));
+  return removed;
+}
+
+async function readInstalledClaudeCodeHookBunPath(substrateHome: string): Promise<string | undefined> {
+  const configPath = resolve(substrateHome, SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH);
+  const content = await readFile(configPath, "utf8").catch((error: unknown) => {
+    if (isEnoent(error)) return undefined;
+    throw error;
+  });
+  if (content === undefined) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (isObject(parsed) && typeof parsed.bunPath === "string" && parsed.bunPath.trim().length > 0) {
+      return parsed.bunPath;
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function renderClaudeCodeSomaHook(): string {
+  const runnerHandlers = Object.fromEntries(SOMA_CLAUDE_HOOK_EVENTS.map((event) => [event.commandEvent, event.runner]));
+  const source = readFileSync(new URL("./hook-runner.mjs", import.meta.url), "utf8");
+  const rendered = source.replace("__SOMA_CLAUDE_HOOK_EVENT_HANDLERS__", JSON.stringify(runnerHandlers, null, 2));
+  if (rendered === source) throw new Error("Claude Code hook runner asset is missing the handler placeholder.");
+  return rendered;
+}

--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -1,15 +1,33 @@
 import { isaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
 import { CLAUDE_CODE_RULES_FILES } from "../claude-code";
+import {
+  SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH,
+  SOMA_CLAUDE_HOOK_RELATIVE_PATH,
+  installClaudeCodeSomaHooks,
+  removeClaudeCodeSomaHookFiles,
+} from "./hooks";
 
 export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
   substrate: "claude-code",
   defaultHome: ".claude",
-  homeFiles: CLAUDE_CODE_RULES_FILES,
+  homeFiles: [
+    ...CLAUDE_CODE_RULES_FILES,
+    SOMA_CLAUDE_HOOK_RELATIVE_PATH,
+    SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH,
+    "settings.json",
+  ],
   isaSkillProjection: {
     destinationDir: isaSkillUnder(),
   },
+  postProjection: [
+    {
+      name: "claude-code-soma-hooks",
+      run: installClaudeCodeSomaHooks,
+    },
+  ],
   uninstall: {
     kind: "implemented",
     remove: ["rules/soma", "skills/ISA"],
+    postRemove: (context) => removeClaudeCodeSomaHookFiles(context.substrateHome),
   },
 };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,6 +73,12 @@ import {
   type ParsedLifecycleArgs,
 } from "./cli/lifecycle";
 import {
+  WRITEBACK_COMMAND_HELP,
+  parseWritebackArgs,
+  runWritebackCli,
+  type ParsedWritebackArgs,
+} from "./cli/writeback";
+import {
   ONBOARDING_COMMAND_HELP,
   parseAdoptArgs,
   parseDoctorArgs,
@@ -119,6 +125,7 @@ type ParsedArgs =
   | ParsedFeedbackArgs
   | ParsedResultArgs
   | ParsedPolicyArgs
+  | ParsedWritebackArgs
   | ParsedIsaArgs
   | ParsedToolArgs;
 
@@ -149,6 +156,7 @@ const TOP_LEVEL_COMMANDS = [
   "telemetry",
   "uninstall",
   "upgrade",
+  "writeback",
   "wisdom",
 ] as const;
 
@@ -161,6 +169,7 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
   ...TOOL_COMMAND_HELP,
   result: RESULT_COMMAND_HELP,
   policy: POLICY_COMMAND_HELP,
+  writeback: WRITEBACK_COMMAND_HELP,
   lifecycle: LIFECYCLE_COMMAND_HELP,
   install: SUBSTRATE_LIFECYCLE_COMMAND_HELP.install,
   uninstall: SUBSTRATE_LIFECYCLE_COMMAND_HELP.uninstall,
@@ -235,6 +244,10 @@ function parseArgs(args: string[]): ParsedArgs {
 
   if (args[0] === "policy") {
     return parsePolicyArgs(args);
+  }
+
+  if (args[0] === "writeback") {
+    return parseWritebackArgs(args);
   }
 
   if (args[0] === "install") {
@@ -432,6 +445,10 @@ export async function runSomaCli(args: string[]): Promise<string> {
 
   if (parsed.command === "policy") {
     return runPolicyCli(parsed);
+  }
+
+  if (parsed.command === "writeback") {
+    return runWritebackCli(parsed);
   }
 
   if (parsed.command === "import") {

--- a/src/cli/writeback.ts
+++ b/src/cli/writeback.ts
@@ -1,0 +1,340 @@
+import { createReadStream } from "node:fs";
+import { readFile, rm, stat, writeFile } from "node:fs/promises";
+import { createInterface } from "node:readline";
+import { isEnoent } from "../fs-errors";
+import { applySomaMemoryEventWritebacks, applySomaWriteback, type SomaWritebackResult } from "../writeback";
+import type { SomaMemoryEventInput } from "../types";
+import { readOption } from "./parse-utils";
+import { parseSubstrate } from "./substrate";
+
+const WRITEBACK_QUEUE_BATCH_SIZE = 500;
+
+interface ParsedWritebackEventArgs {
+  command: "writeback";
+  action: "event";
+  options: {
+    somaHome: string;
+    substrate?: SomaMemoryEventInput["substrate"];
+    timestamp?: string;
+    event: Omit<SomaMemoryEventInput, "substrate" | "timestamp"> & {
+      substrate?: SomaMemoryEventInput["substrate"];
+      timestamp?: string;
+    };
+  };
+}
+
+interface ParsedWritebackEventsArgs {
+  command: "writeback";
+  action: "events";
+  options: {
+    somaHome: string;
+    queueFile: string;
+    checkpointFile?: string;
+    substrate?: SomaMemoryEventInput["substrate"];
+  };
+}
+
+export type ParsedWritebackArgs = ParsedWritebackEventArgs | ParsedWritebackEventsArgs;
+
+export const WRITEBACK_COMMAND_HELP: { usage: string; subcommands: Record<ParsedWritebackArgs["action"], string> } = {
+  usage:
+    "Usage: soma writeback <event|events> --soma-home <dir> ...",
+  subcommands: {
+    event:
+      "Usage: soma writeback event --soma-home <dir> --kind <kind> --summary <text> [--substrate <id>] [--timestamp <iso>] [--metadata-env <env>] [--artifact-path <path>...]",
+    events:
+      "Usage: soma writeback events --soma-home <dir> --queue-file <path> [--checkpoint-file <path>] [--substrate <id>]",
+  },
+};
+
+interface CommonWritebackOptions {
+  somaHome?: string;
+  substrate?: SomaMemoryEventInput["substrate"];
+}
+
+function readCommonWritebackOption(rest: string[], index: number, options: CommonWritebackOptions): number | undefined {
+  const arg = rest[index];
+  switch (arg) {
+    case "--soma-home":
+      options.somaHome = readOption(rest, index, arg);
+      return index + 1;
+    case "--substrate":
+      options.substrate = parseSubstrate(readOption(rest, index, arg));
+      return index + 1;
+    default:
+      return undefined;
+  }
+}
+
+function parseWritebackOptions(
+  rest: string[],
+  readSpecificOption: (arg: string, index: number) => number | undefined,
+): CommonWritebackOptions {
+  const common: CommonWritebackOptions = {};
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    const nextIndex = readCommonWritebackOption(rest, index, common) ?? readSpecificOption(arg, index);
+    if (nextIndex === undefined) throw new Error(`Unknown option: ${arg}`);
+    index = nextIndex;
+  }
+  return common;
+}
+
+export function parseWritebackArgs(args: string[]): ParsedWritebackArgs {
+  const [command, action, ...rest] = args;
+  if (command !== "writeback") {
+    throw new Error(WRITEBACK_COMMAND_HELP.usage);
+  }
+  if (action === "events") {
+    return parseWritebackEventsArgs(command, action, rest);
+  }
+  if (action !== "event") {
+    throw new Error(WRITEBACK_COMMAND_HELP.usage);
+  }
+  return parseWritebackEventArgs(command, action, rest);
+}
+
+function parseWritebackEventArgs(command: "writeback", action: "event", rest: string[]): ParsedWritebackEventArgs {
+  let timestamp: string | undefined;
+  let kind: string | undefined;
+  let summary: string | undefined;
+  let metadata: Record<string, unknown> | undefined;
+  const artifactPaths: string[] = [];
+
+  const common = parseWritebackOptions(rest, (arg, index) => {
+    switch (arg) {
+      case "--timestamp":
+        timestamp = readOption(rest, index, arg);
+        return index + 1;
+      case "--kind":
+        kind = readOption(rest, index, arg);
+        return index + 1;
+      case "--summary":
+        summary = readOption(rest, index, arg);
+        return index + 1;
+      case "--metadata-env": {
+        const envName = readOption(rest, index, arg);
+        metadata = parseMetadataEnv(envName);
+        return index + 1;
+      }
+      case "--artifact-path":
+        artifactPaths.push(readOption(rest, index, arg));
+        return index + 1;
+      default:
+        return undefined;
+    }
+  });
+
+  if (!common.somaHome) throw new Error("soma writeback event is missing required option: --soma-home.");
+  if (!kind) throw new Error("soma writeback event is missing required option: --kind.");
+  if (!summary) throw new Error("soma writeback event is missing required option: --summary.");
+
+  return {
+    command,
+    action,
+    options: {
+      somaHome: common.somaHome,
+      substrate: common.substrate,
+      timestamp,
+      event: {
+        kind,
+        summary,
+        metadata,
+        artifactPaths: artifactPaths.length > 0 ? artifactPaths : undefined,
+      },
+    },
+  };
+}
+
+function parseWritebackEventsArgs(command: "writeback", action: "events", rest: string[]): ParsedWritebackEventsArgs {
+  let queueFile: string | undefined;
+  let checkpointFile: string | undefined;
+
+  const common = parseWritebackOptions(rest, (arg, index) => {
+    switch (arg) {
+      case "--queue-file":
+        queueFile = readOption(rest, index, arg);
+        return index + 1;
+      case "--checkpoint-file":
+        checkpointFile = readOption(rest, index, arg);
+        return index + 1;
+      default:
+        return undefined;
+    }
+  });
+
+  if (!common.somaHome) throw new Error("soma writeback events is missing required option: --soma-home.");
+  if (!queueFile) throw new Error("soma writeback events is missing required option: --queue-file.");
+  return { command, action, options: { somaHome: common.somaHome, queueFile, checkpointFile, substrate: common.substrate } };
+}
+
+function parseMetadataEnv(envName: string): Record<string, unknown> {
+  const raw = process.env[envName];
+  if (!raw) return {};
+  const parsed: unknown = JSON.parse(raw);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`Metadata env ${envName} must contain a JSON object.`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+export async function runWritebackCli(parsed: ParsedWritebackArgs): Promise<string> {
+  if (parsed.action === "events") {
+    return runWritebackEventsCli(parsed);
+  }
+  return formatWritebackResult(await applySomaWriteback({
+    somaHome: parsed.options.somaHome,
+    substrate: parsed.options.substrate,
+    timestamp: parsed.options.timestamp,
+    operation: {
+      kind: "memory-event",
+      event: parsed.options.event,
+    },
+  }));
+}
+
+async function runWritebackEventsCli(parsed: ParsedWritebackEventsArgs): Promise<string> {
+  const queueFilePath = parsed.options.queueFile;
+  const checkpointPath = parsed.options.checkpointFile ?? `${queueFilePath}.checkpoint`;
+  const checkpoint = await readQueueCheckpoint(checkpointPath);
+  const result = await drainQueuedEvents(parsed, { queueFilePath, checkpointPath, checkpoint });
+  if (result.drained) await removeDrainedQueueFiles(queueFilePath, checkpointPath);
+  return formatWritebackQueueResult(result.applied, result.writes);
+}
+
+async function drainQueuedEvents(
+  parsed: ParsedWritebackEventsArgs,
+  options: { queueFilePath: string; checkpointPath: string; checkpoint: number },
+): Promise<{ applied: number; writes: string[]; drained: boolean }> {
+  const writes = new Set<string>();
+  let batch: ParsedWritebackEventArgs["options"]["event"][] = [];
+  let eventIndex = 0;
+  let applied = 0;
+  let nextCheckpoint = options.checkpoint;
+
+  const flushBatch = async (): Promise<void> => {
+    if (batch.length === 0) return;
+    const batchSize = batch.length;
+    const result = await applyQueuedEventBatch(parsed, batch);
+    result.writes.forEach((write) => writes.add(write));
+    applied += batchSize;
+    nextCheckpoint += batchSize;
+    await writeQueueCheckpoint(options.checkpointPath, nextCheckpoint);
+    batch = [];
+  };
+
+  for await (const line of readQueuedEventLines(options.queueFilePath)) {
+    if (line.trim().length === 0) throw new Error("Queued writeback event line must not be blank.");
+    if (eventIndex < options.checkpoint) {
+      eventIndex += 1;
+      continue;
+    }
+    const event = parseQueuedEvent(line, parsed.options.substrate);
+    batch.push(event);
+    eventIndex += 1;
+    if (batch.length >= WRITEBACK_QUEUE_BATCH_SIZE) {
+      await flushBatch();
+    }
+  }
+
+  await flushBatch();
+  return { applied, writes: Array.from(writes), drained: true };
+}
+
+async function removeDrainedQueueFiles(queueFilePath: string, checkpointPath: string): Promise<void> {
+  await rm(queueFilePath, { force: true });
+  await rm(checkpointPath, { force: true });
+}
+
+function applyQueuedEventBatch(
+  parsed: ParsedWritebackEventsArgs,
+  events: ParsedWritebackEventArgs["options"]["event"][],
+): Promise<SomaWritebackResult> {
+  return applySomaMemoryEventWritebacks({
+    somaHome: parsed.options.somaHome,
+    substrate: parsed.options.substrate,
+    events,
+  });
+}
+
+async function* readQueuedEventLines(path: string): AsyncGenerator<string> {
+  const exists = await stat(path).then(
+    () => true,
+    (error: unknown) => {
+      if (isEnoent(error)) return false;
+      throw error;
+    },
+  );
+  if (!exists) throw new Error(`Queued writeback file does not exist: ${path}`);
+
+  const lines = createInterface({
+    input: createReadStream(path, { encoding: "utf8" }),
+    crlfDelay: Infinity,
+  });
+  for await (const line of lines) {
+    yield line;
+  }
+}
+
+async function readQueueCheckpoint(path: string): Promise<number> {
+  const raw = await readFile(path, "utf8").catch((error: unknown) => {
+    if (isEnoent(error)) return undefined;
+    throw error;
+  });
+  if (raw === undefined) return 0;
+  const value = Number.parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+async function writeQueueCheckpoint(path: string, appliedEvents: number): Promise<void> {
+  await writeFile(path, `${appliedEvents}`, "utf8");
+}
+
+function parseQueuedEvent(line: string, defaultSubstrate?: SomaMemoryEventInput["substrate"]): ParsedWritebackEventArgs["options"]["event"] {
+  const parsed: unknown = JSON.parse(line);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Queued writeback event must be a JSON object.");
+  }
+  const event = parsed as Record<string, unknown>;
+  if (typeof event.kind !== "string" || event.kind.trim().length === 0) {
+    throw new Error("Queued writeback event is missing required field: kind.");
+  }
+  if (typeof event.summary !== "string" || event.summary.trim().length === 0) {
+    throw new Error("Queued writeback event is missing required field: summary.");
+  }
+  const substrate = typeof event.substrate === "string" ? parseSubstrate(event.substrate) : defaultSubstrate;
+  const artifactPaths = Array.isArray(event.artifactPaths)
+    ? event.artifactPaths.filter((path): path is string => typeof path === "string")
+    : undefined;
+  const metadata = typeof event.metadata === "object" && event.metadata !== null && !Array.isArray(event.metadata)
+    ? event.metadata as Record<string, unknown>
+    : undefined;
+  return {
+    kind: event.kind,
+    summary: event.summary,
+    substrate,
+    timestamp: typeof event.timestamp === "string" ? event.timestamp : undefined,
+    artifactPaths: artifactPaths && artifactPaths.length > 0 ? artifactPaths : undefined,
+    metadata,
+  };
+}
+
+function formatWritebackResult(result: SomaWritebackResult): string {
+  return [
+    "Soma writeback applied",
+    `merge: ${result.merge}`,
+    "",
+    "Writes:",
+    ...result.writes.map((path: string) => `- ${path}`),
+  ].join("\n");
+}
+
+function formatWritebackQueueResult(count: number, writes: string[]): string {
+  return [
+    "Soma writeback queue applied",
+    `events: ${count}`,
+    "",
+    "Writes:",
+    ...writes.map((path: string) => `- ${path}`),
+  ].join("\n");
+}

--- a/src/install.ts
+++ b/src/install.ts
@@ -237,10 +237,9 @@ export async function installSomaForPiDev(options: SomaInstallOptions = {}): Pro
  * installs the ISA skill into `~/.claude/skills/ISA/`, and writes the
  * full projection skeleton at `~/.claude/rules/soma/` (auto-discovered
  * by Claude Code, per the soma#64 pivot away from `@`-imports).
- *
- * Out of scope (follow-up issue): hook scripts +
- * settings.local.json patching, CLI command wiring, CLAUDE.md
- * composition.
+ * It also installs Soma-owned lifecycle/writeback hooks and patches
+ * `~/.claude/settings.json` idempotently. CLAUDE.md composition remains
+ * intentionally out of scope.
  */
 export async function installSomaForClaudeCode(options: SomaInstallOptions = {}): Promise<SomaInstallResult> {
   return installSomaForSubstrate("claude-code", options);

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -33,25 +33,33 @@ function assertNonEmpty(value: string, field: string): void {
 }
 
 export async function appendSomaMemoryEvent(somaHome: string, input: SomaMemoryEventInput): Promise<SomaMemoryEvent> {
-  assertNonEmpty(input.substrate, "substrate");
-  assertNonEmpty(input.kind, "kind");
-  assertNonEmpty(input.summary, "summary");
+  const [event] = await appendSomaMemoryEvents(somaHome, [input]);
+  return event;
+}
 
-  const event: SomaMemoryEvent = {
-    id: input.id ?? createEventId(),
-    timestamp: input.timestamp ?? new Date().toISOString(),
-    substrate: input.substrate,
-    kind: input.kind,
-    summary: input.summary,
-    artifactPaths: input.artifactPaths,
-    metadata: input.metadata,
-  };
+export async function appendSomaMemoryEvents(somaHome: string, inputs: readonly SomaMemoryEventInput[]): Promise<SomaMemoryEvent[]> {
+  if (inputs.length === 0) return [];
+  const events = inputs.map((input) => {
+    assertNonEmpty(input.substrate, "substrate");
+    assertNonEmpty(input.kind, "kind");
+    assertNonEmpty(input.summary, "summary");
+
+    return {
+      id: input.id ?? createEventId(),
+      timestamp: input.timestamp ?? new Date().toISOString(),
+      substrate: input.substrate,
+      kind: input.kind,
+      summary: input.summary,
+      artifactPaths: input.artifactPaths,
+      metadata: input.metadata,
+    };
+  });
   const eventPath = createPaths(somaHome).events();
 
   await mkdir(dirname(eventPath), { recursive: true });
-  await appendFile(eventPath, `${JSON.stringify(event)}\n`, "utf8");
+  await appendFile(eventPath, `${events.map((event) => JSON.stringify(event)).join("\n")}\n`, "utf8");
 
-  return event;
+  return events;
 }
 
 export function somaMemoryEventsPath(somaHome: string): string {

--- a/src/writeback.ts
+++ b/src/writeback.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import { applyIsaUpdate, getActiveIsa, isaPath } from "./isa";
-import { appendSomaMemoryEvent, somaMemoryEventsPath } from "./memory";
+import { appendSomaMemoryEvent, appendSomaMemoryEvents, somaMemoryEventsPath } from "./memory";
 import { checkSomaPolicy } from "./policy-audit";
 import type { IsaUpdatePayload, SomaMemoryEventInput, SubstrateId } from "./types";
 
@@ -78,26 +78,12 @@ export async function applySomaWriteback(options: SomaWritebackOptions): Promise
 
   switch (options.operation.kind) {
     case "memory-event": {
-      const eventPath = somaMemoryEventsPath(options.somaHome);
-      await assertWritebackAllowed({
+      return applySomaMemoryEventWritebacks({
         somaHome: options.somaHome,
         substrate,
-        destinationPath: eventPath,
         timestamp: options.timestamp,
-        deniedMessage: "Writeback gate denied memory-event write",
+        events: [options.operation.event],
       });
-
-      await appendSomaMemoryEvent(options.somaHome, {
-        ...options.operation.event,
-        substrate: options.operation.event.substrate ?? substrate,
-        timestamp: options.operation.event.timestamp ?? options.timestamp,
-      });
-
-      return {
-        decision: "applied",
-        merge: "append-only",
-        writes: [eventPath],
-      };
     }
     case "isa-log": {
       const active = await getActiveIsa({ somaHome: options.somaHome });
@@ -158,4 +144,41 @@ export async function applySomaWriteback(options: SomaWritebackOptions): Promise
       );
     }
   }
+}
+
+export async function applySomaMemoryEventWritebacks(
+  options: SomaWritebackBaseOptions & {
+    events: readonly SomaMemoryEventWritebackOperation["event"][];
+  },
+): Promise<SomaWritebackResult> {
+  const substrate = options.substrate ?? "custom";
+  const eventPath = somaMemoryEventsPath(options.somaHome);
+  if (options.events.length === 0) {
+    return { decision: "applied", merge: "append-only", writes: [] };
+  }
+  const substrates = new Set(options.events.map((event) => event.substrate ?? substrate));
+  for (const eventSubstrate of substrates) {
+    await assertWritebackAllowed({
+      somaHome: options.somaHome,
+      substrate: eventSubstrate,
+      destinationPath: eventPath,
+      timestamp: options.timestamp,
+      deniedMessage: "Writeback gate denied memory-event write",
+    });
+  }
+
+  await appendSomaMemoryEvents(
+    options.somaHome,
+    options.events.map((event) => ({
+      ...event,
+      substrate: event.substrate ?? substrate,
+      timestamp: event.timestamp ?? options.timestamp,
+    })),
+  );
+
+  return {
+    decision: "applied",
+    merge: "append-only",
+    writes: [eventPath],
+  };
 }

--- a/test/claude-code-install.test.ts
+++ b/test/claude-code-install.test.ts
@@ -1,10 +1,10 @@
 /**
  * #29 Claude Code adapter — full install + projection (per soma#64 pivot).
  * Minimal-correct scope: rules/soma/ skeleton + ISA skill projection +
- * uninstaller. Hooks/settings.local.json patching/CLI integration land in
- * the follow-up issue tracked in the PR body.
+ * lifecycle/writeback hooks + uninstaller.
  */
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
@@ -26,6 +26,60 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
   } finally {
     await rm(homeDir, { recursive: true, force: true });
   }
+}
+
+function readJson<T>(path: string): Promise<T> {
+  return readFile(path, "utf8").then((content) => JSON.parse(content) as T);
+}
+
+function countSomaHookCommands(settings: { hooks?: Record<string, unknown[]> }): number {
+  return Object.values(settings.hooks ?? {}).flatMap((groups) =>
+    groups.flatMap((group) => {
+      if (!group || typeof group !== "object" || !("hooks" in group) || !Array.isArray(group.hooks)) return [];
+      return group.hooks.filter((hook) =>
+        hook &&
+        typeof hook === "object" &&
+        "command" in hook &&
+        typeof hook.command === "string" &&
+        hook.command.includes("hooks/soma/soma-claude-code-hook.mjs"),
+      );
+    }),
+  ).length;
+}
+
+function runClaudeHook(homeDir: string, event: string, input: Record<string, unknown>): void {
+  const hook = join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.mjs");
+  const result = spawnSync(process.execPath, [hook, event], {
+    cwd: process.cwd(),
+    env: { ...process.env, HOME: homeDir },
+    input: JSON.stringify(input),
+    encoding: "utf8",
+  });
+  expect(result.status).toBe(0);
+}
+
+async function waitForEvents(homeDir: string, predicate: (events: ClaudeHookEvent[]) => boolean): Promise<ClaudeHookEvent[]> {
+  const eventsPath = join(homeDir, ".soma/memory/STATE/events.jsonl");
+  let events: ClaudeHookEvent[] = [];
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    const content = await readFile(eventsPath, "utf8").catch(() => "");
+    events = content
+      .trim()
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as ClaudeHookEvent);
+    if (predicate(events)) return events;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return events;
+}
+
+interface ClaudeHookEvent {
+  substrate: string;
+  kind: string;
+  summary: string;
+  artifactPaths?: string[];
+  metadata?: Record<string, unknown>;
 }
 
 test("AC-1: projectClaudeCodeHome writes everything under rules/soma/", () => {
@@ -60,6 +114,9 @@ test("AC-2: planSomaForClaudeCodeInstall lists every file written", () => {
     "/tmp/test-home/.claude/rules/soma/SKILLS.md",
     "/tmp/test-home/.claude/rules/soma/POLICY.md",
     "/tmp/test-home/.claude/rules/soma/ACTIVE_ISA.md",
+    "/tmp/test-home/.claude/hooks/soma/soma-claude-code-hook.mjs",
+    "/tmp/test-home/.claude/hooks/soma/soma-claude-code-hook.config.json",
+    "/tmp/test-home/.claude/settings.json",
   ]);
 });
 
@@ -75,9 +132,82 @@ test("AC-4: installSomaForClaudeCode is idempotent (second install bytes-identic
   await withTempHome(async (homeDir) => {
     await installSomaForClaudeCode({ homeDir });
     const before = await readFile(join(homeDir, ".claude/rules/soma/CONTEXT.md"), "utf8");
+    const settingsBefore = await readFile(join(homeDir, ".claude/settings.json"), "utf8");
     await installSomaForClaudeCode({ homeDir });
     const after = await readFile(join(homeDir, ".claude/rules/soma/CONTEXT.md"), "utf8");
+    const settingsAfter = await readFile(join(homeDir, ".claude/settings.json"), "utf8");
     expect(after).toBe(before);
+    expect(settingsAfter).toBe(settingsBefore);
+  });
+});
+
+test("issue #236: claude-code install wires Soma-owned hooks without overwriting user hooks", async () => {
+  await withTempHome(async (homeDir) => {
+    await mkdir(join(homeDir, ".claude"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".claude/settings.json"),
+      JSON.stringify({
+        hooks: {
+          SessionStart: [
+            {
+              description: "user hook",
+              hooks: [{ type: "command", command: "echo user-start" }],
+            },
+          ],
+        },
+      }, null, 2),
+      "utf8",
+    );
+
+    await installSomaForClaudeCode({ homeDir });
+    await installSomaForClaudeCode({ homeDir });
+
+    const hookInfo = await stat(join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.mjs"));
+    expect((hookInfo.mode & 0o100) !== 0).toBe(true);
+    const hookContent = await readFile(join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.mjs"), "utf8");
+    expect(hookContent).toContain('"src/cli.ts"');
+    expect(hookContent).not.toContain('"run",\n    "soma"');
+    expect(hookContent).toContain('child.on("error", onError)');
+    expect(hookContent).toContain("flush-writeback-queue");
+    const settings = await readJson<{ hooks: Record<string, unknown[]> }>(join(homeDir, ".claude/settings.json"));
+    const config = await readJson<{ bunPath: string }>(join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.config.json"));
+    expect(JSON.stringify(settings)).toContain("echo user-start");
+    expect(JSON.stringify(settings)).toContain(config.bunPath);
+    expect(Object.keys(settings.hooks).sort()).toEqual(["PostToolUse", "SessionEnd", "SessionStart", "SubagentStart", "SubagentStop"]);
+    expect(countSomaHookCommands(settings)).toBe(5);
+  });
+});
+
+test("issue #236: installed Claude hook appends lifecycle and metadata-only writeback events", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir });
+
+    runClaudeHook(homeDir, "session-start", { session_id: "claude-session-1" });
+    runClaudeHook(homeDir, "writeback-tool", {
+      session_id: "claude-session-1",
+      hook_event_name: "PostToolUse",
+      cwd: "/workspace/example",
+      tool_name: "Write",
+      tool_input: { file_path: "/workspace/example/result.md", content: "private transcript content must not be mirrored" },
+    });
+    runClaudeHook(homeDir, "session-end", { session_id: "claude-session-1" });
+
+    const events = await waitForEvents(homeDir, (items) =>
+      ["lifecycle.session_start", "writeback.claude_code.tool", "lifecycle.session_end"].every((kind) =>
+        items.some((event) => event.kind === kind),
+      ),
+    );
+    expect(events.some((event) => event.substrate === "claude-code" && event.kind === "lifecycle.session_start")).toBe(true);
+    expect(events.some((event) => event.substrate === "claude-code" && event.kind === "lifecycle.session_end")).toBe(true);
+    const toolEvent = events.find((event) => event.kind === "writeback.claude_code.tool");
+    expect(toolEvent).toBeDefined();
+    expect(toolEvent?.artifactPaths).toEqual(["/workspace/example/result.md"]);
+    expect(toolEvent?.metadata).toMatchObject({
+      sessionId: "claude-session-1",
+      source: "PostToolUse",
+      toolName: "Write",
+    });
+    expect(JSON.stringify(toolEvent)).not.toContain("private transcript content");
   });
 });
 
@@ -92,23 +222,70 @@ test("AC-5: CLAUDE.md left untouched (pivot dropped @-import composition)", asyn
   });
 });
 
-test("AC-10: uninstallSomaForClaudeCode removes rules/soma/ and skills/ISA/ only", async () => {
+test("AC-10: uninstallSomaForClaudeCode removes only Soma-owned projection and hook entries", async () => {
   await withTempHome(async (homeDir) => {
     // User-owned sibling file that must survive uninstall.
     await mkdir(join(homeDir, ".claude/rules/user-rule"), { recursive: true });
     await writeFile(join(homeDir, ".claude/rules/user-rule/note.md"), "user note", "utf8");
     await mkdir(join(homeDir, ".claude/skills/UserSkill"), { recursive: true });
     await writeFile(join(homeDir, ".claude/skills/UserSkill/SKILL.md"), "user skill", "utf8");
+    await mkdir(join(homeDir, ".claude/hooks/user"), { recursive: true });
+    await writeFile(join(homeDir, ".claude/hooks/user/hook.mjs"), "user hook", "utf8");
+    await mkdir(join(homeDir, ".claude"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".claude/settings.json"),
+      JSON.stringify({
+        hooks: {
+          PostToolUse: [
+            {
+              description: "user-owned empty group",
+              hooks: [],
+            },
+          ],
+        },
+      }, null, 2),
+      "utf8",
+    );
 
     await installSomaForClaudeCode({ homeDir });
     const result = await uninstallSomaForClaudeCode({ homeDir });
 
-    expect(result.removed.length).toBe(2);
+    expect(result.removed).toContain(join(homeDir, ".claude/rules/soma"));
+    expect(result.removed).toContain(join(homeDir, ".claude/skills/ISA"));
+    expect(result.removed).toContain(join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.mjs"));
+    expect(result.removed).toContain(join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.config.json"));
     await expect(stat(join(homeDir, ".claude/rules/soma"))).rejects.toThrow();
     await expect(stat(join(homeDir, ".claude/skills/ISA"))).rejects.toThrow();
+    await expect(stat(join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.mjs"))).rejects.toThrow();
     // User-owned siblings survive.
     expect(await readFile(join(homeDir, ".claude/rules/user-rule/note.md"), "utf8")).toBe("user note");
     expect(await readFile(join(homeDir, ".claude/skills/UserSkill/SKILL.md"), "utf8")).toBe("user skill");
+    expect(await readFile(join(homeDir, ".claude/hooks/user/hook.mjs"), "utf8")).toBe("user hook");
+    const settings = await readJson<Record<string, unknown>>(join(homeDir, ".claude/settings.json"));
+    expect(JSON.stringify(settings)).not.toContain("soma-claude-code-hook");
+    expect(settings).toMatchObject({
+      hooks: {
+        PostToolUse: [{ description: "user-owned empty group", hooks: [] }],
+      },
+    });
+  });
+});
+
+test("issue #236: uninstall removes settings entries using the installed Bun path", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir });
+    const configPath = join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.config.json");
+    const settingsPath = join(homeDir, ".claude/settings.json");
+    const config = await readJson<{ bunPath: string }>(configPath);
+    const oldBunPath = "/tmp/soma-test-old-bun";
+    await writeFile(configPath, `${JSON.stringify({ ...config, bunPath: oldBunPath }, null, 2)}\n`, "utf8");
+    const settings = await readFile(settingsPath, "utf8");
+    await writeFile(settingsPath, settings.replaceAll(config.bunPath, oldBunPath), "utf8");
+
+    await uninstallSomaForClaudeCode({ homeDir });
+
+    const after = await readFile(settingsPath, "utf8");
+    expect(after).not.toContain("soma-claude-code-hook");
   });
 });
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -208,6 +208,7 @@ test("install spec registry has adapter-owned facts for every install substrate"
     kind: "implemented",
     remove: ["rules/soma", "skills/ISA"],
   });
+  expect(installSpecFor("claude-code").postProjection?.map((step) => step.name)).toEqual(["claude-code-soma-hooks"]);
   expect(installSpecFor("cursor").uninstall.kind).toBe("implemented");
 });
 

--- a/test/writeback-gate.test.ts
+++ b/test/writeback-gate.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { parseWritebackArgs, runWritebackCli } from "../src/cli/writeback";
 import { applySomaWriteback, bootstrapSomaHome, readIsa, scaffoldIsa, setActiveIsa } from "../src/index";
 
 async function tempHome(): Promise<string> {
@@ -122,5 +123,106 @@ describe("applySomaWriteback", () => {
         },
       }),
     ).rejects.toThrow("requires an active ISA");
+  });
+});
+
+describe("writeback queue CLI", () => {
+  test("#236: drains large queues in bounded batches and clears checkpoint state", async () => {
+    const homeDir = await tempHome();
+    const somaHome = join(homeDir, ".soma");
+    const queueFile = join(homeDir, "writeback-queue.jsonl");
+    const queuedEvents = Array.from({ length: 501 }, (_, index) => ({
+      kind: "writeback.queue.test",
+      summary: `Queued writeback ${index}`,
+    }));
+    await writeFile(queueFile, `${queuedEvents.map((event) => JSON.stringify(event)).join("\n")}\n`, "utf8");
+
+    const output = await runWritebackCli(parseWritebackArgs([
+      "writeback",
+      "events",
+      "--soma-home",
+      somaHome,
+      "--queue-file",
+      queueFile,
+      "--substrate",
+      "claude-code",
+    ]));
+
+    expect(output).toContain("events: 501");
+    const events = await readFile(join(somaHome, "memory/STATE/events.jsonl"), "utf8");
+    expect(events.trim().split("\n")).toHaveLength(501);
+    await expect(stat(queueFile)).rejects.toThrow();
+    await expect(stat(`${queueFile}.checkpoint`)).rejects.toThrow();
+  });
+
+  test("#236: removes the claimed retry queue after a successful drain", async () => {
+    const homeDir = await tempHome();
+    const somaHome = join(homeDir, ".soma");
+    const baseQueueFile = join(homeDir, "writeback-queue.jsonl");
+    const checkpointFile = `${baseQueueFile}.checkpoint`;
+    const retryQueueFile = join(homeDir, "writeback-queue.jsonl.retry");
+    await writeFile(
+      retryQueueFile,
+      `${JSON.stringify({ kind: "writeback.queue.retry", summary: "Retry queue event" })}\n`,
+      "utf8",
+    );
+
+    const output = await runWritebackCli(parseWritebackArgs([
+      "writeback",
+      "events",
+      "--soma-home",
+      somaHome,
+      "--queue-file",
+      retryQueueFile,
+      "--checkpoint-file",
+      checkpointFile,
+      "--substrate",
+      "claude-code",
+    ]));
+
+    expect(output).toContain("events: 1");
+    const events = await readFile(join(somaHome, "memory/STATE/events.jsonl"), "utf8");
+    expect(events).toContain('"kind":"writeback.queue.retry"');
+    await expect(stat(retryQueueFile)).rejects.toThrow();
+    await expect(stat(checkpointFile)).rejects.toThrow();
+  });
+
+  test("#236: missing queue file is refused instead of reported as drained", async () => {
+    const homeDir = await tempHome();
+    const somaHome = join(homeDir, ".soma");
+    const queueFile = join(homeDir, "missing-writeback-queue.jsonl");
+
+    await expect(
+      runWritebackCli(parseWritebackArgs([
+        "writeback",
+        "events",
+        "--soma-home",
+        somaHome,
+        "--queue-file",
+        queueFile,
+        "--substrate",
+        "claude-code",
+      ])),
+    ).rejects.toThrow("Queued writeback file does not exist");
+  });
+
+  test("#236: blank queue lines are refused to keep checkpoint accounting unambiguous", async () => {
+    const homeDir = await tempHome();
+    const somaHome = join(homeDir, ".soma");
+    const queueFile = join(homeDir, "blank-writeback-queue.jsonl");
+    await writeFile(queueFile, "\n", "utf8");
+
+    await expect(
+      runWritebackCli(parseWritebackArgs([
+        "writeback",
+        "events",
+        "--soma-home",
+        somaHome,
+        "--queue-file",
+        queueFile,
+        "--substrate",
+        "claude-code",
+      ])),
+    ).rejects.toThrow("Queued writeback event line must not be blank");
   });
 });


### PR DESCRIPTION
## Summary
- install Soma-owned Claude Code hook runner/config and idempotently patch settings.json for SessionStart, SessionEnd, PostToolUse, SubagentStart, and SubagentStop
- add a narrow soma writeback event CLI path so Claude hook metadata goes through applySomaWriteback
- update tests and docs for lifecycle/writeback hooks, uninstall cleanup, and context-vs-shared-memory boundaries

Fixes #236

## Verification
- bun test
- bunx tsc --noEmit
- bun test test/claude-code-install.test.ts
- bun test test/install.test.ts test/cli-adopt.test.ts
- bunx eslint src/adapters/claude-code/hooks.ts src/cli/writeback.ts test/claude-code-install.test.ts test/install.test.ts

Note: repo-wide bun run lint still reports pre-existing lint debt outside this change.