### PR TITLE
feat(cli): add `soma --version` / `-v` flag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,3 +1,4 @@
+import packageJson from "../package.json";
 import { ISA_SUBCOMMAND_HELP, ISA_USAGE_HEADER, runIsaCli } from "./cli-isa";
 import {
   ALGORITHM_COMMAND_HELP,
@@ -102,6 +103,10 @@ interface ParsedHelpArgs {
   topic: string[];
 }
 
+interface ParsedVersionArgs {
+  command: "version";
+}
+
 interface ParsedIsaArgs {
   command: "isa";
   args: string[];
@@ -109,6 +114,7 @@ interface ParsedIsaArgs {
 
 type ParsedArgs =
   | ParsedHelpArgs
+  | ParsedVersionArgs
   | ParsedInstallArgs
   | ParsedUninstallArgs
   | ParsedReprojectArgs
@@ -197,6 +203,10 @@ function commandUsage(command: string, action?: string): string {
 function parseArgs(args: string[]): ParsedArgs {
   if (args.length === 0) {
     return { command: "help", topic: [] };
+  }
+
+  if (args.length === 1 && (args[0] === "--version" || args[0] === "-v")) {
+    return { command: "version" };
   }
 
   if (isHelpRequest(args)) {
@@ -332,6 +342,9 @@ function renderUsage(): string {
   return [
     "Usage:",
     ...usageLines,
+    "",
+    "Global flags:",
+    "  --version, -v   Print the soma version and exit",
   ].join("\n");
 }
 
@@ -399,6 +412,10 @@ export async function runSomaCli(args: string[]): Promise<string> {
 
   if (parsed.command === "help") {
     return renderHelp(parsed.topic);
+  }
+
+  if (parsed.command === "version") {
+    return `soma ${packageJson.version}`;
   }
 
   if (parsed.command === "lifecycle") {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -116,6 +116,21 @@ test("cli shows no-argument usage as normal help", async () => {
   expect(result.stderr).not.toContain("error: script");
 });
 
+test("cli reports version via --version and -v", async () => {
+  const packageJson = (await import("../package.json")).default as { version: string };
+  const expected = `soma ${packageJson.version}`;
+
+  await expect(runSomaCli(["--version"])).resolves.toBe(expected);
+  await expect(runSomaCli(["-v"])).resolves.toBe(expected);
+});
+
+test("cli lists --version under global flags in usage", async () => {
+  const output = await runSomaCli([]);
+
+  expect(output).toContain("Global flags:");
+  expect(output).toContain("--version, -v");
+});
+
 test("cli supports explicit main help as normal help", async () => {
   const output = await runSomaCli(["--help"]);
 


### PR DESCRIPTION
Closes #247.

## What
- `soma --version` / `soma -v` now print `soma <version>` (sourced from `package.json`) and exit 0.
- Added a **Global flags** section to the usage/help output for discoverability.

## Why
The CLI advertised a version (README badge) but had no way to report it — `--version` fell through to the `Unknown command` path. Especially useful since there's no `soma` shim on PATH (runs via `bun src/cli.ts`).

## Verification
```
$ bun src/cli.ts --version
soma 0.7.1
$ bun src/cli.ts -v
soma 0.7.1
```
- `bun test test/cli.test.ts` → 81 pass / 0 fail (2 new tests: flag output + usage listing).
- `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)