### PR TITLE
Fix #243: harden direct path guard targets

### DIFF
--- a/src/policy-path-guard.ts
+++ b/src/policy-path-guard.ts
@@ -507,9 +507,10 @@ export function evaluatePathGuard(options: SomaPathGuardOptions): SomaPathGuardR
   const matchedDescriptions: string[] = [];
 
   for (const target of options.targetPaths) {
-    const match = findProtectedPath(target, protectedPaths, options.action, realScopeCache, protectedRootCache);
+    const resolvedTarget = resolvePath(target, options.cwd);
+    const match = findProtectedPath(resolvedTarget, protectedPaths, options.action, realScopeCache, protectedRootCache);
     if (match) {
-      matchedPaths.push(target);
+      matchedPaths.push(resolvedTarget);
       matchedDescriptions.push(match.description ? `${match.path} (${match.description})` : match.path);
     }
   }

--- a/test/policy-path-guard.test.ts
+++ b/test/policy-path-guard.test.ts
@@ -341,6 +341,33 @@ test("blocks rm -rf on Claude/PAI home", () => {
   expect(result.matchedDescriptions[0]).toContain("Claude Code / PAI home");
 });
 
+test("blocks direct tilde delete targets on Claude/PAI home", () => {
+  const claudeMemory = "~/." + "claude/memory";
+  const result = evaluatePathGuard({
+    targetPaths: [claudeMemory],
+    cwd: "/tmp",
+    action: "delete",
+  });
+
+  expect(result.blocked).toBe(true);
+  expect(result.matchedPaths[0]).toContain(".claude/memory");
+  expect(result.matchedDescriptions[0]).toContain("Claude Code / PAI home");
+});
+
+test("blocks direct relative delete targets under protected roots", () => {
+  const root = "/tmp/soma-direct-path-guard";
+  const result = evaluatePathGuard({
+    targetPaths: ["memory"],
+    cwd: root,
+    action: "delete",
+    protectedPaths: [{ path: root, description: "custom" }],
+  });
+
+  expect(result.blocked).toBe(true);
+  expect(result.matchedPaths).toEqual([resolve(root, "memory")]);
+  expect(result.matchedDescriptions[0]).toContain("custom");
+});
+
 test("blocks rm -rf on Pi.dev home", () => {
   const piHome = join(process.env.HOME ?? "/tmp", ".pi");
   const result = evaluatePathGuard({


### PR DESCRIPTION
Closes #243\n\n## Summary\n- Normalize direct evaluatePathGuard targets through cwd and tilde expansion before protected-root matching.\n- Preserve normalized matched paths in guard findings.\n- Add regression coverage for literal tilde and relative direct delete targets.\n\n## Verification\n- bun test test/policy-path-guard.test.ts\n- bun test test/policy-targets.test.ts\n- bun run lint\n- bun run typecheck\n- bun test