### PR TITLE
Fix #265: honor ISA frontmatter progress

### DIFF
--- a/src/algorithm-isa-sync.ts
+++ b/src/algorithm-isa-sync.ts
@@ -254,12 +254,40 @@ function advanceRunToPhase(run: AlgorithmRun, target: AlgorithmPhase, timestamp:
   return next;
 }
 
-/** Mark run criteria passed for every ISA criterion that is `passed`/`dropped`. Idempotent. */
-function reconcileCriteria(run: AlgorithmRun, isaCriteria: readonly IdealStateCriterion[], timestamp: string): AlgorithmRun {
+function isClosedCriterion(
+  criterion: IdealStateCriterion,
+): criterion is IdealStateCriterion & { status: "passed" | "dropped" } {
+  return criterion.status === "passed" || criterion.status === "dropped";
+}
+
+function progressCompletedCount(progress: string, total: number): number | null {
+  const match = /^(\d+)\/(\d+)$/.exec(progress.trim());
+  if (!match) return null;
+  const completed = Number.parseInt(match[1], 10);
+  const denominator = Number.parseInt(match[2], 10);
+  if (!Number.isSafeInteger(completed) || !Number.isSafeInteger(denominator)) return null;
+  if (denominator !== total || completed < 0 || completed > total) return null;
+  return completed;
+}
+
+function frontmatterCompletionCount(isa: IdealStateArtifact, isaCriteria: readonly IdealStateCriterion[]): number {
+  const checked = isaCriteria.filter(isClosedCriterion).length;
+  const progress = progressCompletedCount(isa.frontmatter.progress, isaCriteria.length) ?? 0;
+  const phaseCompleted = phaseIndex(isa.frontmatter.phase) >= phaseIndex("learn") ? isaCriteria.length : 0;
+  return Math.max(checked, progress, phaseCompleted);
+}
+
+/** Mark run criteria passed for every completed ISA signal. Idempotent. */
+function reconcileCriteria(
+  run: AlgorithmRun,
+  isa: IdealStateArtifact,
+  isaCriteria: readonly IdealStateCriterion[],
+  timestamp: string,
+): AlgorithmRun {
   let next = run;
   const runCriteriaById = new Map(getCriteria(next.isa).map((c) => [c.id, c]));
   for (const isaCriterion of isaCriteria) {
-    if (isaCriterion.status !== "passed" && isaCriterion.status !== "dropped") continue;
+    if (!isClosedCriterion(isaCriterion)) continue;
     const existing = runCriteriaById.get(isaCriterion.id);
     if (existing === undefined) continue;
     if (existing.status === isaCriterion.status) continue; // already reconciled — idempotent
@@ -267,6 +295,21 @@ function reconcileCriteria(run: AlgorithmRun, isaCriteria: readonly IdealStateCr
     const evidence = verification && verification.length > 0 ? verification : `synced from ISA: ${isaCriterion.text}`;
     next = verifyAlgorithmCriterion(next, isaCriterion.id, isaCriterion.status, evidence, timestamp);
   }
+
+  const targetCompleted = frontmatterCompletionCount(isa, isaCriteria);
+  let runCriteria = getCriteria(next.isa);
+  let completed = runCriteria.filter(isClosedCriterion).length;
+  for (const isaCriterion of isaCriteria) {
+    if (completed >= targetCompleted) break;
+    const existing = runCriteria.find((criterion) => criterion.id === isaCriterion.id);
+    if (existing === undefined || isClosedCriterion(existing)) continue;
+    const goal = getGoal(isa);
+    const evidence = goal ? `synced from ISA progress: ${goal}` : `synced from ISA progress: ${isaCriterion.text}`;
+    next = verifyAlgorithmCriterion(next, isaCriterion.id, "passed", evidence, timestamp);
+    runCriteria = getCriteria(next.isa);
+    completed = runCriteria.filter(isClosedCriterion).length;
+  }
+
   return next;
 }
 
@@ -365,16 +408,17 @@ async function syncAlgorithmRunFromIsaInner(
   // 1. Reconcile checked criteria FIRST. The LEARN gate refuses entry until
   //    every criterion is passed/dropped, so criteria state must be current
   //    before we attempt to advance the phase.
-  run = reconcileCriteria(run, isaCriteria, timestamp);
+  run = reconcileCriteria(run, isa, isaCriteria, timestamp);
+  const reconciledCriteria = getCriteria(run.isa);
 
   // 2. Advance forward to (a reachable cap of) the ISA's declared phase. Never backward.
-  const targetPhase = reachableTargetPhase(isa.frontmatter.phase, isaCriteria);
+  const targetPhase = reachableTargetPhase(isa.frontmatter.phase, reconciledCriteria);
   if (phaseIndex(getRunPhase(run)) < phaseIndex(targetPhase)) {
     run = advanceRunToPhase(run, targetPhase, timestamp);
   }
 
   // 3. If at learn (or all criteria closed), record a learn entry. Idempotent.
-  const allClosed = isaCriteria.every((c) => c.status === "passed" || c.status === "dropped");
+  const allClosed = getCriteria(run.isa).every(isClosedCriterion);
   const atLearn = getRunPhase(run) === "learn" || getRunPhase(run) === "complete";
   if ((atLearn || allClosed) && run.learning.length === 0) {
     run = recordAlgorithmLearning(run, deriveLearningText(isa), timestamp);

--- a/src/algorithm-isa-sync.ts
+++ b/src/algorithm-isa-sync.ts
@@ -299,6 +299,8 @@ function reconcileCriteria(
   const targetCompleted = frontmatterCompletionCount(isa, isaCriteria);
   let runCriteria = getCriteria(next.isa);
   let completed = runCriteria.filter(isClosedCriterion).length;
+  // Frontmatter progress is count-only; when it is partial, document order is
+  // the only deterministic way to choose which unchecked criteria to catch up.
   for (const isaCriterion of isaCriteria) {
     if (completed >= targetCompleted) break;
     const existing = runCriteria.find((criterion) => criterion.id === isaCriterion.id);

--- a/test/algorithm-isa-sync.test.ts
+++ b/test/algorithm-isa-sync.test.ts
@@ -28,6 +28,7 @@ async function writeIsaFile(dir: string, slug: string, markdown: string): Promis
 function isaMarkdown(input: {
   slug: string;
   phase: string;
+  progress?: string;
   effort?: string;
   goal: string;
   criteria: { id: string; text: string; done?: boolean }[];
@@ -44,7 +45,7 @@ task: ${input.goal}
 slug: ${input.slug}
 effort: ${input.effort ?? "E2"}
 phase: ${input.phase}
-progress: 0/${input.criteria.length}
+progress: ${input.progress ?? `0/${input.criteria.length}`}
 mode: ALGORITHM
 started: 2026-05-29
 updated: 2026-05-29
@@ -196,6 +197,63 @@ test("reconciles checked ISA criteria [x] into passed run criteria", async () =>
     const criteria = getCriteria(run.isa);
     expect(criteria.find((c) => c.id === "ISC-1")?.status).toBe("passed");
     expect(criteria.find((c) => c.id === "ISC-2")?.status).toBe("open");
+  });
+});
+
+test("reconciles frontmatter progress when ISA checkboxes remain unticked", async () => {
+  await withSomaHome(async (somaHome, dir) => {
+    const isaPath = await writeIsaFile(
+      dir,
+      "demo-frontmatter-progress",
+      isaMarkdown({
+        slug: "demo-frontmatter-progress",
+        phase: "learn",
+        progress: "3/3",
+        goal: "Honor frontmatter completion",
+        criteria: [
+          { id: "ISC-1", text: "first", done: false },
+          { id: "ISC-2", text: "second", done: false },
+          { id: "ISC-3", text: "third", done: false },
+        ],
+      }),
+    );
+
+    const result = await syncAlgorithmRunFromIsa({ isaPath, substrate: "claude-code", somaHome });
+    expect(result.criteriaPassed).toBe(3);
+    expect(result.criteriaTotal).toBe(3);
+    expect(result.phase).toBe("learn");
+
+    const { run } = await readAlgorithmRunById(result.runId!, { somaHome });
+    expect(getCriteria(run.isa).map((c) => c.status)).toEqual(["passed", "passed", "passed"]);
+    expect(run.verification.map((entry) => entry.text)).toContain(
+      "ISC-1: passed. synced from ISA progress: Honor frontmatter completion",
+    );
+  });
+});
+
+test("frontmatter progress never reopens checked ISA criteria", async () => {
+  await withSomaHome(async (somaHome, dir) => {
+    const isaPath = await writeIsaFile(
+      dir,
+      "demo-frontmatter-lower",
+      isaMarkdown({
+        slug: "demo-frontmatter-lower",
+        phase: "verify",
+        progress: "1/3",
+        goal: "Prefer stronger checkbox signal",
+        criteria: [
+          { id: "ISC-1", text: "first", done: true },
+          { id: "ISC-2", text: "second", done: true },
+          { id: "ISC-3", text: "third", done: false },
+        ],
+      }),
+    );
+
+    const result = await syncAlgorithmRunFromIsa({ isaPath, substrate: "claude-code", somaHome });
+    expect(result.criteriaPassed).toBe(2);
+
+    const { run } = await readAlgorithmRunById(result.runId!, { somaHome });
+    expect(getCriteria(run.isa).map((c) => c.status)).toEqual(["passed", "passed", "open"]);
   });
 });
 


### PR DESCRIPTION
Fixes #265.

Summary:
- Reconcile sync-from-ISA criteria from the strongest completion signal across checked boxes, frontmatter progress, and learn/complete phase.
- Mark additional open criteria passed up to progress:N/N while preserving already-checked criteria.
- Use reconciled criteria before phase advancement so completed frontmatter can reach learn.

Verification:
- bun test test/algorithm-isa-sync.test.ts -t "frontmatter"
- bun test test/algorithm-isa-sync.test.ts
- bun run lint
- bun run typecheck
- bun test