### PR TITLE
Fix #272: date-prefix generated slugs

### DIFF
--- a/src/cli-isa.ts
+++ b/src/cli-isa.ts
@@ -13,6 +13,7 @@ import {
   type IsaListEntry,
 } from "./isa";
 import { installIsaSkill } from "./isa-skill-installer";
+import { datePrefixSlug } from "./dated-slug";
 
 /**
  * `soma isa <action>` CLI surface (#36). Thin shell over the library
@@ -233,7 +234,7 @@ async function runUse(args: string[]): Promise<IsaCliResult> {
 
 async function runScaffold(args: string[]): Promise<IsaCliResult> {
   const parsed = parseFlags(args);
-  const slug = typeof parsed.flags.slug === "string" ? parsed.flags.slug : null;
+  const slug = typeof parsed.flags.slug === "string" ? datePrefixSlug(parsed.flags.slug) : null;
   const effort = typeof parsed.flags.effort === "string" ? parsed.flags.effort.toUpperCase() as EffortTier : null;
   const goal = typeof parsed.flags.goal === "string" ? parsed.flags.goal : null;
   if (slug === null) return { exitCode: 1, text: "soma isa scaffold requires --slug.\n" };

--- a/src/cli/algorithm.ts
+++ b/src/cli/algorithm.ts
@@ -437,7 +437,7 @@ export function parseAlgorithmArgs(args: string[]): ParsedAlgorithmArgs {
     validateAlgorithmRunInput(run);
     const idBase = run.intent ?? run.goal ?? run.prompt;
     if (idBase === undefined) {
-      throw new Error("soma algorithm new is missing required option(s): --intent.");
+      throw new Error("soma algorithm new requires at least one of --intent, --goal, or --prompt.");
     }
     run.id = options.id ?? datePrefixSlug(idBase);
     run.substrate = options.substrate;

--- a/src/cli/algorithm.ts
+++ b/src/cli/algorithm.ts
@@ -20,6 +20,7 @@ import {
 } from "../index";
 import { registerSomaHomeAlgorithmCapabilities } from "../algorithm-capabilities";
 import { syncAlgorithmRunFromIsa, formatSyncResult } from "../algorithm-isa-sync";
+import { datePrefixSlug } from "../dated-slug";
 import { getCriteria, getGoal } from "../isa-accessors";
 import { getRunPhase } from "../algorithm-lifecycle";
 import { readOption } from "./parse-utils";
@@ -434,7 +435,11 @@ export function parseAlgorithmArgs(args: string[]): ParsedAlgorithmArgs {
 
   if (action === "new") {
     validateAlgorithmRunInput(run);
-    run.id = options.id;
+    const idBase = run.intent ?? run.goal ?? run.prompt;
+    if (idBase === undefined) {
+      throw new Error("soma algorithm new is missing required option(s): --intent.");
+    }
+    run.id = options.id ?? datePrefixSlug(idBase);
     run.substrate = options.substrate;
     options.run = run as AlgorithmRunInput;
   }

--- a/src/dated-slug.ts
+++ b/src/dated-slug.ts
@@ -1,5 +1,6 @@
 const DATE_PREFIX_PATTERN = /^\d{4}-\d{2}-\d{2}-/;
 
+// Separate from PAI pack kebab slugs: user-facing run slugs preserve dots and underscores.
 export function slugifyBase(value: string): string {
   const slug = value
     .trim()

--- a/src/dated-slug.ts
+++ b/src/dated-slug.ts
@@ -1,0 +1,20 @@
+const DATE_PREFIX_PATTERN = /^\d{4}-\d{2}-\d{2}-/;
+
+export function slugifyBase(value: string): string {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[._-]+|[._-]+$/g, "");
+  if (slug.length === 0) {
+    throw new Error("Slug base must contain at least one alphanumeric character.");
+  }
+  return slug;
+}
+
+export function datePrefixSlug(base: string, timestamp = new Date().toISOString()): string {
+  const slug = slugifyBase(base);
+  if (DATE_PREFIX_PATTERN.test(slug)) return slug;
+  return `${timestamp.slice(0, 10)}-${slug}`;
+}

--- a/test/cli-isa.test.ts
+++ b/test/cli-isa.test.ts
@@ -99,6 +99,7 @@ test("soma isa use --dry-run does not mutate active.json", async () => {
 
 test("AC-7: soma isa scaffold requires slug/effort/goal", async () => {
   await withSomaHome(async (homeDir) => {
+    const today = new Date().toISOString().slice(0, 10);
     expect((await runIsaCli(["scaffold", "--home-dir", homeDir])).exitCode).toBe(1);
     expect(
       (await runIsaCli(["scaffold", "--slug", "x", "--home-dir", homeDir])).exitCode,
@@ -108,7 +109,44 @@ test("AC-7: soma isa scaffold requires slug/effort/goal", async () => {
     ).toBe(1);
     const ok = await runIsaCli(["scaffold", "--slug", "x", "--effort", "E1", "--goal", "G", "--home-dir", homeDir]);
     expect(ok.exitCode).toBe(0);
-    expect(ok.text).toContain("Scaffolded x (E1)");
+    expect(ok.text).toContain(`Scaffolded ${today}-x (E1)`);
+  });
+});
+
+test("soma isa scaffold uses date-prefixed slugs and does not double-prefix", async () => {
+  await withSomaHome(async (homeDir) => {
+    const today = new Date().toISOString().slice(0, 10);
+    const derived = await runIsaCli([
+      "scaffold",
+      "--slug",
+      "roesti-soc-tabletop",
+      "--effort",
+      "E1",
+      "--goal",
+      "Run the tabletop",
+      "--home-dir",
+      homeDir,
+    ]);
+    expect(derived.exitCode).toBe(0);
+    expect(derived.text).toContain(`Scaffolded ${today}-roesti-soc-tabletop`);
+    await expect(readFile(join(homeDir, ".soma", "isa", `${today}-roesti-soc-tabletop.md`), "utf8")).resolves.toContain(
+      "Run the tabletop",
+    );
+
+    const alreadyDated = await runIsaCli([
+      "scaffold",
+      "--slug",
+      "2026-05-30-roesti-soc-tabletop",
+      "--effort",
+      "E1",
+      "--goal",
+      "Run the tabletop again",
+      "--home-dir",
+      homeDir,
+    ]);
+    expect(alreadyDated.exitCode).toBe(0);
+    expect(alreadyDated.text).toContain("Scaffolded 2026-05-30-roesti-soc-tabletop");
+    expect(alreadyDated.text).not.toContain(`${today}-2026-05-30-roesti-soc-tabletop`);
   });
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -460,6 +460,34 @@ test("cli emits Algorithm classification as JSON", async () => {
   expect(classification.effort).toBe("E3");
 });
 
+test("cli algorithm new derives a date-prefixed slug when --id is omitted", async () => {
+  await withTempHome(async (homeDir) => {
+    const today = new Date().toISOString().slice(0, 10);
+    const expectedId = `${today}-drive-work-through-gates`;
+    const output = await runSomaCli([
+      "algorithm",
+      "new",
+      "--home-dir",
+      homeDir,
+      "--prompt",
+      "Use the harness",
+      "--intent",
+      "Drive work through gates.",
+      "--current-state",
+      "Only create exists.",
+      "--goal",
+      "Run reaches learn phase.",
+      "--criterion",
+      "C1:Mutation commands work.",
+    ]);
+
+    expect(output).toContain(`id: ${expectedId}`);
+    await expect(readFile(join(homeDir, `.soma/memory/WORK/algorithm-runs/${expectedId}.json`), "utf8")).resolves.toContain(
+      `"id": "${expectedId}"`,
+    );
+  });
+});
+
 test("cli drives Algorithm runs through gated mutations", async () => {
   await withTempHome(async (homeDir) => {
     await runSomaCli([


### PR DESCRIPTION
## Summary
- derive date-prefixed run ids for `soma algorithm new` when `--id` is omitted
- date-prefix `soma isa scaffold --slug` values without double-prefixing existing yyyy-mm-dd slugs
- keep explicit Algorithm `--id` behavior unchanged

Fixes #272.

## Verification
- `rtk bun test test/cli.test.ts -t "cli algorithm new derives"`
- `rtk bun test test/cli-isa.test.ts -t "scaffold"`
- `rtk bun test test/pai-docs-importer.test.ts -t "AC-2/AC-5"`
- `rtk bun run typecheck`
- `rtk bun run lint`
- `rtk bun test`
