### PR TITLE
Fix #266: persist substrate provenance

### DIFF
--- a/src/algorithm-capabilities.ts
+++ b/src/algorithm-capabilities.ts
@@ -14,6 +14,7 @@ import type {
   SubstrateId,
 } from "./types";
 import { getRunPhase } from "./algorithm-lifecycle";
+import { appendAlgorithmProvenance } from "./algorithm-provenance";
 
 const CORE_PHASES: AlgorithmPhase[] = ["observe", "think", "plan", "build", "execute", "verify", "learn"];
 const CAPABILITY_INVOKE_KINDS = ["skill", "inline", "agent", "command", "adapter"] as const;
@@ -657,7 +658,7 @@ export function recordAlgorithmCapabilityInvocation(
     evidence,
   };
 
-  return {
+  const next = {
     ...run,
     updatedAt: timestamp,
     capabilities: dedupeCapabilities(run.capabilities, name),
@@ -665,12 +666,19 @@ export function recordAlgorithmCapabilityInvocation(
       index === selectionIndex
         ? {
             ...selection,
-            status: "invoked",
+            status: "invoked" as const,
             invocation,
           }
         : selection,
     ),
   };
+  return appendAlgorithmProvenance(next, {
+    timestamp,
+    phase: getRunPhase(run),
+    operation: "capability.invoke",
+    substrate: invocation.substrate,
+    detail: name,
+  });
 }
 
 export function removeAlgorithmCapabilitySelection(

--- a/src/algorithm-isa-sync.ts
+++ b/src/algorithm-isa-sync.ts
@@ -200,7 +200,7 @@ function reachableTargetPhase(target: AlgorithmPhase, criteria: readonly IdealSt
  * Algorithm requires, then advance one phase. Synthetic artifacts are tagged so
  * they are recognizable as sync-generated.
  */
-function prepareAndAdvance(run: AlgorithmRun, target: AlgorithmPhase, timestamp: string): AlgorithmRun {
+function prepareAndAdvance(run: AlgorithmRun, target: AlgorithmPhase, timestamp: string, substrate: SubstrateId): AlgorithmRun {
   let next = run;
   switch (target) {
     case "plan":
@@ -239,16 +239,16 @@ function prepareAndAdvance(run: AlgorithmRun, target: AlgorithmPhase, timestamp:
     default:
       break;
   }
-  return advanceAlgorithmRun(next, timestamp);
+  return advanceAlgorithmRun(next, timestamp, { substrate });
 }
 
-function advanceRunToPhase(run: AlgorithmRun, target: AlgorithmPhase, timestamp: string): AlgorithmRun {
+function advanceRunToPhase(run: AlgorithmRun, target: AlgorithmPhase, timestamp: string, substrate: SubstrateId): AlgorithmRun {
   let next = run;
   let guard = 0;
   while (phaseIndex(getRunPhase(next)) < phaseIndex(target) && guard < PHASE_ORDER.length) {
     const upcoming = nextAlgorithmPhase(getRunPhase(next));
     if (upcoming === undefined) return next;
-    next = prepareAndAdvance(next, upcoming, timestamp);
+    next = prepareAndAdvance(next, upcoming, timestamp, substrate);
     guard += 1;
   }
   return next;
@@ -283,6 +283,7 @@ function reconcileCriteria(
   isa: IdealStateArtifact,
   isaCriteria: readonly IdealStateCriterion[],
   timestamp: string,
+  substrate: SubstrateId,
 ): AlgorithmRun {
   let next = run;
   const runCriteriaById = new Map(getCriteria(next.isa).map((c) => [c.id, c]));
@@ -293,7 +294,7 @@ function reconcileCriteria(
     if (existing.status === isaCriterion.status) continue; // already reconciled — idempotent
     const verification = isaCriterion.verification?.trim();
     const evidence = verification && verification.length > 0 ? verification : `synced from ISA: ${isaCriterion.text}`;
-    next = verifyAlgorithmCriterion(next, isaCriterion.id, isaCriterion.status, evidence, timestamp);
+    next = verifyAlgorithmCriterion(next, isaCriterion.id, isaCriterion.status, evidence, timestamp, { substrate });
   }
 
   const targetCompleted = frontmatterCompletionCount(isa, isaCriteria);
@@ -307,7 +308,7 @@ function reconcileCriteria(
     if (existing === undefined || isClosedCriterion(existing)) continue;
     const goal = getGoal(isa);
     const evidence = goal ? `synced from ISA progress: ${goal}` : `synced from ISA progress: ${isaCriterion.text}`;
-    next = verifyAlgorithmCriterion(next, isaCriterion.id, "passed", evidence, timestamp);
+    next = verifyAlgorithmCriterion(next, isaCriterion.id, "passed", evidence, timestamp, { substrate });
     runCriteria = getCriteria(next.isa);
     completed = runCriteria.filter(isClosedCriterion).length;
   }
@@ -410,20 +411,20 @@ async function syncAlgorithmRunFromIsaInner(
   // 1. Reconcile checked criteria FIRST. The LEARN gate refuses entry until
   //    every criterion is passed/dropped, so criteria state must be current
   //    before we attempt to advance the phase.
-  run = reconcileCriteria(run, isa, isaCriteria, timestamp);
+  run = reconcileCriteria(run, isa, isaCriteria, timestamp, options.substrate);
   const reconciledCriteria = getCriteria(run.isa);
 
   // 2. Advance forward to (a reachable cap of) the ISA's declared phase. Never backward.
   const targetPhase = reachableTargetPhase(isa.frontmatter.phase, reconciledCriteria);
   if (phaseIndex(getRunPhase(run)) < phaseIndex(targetPhase)) {
-    run = advanceRunToPhase(run, targetPhase, timestamp);
+    run = advanceRunToPhase(run, targetPhase, timestamp, options.substrate);
   }
 
   // 3. If at learn (or all criteria closed), record a learn entry. Idempotent.
   const allClosed = getCriteria(run.isa).every(isClosedCriterion);
   const atLearn = getRunPhase(run) === "learn" || getRunPhase(run) === "complete";
   if ((atLearn || allClosed) && run.learning.length === 0) {
-    run = recordAlgorithmLearning(run, deriveLearningText(isa), timestamp);
+    run = recordAlgorithmLearning(run, deriveLearningText(isa), timestamp, { substrate: options.substrate });
   }
 
   const after = snapshot(run);

--- a/src/algorithm-provenance.ts
+++ b/src/algorithm-provenance.ts
@@ -1,0 +1,42 @@
+import { getRunPhase } from "./algorithm-lifecycle";
+import type {
+  AlgorithmPhase,
+  AlgorithmProvenanceOperation,
+  AlgorithmRun,
+  SubstrateId,
+} from "./types";
+
+export interface AlgorithmProvenanceInput {
+  operation: AlgorithmProvenanceOperation;
+  timestamp: string;
+  substrate?: SubstrateId;
+  phase?: AlgorithmPhase;
+  detail?: string;
+}
+
+export function appendAlgorithmProvenance(run: AlgorithmRun, input: AlgorithmProvenanceInput): AlgorithmRun {
+  const substrate = input.substrate ?? run.substrate ?? "custom";
+  const detail = input.detail?.trim();
+  return {
+    ...run,
+    provenance: [
+      ...run.provenance,
+      {
+        timestamp: input.timestamp,
+        phase: input.phase ?? getRunPhase(run),
+        operation: input.operation,
+        substrate,
+        ...(detail ? { detail } : {}),
+      },
+    ],
+  };
+}
+
+export function algorithmTouchedBy(run: Pick<AlgorithmRun, "substrate" | "provenance">): SubstrateId[] {
+  const touched = new Set<SubstrateId>();
+  if (run.substrate) touched.add(run.substrate);
+  for (const entry of run.provenance) {
+    touched.add(entry.substrate);
+  }
+  return Array.from(touched);
+}

--- a/src/algorithm-store.ts
+++ b/src/algorithm-store.ts
@@ -119,7 +119,7 @@ export function loadAlgorithmRun(raw: unknown): AlgorithmRun {
   return ensureAlgorithmRunDefaults(migrateRunV1toV2(candidate as LegacyAlgorithmRun));
 }
 
-type AlgorithmRunWithDefaults = Omit<AlgorithmRun, "loop"> & Partial<Pick<AlgorithmRun, "loop">>;
+type AlgorithmRunWithDefaults = Omit<AlgorithmRun, "loop" | "provenance"> & Partial<Pick<AlgorithmRun, "loop" | "provenance">>;
 
 function ensureAlgorithmRunDefaults(run: AlgorithmRunWithDefaults): AlgorithmRun {
   return {
@@ -127,6 +127,7 @@ function ensureAlgorithmRunDefaults(run: AlgorithmRunWithDefaults): AlgorithmRun
     loop: run.loop ?? { ...DEFAULT_ALGORITHM_LOOP_STATE, iterations: [] },
     capabilityDefinitions: run.capabilityDefinitions ?? [],
     capabilitySelections: run.capabilitySelections ?? [],
+    provenance: run.provenance ?? [],
   };
 }
 
@@ -179,6 +180,7 @@ function migrateRunV1toV2(legacy: LegacyAlgorithmRun): AlgorithmRun {
     changelog: legacy.changelog ?? [],
     verification: legacy.verification ?? [],
     learning: legacy.learning ?? [],
+    provenance: legacy.provenance ?? [],
   };
 }
 

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -24,6 +24,8 @@ import {
 } from "./isa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
 import { DEFAULT_ALGORITHM_LOOP_STATE } from "./algorithm-execution-modes";
+import { appendAlgorithmProvenance } from "./algorithm-provenance";
+import type { AlgorithmProvenanceInput } from "./algorithm-provenance";
 
 const PHASES: AlgorithmPhase[] = ["observe", "think", "plan", "build", "execute", "verify", "learn", "complete"];
 
@@ -97,7 +99,7 @@ export function createAlgorithmRun(input: AlgorithmRunInput): AlgorithmRun {
   const classificationReason = input.classificationReason ?? classification.reason;
   const slug = input.id ?? "algorithm-run";
 
-  return {
+  const run: AlgorithmRun = {
     schemaVersion: 2,
     id: input.id ?? createRunId(timestamp),
     createdAt: timestamp,
@@ -129,7 +131,16 @@ export function createAlgorithmRun(input: AlgorithmRunInput): AlgorithmRun {
     changelog: [],
     verification: [],
     learning: [],
+    provenance: [],
   };
+  return input.substrate
+    ? appendAlgorithmProvenance(run, {
+        timestamp,
+        operation: "run.created",
+        substrate: input.substrate,
+        phase: "observe",
+      })
+    : run;
 }
 
 export function nextAlgorithmPhase(phase: AlgorithmPhase): AlgorithmPhase | undefined {
@@ -205,14 +216,25 @@ export function recordAlgorithmDecision(run: AlgorithmRun, text: string, timesta
   };
 }
 
-export function recordAlgorithmLearning(run: AlgorithmRun, text: string, timestamp?: string): AlgorithmRun {
+export function recordAlgorithmLearning(
+  run: AlgorithmRun,
+  text: string,
+  timestamp?: string,
+  provenance?: Pick<AlgorithmProvenanceInput, "substrate">,
+): AlgorithmRun {
   const entry = logEntry(getRunPhase(run), text, timestamp);
 
-  return {
+  const next = {
     ...run,
     updatedAt: entry.timestamp,
     learning: [...run.learning, entry],
   };
+  return appendAlgorithmProvenance(next, {
+    timestamp: entry.timestamp,
+    phase: entry.phase,
+    operation: "learning.record",
+    substrate: provenance?.substrate,
+  });
 }
 
 export function verifyAlgorithmCriterion(
@@ -221,6 +243,7 @@ export function verifyAlgorithmCriterion(
   status: "passed" | "failed" | "dropped",
   evidence: string,
   timestamp?: string,
+  provenance?: Pick<AlgorithmProvenanceInput, "substrate">,
 ): AlgorithmRun {
   assertNonEmpty(evidence, "verification evidence");
 
@@ -241,12 +264,19 @@ export function verifyAlgorithmCriterion(
     },
   };
 
-  return {
+  const next = {
     ...run,
     updatedAt: entry.timestamp,
     isa: isaWithRecompute,
     verification: [...run.verification, entry],
   };
+  return appendAlgorithmProvenance(next, {
+    timestamp: entry.timestamp,
+    phase: entry.phase,
+    operation: "criterion.verify",
+    substrate: provenance?.substrate,
+    detail: criterionId,
+  });
 }
 
 function assertGate(run: AlgorithmRun, target: AlgorithmPhase): void {
@@ -299,7 +329,11 @@ function assertGate(run: AlgorithmRun, target: AlgorithmPhase): void {
   }
 }
 
-export function advanceAlgorithmRun(run: AlgorithmRun, timestamp = new Date().toISOString()): AlgorithmRun {
+export function advanceAlgorithmRun(
+  run: AlgorithmRun,
+  timestamp = new Date().toISOString(),
+  provenance?: Pick<AlgorithmProvenanceInput, "substrate">,
+): AlgorithmRun {
   const current = getRunPhase(run);
   if (current === "abandoned") {
     throw new Error("Algorithm run was abandoned and cannot advance.");
@@ -313,7 +347,7 @@ export function advanceAlgorithmRun(run: AlgorithmRun, timestamp = new Date().to
 
   assertGate(run, target);
 
-  return {
+  const next = {
     ...run,
     updatedAt: timestamp,
     isa: {
@@ -325,6 +359,12 @@ export function advanceAlgorithmRun(run: AlgorithmRun, timestamp = new Date().to
       },
     },
   };
+  return appendAlgorithmProvenance(next, {
+    timestamp,
+    phase: target,
+    operation: "phase.advance",
+    substrate: provenance?.substrate,
+  });
 }
 
 export function updateAlgorithmPlanStep(
@@ -361,6 +401,7 @@ export function applyAlgorithmBatch(
   run: AlgorithmRun,
   operations: AlgorithmBatchOperation[],
   timestamp = new Date().toISOString(),
+  provenance?: Pick<AlgorithmProvenanceInput, "substrate">,
 ): AlgorithmRun {
   if (operations.length === 0) {
     throw new Error("Algorithm batch requires at least one operation.");
@@ -373,11 +414,11 @@ export function applyAlgorithmBatch(
       case "change":
         return recordAlgorithmChange(current, operation.text, timestamp);
       case "learn":
-        return recordAlgorithmLearning(current, operation.text, timestamp);
+        return recordAlgorithmLearning(current, operation.text, timestamp, provenance);
       case "step":
         return updateAlgorithmPlanStep(current, operation.stepId, operation.status, operation.evidence, timestamp);
       case "verify":
-        return verifyAlgorithmCriterion(current, operation.criterionId, operation.status, operation.evidence, timestamp);
+        return verifyAlgorithmCriterion(current, operation.criterionId, operation.status, operation.evidence, timestamp, provenance);
       case "capability":
         return selectAlgorithmCapability(current, {
           name: operation.capability,
@@ -387,7 +428,7 @@ export function applyAlgorithmBatch(
       case "capability-invocation":
         return recordAlgorithmCapabilityInvocation(current, {
           name: operation.capability,
-          substrate: operation.substrate,
+          substrate: operation.substrate ?? provenance?.substrate,
           evidence: operation.evidence,
         }, timestamp);
       case "capability-removal":
@@ -396,7 +437,7 @@ export function applyAlgorithmBatch(
           reason: operation.reason,
         }, timestamp);
       case "advance":
-        return advanceAlgorithmRun(current, timestamp);
+        return advanceAlgorithmRun(current, timestamp, provenance);
       default:
         operation satisfies never;
         return current;

--- a/src/cli/algorithm.ts
+++ b/src/cli/algorithm.ts
@@ -20,6 +20,7 @@ import {
 } from "../index";
 import { registerSomaHomeAlgorithmCapabilities } from "../algorithm-capabilities";
 import { syncAlgorithmRunFromIsa, formatSyncResult } from "../algorithm-isa-sync";
+import { algorithmTouchedBy } from "../algorithm-provenance";
 import { datePrefixSlug } from "../dated-slug";
 import { getCriteria, getGoal } from "../isa-accessors";
 import { getRunPhase } from "../algorithm-lifecycle";
@@ -59,9 +60,9 @@ export type AlgorithmCliAction = (typeof ALGORITHM_ACTIONS)[number];
 export const ALGORITHM_COMMAND_HELP: { usage: string; subcommands: Record<AlgorithmCliAction, string> } = {
   usage: `Usage: soma algorithm <${ALGORITHM_ACTIONS.join("|")}> ...`,
   subcommands: {
-    new: "Usage: soma algorithm new --prompt <text> --intent <text> --current-state <text> --goal <text> --criterion <id:text> [--effort <E1|E2|E3|E4|E5>] [--home-dir <dir>] [--soma-home <dir>]",
+    new: "Usage: soma algorithm new --prompt <text> --intent <text> --current-state <text> --goal <text> --criterion <id:text> [--effort <E1|E2|E3|E4|E5>] [--substrate <id>] [--home-dir <dir>] [--soma-home <dir>]",
     classify: "Usage: soma algorithm classify --prompt <text> [--json]",
-    batch: "Usage: soma algorithm batch --id <run-id> --op <kind:...> [--op <kind:...>]",
+    batch: "Usage: soma algorithm batch --id <run-id> --op <kind:...> [--op <kind:...>] [--substrate <id>]",
     list: "Usage: soma algorithm list [--home-dir <dir>] [--soma-home <dir>]",
     show: "Usage: soma algorithm show --id <run-id> [--home-dir <dir>] [--soma-home <dir>]",
     capabilities: "Usage: soma algorithm capabilities --id <run-id> --capability <name> [--phase <phase>] [--reason <text>] [--home-dir <dir>] [--soma-home <dir>]",
@@ -71,9 +72,9 @@ export const ALGORITHM_COMMAND_HELP: { usage: string; subcommands: Record<Algori
     decision: "Usage: soma algorithm decision --id <run-id> --text <text> [--home-dir <dir>] [--soma-home <dir>]",
     change: "Usage: soma algorithm change --id <run-id> --text <text> [--home-dir <dir>] [--soma-home <dir>]",
     step: "Usage: soma algorithm step --id <run-id> --step-id <id> --status <open|done|blocked> [--evidence <text>]",
-    verify: "Usage: soma algorithm verify --id <run-id> --criterion-id <id> --status <passed|failed|dropped> --evidence <text>",
-    learn: "Usage: soma algorithm learn --id <run-id> --text <text> [--home-dir <dir>] [--soma-home <dir>]",
-    advance: "Usage: soma algorithm advance --id <run-id> [--home-dir <dir>] [--soma-home <dir>]",
+    verify: "Usage: soma algorithm verify --id <run-id> --criterion-id <id> --status <passed|failed|dropped> --evidence <text> [--substrate <id>]",
+    learn: "Usage: soma algorithm learn --id <run-id> --text <text> [--substrate <id>] [--home-dir <dir>] [--soma-home <dir>]",
+    advance: "Usage: soma algorithm advance --id <run-id> [--substrate <id>] [--home-dir <dir>] [--soma-home <dir>]",
     "sync-from-isa":
       "Usage: soma algorithm sync-from-isa --isa <path> --substrate <id> [--soma-home <dir>] [--home-dir <dir>] [--promote-on-complete]",
   },
@@ -490,6 +491,7 @@ function formatAlgorithmClassificationJson(prompt: string): string {
 }
 
 function formatAlgorithmRun(run: AlgorithmRun, path: string): string {
+  const touchedBy = algorithmTouchedBy(run);
   return [
     "Soma Algorithm run",
     `id: ${run.id}`,
@@ -500,6 +502,7 @@ function formatAlgorithmRun(run: AlgorithmRun, path: string): string {
     `classificationReason: ${run.classificationReason}`,
     `path: ${path}`,
     `goal: ${getGoal(run.isa) ?? ""}`,
+    `touched by: ${touchedBy.length > 0 ? touchedBy.join(", ") : "none"}`,
     "",
     "Criteria:",
     ...getCriteria(run.isa).map((criterion) => `- [${criterion.status}] ${criterion.id}: ${criterion.text}${criterion.verification ? ` | ${criterion.verification}` : ""}`),
@@ -700,18 +703,18 @@ export async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<stri
     const criterionStatus = options.criterionStatus;
     const evidence = options.evidence;
     return updateAndReportAlgorithmRun(options, (run) =>
-      verifyAlgorithmCriterion(run, criterionId, criterionStatus, evidence),
+      verifyAlgorithmCriterion(run, criterionId, criterionStatus, evidence, undefined, { substrate: options.substrate }),
     );
   }
 
   if (parsed.action === "learn") {
     const text = requireText(options);
-    return updateAndReportAlgorithmRun(options, (run) => recordAlgorithmLearning(run, text));
+    return updateAndReportAlgorithmRun(options, (run) => recordAlgorithmLearning(run, text, undefined, { substrate: options.substrate }));
   }
 
   if (parsed.action === "batch") {
     const operations = options.batchOperations ?? [];
-    return updateAndReportAlgorithmRun(options, (run) => applyAlgorithmBatch(run, operations), {
+    return updateAndReportAlgorithmRun(options, (run) => applyAlgorithmBatch(run, operations, undefined, { substrate: options.substrate }), {
       registerCapabilities: true,
     });
   }
@@ -729,7 +732,7 @@ export async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<stri
     return formatSyncResult(result);
   }
 
-  return updateAndReportAlgorithmRun(options, (run) => advanceAlgorithmRun(run), {
+  return updateAndReportAlgorithmRun(options, (run) => advanceAlgorithmRun(run, undefined, { substrate: options.substrate }), {
     registerCapabilities: true,
   });
 }

--- a/src/memory-promotion.ts
+++ b/src/memory-promotion.ts
@@ -1,7 +1,8 @@
 import { mkdir, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { readAlgorithmRunById } from "./algorithm-store";
+import { readAlgorithmRunById, writeAlgorithmRun } from "./algorithm-store";
+import { appendAlgorithmProvenance } from "./algorithm-provenance";
 import { appendSomaMemoryEvent } from "./memory";
 import { getCriteria, getGoal } from "./isa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
@@ -153,6 +154,15 @@ export async function promoteAlgorithmRunMemory(options: SomaMemoryPromotionOpti
     await unlink(path).catch(() => undefined);
     throw new Error(`Soma memory promotion event append failed; removed promotion note: ${path}`, { cause: error });
   });
+  await writeAlgorithmRun(
+    appendAlgorithmProvenance(run, {
+      timestamp,
+      operation: "memory.promote",
+      substrate: options.substrate,
+      detail: options.store,
+    }),
+    { somaHome },
+  );
 
   return {
     somaHome,

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,22 @@ export interface AlgorithmLogEntry {
   text: string;
 }
 
+export type AlgorithmProvenanceOperation =
+  | "run.created"
+  | "phase.advance"
+  | "criterion.verify"
+  | "capability.invoke"
+  | "learning.record"
+  | "memory.promote";
+
+export interface AlgorithmProvenanceEntry {
+  timestamp: string;
+  phase: AlgorithmPhase;
+  operation: AlgorithmProvenanceOperation;
+  substrate: SubstrateId;
+  detail?: string;
+}
+
 export type AlgorithmCapabilityKind = "skill" | "inline" | "agent" | "command" | "adapter";
 
 export type AlgorithmCapabilityContract = "skill" | "inline" | "agent" | "command" | "adapter";
@@ -259,6 +275,7 @@ export interface AlgorithmRun {
   changelog: AlgorithmLogEntry[];
   verification: AlgorithmLogEntry[];
   learning: AlgorithmLogEntry[];
+  provenance: AlgorithmProvenanceEntry[];
 }
 
 export interface AlgorithmRunSummary {

--- a/test/algorithm-isa-sync.test.ts
+++ b/test/algorithm-isa-sync.test.ts
@@ -86,6 +86,10 @@ test("creates a soma run from an ISA, keyed by slug, mapping goal + criteria", a
 
     const { run } = await readAlgorithmRunById(result.runId!, { somaHome });
     expect(run.substrate).toBe("claude-code");
+    expect(run.provenance.map((entry) => [entry.operation, entry.substrate])).toEqual([
+      ["run.created", "claude-code"],
+      ["phase.advance", "claude-code"],
+    ]);
     const criteria = getCriteria(run.isa);
     expect(criteria.map((c) => c.id)).toEqual(["ISC-1", "ISC-2"]);
     // Advanced forward to match ISA phase `think`.

--- a/test/algorithm.test.ts
+++ b/test/algorithm.test.ts
@@ -10,6 +10,7 @@ import {
   getCriteria,
   getRunPhase,
   recordAlgorithmCapabilityInvocation,
+  recordAlgorithmLearning,
   registerAlgorithmCapabilityDefinition,
   applyAlgorithmBatch,
   removeAlgorithmCapabilitySelection,
@@ -865,6 +866,60 @@ test("applies Algorithm batch operations with one timestamp", () => {
   expect(run.updatedAt).toBe("2026-05-21T10:02:00.000Z");
   expect(run.capabilitySelections?.[0]?.selectedAt).toBe("2026-05-21T10:02:00.000Z");
   expect(run.capabilitySelections?.[0]?.invocation?.timestamp).toBe("2026-05-21T10:02:00.000Z");
+});
+
+test("records per-hop substrate provenance for Algorithm mutations", () => {
+  let run = createAlgorithmRun({
+    id: "provenance-run",
+    substrate: "claude-code",
+    prompt: "Track cross-substrate provenance.",
+    intent: "Track cross-substrate provenance.",
+    currentState: "Run is new.",
+    goal: "Run records substrate hops.",
+    criteria: [{ id: "C1", text: "Criterion is verified." }],
+    timestamp: "2026-05-14T10:00:00.000Z",
+  });
+
+  run = advanceAlgorithmRun(run, "2026-05-14T10:01:00.000Z", { substrate: "codex" });
+  run = verifyAlgorithmCriterion(
+    run,
+    "C1",
+    "passed",
+    "Codex verified the criterion.",
+    "2026-05-14T10:02:00.000Z",
+    { substrate: "codex" },
+  );
+  run = recordAlgorithmLearning(run, "Pi.dev captured the lesson.", "2026-05-14T10:03:00.000Z", {
+    substrate: "pi-dev",
+  });
+
+  expect(run.provenance).toEqual([
+    {
+      timestamp: "2026-05-14T10:00:00.000Z",
+      phase: "observe",
+      operation: "run.created",
+      substrate: "claude-code",
+    },
+    {
+      timestamp: "2026-05-14T10:01:00.000Z",
+      phase: "think",
+      operation: "phase.advance",
+      substrate: "codex",
+    },
+    {
+      timestamp: "2026-05-14T10:02:00.000Z",
+      phase: "think",
+      operation: "criterion.verify",
+      substrate: "codex",
+      detail: "C1",
+    },
+    {
+      timestamp: "2026-05-14T10:03:00.000Z",
+      phase: "think",
+      operation: "learning.record",
+      substrate: "pi-dev",
+    },
+  ]);
 });
 
 test("abandoned runs cannot advance", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -541,6 +541,67 @@ test("cli drives Algorithm runs through gated mutations", async () => {
   });
 });
 
+test("cli records substrate provenance and surfaces touched-by summary", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli([
+      "algorithm",
+      "new",
+      "--home-dir",
+      homeDir,
+      "--id",
+      "provenance-cli-run",
+      "--substrate",
+      "claude-code",
+      "--prompt",
+      "Record provenance",
+      "--intent",
+      "Record provenance.",
+      "--current-state",
+      "No hops recorded.",
+      "--goal",
+      "Substrate hops are queryable.",
+      "--criterion",
+      "C1:Codex verifies work.",
+    ]);
+    await runSomaCli(["algorithm", "advance", "--home-dir", homeDir, "--id", "provenance-cli-run", "--substrate", "codex"]);
+    await runSomaCli([
+      "algorithm",
+      "verify",
+      "--home-dir",
+      homeDir,
+      "--id",
+      "provenance-cli-run",
+      "--substrate",
+      "codex",
+      "--criterion-id",
+      "C1",
+      "--status",
+      "passed",
+      "--evidence",
+      "Codex verified the criterion.",
+    ]);
+    await runSomaCli([
+      "algorithm",
+      "learn",
+      "--home-dir",
+      homeDir,
+      "--id",
+      "provenance-cli-run",
+      "--substrate",
+      "pi-dev",
+      "--text",
+      "Pi.dev captured the lesson.",
+    ]);
+
+    const output = await runSomaCli(["algorithm", "show", "--home-dir", homeDir, "--id", "provenance-cli-run"]);
+    expect(output).toContain("touched by: claude-code, codex, pi-dev");
+
+    const raw = await readFile(join(homeDir, ".soma/memory/WORK/algorithm-runs/provenance-cli-run.json"), "utf8");
+    expect(raw).toContain('"operation": "criterion.verify"');
+    expect(raw).toContain('"substrate": "pi-dev"');
+  });
+});
+
 test("cli batches routine Algorithm run mutations", async () => {
   await withTempHome(async (homeDir) => {
     await runSomaCli([

--- a/test/memory.test.ts
+++ b/test/memory.test.ts
@@ -10,6 +10,7 @@ import {
   classifySomaFeedback,
   createAlgorithmRun,
   promoteAlgorithmRunMemory,
+  readAlgorithmRunById,
   searchSomaMemory,
   searchSomaResults,
   somaMemoryEventsPath,
@@ -536,6 +537,7 @@ test("promotes an Algorithm run into durable Soma memory", async () => {
     });
     const content = await readFile(result.path, "utf8");
     const events = parseEvents(await readFile(somaMemoryEventsPath(somaHome), "utf8"));
+    const { run } = await readAlgorithmRunById("consulting-lesson", { homeDir });
 
     expect(result.path).toEndWith("memory/KNOWLEDGE/PROMOTED/consulting-autonomy-metric-consulting-lesson.md");
     expect(content).toContain("Measure autonomy transfer, not dependency.");
@@ -544,6 +546,12 @@ test("promotes an Algorithm run into durable Soma memory", async () => {
       substrate: "codex",
       kind: "memory.promotion",
       summary: "Promoted Algorithm run consulting-lesson to knowledge: Consulting autonomy metric",
+    });
+    expect(run.provenance.at(-1)).toMatchObject({
+      timestamp: "2026-05-14T12:30:00.000Z",
+      operation: "memory.promote",
+      substrate: "codex",
+      detail: "knowledge",
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add append-only `AlgorithmRun.provenance` entries for Algorithm substrate hops.
- Record provenance on run creation, phase advance, criterion verification, capability invocation, learning, memory promotion, and sync-from-ISA.
- Surface queryable run provenance in `soma algorithm show` as `touched by: ...`.

Fixes #266.

## Verification

- `rtk bun run lint`
- `rtk bun run typecheck`
- `rtk bun test`
- `rtk bun test test/algorithm.test.ts -t "records per-hop"`
- `rtk bun test test/cli.test.ts -t "cli records substrate provenance"`
- `rtk bun test test/algorithm-isa-sync.test.ts`
- `rtk bun test test/memory.test.ts -t "promotes an Algorithm run"`
