### PR TITLE
Fix #263: clarify install dry-run output

### DIFF
--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -472,8 +472,10 @@ function formatExportResult(result: { files: { path: string; content: string }[]
 }
 
 export function formatPlan(plan: SomaInstallPlan): string {
+  const title = plan.apply ? "Soma install plan" : "Soma install PLAN (no changes written) - pass --apply to apply";
+  const footer = plan.apply ? [] : ["", "No changes were written. Re-run with --apply to apply this plan."];
   return [
-    "Soma install plan",
+    title,
     `substrate: ${plan.substrate}`,
     `mode: ${plan.apply ? "apply" : "dry-run"}`,
     `somaHome: ${plan.somaHome}`,
@@ -487,6 +489,7 @@ export function formatPlan(plan: SomaInstallPlan): string {
     "",
     "Substrate files:",
     ...plan.substrateFiles.map((path) => `- ${path}`),
+    ...footer,
   ].join("\n");
 }
 

--- a/test/cli-adopt.test.ts
+++ b/test/cli-adopt.test.ts
@@ -22,7 +22,9 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
 test("soma adopt claude (no flags) → dry-run plan", async () => {
   await withTempHome(async (homeDir) => {
     const output = await runSomaCli(["adopt", "claude", "--home-dir", homeDir]);
-    expect(output).toContain("Soma install plan");
+    expect(output).toContain("PLAN (no changes written)");
+    expect(output).toContain("pass --apply to apply");
+    expect(output).toContain("No changes were written.");
     expect(output).toContain("substrate: claude-code");
     expect(output).toContain("rules/soma/");
     // No writes happened.

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1561,6 +1561,19 @@ test("cli applies codex install only with explicit apply flag", async () => {
   });
 });
 
+test("cli install dry-run output is explicit for all substrates", async () => {
+  await withTempHome(async (homeDir) => {
+    for (const substrate of ["codex", "pi-dev", "claude-code", "cursor"] as const) {
+      const output = await runSomaCli(["install", substrate, "--home-dir", homeDir]);
+
+      expect(output).toContain("PLAN (no changes written)");
+      expect(output).toContain("pass --apply to apply");
+      expect(output).toContain("No changes were written.");
+      expect(output).toContain(`substrate: ${substrate}`);
+    }
+  });
+});
+
 test("cli dry-runs and applies pi.dev install", async () => {
   await withTempHome(async (homeDir) => {
     const dryRun = await runSomaCli(["install", "pi-dev", "--home-dir", homeDir]);


### PR DESCRIPTION
Fixes #263.

Summary:
- Add an explicit no-changes-written banner to install dry-run plans.
- Add a trailing reminder to re-run with --apply.
- Cover all install substrates and the adopt claude alias.

Verification:
- bun test test/cli.test.ts -t "cli install dry-run output is explicit for all substrates"
- bun test test/cli-adopt.test.ts
- bun test test/cli.test.ts test/install.test.ts
- bun run lint
- bun run typecheck
- bun test