### PR TITLE
Document optional Soma MCP server design

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,9 @@ Adapters decide how the skill is projected into each substrate.
 Soma supports progressive skill loading: project a compact registry by default,
 then load the selected skill body only when a task route needs it. See
 [docs/progressive-skill-loading.md](docs/progressive-skill-loading.md).
+MCP-capable substrates can use the optional
+[docs/mcp-server.md](docs/mcp-server.md) surface for the same on-demand loading
+without replacing the eager projection.
 
 ### Learning patterns
 
@@ -404,6 +407,7 @@ writeback gates, and adapter behavior are stable.
 - [docs/integration-with-pai.md](docs/integration-with-pai.md), PAI integration walkthrough
 - [docs/pai-pack-importer.md](docs/pai-pack-importer.md), PAI pack import rules
 - [docs/progressive-skill-loading.md](docs/progressive-skill-loading.md), skill registry and just-in-time loading
+- [docs/mcp-server.md](docs/mcp-server.md), optional read-mostly MCP tool surface
 - [docs/writeback-and-policy.md](docs/writeback-and-policy.md), projection, writeback, conflict, and policy semantics
 - [docs/portability-proof.md](docs/portability-proof.md), the first portability proof and evidence contract
 

--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -513,3 +513,67 @@ runtime policy decisions.
   exposes a reliable gate.
 
 **Discussion:** issue #255 design pass, 2026-05-29.
+
+### DD-10: MCP is an optional read-mostly Soma access surface
+
+**Status:** Decided (2026-05-31)
+
+**Context:** Issue #153 asks whether Soma should expose memory, skills, ISA,
+Algorithm, and identity through an MCP server. MCP-capable substrates can call
+tools directly, but MCP tool schemas carry always-on token cost and mutating
+tools can bypass the deliberate writeback gates if the boundary is unclear.
+
+Three candidates surfaced:
+- **(a) Treat MCP as a replacement adapter.** Build substrate behavior around
+  MCP and reduce filesystem projection work.
+- **(b) Treat MCP as an optional shared library/daemon surface.** Keep home and
+  workspace projections eager or indexed as appropriate, while MCP provides
+  on-demand read-only access and later confirmed writes.
+- **(c) Defer MCP entirely.** Keep only per-substrate hooks, rules, and
+  extension APIs until a substrate requires MCP.
+
+**Decision:** **(b)** — MCP is an optional read-mostly access surface over Soma
+core. It is not a substrate adapter replacement. Adapters may configure
+substrate-native MCP clients, but the MCP server owns one portable tool
+inventory and calls Soma core APIs for memory, skills, ISA, Algorithm, identity,
+policy, and writeback.
+
+The first implementation slice should expose read-only tools only:
+`soma_memory_search`, `soma_memory_read`, `soma_skill_registry`,
+`soma_skill_route`, `soma_skill_load`, `soma_isa_active`, `soma_isa_check`,
+`soma_algorithm_classify`, and `soma_identity_context`.
+
+Mutating tools are reserved behind a confirmation model:
+`soma_memory_promote`, `soma_isa_scaffold`, `soma_algorithm_new`, and
+`soma_algorithm_advance`. A mutating call must first return a deterministic
+preview, affected paths, policy checks, and a short-lived confirmation token.
+The token must be single-use and bound to the requesting principal, MCP client
+session, substrate, affected paths, policy result, and mutation fingerprint.
+The write only happens when a second call submits the token and matching
+mutation fingerprint from the same bound client session.
+
+MCP schemas must be budgeted. The default manifest should stay small, registry
+calls must not return full skill or memory bodies, and large responses must
+require selector or pagination arguments.
+
+Read tools must validate the requesting principal, MCP client session,
+substrate, and allowed memory/identity/ISA/skill/Algorithm scope before
+returning data. Unauthorized, out-of-scope, or malformed reads fail closed
+without returning private excerpts.
+
+**Rejected:**
+- (a) makes MCP support a prerequisite for Soma eager availability and would
+  collapse adapter responsibilities into a protocol server.
+- (c) misses the main benefit of MCP: a shared on-demand loading surface for
+  substrates that already know how to call tools.
+
+**Implications:**
+- The canonical design is documented in `docs/mcp-server.md`.
+- Cursor, Claude Code, Codex plugins, Pi.dev, and daemon substrates should
+  reuse the same MCP tool names instead of inventing per-substrate vocabularies.
+- Read-only tools must not write raw prompts, transcripts, full tool inputs, or
+  command output by default.
+- Deferred write tools should return structured `requires_confirmation` results
+  until the confirmation protocol is implemented.
+- Home and workspace projections remain required. MCP is an on-demand
+  optimization, not the only way to inhabit Soma.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,6 +80,11 @@ The progressive loading contract is specified in
 project a compact skill registry by default and load skill bodies only after a
 task route selects them.
 
+MCP-capable substrates may use the optional
+[MCP server](./mcp-server.md) as the on-demand loading surface for skills,
+memory, ISA, Algorithm, and identity context. The server remains a core/library
+access surface; adapters only configure substrate-native MCP clients.
+
 ### Memory
 
 Memory is structured as files first:
@@ -144,6 +149,10 @@ Overlays the home projection if both exist.
 
 A substrate CLI loads Soma as code and exposes tools. No projection on disk.
 The substrate owns the process.
+
+The optional MCP server is a library/daemon-compatible tool surface. It can
+serve read-only context to MCP-capable substrates without replacing home and
+workspace projections.
 
 ### daemon
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -1,0 +1,134 @@
+# Soma MCP Server Design
+
+Soma should expose an optional Model Context Protocol server for substrates that
+can call tools directly. The MCP server is a thin access surface over Soma core;
+it is not a substrate adapter replacement and it does not own assistant state.
+
+The first implementation slice should be read-only. Mutating tools stay behind
+an explicit confirmation model so the MCP surface cannot become a silent
+writeback channel.
+
+## Goals
+
+- Let MCP-capable substrates discover Soma memory, skills, ISA, Algorithm, and
+  identity context on demand.
+- Keep eager startup context small by making large registries and skill bodies
+  indexed with on-demand bodies.
+- Share one portable tool contract across Cursor, Claude Code, Codex plugins,
+  Pi.dev, and future daemon-backed substrates.
+- Preserve adapter boundaries: adapters install and configure substrate-native
+  MCP clients, while the MCP server reads and, after confirmation, mutates Soma
+  through core APIs.
+
+## Non-Goals
+
+- The MCP server is not required for home projections, lifecycle hooks, or
+  eager startup availability.
+- The MCP server does not replace filesystem-native Soma memory.
+- The MCP server does not mirror raw prompts, transcripts, full tool inputs, or
+  command output into shared memory by default.
+- The first implementation does not include mutating writes.
+
+## Tool Inventory
+
+The canonical tool set is grouped by Soma area. Tool schemas should stay
+small: each tool needs a narrow description, bounded input shape, and
+pagination or selector arguments for large outputs.
+
+| Domain | Tool | First slice | Purpose |
+|--------|------|-------------|---------|
+| Memory | `soma_memory_search` | read | Search indexed Soma memory using filenames, metadata, and text snippets. |
+| Memory | `soma_memory_read` | read | Read a bounded memory artifact by stable path or ID. |
+| Memory | `soma_memory_promote` | deferred write | Promote reviewed material into durable memory. |
+| Skills | `soma_skill_registry` | read | List available skills with names, summaries, token estimates, and entrypoints. |
+| Skills | `soma_skill_route` | read | Route a task description to likely skills without loading every skill body. |
+| Skills | `soma_skill_load` | read | Load one selected skill entrypoint or referenced file. |
+| ISA | `soma_isa_active` | read | Return the active ISA summary and criterion IDs. |
+| ISA | `soma_isa_check` | read | Check proposed evidence against active ISA criteria without mutating state. |
+| ISA | `soma_isa_scaffold` | deferred write | Create a new ISA draft after explicit confirmation. |
+| Algorithm | `soma_algorithm_classify` | read | Classify a prompt as MINIMAL, NATIVE, or ALGORITHM and map Algorithm depth. |
+| Algorithm | `soma_algorithm_new` | deferred write | Create a new Algorithm run. |
+| Algorithm | `soma_algorithm_advance` | deferred write | Advance an existing Algorithm run through phase gates. |
+| Identity | `soma_identity_context` | read | Return bounded assistant/principal identity context for the current substrate. |
+
+## Schema Budget
+
+MCP tool schemas are loaded by the MCP client and can become always-on prompt
+cost. The server should therefore expose a compact default manifest:
+
+- default tools: `soma_identity_context`, `soma_skill_registry`,
+  `soma_skill_route`, `soma_skill_load`, `soma_isa_active`,
+  `soma_isa_check`, `soma_algorithm_classify`, `soma_memory_search`, and
+  `soma_memory_read`
+- deferred tools: `soma_memory_promote`, `soma_isa_scaffold`,
+  `soma_algorithm_new`, and `soma_algorithm_advance`
+- each tool description should stay under roughly 40 words
+- large responses must require `limit`, `cursor`, `path`, `skill`, or
+  `criterionId` selectors
+- skill bodies and memory artifact bodies are never returned in registry calls
+
+This mirrors the progressive loading contract in
+[progressive-skill-loading.md](./progressive-skill-loading.md): start with a
+small registry, route, then load only the selected body.
+
+## Read Authorization Model
+
+Every read tool must validate the requesting principal, MCP client session,
+substrate, and allowed scope before returning data. Scope includes the requested
+memory path or ID, identity context, active ISA, skill entrypoint, Algorithm
+classification input, and any substrate-specific visibility limit.
+
+Path-based reads must resolve through Soma core path validation and must not
+accept raw filesystem paths from an untrusted client as authority. Unauthorized,
+out-of-scope, or malformed reads fail closed with a bounded error and no private
+content excerpt.
+
+## Write Confirmation Model
+
+Mutating tools require a two-step confirmation protocol:
+
+1. The tool returns a proposed mutation with a deterministic preview, affected
+   paths, policy checks, and a short-lived confirmation token.
+2. A second call submits the token and the same mutation fingerprint before Soma
+   writes through the normal core API.
+
+Confirmation tokens must be single-use and bound to the requesting principal,
+MCP client session, substrate, affected paths, policy result, and mutation
+fingerprint. A token presented from a different client session or for a changed
+mutation is refused.
+
+The first MCP PR should not implement writes. It should reserve the protocol and
+return structured `requires_confirmation` results for deferred write tools until
+the confirmation implementation exists.
+
+The confirmation model must use the same safety line as the adapter writeback
+gate: no raw prompt, transcript, full tool input, or command output is written
+by default.
+
+## Adapter Boundary
+
+The MCP server is a library/daemon surface. It owns the protocol transport and
+tool schemas, but it calls Soma core for identity, memory, skill routing, ISA,
+Algorithm, policy, and writeback.
+
+Adapters own substrate-native install facts:
+
+- Cursor may project MCP setup notes into `.cursor/rules/soma/MCP.md`.
+- Claude Code may patch `mcpServers` in its settings only when explicitly
+  requested.
+- Codex plugin wiring is future work and should consume the same server.
+- Pi.dev can keep its existing `soma_context` extension surface while MCP
+  parity remains optional.
+
+Substrates without MCP support still receive eager filesystem projections. MCP
+is an on-demand optimization, not the only way to inhabit Soma.
+
+## First Implementation Slice
+
+The first code slice should add a server entrypoint that exposes the read tools
+from the Tool Inventory table, matching the default manifest in the Schema
+Budget section.
+
+It should include fixture-backed tests for schema shape, bounded responses,
+path validation, missing active ISA, missing skill, no raw prompt persistence,
+and no writes from read-only tools.

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -166,7 +166,9 @@ emits the deterministic file bundle without writing files.
 projection and a Soma-owned `.cursorrules` marker file. A pre-existing
 workspace `.cursorrules` that does not start with the Soma marker is preserved.
 Cursor execution and MCP runtime wiring are deferred; the adapter exposes
-context projection first.
+context projection first. The portable MCP server contract is specified in
+[mcp-server.md](./mcp-server.md); Cursor adapter work should configure that
+server rather than defining a Cursor-only tool vocabulary.
 
 ## Cortex / Myelin
 
@@ -225,10 +227,15 @@ extensions; Signal remains the telemetry-system owner.
 
 Adapters own their substrate-native install facts: default home, projected file
 paths, substrate-specific skill destinations, lifecycle projection paths,
-validators, cleanup hooks, private projection roots, and uninstall targets. The
-installer owns orchestration: bootstrapping Soma home, loading active ISA,
-running lifecycle updates, writing projections, and applying the install,
-reproject, upgrade, and uninstall verbs.
+validators, cleanup hooks, private projection roots, MCP client configuration,
+and uninstall targets. The installer owns orchestration: bootstrapping Soma
+home, loading active ISA, running lifecycle updates, writing projections, and
+applying the install, reproject, upgrade, and uninstall verbs.
+
+The optional MCP server is a shared library/daemon surface, not an adapter.
+Adapters may install or advertise substrate-native MCP client configuration, but
+the tool inventory, schema budget, confirmation model, and read/write semantics
+belong to Soma core. See [mcp-server.md](./mcp-server.md).
 
 The first portability proof is documented in
 [portability-proof.md](./portability-proof.md). Memory and policy v0 are

--- a/test/mcp-server-design.test.ts
+++ b/test/mcp-server-design.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "bun:test";
+
+const designDoc = readFileSync("docs/mcp-server.md", "utf8");
+const adapterDoc = readFileSync("docs/substrate-adapters.md", "utf8");
+const decisions = readFileSync("design/design-decisions.md", "utf8");
+
+const firstSliceTools = [
+  "soma_identity_context",
+  "soma_skill_registry",
+  "soma_skill_route",
+  "soma_skill_load",
+  "soma_isa_active",
+  "soma_isa_check",
+  "soma_algorithm_classify",
+  "soma_memory_search",
+  "soma_memory_read",
+] as const;
+
+const deferredWriteTools = [
+  "soma_memory_promote",
+  "soma_isa_scaffold",
+  "soma_algorithm_new",
+  "soma_algorithm_advance",
+] as const;
+
+test("MCP design records the canonical read-only first slice", () => {
+  expect(designDoc).toContain("The first implementation slice should be read-only");
+  const defaultTools = /- default tools:([\s\S]*?)- deferred tools:/.exec(designDoc)?.[1] ?? "";
+  for (const tool of firstSliceTools) {
+    expect(designDoc).toContain(tool);
+    expect(decisions).toContain(tool);
+    expect(defaultTools).toContain(tool);
+  }
+});
+
+test("MCP design keeps mutating tools behind confirmation", () => {
+  expect(designDoc).toContain("two-step confirmation protocol");
+  expect(decisions).toContain("short-lived confirmation token");
+  expect(designDoc).toContain("single-use and bound to the requesting principal");
+  expect(decisions).toContain("single-use and bound to the requesting principal");
+  expect(designDoc).toContain("MCP client session");
+  for (const tool of deferredWriteTools) {
+    expect(designDoc).toContain(tool);
+    expect(decisions).toContain(tool);
+  }
+});
+
+test("MCP design preserves adapter and writeback boundaries", () => {
+  expect(designDoc).toContain("not a substrate adapter replacement");
+  expect(adapterDoc).toContain("The optional MCP server is a shared library/daemon surface, not an adapter.");
+  expect(designDoc).toMatch(/no raw prompt, transcript, full tool input, or command output is written\s+by default/);
+});
+
+test("MCP read tools require authorization scope", () => {
+  expect(designDoc).toContain("Every read tool must validate the requesting principal");
+  expect(designDoc).toContain("MCP client session");
+  expect(designDoc).toContain("allowed scope");
+  expect(decisions).toContain("Read tools must validate the requesting principal");
+  expect(decisions).toContain("fail closed");
+});


### PR DESCRIPTION
## Summary

- adds `docs/mcp-server.md` with the optional read-mostly MCP server design for #153
- records DD-10: MCP is a shared library/daemon access surface, not an adapter replacement
- links the design from README, architecture, and substrate adapter docs
- adds a focused doc contract test for canonical tool names and write confirmation boundaries

## Scope

Design slice for #153. This does not implement the MCP server yet; it defines the tool inventory, schema budget, read-only first slice, write confirmation model, and adapter boundary needed before code work starts.

## Verification

- `rtk bun test test/mcp-server-design.test.ts`
- `git diff --check`
- `rtk bun run typecheck`
- `rtk bun run lint`
- `rtk bun test`
