### PR TITLE
Add opt-in Claude Code mode classifier

### DIFF
--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -129,6 +129,11 @@ Current home install behavior:
   `SessionStart`, `SessionEnd`, `PostToolUse`, `SubagentStart`, and
   `SubagentStop`. Re-running install is idempotent and preserves existing
   user, project, PAI, and non-Soma hook entries.
+- `soma install claude-code --mode-classifier --apply` additionally installs
+  an opt-in `UserPromptSubmit` mode-classifier hook. The hook calls
+  `soma algorithm classify --json`, injects a concise MODE context block, and
+  temporarily disables any detected PAI `ModeClassifier.hook.*` entry. Uninstall
+  removes Soma's classifier hook and restores the disabled PAI entry.
 - Lifecycle hooks call Soma lifecycle APIs with `--substrate claude-code`.
   Tool and subagent hooks emit metadata-only events through the Soma writeback
   gate; they do not mirror full raw transcripts or prompt text.

--- a/src/adapters/claude-code/hooks.ts
+++ b/src/adapters/claude-code/hooks.ts
@@ -3,10 +3,15 @@ import { chmod, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { resolveBunExecutable } from "../../bun-probe";
 import { isEnoent } from "../../fs-errors";
+import { isClaudeCodeInstallOptions } from "./install-options";
 
 export const SOMA_CLAUDE_HOOK_RELATIVE_PATH = "hooks/soma/soma-claude-code-hook.mjs";
 export const SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH = "hooks/soma/soma-claude-code-hook.config.json";
+export const SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH = "hooks/soma/soma-mode-classifier.mjs";
+export const SOMA_CLAUDE_MODE_CLASSIFIER_CONFIG_RELATIVE_PATH = "hooks/soma/soma-mode-classifier.config.json";
 const SOMA_CLAUDE_SETTINGS_RELATIVE_PATH = "settings.json";
+const SOMA_DISABLED_HOOKS_KEY = "somaDisabledHooks";
+const PAI_MODE_CLASSIFIER_KEY = "paiModeClassifier";
 
 const SOMA_CLAUDE_HOOK_EVENTS = [
   {
@@ -109,27 +114,71 @@ function somaHookEntry(substrateHome: string, bunPath: string, commandEvent: str
   };
 }
 
-function appendSomaHookGroup(settings: JsonObject, input: (typeof SOMA_CLAUDE_HOOK_EVENTS)[number], substrateHome: string, bunPath: string): boolean {
+function legacySomaModeClassifierCommand(substrateHome: string): string {
+  return shellQuote(resolve(substrateHome, SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH));
+}
+
+function somaModeClassifierCommand(substrateHome: string, bunPath: string): string {
+  return `${shellQuote(bunPath)} ${shellQuote(resolve(substrateHome, SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH))}`;
+}
+
+function somaModeClassifierCommands(substrateHome: string, bunPath: string): Set<string> {
+  return new Set([
+    somaModeClassifierCommand(substrateHome, bunPath),
+    legacySomaModeClassifierCommand(substrateHome),
+  ]);
+}
+
+function somaModeClassifierEntry(substrateHome: string, bunPath: string): JsonObject {
+  return {
+    type: "command",
+    command: somaModeClassifierCommand(substrateHome, bunPath),
+    timeout: 10,
+  };
+}
+
+function appendCommandHookGroup(
+  settings: JsonObject,
+  input: { event: string; description: string; matcher?: string; entry: JsonObject; knownCommands: Set<string> },
+): boolean {
   const hooks = isObject(settings.hooks) ? settings.hooks : {};
   const eventGroups = Array.isArray(hooks[input.event]) ? hooks[input.event] as unknown[] : [];
-  const knownCommands = somaHookCommands(substrateHome, bunPath);
 
   for (const group of eventGroups) {
     if (!isObject(group) || !Array.isArray(group.hooks)) continue;
-    if (group.hooks.some((hook) => isObject(hook) && typeof hook.command === "string" && knownCommands.has(hook.command))) {
+    if (group.hooks.some((hook) => isObject(hook) && typeof hook.command === "string" && input.knownCommands.has(hook.command))) {
       settings.hooks = hooks;
       return false;
     }
   }
 
   eventGroups.push({
-    description: `Soma: ${input.summary}`,
-    ...("matcher" in input ? { matcher: input.matcher } : {}),
-    hooks: [somaHookEntry(substrateHome, bunPath, input.commandEvent)],
+    description: input.description,
+    ...(input.matcher ? { matcher: input.matcher } : {}),
+    hooks: [input.entry],
   });
   hooks[input.event] = eventGroups;
   settings.hooks = hooks;
   return true;
+}
+
+function appendSomaHookGroup(settings: JsonObject, input: (typeof SOMA_CLAUDE_HOOK_EVENTS)[number], substrateHome: string, bunPath: string): boolean {
+  return appendCommandHookGroup(settings, {
+    event: input.event,
+    description: `Soma: ${input.summary}`,
+    ...("matcher" in input ? { matcher: input.matcher } : {}),
+    entry: somaHookEntry(substrateHome, bunPath, input.commandEvent),
+    knownCommands: somaHookCommands(substrateHome, bunPath),
+  });
+}
+
+function appendSomaModeClassifierHookGroup(settings: JsonObject, substrateHome: string, bunPath: string): boolean {
+  return appendCommandHookGroup(settings, {
+    event: "UserPromptSubmit",
+    description: "Soma: Classify prompts into MINIMAL, NATIVE, or ALGORITHM mode",
+    entry: somaModeClassifierEntry(substrateHome, bunPath),
+    knownCommands: somaModeClassifierCommands(substrateHome, bunPath),
+  });
 }
 
 function removeSomaHooksFromSettings(settings: JsonObject, substrateHome: string, bunPath: string): boolean {
@@ -162,6 +211,34 @@ function removeSomaHooksFromSettings(settings: JsonObject, substrateHome: string
   return changed;
 }
 
+function removeSomaModeClassifierFromSettings(settings: JsonObject, substrateHome: string, bunPath: string): boolean {
+  const changed = removeCommandsFromSettingsEvent(settings, "UserPromptSubmit", somaModeClassifierCommands(substrateHome, bunPath));
+  return restorePaiModeClassifierHooks(settings) || changed;
+}
+
+function removeCommandsFromSettingsEvent(settings: JsonObject, event: string, commands: Set<string>): boolean {
+  if (!isObject(settings.hooks)) return false;
+  const hooks = settings.hooks;
+  const groups = hooks[event];
+  if (!Array.isArray(groups)) return false;
+
+  const nextGroups: unknown[] = [];
+  let changed = false;
+  for (const group of groups) {
+    const result = removeSomaCommandsFromGroup(group, commands);
+    changed = result.changed || changed;
+    if (result.group) nextGroups.push(result.group);
+  }
+  if (!changed) return false;
+
+  const nextHooks = nextGroups.length > 0
+    ? { ...hooks, [event]: nextGroups }
+    : Object.fromEntries(Object.entries(hooks).filter(([key]) => key !== event));
+  if (Object.keys(nextHooks).length === 0) delete settings.hooks;
+  else settings.hooks = nextHooks;
+  return true;
+}
+
 function removeSomaCommandsFromGroup(group: unknown, commands: Set<string>): { group?: unknown; changed: boolean } {
   if (!isObject(group) || !Array.isArray(group.hooks)) {
     return { group, changed: false };
@@ -174,6 +251,110 @@ function removeSomaCommandsFromGroup(group: unknown, commands: Set<string>): { g
     return { changed: true };
   }
   return { group: { ...group, hooks: nextHooks }, changed: true };
+}
+
+function isPaiModeClassifierCommand(command: string): boolean {
+  return /(?:^|[/\\])ModeClassifier\.hook\.(?:ts|js|mjs)(?:[\s"']|$)/.test(command) || command.includes("ModeClassifier.hook.ts");
+}
+
+function groupCommands(group: unknown): string[] {
+  if (!isObject(group) || !Array.isArray(group.hooks)) return [];
+  return group.hooks.flatMap((hook) => isObject(hook) && typeof hook.command === "string" ? [hook.command] : []);
+}
+
+function disabledPaiModeClassifierGroups(settings: JsonObject): unknown[] {
+  if (!isObject(settings[SOMA_DISABLED_HOOKS_KEY])) return [];
+  const stored = settings[SOMA_DISABLED_HOOKS_KEY][PAI_MODE_CLASSIFIER_KEY];
+  return Array.isArray(stored) ? stored : [];
+}
+
+function setDisabledPaiModeClassifierGroups(settings: JsonObject, groups: unknown[]): void {
+  const disabled = isObject(settings[SOMA_DISABLED_HOOKS_KEY]) ? settings[SOMA_DISABLED_HOOKS_KEY] : {};
+  if (groups.length === 0) {
+    Reflect.deleteProperty(disabled, PAI_MODE_CLASSIFIER_KEY);
+  } else {
+    disabled[PAI_MODE_CLASSIFIER_KEY] = groups;
+  }
+  if (Object.keys(disabled).length === 0) {
+    Reflect.deleteProperty(settings, SOMA_DISABLED_HOOKS_KEY);
+  } else {
+    settings[SOMA_DISABLED_HOOKS_KEY] = disabled;
+  }
+}
+
+function disablePaiModeClassifierHooks(settings: JsonObject): boolean {
+  if (!isObject(settings.hooks)) return false;
+  const groups = settings.hooks.UserPromptSubmit;
+  if (!Array.isArray(groups)) return false;
+
+  const disabled = [...disabledPaiModeClassifierGroups(settings)];
+  const knownDisabledCommands = new Set(disabled.flatMap(groupCommands));
+  const nextGroups: unknown[] = [];
+  let changed = false;
+
+  for (const group of groups) {
+    if (!isObject(group) || !Array.isArray(group.hooks)) {
+      nextGroups.push(group);
+      continue;
+    }
+
+    const removedHooks = group.hooks.filter((hook) =>
+      isObject(hook) && typeof hook.command === "string" && isPaiModeClassifierCommand(hook.command),
+    );
+    if (removedHooks.length === 0) {
+      nextGroups.push(group);
+      continue;
+    }
+
+    const keptHooks = group.hooks.filter((hook) => !removedHooks.includes(hook));
+    if (removedHooks.some((hook) => isObject(hook) && typeof hook.command === "string" && !knownDisabledCommands.has(hook.command))) {
+      disabled.push({ ...group, hooks: removedHooks });
+    }
+    if (keptHooks.length > 0) nextGroups.push({ ...group, hooks: keptHooks });
+    changed = true;
+  }
+
+  if (!changed) return false;
+  if (nextGroups.length > 0) {
+    settings.hooks.UserPromptSubmit = nextGroups;
+  } else {
+    delete settings.hooks.UserPromptSubmit;
+  }
+  if (Object.keys(settings.hooks).length === 0) delete settings.hooks;
+  setDisabledPaiModeClassifierGroups(settings, disabled);
+  return true;
+}
+
+function restorePaiModeClassifierHooks(settings: JsonObject): boolean {
+  const disabled = disabledPaiModeClassifierGroups(settings);
+  if (disabled.length === 0) return false;
+
+  const hooks = isObject(settings.hooks) ? settings.hooks : {};
+  const groups = Array.isArray(hooks.UserPromptSubmit) ? hooks.UserPromptSubmit as unknown[] : [];
+  const existingCommands = new Set(groups.flatMap(groupCommands));
+  let restored = false;
+  for (const group of disabled) {
+    const missingGroup = groupWithMissingCommands(group, existingCommands);
+    const commands = groupCommands(missingGroup);
+    if (commands.length === 0) continue;
+    groups.push(missingGroup);
+    restored = true;
+    for (const command of commands) existingCommands.add(command);
+  }
+  if (restored) {
+    hooks.UserPromptSubmit = groups;
+    settings.hooks = hooks;
+  }
+  setDisabledPaiModeClassifierGroups(settings, []);
+  return true;
+}
+
+function groupWithMissingCommands(group: unknown, existingCommands: Set<string>): unknown {
+  if (!isObject(group) || !Array.isArray(group.hooks)) return group;
+  const hooks = group.hooks.filter((hook) =>
+    isObject(hook) && typeof hook.command === "string" && !existingCommands.has(hook.command),
+  );
+  return { ...group, hooks };
 }
 
 async function writeJsonIfChanged(path: string, value: JsonObject, before?: string): Promise<string[]> {
@@ -195,6 +376,16 @@ export async function patchClaudeCodeSomaHookSettings(substrateHome: string, bun
   return writeJsonIfChanged(settingsPath, settings, before);
 }
 
+export async function patchClaudeCodeModeClassifierSettings(substrateHome: string, bunPath = resolveBunExecutable()): Promise<string[]> {
+  const settingsPath = resolve(substrateHome, SOMA_CLAUDE_SETTINGS_RELATIVE_PATH);
+  const { before, settings } = await readSettingsWithRaw(settingsPath);
+  const disabledPai = disablePaiModeClassifierHooks(settings);
+  const appendedSoma = appendSomaModeClassifierHookGroup(settings, substrateHome, bunPath);
+  const changed = disabledPai || appendedSoma;
+  if (!changed && before.trim().length > 0) return [];
+  return writeJsonIfChanged(settingsPath, settings, before);
+}
+
 export async function unpatchClaudeCodeSomaHookSettings(substrateHome: string, bunPath = resolveBunExecutable()): Promise<string[]> {
   const settingsPath = resolve(substrateHome, SOMA_CLAUDE_SETTINGS_RELATIVE_PATH);
   const { before, settings } = await readSettingsWithRaw(settingsPath);
@@ -203,10 +394,19 @@ export async function unpatchClaudeCodeSomaHookSettings(substrateHome: string, b
   return writeJsonIfChanged(settingsPath, settings, before);
 }
 
+export async function unpatchClaudeCodeModeClassifierSettings(substrateHome: string, bunPath = resolveBunExecutable()): Promise<string[]> {
+  const settingsPath = resolve(substrateHome, SOMA_CLAUDE_SETTINGS_RELATIVE_PATH);
+  const { before, settings } = await readSettingsWithRaw(settingsPath);
+  if (before.trim().length === 0) return [];
+  if (!removeSomaModeClassifierFromSettings(settings, substrateHome, bunPath)) return [];
+  return writeJsonIfChanged(settingsPath, settings, before);
+}
+
 export async function installClaudeCodeSomaHooks(context: {
   somaHome: string;
   somaRepoPath: string;
   substrateHome: string;
+  options?: unknown;
 }): Promise<string[]> {
   const hookPath = resolve(context.substrateHome, SOMA_CLAUDE_HOOK_RELATIVE_PATH);
   const configPath = resolve(context.substrateHome, SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH);
@@ -217,18 +417,59 @@ export async function installClaudeCodeSomaHooks(context: {
     bunPath,
   };
 
-  await mkdir(dirname(hookPath), { recursive: true });
-  await writeFile(hookPath, renderClaudeCodeSomaHook(), { encoding: "utf8", mode: 0o755 });
-  await chmod(hookPath, 0o755);
-  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+  await installClaudeCodeHookAsset({
+    hookPath,
+    configPath,
+    source: renderClaudeCodeSomaHook(),
+    config,
+  });
   const settingsFiles = await patchClaudeCodeSomaHookSettings(context.substrateHome, bunPath);
+  const modeClassifierFiles = isClaudeCodeInstallOptions(context.options) && context.options.modeClassifier === true
+    ? await installClaudeCodeModeClassifierHook(context, config, bunPath)
+    : [];
+  return Array.from(new Set([hookPath, configPath, ...settingsFiles, ...modeClassifierFiles]));
+}
+
+async function installClaudeCodeModeClassifierHook(
+  context: { somaHome: string; somaRepoPath: string; substrateHome: string },
+  config: { somaHome: string; trustedSomaRepo: string; bunPath: string },
+  bunPath: string,
+): Promise<string[]> {
+  const hookPath = resolve(context.substrateHome, SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH);
+  const configPath = resolve(context.substrateHome, SOMA_CLAUDE_MODE_CLASSIFIER_CONFIG_RELATIVE_PATH);
+
+  await installClaudeCodeHookAsset({
+    hookPath,
+    configPath,
+    source: renderClaudeCodeModeClassifierHook(),
+    config,
+  });
+  const settingsFiles = await patchClaudeCodeModeClassifierSettings(context.substrateHome, bunPath);
   return [hookPath, configPath, ...settingsFiles];
+}
+
+async function installClaudeCodeHookAsset(input: {
+  hookPath: string;
+  configPath: string;
+  source: string;
+  config: unknown;
+}): Promise<void> {
+  await mkdir(dirname(input.hookPath), { recursive: true });
+  await writeFile(input.hookPath, input.source, { encoding: "utf8", mode: 0o755 });
+  await chmod(input.hookPath, 0o755);
+  await writeFile(input.configPath, `${JSON.stringify(input.config, null, 2)}\n`, "utf8");
 }
 
 export async function removeClaudeCodeSomaHookFiles(substrateHome: string): Promise<string[]> {
   const removed: string[] = [];
   const installedBunPath = await readInstalledClaudeCodeHookBunPath(substrateHome);
-  for (const relativePath of [SOMA_CLAUDE_HOOK_RELATIVE_PATH, SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH]) {
+  const installedModeClassifierBunPath = await readInstalledClaudeCodeModeClassifierBunPath(substrateHome);
+  for (const relativePath of [
+    SOMA_CLAUDE_HOOK_RELATIVE_PATH,
+    SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH,
+    SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH,
+    SOMA_CLAUDE_MODE_CLASSIFIER_CONFIG_RELATIVE_PATH,
+  ]) {
     const target = resolve(substrateHome, relativePath);
     const exists = await stat(target).then(
       () => true,
@@ -246,11 +487,20 @@ export async function removeClaudeCodeSomaHookFiles(substrateHome: string): Prom
     );
   }
   removed.push(...(await unpatchClaudeCodeSomaHookSettings(substrateHome, installedBunPath)));
-  return removed;
+  removed.push(...(await unpatchClaudeCodeModeClassifierSettings(substrateHome, installedModeClassifierBunPath ?? installedBunPath)));
+  return Array.from(new Set(removed));
 }
 
 async function readInstalledClaudeCodeHookBunPath(substrateHome: string): Promise<string | undefined> {
-  const configPath = resolve(substrateHome, SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH);
+  return readInstalledClaudeCodeHookConfigBunPath(substrateHome, SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH);
+}
+
+async function readInstalledClaudeCodeModeClassifierBunPath(substrateHome: string): Promise<string | undefined> {
+  return readInstalledClaudeCodeHookConfigBunPath(substrateHome, SOMA_CLAUDE_MODE_CLASSIFIER_CONFIG_RELATIVE_PATH);
+}
+
+async function readInstalledClaudeCodeHookConfigBunPath(substrateHome: string, relativePath: string): Promise<string | undefined> {
+  const configPath = resolve(substrateHome, relativePath);
   const content = await readFile(configPath, "utf8").catch((error: unknown) => {
     if (isEnoent(error)) return undefined;
     throw error;
@@ -273,4 +523,8 @@ function renderClaudeCodeSomaHook(): string {
   const rendered = source.replace("__SOMA_CLAUDE_HOOK_EVENT_HANDLERS__", JSON.stringify(runnerHandlers, null, 2));
   if (rendered === source) throw new Error("Claude Code hook runner asset is missing the handler placeholder.");
   return rendered;
+}
+
+function renderClaudeCodeModeClassifierHook(): string {
+  return readFileSync(new URL("./mode-classifier-hook.mjs", import.meta.url), "utf8");
 }

--- a/src/adapters/claude-code/install-options.ts
+++ b/src/adapters/claude-code/install-options.ts
@@ -1,0 +1,9 @@
+import type { SomaInstallOptions } from "../../types";
+
+export interface ClaudeCodeInstallOptions extends SomaInstallOptions {
+  modeClassifier?: boolean;
+}
+
+export function isClaudeCodeInstallOptions(options: unknown): options is ClaudeCodeInstallOptions {
+  return typeof options === "object" && options !== null && !Array.isArray(options);
+}

--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -3,9 +3,12 @@ import { CLAUDE_CODE_RULES_FILES } from "../claude-code";
 import {
   SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH,
   SOMA_CLAUDE_HOOK_RELATIVE_PATH,
+  SOMA_CLAUDE_MODE_CLASSIFIER_CONFIG_RELATIVE_PATH,
+  SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH,
   installClaudeCodeSomaHooks,
   removeClaudeCodeSomaHookFiles,
 } from "./hooks";
+import { isClaudeCodeInstallOptions } from "./install-options";
 
 export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
   substrate: "claude-code",
@@ -16,6 +19,9 @@ export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
     SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH,
     "settings.json",
   ],
+  optionalHomeFiles: (options) => isClaudeCodeInstallOptions(options) && options.modeClassifier === true
+    ? [SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH, SOMA_CLAUDE_MODE_CLASSIFIER_CONFIG_RELATIVE_PATH]
+    : [],
   isaSkillProjection: {
     destinationDir: isaSkillUnder(),
   },

--- a/src/adapters/claude-code/mode-classifier-hook.mjs
+++ b/src/adapters/claude-code/mode-classifier-hook.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env bun
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function hookDir() {
+  return dirname(fileURLToPath(import.meta.url));
+}
+
+function readConfig() {
+  try {
+    return JSON.parse(readFileSync(join(hookDir(), "soma-mode-classifier.config.json"), "utf8"));
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function readHookInput() {
+  try {
+    const raw = readFileSync(0, "utf8");
+    if (raw.trim().length === 0) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function promptFromInput(input) {
+  for (const key of ["prompt", "userPrompt", "message", "input"]) {
+    if (typeof input[key] === "string") return input[key];
+  }
+  return "";
+}
+
+function runSomaClassification(config, prompt) {
+  return spawnSync(config.bunPath, ["src/cli.ts", "algorithm", "classify", "--prompt", prompt || "", "--json"], {
+    cwd: config.trustedSomaRepo,
+    encoding: "utf8",
+    timeout: 3000,
+    env: process.env,
+  });
+}
+
+function parseClassification(output) {
+  try {
+    return JSON.parse(output);
+  } catch {
+    return { mode: "algorithm", effort: "E3", source: "fail-safe", reason: "Classifier returned invalid JSON." };
+  }
+}
+
+function truncateDetails(text, maxLength = 500) {
+  if (!text || text.length <= maxLength) return text || "";
+  return `${text.slice(0, maxLength)}...`;
+}
+
+function renderModeContext(classification) {
+  const mode = String(classification.mode || "algorithm").toLowerCase();
+  const effort = typeof classification.effort === "string" ? classification.effort : "";
+  const source = classification.source || "unknown";
+  const reason = classification.reason || "No classifier reason returned.";
+  const label = effort ? `${mode.toUpperCase()} ${effort}` : mode.toUpperCase();
+  const lines = [
+    `Soma MODE: ${label} (${source}).`,
+    `Classifier reason: ${reason}`,
+  ];
+
+  if (mode === "algorithm") {
+    lines.push(
+      `Use the Algorithm rendering contract for ${effort || "E3"} work.`,
+      "Do not downshift to native execution unless the principal explicitly overrides this classification.",
+    );
+  } else if (mode === "native") {
+    lines.push(
+      "Use the substrate-native workflow; do not start an Algorithm run unless the principal explicitly asks for one.",
+      "Do not upshift to Algorithm only because Soma is installed.",
+    );
+  } else {
+    lines.push(
+      "Treat this as a minimal acknowledgement or small conversational turn.",
+      "Do not start an Algorithm run or expand scope unless the principal explicitly asks.",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function emitAndExit(payload) {
+  console.log(JSON.stringify(payload));
+  process.exit(0);
+}
+
+function emitFailOpen(reason) {
+  emitAndExit({
+    continue: true,
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: `Soma mode classifier unavailable; continue natively unless this prompt clearly needs Algorithm. ${truncateDetails(reason)}`,
+    },
+  });
+}
+
+function main() {
+  const config = readConfig();
+  if (config.error || typeof config.bunPath !== "string" || typeof config.trustedSomaRepo !== "string") {
+    emitFailOpen(config.error || "Invalid mode classifier config.");
+  }
+  const input = readHookInput();
+  const result = runSomaClassification(config, promptFromInput(input));
+  if (result.status !== 0) {
+    emitFailOpen(result.stderr || result.stdout || "");
+  }
+  emitAndExit({
+    continue: true,
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: renderModeContext(parseClassification(result.stdout)),
+    },
+  });
+}
+
+main();

--- a/src/algorithm-classifier.ts
+++ b/src/algorithm-classifier.ts
@@ -9,6 +9,8 @@ const MINIMAL_PROMPTS = new Set([
   "no",
   "thanks",
   "thank you",
+  "ok thanks",
+  "okay thanks",
   "works",
   "worked",
   "working",
@@ -31,6 +33,7 @@ const MINIMAL_PROMPTS = new Set([
 const NATIVE_PATTERNS = [
   /\b(what'?s next|next step|status|is that installed|does that work|what changed|what did you change)\b/i,
   /^(what|who|when|where) (is|are|was|were)\b/i,
+  /^what (time|date|day)\b/i,
   /^how (does|do|did|is|are)\b/i,
   /\b(run|execute)\b.+\b(tests?|command|script|lint|typecheck|date|pwd|ls)\b/i,
   /\b(read|show|summarize|inspect|check)\b.+\b(file|output|log|diff|status)\b/i,

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -19,6 +19,7 @@ import {
   type UninstallClaudeCodeResult,
   type UninstallCursorResult,
 } from "../index";
+import type { ClaudeCodeInstallOptions } from "../adapters/claude-code/install-options";
 import type {
   ProjectionInput,
   SomaInstallOptions,
@@ -30,13 +31,14 @@ import { SomaCliError } from "./errors";
 import { readOption } from "./parse-utils";
 
 export type InstallSubstrate = Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor">;
+type InstallCliOptions = SomaInstallOptions & Partial<Pick<ClaudeCodeInstallOptions, "modeClassifier">>;
 
 export interface ParsedInstallArgs {
   command: "install";
   substrate: InstallSubstrate;
   apply: boolean;
   workspace: boolean;
-  options: SomaInstallOptions;
+  options: InstallCliOptions;
 }
 
 export interface ParsedUninstallArgs {
@@ -82,7 +84,7 @@ export type ParsedSubstrateLifecycleArgs =
 export const INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code", "cursor"] as const satisfies readonly InstallSubstrate[];
 
 const substrateList = INSTALL_SUBSTRATES.join("|");
-const installOptions = "[--dry-run] [--apply] [--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
+const installOptions = "[--dry-run] [--apply] [--workspace] [--mode-classifier] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 const uninstallOptions = "[--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 
 function lifecycleUsage(command: string, target: string, options: string): string {
@@ -179,12 +181,12 @@ function resolveJoin(...parts: string[]): string {
   return parts.join("/").replace(/\/+/g, "/");
 }
 
-function parseSubstrateLifecycleOptions(
+function parseSubstrateLifecycleOptions<TOptions extends SomaInstallOptions = SomaInstallOptions>(
   substrate: InstallSubstrate,
   rest: string[],
-  extra: (arg: string, index: number) => boolean,
-): { workspace: boolean; options: SomaInstallOptions } {
-  const options: SomaInstallOptions = {};
+  extra: (arg: string, index: number, options: TOptions) => boolean,
+): { workspace: boolean; options: TOptions } {
+  const options = {} as TOptions;
   let workspace = false;
   let substrateHomeExplicit = false;
 
@@ -210,7 +212,7 @@ function parseSubstrateLifecycleOptions(
         continue;
     }
 
-    if (extra(arg, index)) continue;
+    if (extra(arg, index, options)) continue;
 
     throw new Error(`Unknown option: ${arg}`);
   }
@@ -230,7 +232,7 @@ export function parseInstallArgs(args: string[]): ParsedInstallArgs {
   }
 
   let apply = false;
-  const { workspace, options } = parseSubstrateLifecycleOptions(substrate, rest, (arg) => {
+  const { workspace, options } = parseSubstrateLifecycleOptions<InstallCliOptions>(substrate, rest, (arg, _index, parsedOptions) => {
     switch (arg) {
       case "--dry-run":
         apply = false;
@@ -238,9 +240,15 @@ export function parseInstallArgs(args: string[]): ParsedInstallArgs {
       case "--apply":
         apply = true;
         return true;
+      case "--mode-classifier":
+        parsedOptions.modeClassifier = true;
+        return true;
     }
     return false;
   });
+  if (options.modeClassifier === true && substrate !== "claude-code") {
+    throw new Error("--mode-classifier is only supported for claude-code installs.");
+  }
 
   return { command, substrate, apply, workspace, options };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -368,6 +368,7 @@ export {
   type UninstallCursorOptions,
   type UninstallCursorResult,
 } from "./install";
+export type { ClaudeCodeInstallOptions } from "./adapters/claude-code/install-options";
 // Adapter active-ISA projection helpers (#37).
 export {
   activeIsaProjectionPath,

--- a/src/install-spec.ts
+++ b/src/install-spec.ts
@@ -13,6 +13,7 @@ export interface InstallPostProjectionContext {
   somaHome: string;
   somaRepoPath: string;
   substrateHome: string;
+  options?: unknown;
 }
 
 export interface InstallPostProjectionStep {
@@ -60,6 +61,7 @@ export interface SubstrateInstallSpec<S extends InstallSubstrate = InstallSubstr
   substrate: S;
   defaultHome: string;
   homeFiles: readonly string[];
+  optionalHomeFiles?(options: unknown): readonly string[];
   isaSkillProjection: IsaSkillProjectionSpec;
   validator?: InstallValidator;
   lifecycleProjection?: LifecycleProjectionSpec;

--- a/src/install.ts
+++ b/src/install.ts
@@ -7,6 +7,7 @@ import {
   installCursorHomeProjection,
   installPiDevHomeProjection,
 } from "./home-projection";
+import type { ClaudeCodeInstallOptions } from "./adapters/claude-code/install-options";
 import { buildSomaStartupContext, runSomaLifecycleAlgorithmUpdated } from "./lifecycle";
 import { SOMA_MEMORY_CATEGORIES } from "./memory-readmes";
 import { defaultSomaRepoPath } from "./repo-path";
@@ -23,6 +24,8 @@ import {
 } from "./install-spec";
 import { defaultSubstrateHome, installSpecFor } from "./install-spec-registry";
 import type { ProjectionInput, SomaInstallOptions, SomaInstallPlan, SomaInstallResult } from "./types";
+
+export type { ClaudeCodeInstallOptions } from "./adapters/claude-code/install-options";
 
 const SOMA_BOOTSTRAP_FILES = [
   "profile/assistant.md",
@@ -66,8 +69,16 @@ export function planSomaInstall(
   substrate: InstallSubstrate,
   options: SomaInstallOptions = {},
 ): SomaInstallPlan {
+  return planSomaInstallBase(substrate, options);
+}
+
+function planSomaInstallBase(
+  substrate: InstallSubstrate,
+  options: SomaInstallOptions = {},
+): SomaInstallPlan {
   const spec = installSpecFor(substrate);
   const homes = resolveInstallHomes(substrate, options);
+  const optionalSubstrateFiles = spec.optionalHomeFiles?.(options) ?? [];
 
   return {
     substrate,
@@ -76,7 +87,7 @@ export function planSomaInstall(
     substrateHome: homes.substrateHome,
     somaDirectories: SOMA_BOOTSTRAP_DIRECTORIES.map((path) => `${homes.somaHome}/${path}`),
     somaFiles: SOMA_BOOTSTRAP_FILES.map((path) => `${homes.somaHome}/${path}`),
-    substrateFiles: spec.homeFiles.map((path) => `${homes.substrateHome}/${path}`),
+    substrateFiles: [...spec.homeFiles, ...optionalSubstrateFiles].map((path) => `${homes.substrateHome}/${path}`),
   };
 }
 
@@ -88,8 +99,8 @@ export function planSomaForPiDevInstall(options: SomaInstallOptions = {}): SomaI
   return planSomaInstall("pi-dev", options);
 }
 
-export function planSomaForClaudeCodeInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
-  return planSomaInstall("claude-code", options);
+export function planSomaForClaudeCodeInstall(options: ClaudeCodeInstallOptions = {}): SomaInstallPlan {
+  return planSomaInstallBase("claude-code", options);
 }
 
 export function planSomaForCursorInstall(options: SomaInstallOptions = {}): SomaInstallPlan {
@@ -151,6 +162,7 @@ async function installSomaForSubstrate(
     somaHome: somaHome.somaHome,
     somaRepoPath: projectionOptions.somaRepoPath,
     substrateHome: substrateHome.rootDir,
+    options,
   });
   const lifecycleSpec = spec.lifecycleProjection;
   const lifecycleFiles = lifecycleSpec
@@ -174,7 +186,7 @@ async function installSomaForSubstrate(
 
 async function runPostProjectionSteps(
   spec: SubstrateInstallSpec,
-  context: { homeDir?: string; somaHome: string; somaRepoPath: string; substrateHome: string },
+  context: { homeDir?: string; somaHome: string; somaRepoPath: string; substrateHome: string; options?: unknown },
 ): Promise<string[]> {
   const files: string[] = [];
   for (const step of spec.postProjection ?? []) {
@@ -242,7 +254,7 @@ export async function installSomaForPiDev(options: SomaInstallOptions = {}): Pro
  * `~/.claude/settings.json` idempotently. CLAUDE.md composition remains
  * intentionally out of scope.
  */
-export async function installSomaForClaudeCode(options: SomaInstallOptions = {}): Promise<SomaInstallResult> {
+export async function installSomaForClaudeCode(options: ClaudeCodeInstallOptions = {}): Promise<SomaInstallResult> {
   return installSomaForSubstrate("claude-code", options);
 }
 

--- a/test/algorithm.test.ts
+++ b/test/algorithm.test.ts
@@ -126,11 +126,19 @@ test("classifies prompts into Algorithm mode and effort tiers", () => {
     mode: "minimal",
     source: "auto",
   });
+  expect(classifyAlgorithmPrompt("ok thanks")).toMatchObject({
+    mode: "minimal",
+    source: "auto",
+  });
   expect(classifyAlgorithmPrompt("great, that works nicely")).toMatchObject({
     mode: "minimal",
     source: "auto",
   });
   expect(classifyAlgorithmPrompt("what's next?")).toMatchObject({
+    mode: "native",
+    source: "auto",
+  });
+  expect(classifyAlgorithmPrompt("what time is it")).toMatchObject({
     mode: "native",
     source: "auto",
   });

--- a/test/claude-code-install.test.ts
+++ b/test/claude-code-install.test.ts
@@ -17,6 +17,7 @@ import {
   setActiveIsa,
   uninstallSomaForClaudeCode,
 } from "../src/index";
+import { unpatchClaudeCodeModeClassifierSettings } from "../src/adapters/claude-code/hooks";
 import { portableProjectionInput } from "./fixtures";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
@@ -47,6 +48,21 @@ function countSomaHookCommands(settings: { hooks?: Record<string, unknown[]> }):
   ).length;
 }
 
+function countHookCommandsContaining(settings: { hooks?: Record<string, unknown[]> }, text: string): number {
+  return Object.values(settings.hooks ?? {}).flatMap((groups) =>
+    groups.flatMap((group) => {
+      if (!group || typeof group !== "object" || !("hooks" in group) || !Array.isArray(group.hooks)) return [];
+      return group.hooks.filter((hook) =>
+        hook &&
+        typeof hook === "object" &&
+        "command" in hook &&
+        typeof hook.command === "string" &&
+        hook.command.includes(text),
+      );
+    }),
+  ).length;
+}
+
 function runClaudeHook(homeDir: string, event: string, input: Record<string, unknown>): void {
   const hook = join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.mjs");
   const result = spawnSync(process.execPath, [hook, event], {
@@ -56,6 +72,26 @@ function runClaudeHook(homeDir: string, event: string, input: Record<string, unk
     encoding: "utf8",
   });
   expect(result.status).toBe(0);
+}
+
+interface ClaudePromptHookOutput {
+  continue?: boolean;
+  hookSpecificOutput?: {
+    hookEventName?: string;
+    additionalContext?: string;
+  };
+}
+
+function runClaudeModeClassifierHook(homeDir: string, input: Record<string, unknown>): ClaudePromptHookOutput {
+  const hook = join(homeDir, ".claude/hooks/soma/soma-mode-classifier.mjs");
+  const result = spawnSync(process.execPath, [hook], {
+    cwd: process.cwd(),
+    env: { ...process.env, HOME: homeDir },
+    input: JSON.stringify(input),
+    encoding: "utf8",
+  });
+  expect(result.status).toBe(0);
+  return JSON.parse(result.stdout) as ClaudePromptHookOutput;
 }
 
 async function waitForEvents(homeDir: string, predicate: (events: ClaudeHookEvent[]) => boolean): Promise<ClaudeHookEvent[]> {
@@ -120,6 +156,15 @@ test("AC-2: planSomaForClaudeCodeInstall lists every file written", () => {
   ]);
 });
 
+test("issue #274: mode classifier hook files are opt-in in the Claude Code install plan", () => {
+  const defaultPlan = planSomaForClaudeCodeInstall({ homeDir: "/tmp/test-home" });
+  expect(defaultPlan.substrateFiles).not.toContain("/tmp/test-home/.claude/hooks/soma/soma-mode-classifier.mjs");
+
+  const plan = planSomaForClaudeCodeInstall({ homeDir: "/tmp/test-home", modeClassifier: true });
+  expect(plan.substrateFiles).toContain("/tmp/test-home/.claude/hooks/soma/soma-mode-classifier.mjs");
+  expect(plan.substrateFiles).toContain("/tmp/test-home/.claude/hooks/soma/soma-mode-classifier.config.json");
+});
+
 test("AC-3: planSomaForClaudeCodeInstall does not write files (plan.apply === false)", async () => {
   await withTempHome(async (homeDir) => {
     planSomaForClaudeCodeInstall({ homeDir });
@@ -175,6 +220,144 @@ test("issue #236: claude-code install wires Soma-owned hooks without overwriting
     expect(JSON.stringify(settings)).toContain(config.bunPath);
     expect(Object.keys(settings.hooks).sort()).toEqual(["PostToolUse", "SessionEnd", "SessionStart", "SubagentStart", "SubagentStop"]);
     expect(countSomaHookCommands(settings)).toBe(5);
+    expect(JSON.stringify(settings)).not.toContain("soma-mode-classifier");
+  });
+});
+
+test("issue #274: Claude Code mode classifier install disables PAI classifier and restores it on uninstall", async () => {
+  await withTempHome(async (homeDir) => {
+    await mkdir(join(homeDir, ".claude"), { recursive: true });
+    const paiModeClassifierCommand = "bun ~/PAI/TOOLS/ModeClassifier.hook.ts";
+    await writeFile(
+      join(homeDir, ".claude/settings.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            {
+              description: "PAI ModeClassifier",
+              hooks: [{ type: "command", command: paiModeClassifierCommand }],
+            },
+            {
+              description: "user prompt hook",
+              hooks: [{ type: "command", command: "echo user-prompt" }],
+            },
+          ],
+        },
+      }, null, 2),
+      "utf8",
+    );
+
+    await installSomaForClaudeCode({ homeDir, modeClassifier: true });
+    await installSomaForClaudeCode({ homeDir, modeClassifier: true });
+
+    const hookInfo = await stat(join(homeDir, ".claude/hooks/soma/soma-mode-classifier.mjs"));
+    expect((hookInfo.mode & 0o100) !== 0).toBe(true);
+    const settings = await readJson<{ hooks: Record<string, unknown[]>; somaDisabledHooks?: Record<string, unknown[]> }>(join(homeDir, ".claude/settings.json"));
+    expect(countHookCommandsContaining(settings, "soma-mode-classifier.mjs")).toBe(1);
+    expect(JSON.stringify(settings.hooks)).toContain("echo user-prompt");
+    expect(JSON.stringify(settings.hooks)).not.toContain("ModeClassifier.hook.ts");
+    expect(JSON.stringify(settings.somaDisabledHooks)).toContain("ModeClassifier.hook.ts");
+
+    const output = runClaudeModeClassifierHook(homeDir, { prompt: "Implement a multi-file migration for the adapter" });
+    expect(output.continue).toBe(true);
+    expect(output.hookSpecificOutput?.hookEventName).toBe("UserPromptSubmit");
+    expect(output.hookSpecificOutput?.additionalContext).toContain("Soma MODE: ALGORITHM E3");
+    expect(output.hookSpecificOutput?.additionalContext).toContain("Do not downshift");
+
+    const removed = await uninstallSomaForClaudeCode({ homeDir });
+    expect(removed.removed).toContain(join(homeDir, ".claude/hooks/soma/soma-mode-classifier.mjs"));
+    expect(removed.removed).toContain(join(homeDir, ".claude/hooks/soma/soma-mode-classifier.config.json"));
+    await expect(stat(join(homeDir, ".claude/hooks/soma/soma-mode-classifier.mjs"))).rejects.toThrow();
+    const after = await readJson<{ hooks: Record<string, unknown[]>; somaDisabledHooks?: unknown }>(join(homeDir, ".claude/settings.json"));
+    expect(JSON.stringify(after.hooks)).toContain("ModeClassifier.hook.ts");
+    expect(JSON.stringify(after.hooks)).toContain("echo user-prompt");
+    expect(JSON.stringify(after.hooks)).not.toContain("soma-mode-classifier");
+    expect(after.somaDisabledHooks).toBeUndefined();
+  });
+});
+
+test("issue #274: mode classifier uninstall ignores empty disabled PAI hook groups", async () => {
+  await withTempHome(async (homeDir) => {
+    const substrateHome = join(homeDir, ".claude");
+    await mkdir(substrateHome, { recursive: true });
+    const settingsPath = join(substrateHome, "settings.json");
+    await writeFile(
+      settingsPath,
+      JSON.stringify({ somaDisabledHooks: { paiModeClassifier: [{ description: "empty", hooks: [] }] } }, null, 2),
+      "utf8",
+    );
+
+    const before = await readFile(settingsPath, "utf8");
+    const changed = await unpatchClaudeCodeModeClassifierSettings(substrateHome, process.execPath);
+    const after = await readJson<{ somaDisabledHooks?: unknown }>(settingsPath);
+
+    expect(changed).toEqual([settingsPath]);
+    expect(await readFile(settingsPath, "utf8")).not.toBe(before);
+    expect(after.somaDisabledHooks).toBeUndefined();
+  });
+});
+
+test("issue #274: mode classifier uninstall restores only missing PAI hook commands", async () => {
+  await withTempHome(async (homeDir) => {
+    const substrateHome = join(homeDir, ".claude");
+    await mkdir(substrateHome, { recursive: true });
+    const existingCommand = "bun ~/PAI/TOOLS/ModeClassifier.hook.ts";
+    const missingCommand = "node ~/PAI/TOOLS/ModeClassifier.hook.mjs";
+    const settingsPath = join(substrateHome, "settings.json");
+    await writeFile(
+      settingsPath,
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [{ description: "already restored", hooks: [{ type: "command", command: existingCommand }] }],
+        },
+        somaDisabledHooks: {
+          paiModeClassifier: [{ description: "PAI ModeClassifier", hooks: [{ type: "command", command: existingCommand }, { type: "command", command: missingCommand }] }],
+        },
+      }, null, 2),
+      "utf8",
+    );
+
+    await unpatchClaudeCodeModeClassifierSettings(substrateHome, process.execPath);
+
+    const after = await readJson<{ hooks: Record<string, unknown[]>; somaDisabledHooks?: unknown }>(settingsPath);
+    expect(countHookCommandsContaining(after, "ModeClassifier.hook.ts")).toBe(1);
+    expect(countHookCommandsContaining(after, "ModeClassifier.hook.mjs")).toBe(1);
+    expect(after.somaDisabledHooks).toBeUndefined();
+  });
+});
+
+test("issue #274: mode classifier install disables quoted PAI mjs classifier commands", async () => {
+  await withTempHome(async (homeDir) => {
+    await mkdir(join(homeDir, ".claude"), { recursive: true });
+    const paiModeClassifierCommand = 'bun "/workspace/PAI/TOOLS/ModeClassifier.hook.mjs"';
+    await writeFile(
+      join(homeDir, ".claude/settings.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [{ description: "PAI ModeClassifier", hooks: [{ type: "command", command: paiModeClassifierCommand }] }],
+        },
+      }, null, 2),
+      "utf8",
+    );
+
+    await installSomaForClaudeCode({ homeDir, modeClassifier: true });
+
+    const settings = await readJson<{ hooks: Record<string, unknown[]>; somaDisabledHooks?: Record<string, unknown[]> }>(join(homeDir, ".claude/settings.json"));
+    expect(JSON.stringify(settings.hooks)).not.toContain("ModeClassifier.hook.mjs");
+    expect(JSON.stringify(settings.somaDisabledHooks)).toContain("ModeClassifier.hook.mjs");
+  });
+});
+
+test("issue #274: mode classifier hook fails open when config is missing", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir, modeClassifier: true });
+    await rm(join(homeDir, ".claude/hooks/soma/soma-mode-classifier.config.json"));
+
+    const output = runClaudeModeClassifierHook(homeDir, { prompt: "hello" });
+
+    expect(output.continue).toBe(true);
+    expect(output.hookSpecificOutput?.hookEventName).toBe("UserPromptSubmit");
+    expect(output.hookSpecificOutput?.additionalContext).toContain("Soma mode classifier unavailable");
   });
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1696,6 +1696,20 @@ test("cli install supports claude-code substrate (dry-run)", async () => {
   });
 });
 
+test("cli install claude-code supports opt-in mode classifier dry-run", async () => {
+  await withTempHome(async (homeDir) => {
+    const output = await runSomaCli(["install", "claude-code", "--mode-classifier", "--home-dir", homeDir]);
+
+    expect(output).toContain(join(homeDir, ".claude/hooks/soma/soma-mode-classifier.mjs"));
+    expect(output).toContain(join(homeDir, ".claude/hooks/soma/soma-mode-classifier.config.json"));
+    await expect(stat(join(homeDir, ".claude"))).rejects.toThrow();
+  });
+});
+
+test("cli rejects mode classifier flag for non-Claude Code installs", async () => {
+  await expect(runSomaCli(["install", "codex", "--mode-classifier"])).rejects.toThrow("--mode-classifier is only supported");
+});
+
 test("cli dry-runs and applies cursor install", async () => {
   await withTempHome(async (homeDir) => {
     const dryRun = await runSomaCli(["install", "cursor", "--home-dir", homeDir]);


### PR DESCRIPTION
Closes #274.

## Summary

- adds `soma install claude-code --mode-classifier` as an opt-in install flag
- installs a Claude Code `UserPromptSubmit` hook that calls `soma algorithm classify --json` and injects concise MODE context
- disables detected PAI `ModeClassifier.hook.*` entries during opt-in install and restores them on uninstall
- tunes Soma classification for minimal acknowledgements and simple native time/date questions

## Verification

- `rtk bun run typecheck`
- `rtk bun run lint`
- `rtk bun test test/algorithm.test.ts`
- `rtk bun test test/claude-code-install.test.ts`
- `rtk bun test test/cli.test.ts`
- `rtk bun test`
