### PR TITLE
Fix #264: rewrite non-Claude substrate paths

### DIFF
--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -10,6 +10,7 @@ import { activeIsaBundleFile } from "../../adapter-active-isa";
 import { somaPolicyPrivateMarkers } from "../../policy";
 import { somaMemoryPrivateRoots, somaProjectionPrivateRoots } from "../../projection-private-roots";
 import { defaultInboundContentSecurityConfig } from "../../inbound-security";
+import { rewriteSubstrateProjectionContent } from "../../substrate-projection-rewrites";
 
 /**
  * Compute the runtime config the soma-lifecycle.mjs hook reads at
@@ -445,7 +446,11 @@ export function projectCodexHome(input: ProjectionInput, somaHome: string, homeD
   const portableSkillFiles = input.profile.skills.flatMap((skill) =>
     (skill.files ?? []).map((file) => ({
       path: `skills/${skill.name}/${file.path}`,
-      content: file.content,
+      content: rewriteSubstrateProjectionContent({
+        substrate: "codex",
+        path: file.path,
+        content: file.content,
+      }),
     })),
   );
 

--- a/src/adapters/pi-dev/skill-projection.ts
+++ b/src/adapters/pi-dev/skill-projection.ts
@@ -1,6 +1,7 @@
 import { readdir, rm } from "node:fs/promises";
 import { resolve } from "node:path";
 import { rewriteSkillNameFrontmatter } from "../../skill-frontmatter";
+import { rewriteSubstrateProjectionContent } from "../../substrate-projection-rewrites";
 import type { Projection, SomaSkill } from "../../types";
 
 export const PI_DEV_ISA_SKILL_ID = "isa";
@@ -15,7 +16,11 @@ export function piDevSkillId(name: string): string {
 }
 
 export function renderPiDevSkillFileContent(skillName: string, filePath: string, content: string): string {
-  return rewriteSkillNameFrontmatter(filePath, content, piDevSkillId(skillName));
+  return rewriteSkillNameFrontmatter(
+    filePath,
+    rewriteSubstrateProjectionContent({ substrate: "pi-dev", path: filePath, content }),
+    piDevSkillId(skillName),
+  );
 }
 
 export function buildPiDevPortableSkillFiles(skills: SomaSkill[]): Projection["files"] {

--- a/src/install.ts
+++ b/src/install.ts
@@ -137,6 +137,7 @@ async function installSomaForSubstrate(
     somaRepoPath,
     skillDestinationDir: spec.isaSkillProjection.destinationDir(substrateRoot),
     skillNameOverride: spec.isaSkillProjection.skillNameOverride,
+    projectionSubstrate: substrate,
   });
   // Populate the projection input with the active ISA so each
   // substrate writes its `active-isa.md` file (#37 AC-1/AC-2).

--- a/src/isa-skill-installer.ts
+++ b/src/isa-skill-installer.ts
@@ -4,15 +4,18 @@ import { homedir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { defaultSomaRepoPath } from "./repo-path";
 import { SKILL_MD, rewriteSkillNameFrontmatter } from "./skill-frontmatter";
+import { rewriteSubstrateProjectionContent } from "./substrate-projection-rewrites";
 import type {
   IsaSkillInstallOptions,
   IsaSkillInstallResult,
   SomaSkillBaseline,
   SomaSkillBaselines,
+  SubstrateId,
 } from "./types";
 
 interface InternalIsaSkillInstallOptions extends IsaSkillInstallOptions {
   skillNameOverride?: string;
+  projectionSubstrate?: SubstrateId;
 }
 
 const SKILL_NAME = "ISA";
@@ -88,10 +91,11 @@ async function hashSkillFiles(
   root: string,
   relativePaths: string[],
   skillNameOverride?: string,
+  projectionSubstrate?: SubstrateId,
 ): Promise<Record<string, string>> {
   const out: Record<string, string> = {};
   for (const rel of relativePaths) {
-    out[rel] = sha256(transformSkillFileContent(rel, await readFile(join(root, rel), "utf8"), skillNameOverride));
+    out[rel] = sha256(transformSkillFileContent(rel, await readFile(join(root, rel), "utf8"), skillNameOverride, projectionSubstrate));
   }
   return out;
 }
@@ -174,14 +178,28 @@ async function readSkillFrontmatter(skillMdPath: string): Promise<SkillFrontmatt
   return parseSkillFrontmatter(await readFile(skillMdPath, "utf8"));
 }
 
-async function copySkillFile(source: string, destination: string, relPath: string, skillNameOverride?: string): Promise<void> {
+async function copySkillFile(
+  source: string,
+  destination: string,
+  relPath: string,
+  skillNameOverride?: string,
+  projectionSubstrate?: SubstrateId,
+): Promise<void> {
   await mkdir(dirname(destination), { recursive: true });
-  const content = transformSkillFileContent(relPath, await readFile(source, "utf8"), skillNameOverride);
+  const content = transformSkillFileContent(relPath, await readFile(source, "utf8"), skillNameOverride, projectionSubstrate);
   await writeFile(destination, content, "utf8");
 }
 
-function transformSkillFileContent(relPath: string, content: string, skillNameOverride?: string): string {
-  return rewriteSkillNameFrontmatter(relPath, content, skillNameOverride);
+function transformSkillFileContent(
+  relPath: string,
+  content: string,
+  skillNameOverride?: string,
+  projectionSubstrate?: SubstrateId,
+): string {
+  const rewritten = projectionSubstrate
+    ? rewriteSubstrateProjectionContent({ substrate: projectionSubstrate, path: relPath, content })
+    : content;
+  return rewriteSkillNameFrontmatter(relPath, rewritten, skillNameOverride);
 }
 
 interface DetectedDrift {
@@ -274,7 +292,7 @@ async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions =
     throw new Error(`ISA skill source ${SKILL_MD} missing version or pack-id frontmatter.`);
   }
   const sourceFiles = await listSkillFiles(sourceDir);
-  const sourceHashes = await hashSkillFiles(sourceDir, sourceFiles, options.skillNameOverride);
+  const sourceHashes = await hashSkillFiles(sourceDir, sourceFiles, options.skillNameOverride, options.projectionSubstrate);
 
   const runtimeFrontmatter = await readSkillFrontmatter(join(runtimeDir, SKILL_MD));
   const baselinesRead = await readBaselines(somaHome);
@@ -299,6 +317,7 @@ async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions =
       userAdditions,
       skillKey,
       skillNameOverride: options.skillNameOverride,
+      projectionSubstrate: options.projectionSubstrate,
     });
   }
 
@@ -318,6 +337,7 @@ async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions =
       userAdditions,
       skillKey,
       skillNameOverride: options.skillNameOverride,
+      projectionSubstrate: options.projectionSubstrate,
     });
   }
 
@@ -348,6 +368,7 @@ async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions =
     actionOverride: "upgraded",
     skillKey,
     skillNameOverride: options.skillNameOverride,
+    projectionSubstrate: options.projectionSubstrate,
   });
 }
 
@@ -365,6 +386,7 @@ interface ReconcileSameVersionContext {
   userAdditions: string[];
   skillKey: string;
   skillNameOverride?: string;
+  projectionSubstrate?: SubstrateId;
 }
 
 async function reconcileSameVersion(ctx: ReconcileSameVersionContext): Promise<IsaSkillInstallResult> {
@@ -383,7 +405,7 @@ async function reconcileSameVersion(ctx: ReconcileSameVersionContext): Promise<I
   const written: string[] = [];
   for (const rel of missingFiles) {
     const dest = join(ctx.runtimeDir, rel);
-    await copySkillFile(join(ctx.sourceDir, rel), dest, rel, ctx.skillNameOverride);
+    await copySkillFile(join(ctx.sourceDir, rel), dest, rel, ctx.skillNameOverride, ctx.projectionSubstrate);
     written.push(dest);
   }
   // Handle the pre-baselines runtime case: existing runtime installed before
@@ -461,13 +483,14 @@ interface FreshInstallContext {
   actionOverride?: "fresh" | "upgraded";
   skillKey: string;
   skillNameOverride?: string;
+  projectionSubstrate?: SubstrateId;
 }
 
 async function freshInstall(ctx: FreshInstallContext): Promise<IsaSkillInstallResult> {
   const written: string[] = [];
   for (const rel of ctx.sourceFiles) {
     const dest = join(ctx.runtimeDir, rel);
-    await copySkillFile(join(ctx.sourceDir, rel), dest, rel, ctx.skillNameOverride);
+    await copySkillFile(join(ctx.sourceDir, rel), dest, rel, ctx.skillNameOverride, ctx.projectionSubstrate);
     written.push(dest);
   }
 

--- a/src/skills/ISA/SKILL.md
+++ b/src/skills/ISA/SKILL.md
@@ -2,7 +2,7 @@
 name: ISA
 description: "Owns the Ideal State Artifact: the commitment-time scaffold for articulating done, deriving ISC criteria, planning features, recording decisions, and verifying work. Use for ideal state, ISA/ISC criteria, project specs, scaffolding, completeness checks, reconciliation, or seeding an ISA from a repo."
 effort: medium
-version: 1.0.3
+version: 1.0.4
 pack-id: pai-isa-v1.0.0
 ---
 

--- a/src/substrate-projection-rewrites.ts
+++ b/src/substrate-projection-rewrites.ts
@@ -3,7 +3,8 @@ import type { SubstrateId } from "./types";
 
 const CLAUDE_HOME = "~/" + ".claude";
 const SOMA_HOME = "~/" + ".soma";
-const CLAUDE_ONLY_LINE = /\b(?:ISASync\.hook\.ts|ISA[- ]Tool)\b/i;
+const RELATIVE_CLAUDE_HOME = "." + "claude";
+const CLAUDE_ONLY_LINE = /\b(?:ISASync\.hook\.ts|ISA[- ]Tool(?![A-Za-z]))/i;
 
 function replaceAllLiteral(content: string, from: string, to: string): string {
   return content.split(from).join(to);
@@ -11,16 +12,19 @@ function replaceAllLiteral(content: string, from: string, to: string): string {
 
 function rewriteKnownMemoryRoots(content: string): string {
   let next = content;
+  // Run these first because the pack normalizer intentionally maps
+  // unknown Claude memory roots to an UNMAPPED placeholder. Projection
+  // consumers need legacy memory bootstrap refs to land on Soma memory.
   for (const root of [
     `${CLAUDE_HOME}/PAI/MEMORY/`,
     `${CLAUDE_HOME}/memory/`,
     `${CLAUDE_HOME}/memories/`,
-    "." + "claude/PAI/MEMORY/",
-    "." + "claude/memory/",
-    "." + "claude/memories/",
-    "./." + "claude/PAI/MEMORY/",
-    "./." + "claude/memory/",
-    "./." + "claude/memories/",
+    `${RELATIVE_CLAUDE_HOME}/PAI/MEMORY/`,
+    `${RELATIVE_CLAUDE_HOME}/memory/`,
+    `${RELATIVE_CLAUDE_HOME}/memories/`,
+    `./${RELATIVE_CLAUDE_HOME}/PAI/MEMORY/`,
+    `./${RELATIVE_CLAUDE_HOME}/memory/`,
+    `./${RELATIVE_CLAUDE_HOME}/memories/`,
   ]) {
     next = replaceAllLiteral(next, root, `${SOMA_HOME}/memory/`);
   }

--- a/src/substrate-projection-rewrites.ts
+++ b/src/substrate-projection-rewrites.ts
@@ -19,12 +19,12 @@ function rewriteKnownMemoryRoots(content: string): string {
     `${CLAUDE_HOME}/PAI/MEMORY/`,
     `${CLAUDE_HOME}/memory/`,
     `${CLAUDE_HOME}/memories/`,
-    `${RELATIVE_CLAUDE_HOME}/PAI/MEMORY/`,
-    `${RELATIVE_CLAUDE_HOME}/memory/`,
-    `${RELATIVE_CLAUDE_HOME}/memories/`,
     `./${RELATIVE_CLAUDE_HOME}/PAI/MEMORY/`,
     `./${RELATIVE_CLAUDE_HOME}/memory/`,
     `./${RELATIVE_CLAUDE_HOME}/memories/`,
+    `${RELATIVE_CLAUDE_HOME}/PAI/MEMORY/`,
+    `${RELATIVE_CLAUDE_HOME}/memory/`,
+    `${RELATIVE_CLAUDE_HOME}/memories/`,
   ]) {
     next = replaceAllLiteral(next, root, `${SOMA_HOME}/memory/`);
   }

--- a/src/substrate-projection-rewrites.ts
+++ b/src/substrate-projection-rewrites.ts
@@ -1,0 +1,47 @@
+import { normalizeSkillContent } from "./pai-pack-normalizer";
+import type { SubstrateId } from "./types";
+
+const CLAUDE_HOME = "~/" + ".claude";
+const SOMA_HOME = "~/" + ".soma";
+const CLAUDE_ONLY_LINE = /\b(?:ISASync\.hook\.ts|ISA[- ]Tool)\b/i;
+
+function replaceAllLiteral(content: string, from: string, to: string): string {
+  return content.split(from).join(to);
+}
+
+function rewriteKnownMemoryRoots(content: string): string {
+  let next = content;
+  for (const root of [
+    `${CLAUDE_HOME}/PAI/MEMORY/`,
+    `${CLAUDE_HOME}/memory/`,
+    `${CLAUDE_HOME}/memories/`,
+    "." + "claude/PAI/MEMORY/",
+    "." + "claude/memory/",
+    "." + "claude/memories/",
+    "./." + "claude/PAI/MEMORY/",
+    "./." + "claude/memory/",
+    "./." + "claude/memories/",
+  ]) {
+    next = replaceAllLiteral(next, root, `${SOMA_HOME}/memory/`);
+  }
+  return next;
+}
+
+function stripClaudeOnlyInstructionLines(content: string): string {
+  return content
+    .split("\n")
+    .filter((line) => !CLAUDE_ONLY_LINE.test(line))
+    .join("\n");
+}
+
+export function rewriteSubstrateProjectionContent(input: {
+  substrate: SubstrateId;
+  path: string;
+  content: string;
+}): string {
+  if (input.substrate === "claude-code") return input.content;
+
+  const withoutKnownMemoryRoots = rewriteKnownMemoryRoots(input.content);
+  const withoutClaudeOnlyLines = stripClaudeOnlyInstructionLines(withoutKnownMemoryRoots);
+  return normalizeSkillContent(input.path, withoutClaudeOnlyLines).content;
+}

--- a/src/substrate-projection-rewrites.ts
+++ b/src/substrate-projection-rewrites.ts
@@ -4,6 +4,8 @@ import type { SubstrateId } from "./types";
 const CLAUDE_HOME = "~/" + ".claude";
 const SOMA_HOME = "~/" + ".soma";
 const RELATIVE_CLAUDE_HOME = "." + "claude";
+const MEMORY_ROOT_PREFIXES = [CLAUDE_HOME, `./${RELATIVE_CLAUDE_HOME}`, RELATIVE_CLAUDE_HOME] as const;
+const MEMORY_ROOT_SUFFIXES = ["PAI/MEMORY", "memory", "memories"] as const;
 const CLAUDE_ONLY_LINE = /\b(?:ISASync\.hook\.ts|ISA[- ]Tool(?![A-Za-z]))/i;
 
 function replaceAllLiteral(content: string, from: string, to: string): string {
@@ -15,18 +17,11 @@ function rewriteKnownMemoryRoots(content: string): string {
   // Run these first because the pack normalizer intentionally maps
   // unknown Claude memory roots to an UNMAPPED placeholder. Projection
   // consumers need legacy memory bootstrap refs to land on Soma memory.
-  for (const root of [
-    `${CLAUDE_HOME}/PAI/MEMORY/`,
-    `${CLAUDE_HOME}/memory/`,
-    `${CLAUDE_HOME}/memories/`,
-    `./${RELATIVE_CLAUDE_HOME}/PAI/MEMORY/`,
-    `./${RELATIVE_CLAUDE_HOME}/memory/`,
-    `./${RELATIVE_CLAUDE_HOME}/memories/`,
-    `${RELATIVE_CLAUDE_HOME}/PAI/MEMORY/`,
-    `${RELATIVE_CLAUDE_HOME}/memory/`,
-    `${RELATIVE_CLAUDE_HOME}/memories/`,
-  ]) {
-    next = replaceAllLiteral(next, root, `${SOMA_HOME}/memory/`);
+  for (const prefix of MEMORY_ROOT_PREFIXES) {
+    for (const suffix of MEMORY_ROOT_SUFFIXES) {
+      next = replaceAllLiteral(next, `${prefix}/${suffix}/`, `${SOMA_HOME}/memory/`);
+      next = replaceAllLiteral(next, `${prefix}/${suffix}`, `${SOMA_HOME}/memory`);
+    }
   }
   return next;
 }

--- a/src/substrate-projection-rewrites.ts
+++ b/src/substrate-projection-rewrites.ts
@@ -38,6 +38,11 @@ function stripClaudeOnlyInstructionLines(content: string): string {
     .join("\n");
 }
 
+function isMarkdownInstructionFile(path: string): boolean {
+  const lower = path.toLowerCase();
+  return lower === "skill.md" || lower.endsWith(".md");
+}
+
 export function rewriteSubstrateProjectionContent(input: {
   substrate: SubstrateId;
   path: string;
@@ -46,6 +51,8 @@ export function rewriteSubstrateProjectionContent(input: {
   if (input.substrate === "claude-code") return input.content;
 
   const withoutKnownMemoryRoots = rewriteKnownMemoryRoots(input.content);
-  const withoutClaudeOnlyLines = stripClaudeOnlyInstructionLines(withoutKnownMemoryRoots);
+  const withoutClaudeOnlyLines = isMarkdownInstructionFile(input.path)
+    ? stripClaudeOnlyInstructionLines(withoutKnownMemoryRoots)
+    : withoutKnownMemoryRoots;
   return normalizeSkillContent(input.path, withoutClaudeOnlyLines).content;
 }

--- a/test/adapter-active-isa.test.ts
+++ b/test/adapter-active-isa.test.ts
@@ -105,6 +105,23 @@ test("AC-3: installSomaForPiDev projects ISA skill source into Pi-safe ~/.pi/age
   });
 });
 
+test("AC-3: non-Claude ISA skill projections rewrite Claude-specific source paths", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    await installSomaForPiDev({ homeDir });
+
+    const claudeHome = "~/" + ".claude";
+    const somaHome = "~/" + ".soma";
+    const codexScaffold = await readFile(join(homeDir, ".codex/skills/ISA/Workflows/Scaffold.md"), "utf8");
+    const piScaffold = await readFile(join(homeDir, ".pi/agent/skills/isa/Workflows/Scaffold.md"), "utf8");
+    const projected = `${codexScaffold}\n${piScaffold}`;
+
+    expect(projected).not.toContain(claudeHome);
+    expect(projected).toContain(`${somaHome}/memory/WORK/{slug}/ISA.md`);
+    expect(projected).toContain(`${somaHome}/skills/ISA/Examples/canonical-isa.md`);
+  });
+});
+
 test("AC-3: installSomaForPiDev removes legacy uppercase ISA projection", async () => {
   await withTempHome(async (homeDir) => {
     await mkdir(join(homeDir, ".pi/agent/skills/ISA"), { recursive: true });

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -315,6 +315,7 @@ test("non-Claude home projections rewrite Claude-only paths in portable skill pa
   const claudeHome = "~/" + ".claude";
   const somaHome = "~/" + ".soma";
   const relativeClaudeMemory = "." + "claude/memory";
+  const dotRelativeClaudeMemory = "./" + relativeClaudeMemory;
   const input = {
     ...portableProjectionInput,
     profile: {
@@ -345,6 +346,7 @@ test("non-Claude home projections rewrite Claude-only paths in portable skill pa
                 "",
                 `Persist work at ${claudeHome}/PAI/MEMORY/WORK/{slug}/ISA.md.`,
                 `Bootstrap reads \`${relativeClaudeMemory}/decisions.md\` and \`${relativeClaudeMemory}/session-log.md\`.`,
+                `Dot-relative bootstrap reads \`${dotRelativeClaudeMemory}/handoff.md\`.`,
                 `Search with \`rg ${claudeHome}/PAI/MEMORY/KNOWLEDGE/\`.`,
               ].join("\n"),
             },
@@ -364,11 +366,13 @@ test("non-Claude home projections rewrite Claude-only paths in portable skill pa
 
   expect(projected).not.toContain(claudeHome);
   expect(projected).not.toContain(relativeClaudeMemory);
+  expect(projected).not.toContain("./~/");
   expect(projected).not.toContain("ISASync.hook.ts");
   expect(projected).not.toContain("ISA Tool");
   expect(projected).toContain(`${somaHome}/skills/ISA/Examples/canonical-isa.md`);
   expect(projected).toContain(`${somaHome}/memory/WORK/{slug}/ISA.md`);
   expect(projected).toContain(`${somaHome}/memory/decisions.md`);
+  expect(projected).toContain(`${somaHome}/memory/handoff.md`);
   expect(projected).toContain(`${somaHome}/memory/KNOWLEDGE/`);
 });
 

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -347,6 +347,7 @@ test("non-Claude home projections rewrite Claude-only paths in portable skill pa
                 `Persist work at ${claudeHome}/PAI/MEMORY/WORK/{slug}/ISA.md.`,
                 `Bootstrap reads \`${relativeClaudeMemory}/decisions.md\` and \`${relativeClaudeMemory}/session-log.md\`.`,
                 `Dot-relative bootstrap reads \`${dotRelativeClaudeMemory}/handoff.md\`.`,
+                `Bare roots: \`${claudeHome}/memory\`, \`${relativeClaudeMemory}\`, and \`${dotRelativeClaudeMemory}\`.`,
                 `Search with \`rg ${claudeHome}/PAI/MEMORY/KNOWLEDGE/\`.`,
               ].join("\n"),
             },
@@ -379,6 +380,7 @@ test("non-Claude home projections rewrite Claude-only paths in portable skill pa
   expect(projected).toContain(`${somaHome}/memory/decisions.md`);
   expect(projected).toContain(`${somaHome}/memory/handoff.md`);
   expect(projected).toContain(`${somaHome}/memory/KNOWLEDGE/`);
+  expect(projected).toContain(`Bare roots: \`${somaHome}/memory\`, \`${somaHome}/memory\`, and \`${somaHome}/memory\`.`);
   expect(piTool).toContain("ISASync.hook.ts");
 });
 

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -311,6 +311,67 @@ test("pi.dev home projection rejects normalized portable skill id collisions", (
   ).toThrow("Pi.dev skill id collision");
 });
 
+test("non-Claude home projections rewrite Claude-only paths in portable skill payloads", () => {
+  const claudeHome = "~/" + ".claude";
+  const somaHome = "~/" + ".soma";
+  const relativeClaudeMemory = "." + "claude/memory";
+  const input = {
+    ...portableProjectionInput,
+    profile: {
+      ...portableProjectionInput.profile,
+      skills: [
+        {
+          name: "the-algorithm",
+          path: "skills/the-algorithm",
+          description: "Imported Algorithm skill with Claude-specific references.",
+          triggers: ["algorithm"],
+          files: [
+            {
+              path: "SKILL.md",
+              content: [
+                "---",
+                "name: the-algorithm",
+                "---",
+                "",
+                `Read ${claudeHome}/skills/ISA/Examples/canonical-isa.md.`,
+                "Claude hook: ISASync.hook.ts",
+                "Use the ISA Tool before continuing.",
+              ].join("\n"),
+            },
+            {
+              path: "Workflows/RunAlgorithm.md",
+              content: [
+                "# Run Algorithm",
+                "",
+                `Persist work at ${claudeHome}/PAI/MEMORY/WORK/{slug}/ISA.md.`,
+                `Bootstrap reads \`${relativeClaudeMemory}/decisions.md\` and \`${relativeClaudeMemory}/session-log.md\`.`,
+                `Search with \`rg ${claudeHome}/PAI/MEMORY/KNOWLEDGE/\`.`,
+              ].join("\n"),
+            },
+          ],
+        },
+      ],
+    },
+  };
+
+  const codex = buildCodexHomeProjection(input, { homeDir: "/tmp/soma-test-home" });
+  const piDev = buildPiDevHomeProjection(input, { homeDir: "/tmp/soma-test-home" });
+
+  const codexWorkflow = codex.bundle.files.find((file) => file.path === "skills/the-algorithm/Workflows/RunAlgorithm.md")?.content ?? "";
+  const piSkill = piDev.bundle.files.find((file) => file.path === "agent/skills/the-algorithm/SKILL.md")?.content ?? "";
+  const piWorkflow = piDev.bundle.files.find((file) => file.path === "agent/skills/the-algorithm/Workflows/RunAlgorithm.md")?.content ?? "";
+  const projected = [codexWorkflow, piSkill, piWorkflow].join("\n");
+
+  expect(projected).not.toContain(claudeHome);
+  expect(projected).not.toContain(relativeClaudeMemory);
+  expect(projected).not.toContain("ISASync.hook.ts");
+  expect(projected).not.toContain("ISA Tool");
+  expect(projected).toContain(`${somaHome}/skills/ISA/Examples/canonical-isa.md`);
+  expect(projected).toContain(`${somaHome}/memory/WORK/{slug}/ISA.md`);
+  expect(projected).toContain(`${somaHome}/memory/decisions.md`);
+  expect(projected).toContain(`${somaHome}/memory/KNOWLEDGE/`);
+});
+
 
 test("installs codex home projection into a substrate home", async () => {
   await withTempHome(async (homeDir) => {

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -350,6 +350,10 @@ test("non-Claude home projections rewrite Claude-only paths in portable skill pa
                 `Search with \`rg ${claudeHome}/PAI/MEMORY/KNOWLEDGE/\`.`,
               ].join("\n"),
             },
+            {
+              path: "Tools/hook-name.ts",
+              content: 'export const hookName = "ISASync.hook.ts";\n',
+            },
           ],
         },
       ],
@@ -362,6 +366,7 @@ test("non-Claude home projections rewrite Claude-only paths in portable skill pa
   const codexWorkflow = codex.bundle.files.find((file) => file.path === "skills/the-algorithm/Workflows/RunAlgorithm.md")?.content ?? "";
   const piSkill = piDev.bundle.files.find((file) => file.path === "agent/skills/the-algorithm/SKILL.md")?.content ?? "";
   const piWorkflow = piDev.bundle.files.find((file) => file.path === "agent/skills/the-algorithm/Workflows/RunAlgorithm.md")?.content ?? "";
+  const piTool = piDev.bundle.files.find((file) => file.path === "agent/skills/the-algorithm/Tools/hook-name.ts")?.content ?? "";
   const projected = [codexWorkflow, piSkill, piWorkflow].join("\n");
 
   expect(projected).not.toContain(claudeHome);
@@ -374,6 +379,7 @@ test("non-Claude home projections rewrite Claude-only paths in portable skill pa
   expect(projected).toContain(`${somaHome}/memory/decisions.md`);
   expect(projected).toContain(`${somaHome}/memory/handoff.md`);
   expect(projected).toContain(`${somaHome}/memory/KNOWLEDGE/`);
+  expect(piTool).toContain("ISASync.hook.ts");
 });
 
 


### PR DESCRIPTION
## Summary

- Add a shared non-Claude projection rewrite pass for portable skill payloads.
- Rewrite Claude memory and skill paths to Soma paths, and strip Claude-only ISA hook/tool instruction lines for Codex/Pi.dev projections.
- Apply the same rewrite path when installing the bundled ISA skill into non-Claude substrate homes.
- Bump the bundled ISA skill version so existing substrate projections upgrade through the normal installer path.

Closes #264.

## Verification

- `rtk bun run lint`
- `rtk bun run typecheck`
- `rtk bun test`
- `rtk bun test test/home-projection.test.ts`
- `rtk bun test test/adapter-active-isa.test.ts`
- `rtk bun test test/isa-skill-installer.test.ts`
