### PR TITLE
Fix #255: design governance event policy model

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -218,6 +218,16 @@ Runtime policy inspection surfaces are `prompt`, `tool_call`, `permission_reques
 
 ---
 
+## tool_call
+
+A [[runtime policy inspection]] surface for a proposed or observed tool invocation, including bounded metadata such as tool name, command shape, target paths, and substrate-provided arguments.
+
+Tool-call inspection is for concrete tool activity. Use [[governance event|governance events]] for task requests, skill invocations, and qualified assistant-work delegation unless the substrate exposes only a generic tool surface.
+
+**Why:** Runtime policy needs to distinguish concrete tool execution from assistant-work coordination so governance rules do not become fragile command parsers.
+
+---
+
 ## governance event
 
 A [[runtime policy inspection]] surface for proposed, started, or completed assistant-work control events: task requests, skill invocations, and qualified substrate-assistant delegations.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -218,6 +218,30 @@ Runtime policy inspection surfaces are `prompt`, `tool_call`, `permission_reques
 
 ---
 
+## governance event
+
+A [[runtime policy inspection]] surface for proposed, started, or completed assistant-work control events: task requests, skill invocations, and qualified substrate-assistant delegations.
+
+Governance events describe control-plane activity around work, not the content of the work itself. A governance event may ask whether a task request is too vague, whether a skill invocation appears false-positive, whether a Claude Code sub-agent launch should be nudged to background execution, or whether a Cortex agent dispatch should be observable before it starts.
+
+**Not synonyms:** Do not use bare `agent event`. Do not collapse governance events into [[tool call|tool_call]] unless the substrate exposes only a generic tool surface. Do not use `governance_event` for config auditing; that is `config_change`.
+
+**Why:** PAI's governance hooks mixed task quality, skill invocation, and Claude sub-agent execution behavior. Soma needs a portable policy surface that can classify those behaviors without importing Claude-only nouns.
+
+---
+
+## assistant-work event
+
+A substrate-neutral event about work being requested, delegated, started, stopped, or bounded for the [[assistant]].
+
+Assistant-work events include task requests, Soma skill invocations, substrate skill invocations, and qualified substrate-assistant delegations such as a Claude Code sub-agent run or Cortex agent dispatch. They are the input family for [[governance event]] inspection.
+
+**Not synonyms:** Do not shorten this to `agent event`. Use qualified terms such as `Claude Code sub-agent` or `Cortex agent` when naming substrate-native primitives.
+
+**Why:** Governance needs to talk about work coordination without turning the overloaded word `agent` into a Soma core noun.
+
+---
+
 ## principal prompt inspection
 
 A [[runtime policy inspection]] of a prompt submitted by the [[principal]].

--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -442,3 +442,74 @@ Soma-owned runtime policy inspection model. The canonical model is:
   warning channel.
 
 **Discussion:** `/grill-with-docs` session 2026-05-29 for issue #251.
+
+### DD-9: Governance events model assistant-work control, not bare agents
+
+**Status:** Decided (2026-05-29)
+
+**Context:** Issue #255 covers the runtime policy surface reserved by DD-8 as
+`governance_event`. The source material is PAI's governance-oriented Claude Code
+hooks: `TaskGovernance.hook.ts`, `SkillGuard.hook.ts`, and
+`AgentExecutionGuard.hook.ts`. These hooks mix task quality/rate checks, false
+positive skill invocation checks, and Claude Code sub-agent execution nudges.
+Soma needs a portable model without using bare `agent` as a core term.
+
+Three candidates surfaced:
+- **(a) Treat governance as another tool-call policy.** Reuse `tool_call`
+  inspection and avoid a separate event family.
+- **(b) Define governance events as assistant-work control-plane policy.**
+  Model task requests, skill invocations, and qualified substrate-assistant
+  delegations as metadata-only runtime policy inputs.
+- **(c) Treat governance as observability only.** Record task/skill/delegation
+  metadata but never produce runtime policy decisions.
+
+**Decision:** **(b)** — `governance_event` is the runtime policy surface for
+assistant-work control events. The canonical event family is:
+- `task_request`
+- `soma_skill_invocation`
+- `substrate_skill_invocation`
+- `substrate_assistant_delegation`
+
+The model uses qualified substrate terms such as `Claude Code sub-agent` or
+`Cortex agent` when a substrate primitive is itself named agent. Soma core does
+not introduce bare `agent event` or bare `agent` as governance vocabulary.
+
+Governance events can return `allow`, `deny`, `ask`, or `alert`, but the first
+implementation should prefer `alert` and `ask` for quality and coordination
+nudges. `deny` is reserved for malformed enforceable pre-action payloads,
+explicit deterministic policy violations, or deterministic delegation risks.
+
+Governance uses the DD-8 event/trace split:
+`memory/STATE/events.jsonl` gets normalized `runtime_policy.inspect` events,
+while detailed enforcement-affecting traces land under
+`memory/SECURITY/runtime-policy/`. Pure quality/recovery telemetry may later
+route to `memory/OBSERVABILITY/`, but that is not the source of truth for
+runtime policy decisions.
+
+**Rejected:**
+- (a) would hide task/skill/delegation semantics inside generic tool-call
+  parsing and lose the ability to reason about governance by substrate.
+- (c) would preserve useful telemetry but prevent enforceable governance where
+  substrates can ask or block before work starts.
+
+**Implications:**
+- The later governance implementation should extend `RuntimePolicyInspectOptions`
+  with a `governanceEvent` payload rather than adding a new CLI namespace.
+- `soma policy inspect --surface governance_event` should accept metadata-only
+  task/skill/delegation payloads. It must not store raw prompts, full delegated
+  task bodies, transcripts, skill outputs, or tool outputs by default.
+- PAI `TaskGovernance` maps to `task_request` checks. Vague tasks should start
+  as `alert`; excessive task creation may become `ask` where enforceable.
+- PAI `SkillGuard` maps to `soma_skill_invocation` and
+  `substrate_skill_invocation` checks. False-positive skill invocation should
+  start as `alert` or `ask`, not `deny`.
+- PAI `AgentExecutionGuard` maps mostly to substrate projection behavior. A
+  Claude Code sub-agent background-execution nudge is not automatically a Soma
+  core denial; core policy only sees `substrate_assistant_delegation` when a
+  portable decision is needed.
+- Codex has no governance enforcement surface in the current projection beyond
+  generic prompt/tool-call inspection. Claude Code, Pi.dev, and Cortex/Myelin
+  have plausible pre-action or dispatch surfaces; Cursor is advisory until it
+  exposes a reliable gate.
+
+**Discussion:** issue #255 design pass, 2026-05-29.

--- a/docs/governance-event-runtime-policy.md
+++ b/docs/governance-event-runtime-policy.md
@@ -1,0 +1,120 @@
+# Governance Event Runtime Policy
+
+Governance events are the runtime policy surface for assistant-work control
+events. They model task requests, skill invocations, and qualified
+substrate-assistant delegations without making Claude Code, PAI, or any bare
+`agent` concept canonical in Soma.
+
+This document is a design artifact for #255. It does not implement enforcement.
+
+## Canonical Vocabulary
+
+- `governance_event`: the runtime policy surface.
+- `assistant-work event`: the input family for work coordination events.
+- `task_request`: a proposed unit of work.
+- `soma_skill_invocation`: invocation of a portable Soma skill.
+- `substrate_skill_invocation`: invocation of a substrate-native skill.
+- `substrate_assistant_delegation`: delegation to a qualified substrate
+  assistant surface, such as a Claude Code sub-agent or Cortex agent.
+
+Do not use bare `agent` in Soma core. Use qualified substrate terms when the
+substrate primitive is itself named agent.
+
+## Event Shape For Later Implementation
+
+A later implementation should add a governance-event payload under the existing
+runtime policy inspection model:
+
+```ts
+interface RuntimePolicyGovernanceEvent {
+  kind:
+    | "task_request"
+    | "soma_skill_invocation"
+    | "substrate_skill_invocation"
+    | "substrate_assistant_delegation";
+  substrate: SubstrateId;
+  summary: string;
+  actor?: "principal" | "assistant" | "substrate";
+  target?: string;
+  metadata?: Record<string, unknown>;
+}
+```
+
+The `summary` must be bounded and metadata-only. Raw prompts, transcripts,
+skill outputs, tool outputs, and full delegated task bodies should not be
+stored in normalized events by default.
+
+## Decision Semantics
+
+Governance events can produce all runtime policy decisions, but most v0 checks
+should start advisory:
+
+| Behavior | Default decision | Rationale |
+| --- | --- | --- |
+| Vague or underspecified task request | `alert` | Helpful nudge; not a security block. |
+| Excessive task creation rate | `ask` | Principal approval may be needed before spawning more work. |
+| False-positive skill invocation | `alert` or `ask` | Depends on whether the substrate can ask synchronously. |
+| Background-execution nudge | `alert` | Usually projection UX, not a core deny. |
+| Delegation to untrusted/unknown qualified substrate-assistant surface | `ask` | Approval before delegating work outside the current substrate session. |
+| Governance payload malformed at an enforceable pre-action gate | `deny` | Fail closed only when a substrate can enforce before the work starts. |
+
+`deny` should be rare in the first implementation. Use it for malformed
+pre-action payloads, explicit policy violations, or deterministic delegation
+risks, not for ordinary quality nudges.
+
+## Event And Trace Placement
+
+Use the same runtime policy split:
+
+- `memory/STATE/events.jsonl`: normalized `runtime_policy.inspect` event with
+  surface `governance_event`, decision, finding kinds, and trace pointer.
+- `memory/SECURITY/runtime-policy/`: detailed private security trace when the
+  event is security-relevant or enforcement-affecting.
+- `memory/OBSERVABILITY/`: optional future home for pure quality/recovery
+  telemetry that is not security-relevant.
+
+Do not introduce a separate governance log as a source of truth. If an event is
+policy, it belongs under runtime policy. If it is pure product telemetry, route
+it as observability.
+
+## PAI Governance Hook Classification
+
+| PAI behavior | Soma classification | Later implementation scope |
+| --- | --- | --- |
+| `TaskGovernance.hook.ts` task quality checks | `governance_event` policy, mostly advisory | Model `task_request` events; emit `alert` for vague tasks and `ask` for excessive task creation if enforceable. |
+| `TaskGovernance.hook.ts` rate governance | `governance_event` policy | Add bounded counters in runtime policy config or state; do not hardcode PAI thresholds. |
+| `SkillGuard.hook.ts` false-positive skill guard | `governance_event` policy | Model `soma_skill_invocation` and `substrate_skill_invocation`; start with `alert`, use `ask` where the substrate can ask. |
+| `AgentExecutionGuard.hook.ts` background-execution nudge | substrate projection behavior with optional governance alert | Keep Claude Code sub-agent wording in the Claude projection. Core receives `substrate_assistant_delegation` only if a portable decision is needed. |
+| Claude Code sub-agent start/stop metadata | observability/writeback | Continue metadata-only events; not a policy gate unless paired with an enforceable pre-start check. |
+
+## Substrate Enforcement Map
+
+| Substrate | Enforceable governance events | Advisory governance events |
+| --- | --- | --- |
+| Codex | None until Codex exposes a task/delegation hook beyond generic tool calls. | Prompt/tool-call text may mention delegation, but governance is advisory only. |
+| Claude Code | Skill and sub-agent hook surfaces where settings hooks expose pre-action events. | Background-execution nudges and post-start sub-agent metadata. |
+| Pi.dev | Extension-visible tool/session events where the extension can block or ask. | Session lifecycle quality nudges. |
+| Cursor | Advisory rules/projection only unless a reliable hook/MCP gate is available. | Most governance events. |
+| Cortex/Myelin | Dispatch gates before claiming or publishing work envelopes. | Post-dispatch observability and work-registry updates. |
+
+## Implementation-Ready Scope
+
+The later implementation slice should:
+
+1. Extend `RuntimePolicyInspectOptions` with a `governanceEvent` payload.
+2. Add deterministic governance inspectors for task vagueness, excessive task
+   creation rate, false-positive skill invocation, and unknown delegation
+   target.
+3. Keep first implementation metadata-only: no raw delegated task body, no raw
+   transcripts, no full skill output.
+4. Add `soma policy inspect --surface governance_event` CLI parsing.
+5. Project only to substrates with reliable pre-action or advisory surfaces.
+6. Record `runtime_policy.inspect` events and private runtime-policy traces
+   using the existing event/trace split.
+
+Non-goals for that slice:
+
+- no Claude hook file port as-is
+- no bare `agent` core term
+- no claim of equal enforcement across substrates
+- no model-backed governance judgment before #256

--- a/docs/runtime-policy-inspection.md
+++ b/docs/runtime-policy-inspection.md
@@ -20,8 +20,8 @@ The first implemented surfaces are:
 - `tool_call`: tool-call inspection.
 
 The reserved surfaces are `permission_request`, `config_change`, and
-`governance_event`. They are vocabulary-stable but intentionally no-op until
-their issue slices define enforcement semantics.
+`governance_event`. They are vocabulary-stable; `governance_event` now has a
+design model, but enforcement remains deferred to its implementation slice.
 
 `governance_event` is designed in
 [governance-event-runtime-policy.md](./governance-event-runtime-policy.md). It

--- a/docs/runtime-policy-inspection.md
+++ b/docs/runtime-policy-inspection.md
@@ -23,6 +23,11 @@ The reserved surfaces are `permission_request`, `config_change`, and
 `governance_event`. They are vocabulary-stable but intentionally no-op until
 their issue slices define enforcement semantics.
 
+`governance_event` is designed in
+[governance-event-runtime-policy.md](./governance-event-runtime-policy.md). It
+covers assistant-work control events such as task requests, skill invocations,
+and qualified substrate-assistant delegations.
+
 Runtime inspection uses the same audit split as inbound-content security:
 
 - `memory/STATE/events.jsonl` receives append-only metadata events with kind


### PR DESCRIPTION
Closes #255.

## Summary
- define governance_event and assistant-work event vocabulary in CONTEXT.md
- add DD-9 choosing assistant-work control-plane policy over generic tool-call or observability-only models
- add docs/governance-event-runtime-policy.md with future payload shape, decision semantics, trace placement, PAI hook classification, and substrate enforcement map

## Verification
- rtk bun run typecheck
- rtk bun test test/types.test.ts test/substrate-adapters.test.ts
- rtk bun test
- rtk git diff --check
- rtk bun run lint fails on existing repository-wide baseline: 185 problems, no code files changed in this slice