### PR TITLE
Fix #267: accept memory search positional query

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -26,7 +26,7 @@ export type ParsedMemoryArgs = ParsedMemorySearchArgs | ParsedMemoryPromoteArgs;
 export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<ParsedMemoryArgs["action"], string> } = {
   usage: "Usage: soma memory <search|promote> ...",
   subcommands: {
-    search: "Usage: soma memory search --query <text> [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
+    search: "Usage: soma memory search [query] [--query <text>] [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
     promote: "Usage: soma memory promote --from-run <run-id> --store <learning|knowledge|relationship|work> --title <text> [--lesson <text>] [--applies-when <text>]",
   },
 };
@@ -55,6 +55,7 @@ export function parseMemoryArgs(args: string[]): ParsedMemoryArgs {
 
 function parseMemorySearchArgs(args: string[]): SomaMemorySearchOptions {
   const options: Partial<SomaMemorySearchOptions> = {};
+  let positionalQuery: string | undefined;
 
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
@@ -80,12 +81,20 @@ function parseMemorySearchArgs(args: string[]): SomaMemorySearchOptions {
         index += 1;
         break;
       default:
-        throw new Error(`Unknown option: ${arg}`);
+        if (arg.startsWith("-")) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+        if (positionalQuery !== undefined) {
+          throw new Error(`soma memory search accepts only one positional query; unexpected argument: ${arg}`);
+        }
+        positionalQuery = arg;
     }
   }
 
+  options.query ??= positionalQuery;
+
   if (!options.query) {
-    throw new Error("soma memory search is missing required option: --query.");
+    throw new Error("soma memory search needs a query; pass it as the first argument or --query <text>.");
   }
 
   return options as SomaMemorySearchOptions;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1051,6 +1051,55 @@ test("cli searches Soma memory", async () => {
   });
 });
 
+test("cli memory search accepts a positional query", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);
+    await mkdir(join(homeDir, ".soma/memory/LEARNING/consulting"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".soma/memory/LEARNING/consulting/agency.md"),
+      "Measure consulting success by transferred autonomy, not dependency.\n",
+      "utf8",
+    );
+
+    const output = await runSomaCli([
+      "memory",
+      "search",
+      "--home-dir",
+      homeDir,
+      "transferred autonomy consulting",
+    ]);
+
+    expect(output).toContain("Soma memory search");
+    expect(output).toContain("agency.md:1");
+    expect(output).toContain("transferred autonomy");
+  });
+});
+
+test("cli memory search prefers --query over a positional query", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);
+    await mkdir(join(homeDir, ".soma/memory/LEARNING/consulting"), { recursive: true });
+    await writeFile(
+      join(homeDir, ".soma/memory/LEARNING/consulting/agency.md"),
+      "Measure consulting success by transferred autonomy, not dependency.\n",
+      "utf8",
+    );
+
+    const output = await runSomaCli([
+      "memory",
+      "search",
+      "--home-dir",
+      homeDir,
+      "no-match",
+      "--query",
+      "transferred autonomy consulting",
+    ]);
+
+    expect(output).toContain("query: transferred autonomy consulting");
+    expect(output).toContain("agency.md:1");
+  });
+});
+
 test("cli captures feedback candidates", async () => {
   await withTempHome(async (homeDir) => {
     await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);


### PR DESCRIPTION
Fixes #267.

Summary:
- Accept the first non-flag argument as the memory search query.
- Preserve --query support and let --query override a positional query.
- Improve usage and missing-query errors for the new CLI shape.

Verification:
- bun test test/cli.test.ts
- bun test test/memory.test.ts
- bun run lint
- bun run typecheck
- bun test