### PR TITLE
feat(doctor): add claude-code projection health check

### DIFF
--- a/src/adapters/claude-code/doctor.ts
+++ b/src/adapters/claude-code/doctor.ts
@@ -1,0 +1,62 @@
+import { join } from "node:path";
+import { pathExists, pathMtimeMs } from "../../fs-utils";
+import type { SomaDoctorFinding } from "../../types";
+import {
+  SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH,
+  SOMA_CLAUDE_HOOK_RELATIVE_PATH,
+} from "./hooks";
+
+// The Claude Code projection is rooted at `~/.claude`. `rules/soma/CONTEXT.md`
+// is the primary projected context file (the analogue of codex's
+// `soma.rules`), so its presence/mtime is the projection-health signal. The
+// lifecycle hook and `settings.json` wiring are separate install artifacts the
+// projection cannot work without, so each gets its own finding.
+const CLAUDE_CODE_HOME = ".claude";
+const CLAUDE_CODE_CONTEXT_RELATIVE_PATH = "rules/soma/CONTEXT.md";
+const CLAUDE_CODE_SETTINGS_RELATIVE_PATH = "settings.json";
+
+export async function diagnoseClaudeCodeProjectionDrift(options: {
+  homeDir: string;
+  profileMtime: number | null;
+}): Promise<SomaDoctorFinding[]> {
+  const substrateHome = join(options.homeDir, CLAUDE_CODE_HOME);
+  const findings: SomaDoctorFinding[] = [];
+
+  const contextMtime = await pathMtimeMs(join(substrateHome, CLAUDE_CODE_CONTEXT_RELATIVE_PATH));
+  const stale =
+    contextMtime === null ||
+    (options.profileMtime !== null && contextMtime < options.profileMtime);
+  if (stale) {
+    findings.push({
+      id: "claude-code-projection-stale",
+      severity: "warning",
+      message: contextMtime === null
+        ? "Claude Code projection is missing."
+        : "Claude Code projection is older than the Soma profile files.",
+      action: "soma reproject claude-code",
+    });
+  }
+
+  const hookPresent =
+    (await pathExists(join(substrateHome, SOMA_CLAUDE_HOOK_RELATIVE_PATH))) &&
+    (await pathExists(join(substrateHome, SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH)));
+  if (!hookPresent) {
+    findings.push({
+      id: "claude-code-hook-missing",
+      severity: "warning",
+      message: "Claude Code Soma lifecycle hook is not installed.",
+      action: "soma install claude-code --apply",
+    });
+  }
+
+  if (!(await pathExists(join(substrateHome, CLAUDE_CODE_SETTINGS_RELATIVE_PATH)))) {
+    findings.push({
+      id: "claude-code-settings-missing",
+      severity: "warning",
+      message: "Claude Code settings.json is missing — Soma hooks are not wired in.",
+      action: "soma install claude-code --apply",
+    });
+  }
+
+  return findings;
+}

--- a/src/adapters/claude-code/doctor.ts
+++ b/src/adapters/claude-code/doctor.ts
@@ -1,10 +1,25 @@
-import { join } from "node:path";
-import { pathExists, pathMtimeMs } from "../../fs-utils";
+import { readFile } from "node:fs/promises";
+import { basename, join } from "node:path";
+import { isEnoent, pathExists, pathMtimeMs } from "../../fs-utils";
 import type { SomaDoctorFinding } from "../../types";
 import {
   SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH,
   SOMA_CLAUDE_HOOK_RELATIVE_PATH,
 } from "./hooks";
+
+// The hook file's basename (e.g. `soma-claude-code-hook.mjs`) appears in the
+// command string Soma writes into settings.json, so its presence in the file
+// is a reliable "the hook is actually registered" signal.
+const SOMA_HOOK_MARKER = basename(SOMA_CLAUDE_HOOK_RELATIVE_PATH);
+
+async function readFileOrNull(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (isEnoent(error)) return null;
+    throw error;
+  }
+}
 
 // The Claude Code projection is rooted at `~/.claude`. `rules/soma/CONTEXT.md`
 // is the primary projected context file (the analogue of codex's
@@ -49,11 +64,14 @@ export async function diagnoseClaudeCodeProjectionDrift(options: {
     });
   }
 
-  if (!(await pathExists(join(substrateHome, CLAUDE_CODE_SETTINGS_RELATIVE_PATH)))) {
+  const settingsRaw = await readFileOrNull(join(substrateHome, CLAUDE_CODE_SETTINGS_RELATIVE_PATH));
+  if (settingsRaw === null || !settingsRaw.includes(SOMA_HOOK_MARKER)) {
     findings.push({
       id: "claude-code-settings-missing",
       severity: "warning",
-      message: "Claude Code settings.json is missing — Soma hooks are not wired in.",
+      message: settingsRaw === null
+        ? "Claude Code settings.json is missing — Soma hooks are not wired in."
+        : "Claude Code settings.json does not register the Soma hook.",
       action: "soma install claude-code --apply",
     });
   }

--- a/src/adapters/doctor.ts
+++ b/src/adapters/doctor.ts
@@ -1,3 +1,4 @@
+import { diagnoseClaudeCodeProjectionDrift } from "./claude-code/doctor";
 import { diagnoseCodexProjectionDrift } from "./codex/doctor";
 import type { SomaDoctorFinding, SubstrateId } from "../types";
 
@@ -11,5 +12,8 @@ export async function diagnoseProjectionDrift(options: {
   if (options.substrate === "codex") {
     return diagnoseCodexProjectionDrift(options);
   }
-  throw new Error("soma doctor currently supports projection drift checks for --substrate codex only.");
+  if (options.substrate === "claude-code") {
+    return diagnoseClaudeCodeProjectionDrift(options);
+  }
+  throw new Error("soma doctor currently supports projection drift checks for --substrate codex and claude-code only.");
 }

--- a/src/adapters/doctor.ts
+++ b/src/adapters/doctor.ts
@@ -4,6 +4,15 @@ import type { SomaDoctorFinding, SubstrateId } from "../types";
 
 type DoctorSubstrate = Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor">;
 
+// Single source of truth for the substrates `soma doctor` can diagnose, and
+// the error strings shown when an unsupported one is requested. Shared so the
+// CLI parser, the diagnosis entrypoint, and this dispatcher stay in lockstep.
+export const DOCTOR_SUPPORTED_SUBSTRATES = ["codex", "claude-code"] as const satisfies readonly DoctorSubstrate[];
+export const DOCTOR_UNSUPPORTED_SUBSTRATE_MESSAGE =
+  "soma doctor currently supports --substrate codex and claude-code only.";
+export const DOCTOR_UNSUPPORTED_DRIFT_MESSAGE =
+  "soma doctor currently supports projection drift checks for --substrate codex and claude-code only.";
+
 export async function diagnoseProjectionDrift(options: {
   substrate: DoctorSubstrate;
   homeDir: string;
@@ -15,5 +24,5 @@ export async function diagnoseProjectionDrift(options: {
   if (options.substrate === "claude-code") {
     return diagnoseClaudeCodeProjectionDrift(options);
   }
-  throw new Error("soma doctor currently supports projection drift checks for --substrate codex and claude-code only.");
+  throw new Error(DOCTOR_UNSUPPORTED_DRIFT_MESSAGE);
 }

--- a/src/cli/onboarding.ts
+++ b/src/cli/onboarding.ts
@@ -39,7 +39,7 @@ const ADOPT_CLAUDE_USAGE =
 const INIT_USAGE =
   "Usage: soma init [--dry-run] [--yes] [--home-dir <dir>] [--soma-home <dir>] [--substrate <codex|pi-dev|claude-code|cursor>]";
 const DOCTOR_USAGE =
-  "Usage: soma doctor [--home-dir <dir>] [--soma-home <dir>] [--substrate codex]";
+  "Usage: soma doctor [--home-dir <dir>] [--soma-home <dir>] [--substrate <codex|claude-code>]";
 
 export const ONBOARDING_COMMAND_HELP: Record<ParsedOnboardingArgs["command"], { usage: string; subcommands?: Record<string, string> }> = {
   init: {
@@ -73,8 +73,8 @@ export function parseInitArgs(args: string[]): ParsedInitArgs {
 export function parseDoctorArgs(args: string[]): ParsedDoctorArgs {
   const [, ...rest] = args;
   const options = parseOnboardingOptions(rest);
-  if (options.substrate && options.substrate !== "codex") {
-    throw new Error("soma doctor currently supports --substrate codex only.");
+  if (options.substrate && options.substrate !== "codex" && options.substrate !== "claude-code") {
+    throw new Error("soma doctor currently supports --substrate codex and claude-code only.");
   }
   return { command: "doctor", options };
 }

--- a/src/cli/onboarding.ts
+++ b/src/cli/onboarding.ts
@@ -4,6 +4,7 @@ import {
   uninstallSomaForClaudeCode,
   type UninstallClaudeCodeOptions,
 } from "../index";
+import { DOCTOR_UNSUPPORTED_SUBSTRATE_MESSAGE } from "../adapters/doctor";
 import { applySomaInit, diagnoseSomaDoctor, planSomaInit } from "../onboarding";
 import type { SomaDoctorDiagnosis, SomaInitPlan, SomaInstallOptions, SomaOnboardingOptions } from "../types";
 import {
@@ -74,7 +75,7 @@ export function parseDoctorArgs(args: string[]): ParsedDoctorArgs {
   const [, ...rest] = args;
   const options = parseOnboardingOptions(rest);
   if (options.substrate && options.substrate !== "codex" && options.substrate !== "claude-code") {
-    throw new Error("soma doctor currently supports --substrate codex and claude-code only.");
+    throw new Error(DOCTOR_UNSUPPORTED_SUBSTRATE_MESSAGE);
   }
   return { command: "doctor", options };
 }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import { diagnoseProjectionDrift } from "./adapters/doctor";
+import { DOCTOR_UNSUPPORTED_DRIFT_MESSAGE, diagnoseProjectionDrift } from "./adapters/doctor";
 import { installSomaForClaudeCode, installSomaForCodex, installSomaForCursor, installSomaForPiDev } from "./install";
 import { migrateClaudeSkills } from "./claude-skills-migrator";
 import { migratePai } from "./pai-migration";
@@ -232,7 +232,7 @@ export async function diagnoseSomaDoctor(options: SomaOnboardingOptions = {}): P
   const detected = await detectOnboarding(options);
   const findings: SomaDoctorFinding[] = [];
   if (detected.substrate !== "codex" && detected.substrate !== "claude-code") {
-    throw new Error("soma doctor currently supports projection drift checks for --substrate codex and claude-code only.");
+    throw new Error(DOCTOR_UNSUPPORTED_DRIFT_MESSAGE);
   }
 
   if (detected.soma.starterProfile) {

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -231,8 +231,8 @@ async function maxProfileMtime(somaHome: string): Promise<number | null> {
 export async function diagnoseSomaDoctor(options: SomaOnboardingOptions = {}): Promise<SomaDoctorDiagnosis> {
   const detected = await detectOnboarding(options);
   const findings: SomaDoctorFinding[] = [];
-  if (detected.substrate !== "codex") {
-    throw new Error("soma doctor currently supports projection drift checks for --substrate codex only.");
+  if (detected.substrate !== "codex" && detected.substrate !== "claude-code") {
+    throw new Error("soma doctor currently supports projection drift checks for --substrate codex and claude-code only.");
   }
 
   if (detected.soma.starterProfile) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1477,7 +1477,10 @@ export type SomaDoctorFindingId =
   | "starter-profile"
   | "claude-skills-not-migrated"
   | "pai-not-migrated"
-  | "codex-projection-stale";
+  | "codex-projection-stale"
+  | "claude-code-projection-stale"
+  | "claude-code-hook-missing"
+  | "claude-code-settings-missing";
 
 export interface SomaOnboardingOptions {
   homeDir?: string;

--- a/test/onboarding-doctor.test.ts
+++ b/test/onboarding-doctor.test.ts
@@ -90,7 +90,7 @@ test("soma doctor reports missing migrations and projection drift actions", asyn
     await mkdir(join(homeDir, ".soma/profile"), { recursive: true });
     await mkdir(join(homeDir, ".codex/rules"), { recursive: true });
     await writeFile(join(homeDir, ".codex/rules/soma.rules"), "old projection\n", "utf8");
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await new Promise((resolve) => setTimeout(resolve, 50));
     await writeFile(join(homeDir, ".soma/profile/principal.md"), "# Principal\n\n## Profile\n\n- status: starter-profile\n", "utf8");
 
     const diagnosis = await diagnoseSomaDoctor({ homeDir });
@@ -188,7 +188,17 @@ async function writeClaudeCodeProjection(homeDir: string): Promise<void> {
   await writeFile(join(homeDir, ".claude/rules/soma/CONTEXT.md"), "# Soma Claude Code Context\n", "utf8");
   await writeFile(join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.mjs"), "// hook\n", "utf8");
   await writeFile(join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.config.json"), "{}\n", "utf8");
-  await writeFile(join(homeDir, ".claude/settings.json"), "{}\n", "utf8");
+  await writeFile(
+    join(homeDir, ".claude/settings.json"),
+    `${JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: "command", command: "bun hooks/soma/soma-claude-code-hook.mjs" }] },
+        ],
+      },
+    }, null, 2)}\n`,
+    "utf8",
+  );
 }
 
 test("soma doctor --substrate claude-code reports a fully missing projection as drift", async () => {
@@ -214,7 +224,7 @@ test("soma doctor --substrate claude-code reports a fully missing projection as 
 test("soma doctor --substrate claude-code reports a stale projection", async () => {
   await withTempHome(async (homeDir) => {
     await writeClaudeCodeProjection(homeDir);
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await new Promise((resolve) => setTimeout(resolve, 50));
     await writeSomaProfile(homeDir);
 
     const diagnosis = await diagnoseSomaDoctor({ homeDir, substrate: "claude-code" });
@@ -231,7 +241,7 @@ test("soma doctor --substrate claude-code reports a stale projection", async () 
 test("soma doctor --substrate claude-code is clean when the projection is current", async () => {
   await withTempHome(async (homeDir) => {
     await writeSomaProfile(homeDir);
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await new Promise((resolve) => setTimeout(resolve, 50));
     await writeClaudeCodeProjection(homeDir);
 
     const diagnosis = await diagnoseSomaDoctor({ homeDir, substrate: "claude-code" });
@@ -240,6 +250,30 @@ test("soma doctor --substrate claude-code is clean when the projection is curren
     const claudeFindings = diagnosis.findings.filter((finding) => finding.id.startsWith("claude-code-"));
     expect(claudeFindings).toEqual([]);
     expect(output).not.toContain("soma reproject claude-code");
+  });
+});
+
+test("soma doctor --substrate claude-code flags a settings.json that omits the Soma hook", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeSomaProfile(homeDir);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await writeClaudeCodeProjection(homeDir);
+    // Overwrite the projected settings.json with vanilla Claude Code settings
+    // that do NOT register the Soma hook — presence alone must not pass.
+    await writeFile(join(homeDir, ".claude/settings.json"), `${JSON.stringify({ theme: "dark" }, null, 2)}\n`, "utf8");
+
+    const diagnosis = await diagnoseSomaDoctor({ homeDir, substrate: "claude-code" });
+
+    expect(diagnosis.findings).toContainEqual({
+      id: "claude-code-settings-missing",
+      severity: "warning",
+      message: "Claude Code settings.json does not register the Soma hook.",
+      action: "soma install claude-code --apply",
+    });
+    // The projection itself is current and the hook files exist, so the only
+    // claude-code finding should be the unwired settings.
+    const claudeIds = diagnosis.findings.filter((finding) => finding.id.startsWith("claude-code-")).map((finding) => finding.id);
+    expect(claudeIds).toEqual(["claude-code-settings-missing"]);
   });
 });
 

--- a/test/onboarding-doctor.test.ts
+++ b/test/onboarding-doctor.test.ts
@@ -176,3 +176,77 @@ test("soma doctor reports ok after init applies the detected plan", async () => 
     expect(migration).toContain("Last migrated at:");
   });
 });
+
+async function writeSomaProfile(homeDir: string): Promise<void> {
+  await mkdir(join(homeDir, ".soma/profile"), { recursive: true });
+  await writeFile(join(homeDir, ".soma/profile/principal.md"), "# Principal\n\nName: Principal\n", "utf8");
+}
+
+async function writeClaudeCodeProjection(homeDir: string): Promise<void> {
+  await mkdir(join(homeDir, ".claude/rules/soma"), { recursive: true });
+  await mkdir(join(homeDir, ".claude/hooks/soma"), { recursive: true });
+  await writeFile(join(homeDir, ".claude/rules/soma/CONTEXT.md"), "# Soma Claude Code Context\n", "utf8");
+  await writeFile(join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.mjs"), "// hook\n", "utf8");
+  await writeFile(join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.config.json"), "{}\n", "utf8");
+  await writeFile(join(homeDir, ".claude/settings.json"), "{}\n", "utf8");
+}
+
+test("soma doctor --substrate claude-code reports a fully missing projection as drift", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeSomaProfile(homeDir);
+
+    const diagnosis = await diagnoseSomaDoctor({ homeDir, substrate: "claude-code" });
+
+    expect(diagnosis.status).toBe("drift");
+    const ids = diagnosis.findings.map((finding) => finding.id);
+    expect(ids).toContain("claude-code-projection-stale");
+    expect(ids).toContain("claude-code-hook-missing");
+    expect(ids).toContain("claude-code-settings-missing");
+    expect(diagnosis.findings).toContainEqual({
+      id: "claude-code-projection-stale",
+      severity: "warning",
+      message: "Claude Code projection is missing.",
+      action: "soma reproject claude-code",
+    });
+  });
+});
+
+test("soma doctor --substrate claude-code reports a stale projection", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeClaudeCodeProjection(homeDir);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await writeSomaProfile(homeDir);
+
+    const diagnosis = await diagnoseSomaDoctor({ homeDir, substrate: "claude-code" });
+
+    expect(diagnosis.findings).toContainEqual({
+      id: "claude-code-projection-stale",
+      severity: "warning",
+      message: "Claude Code projection is older than the Soma profile files.",
+      action: "soma reproject claude-code",
+    });
+  });
+});
+
+test("soma doctor --substrate claude-code is clean when the projection is current", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeSomaProfile(homeDir);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await writeClaudeCodeProjection(homeDir);
+
+    const diagnosis = await diagnoseSomaDoctor({ homeDir, substrate: "claude-code" });
+    const output = await runSomaCli(["doctor", "--substrate", "claude-code", "--home-dir", homeDir]);
+
+    const claudeFindings = diagnosis.findings.filter((finding) => finding.id.startsWith("claude-code-"));
+    expect(claudeFindings).toEqual([]);
+    expect(output).not.toContain("soma reproject claude-code");
+  });
+});
+
+test("soma doctor rejects unsupported substrates", async () => {
+  await withTempHome(async (homeDir) => {
+    await expect(runSomaCli(["doctor", "--substrate", "pi-dev", "--home-dir", homeDir])).rejects.toThrow(
+      "soma doctor currently supports --substrate codex and claude-code only.",
+    );
+  });
+});


### PR DESCRIPTION
Closes #249.

## What
`soma doctor --substrate claude-code` now runs an onboarding/drift check instead of erroring with `supports --substrate codex only`.

New `diagnoseClaudeCodeProjectionDrift` (mirrors `src/adapters/codex/doctor.ts`) reports:
- `claude-code-projection-stale` — `~/.claude/rules/soma/CONTEXT.md` missing, or older than the Soma profile files → `soma reproject claude-code`
- `claude-code-hook-missing` — lifecycle hook (`hooks/soma/soma-claude-code-hook.mjs` + `.config.json`) absent → `soma install claude-code --apply`
- `claude-code-settings-missing` — `settings.json` absent → `soma install claude-code --apply`

Relaxed the codex-only guards in `parseDoctorArgs` and `diagnoseSomaDoctor` to accept `claude-code`, and updated `DOCTOR_USAGE`.

## Scope
`pi-dev`/`cursor` remain unsupported for now and still return a clear error (the issue listed them as "ideally" follow-ups). Paths reuse the exported hook-path constants so they stay single-source.

## Verification
```
$ bun src/cli.ts doctor --substrate claude-code
soma doctor — ok
No onboarding drift detected.
```
- `bun test test/onboarding-doctor.test.ts` → 13 pass / 0 fail (4 new: missing / stale / current / unsupported-substrate).
- Full suite: `1143 pass / 0 fail`.
- `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)