### PR TITLE
Fix #260: add sync-from-isa debug signal

### DIFF
--- a/src/algorithm-isa-sync.ts
+++ b/src/algorithm-isa-sync.ts
@@ -103,18 +103,54 @@ interface IsaRunIndex {
   bySlug: Record<string, string>;
 }
 
-async function readIndex(somaHome: string): Promise<IsaRunIndex> {
+function debugSyncFromIsa(message: string, error?: unknown): void {
   try {
-    const raw = await readFile(indexPath(somaHome), "utf8");
+    const detail = formatDebugError(error);
+    const line = `[soma sync-from-isa] ${message}${detail ? `: ${detail}` : ""}`;
+    process.stderr.write(`${line.slice(0, 300)}\n`);
+  } catch {
+    // Debug output must never compromise hook failure isolation.
+  }
+}
+
+function formatDebugError(error: unknown): string {
+  if (error === undefined) return "";
+  if (error instanceof Error) {
+    const errorWithCode: Error & { code?: unknown } = error;
+    const code = typeof errorWithCode.code === "string" ? ` ${errorWithCode.code}` : "";
+    return `${error.name}${code}: ${error.message}`.slice(0, 180);
+  }
+  if (typeof error === "string") return error.slice(0, 180);
+  if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint" || typeof error === "symbol") {
+    return String(error).slice(0, 180);
+  }
+  return "non-error thrown";
+}
+
+function isEnoent(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT";
+}
+
+async function readIndex(somaHome: string): Promise<IsaRunIndex> {
+  let raw: string;
+  try {
+    raw = await readFile(indexPath(somaHome), "utf8");
+  } catch (error) {
+    if (!isEnoent(error)) debugSyncFromIsa("could not read isa-run-index.json; starting fresh", error);
+    return { bySlug: {} };
+  }
+
+  try {
     const parsed: unknown = JSON.parse(raw);
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed) && "bySlug" in parsed) {
-      const bySlug = (parsed).bySlug;
+      const bySlug = parsed.bySlug;
       if (bySlug && typeof bySlug === "object" && !Array.isArray(bySlug)) {
         return { bySlug: bySlug as Record<string, string> };
       }
     }
-  } catch {
-    // Missing or malformed index — start fresh.
+    debugSyncFromIsa("ignored malformed isa-run-index.json; expected bySlug object");
+  } catch (error) {
+    debugSyncFromIsa("ignored malformed isa-run-index.json", error);
   }
   return { bySlug: {} };
 }

--- a/src/algorithm-isa-sync.ts
+++ b/src/algorithm-isa-sync.ts
@@ -108,7 +108,8 @@ function debugSyncFromIsa(message: string, error?: unknown): void {
     const detail = formatDebugError(error);
     const line = `[soma sync-from-isa] ${message}${detail ? `: ${detail}` : ""}`;
     process.stderr.write(`${line.slice(0, 300)}\n`);
-  } catch {
+  } catch (_err) {
+    void _err;
     // Debug output must never compromise hook failure isolation.
   }
 }

--- a/test/algorithm-isa-sync.test.ts
+++ b/test/algorithm-isa-sync.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, mkdir, rm, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import { syncAlgorithmRunFromIsa } from "../src/algorithm-isa-sync";
 import { readAlgorithmRunById } from "../src/algorithm-store";
 import { getCriteria } from "../src/isa-accessors";
@@ -111,6 +111,41 @@ test("resumes the existing run on a second sync of the same slug (no duplicate r
     const second = await syncAlgorithmRunFromIsa({ isaPath, substrate: "claude-code", somaHome });
     expect(second.created).toBe(false);
     expect(second.runId).toBe(first.runId);
+  });
+});
+
+test("corrupt run index starts fresh and emits bounded debug output", async () => {
+  await withSomaHome(async (somaHome, dir) => {
+    const isaPath = await writeIsaFile(
+      dir,
+      "demo-corrupt-index",
+      isaMarkdown({
+        slug: "demo-corrupt-index",
+        phase: "think",
+        goal: "Recover from corrupt index",
+        criteria: [{ id: "ISC-1", text: "c1" }],
+      }),
+    );
+    const stateDir = join(somaHome, "memory", "STATE");
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(join(stateDir, "isa-run-index.json"), "{not json", "utf8");
+
+    let stderr = "";
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation((chunk: string | Uint8Array) => {
+      stderr += typeof chunk === "string" ? chunk : chunk.toString();
+      return true;
+    });
+    try {
+      const result = await syncAlgorithmRunFromIsa({ isaPath, substrate: "claude-code", somaHome });
+      expect(result.created).toBe(true);
+      expect(result.slug).toBe("demo-corrupt-index");
+    } finally {
+      stderrSpy.mockRestore();
+    }
+
+    expect(stderr).toContain("sync-from-isa");
+    expect(stderr).toContain("ignored malformed isa-run-index.json");
+    expect(stderr.length).toBeLessThan(512);
   });
 });
 

--- a/test/claude-code-install.test.ts
+++ b/test/claude-code-install.test.ts
@@ -352,7 +352,7 @@ async function waitForRunFile(homeDir: string, slug: string): Promise<boolean> {
   for (let attempt = 0; attempt < 80; attempt += 1) {
     const exists = await stat(runPath).then(() => true, () => false);
     if (exists) return true;
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await Bun.sleep(50);
   }
   return false;
 }


### PR DESCRIPTION
Closes #260\n\n## Summary\n- Emit bounded sync-from-ISA debug output when isa-run-index.json is unreadable or malformed while preserving the no-throw contract.\n- Add corrupt-index coverage proving sync starts fresh and reports a useful debug line.\n- Replace the Claude Code hook-bridge polling helper's manual timeout promise with Bun.sleep.\n\n## Verification\n- bun test test/algorithm-isa-sync.test.ts\n- bun test test/claude-code-install.test.ts\n- bun run lint\n- bun run typecheck\n- bun test