### PR TITLE
Add Soma home snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 !.env.example
 *.tar.gz
 .worktrees/
+.tmp-tests/
 .pi/
 .claude/
 .specflow/

--- a/README.md
+++ b/README.md
@@ -170,8 +170,16 @@ The sync plans or applies these phases in order:
 - a readable manifest for audit and reruns
 
 The sync is idempotent. Dry-run first, inspect what would be written, then
-apply. Afterward the Soma home is the source of truth and each coding agent
-gets a projection from it — a companion layer over PAI, not a replacement.
+apply. Afterward the Soma home is the source of truth and each installed
+substrate gets a projection from it — a companion layer over PAI, not a replacement.
+Apply-mode migrations create a Git-backed Soma snapshot first, so you can
+inspect or roll back the Soma home:
+
+```bash
+soma history
+soma snapshot --name before-big-change
+soma rollback <snapshot-id>
+```
 
 See [docs/integration-with-pai.md](docs/integration-with-pai.md) for the complete
 walkthrough, flags, verification steps, and troubleshooting.

--- a/docs/integration-with-pai.md
+++ b/docs/integration-with-pai.md
@@ -270,7 +270,13 @@ ls ~/.soma/memory/                 # 19 categories (17 + 2 PAI-bound)
 ls ~/.soma/PAI/                    # DOCUMENTATION, TEMPLATES, ALGORITHM
 ls ~/.soma/skills/                 # imported PAI packs as Soma skills
 soma migrate pai --status          # manifest + per-pack outcome table
+soma history                       # Git-backed Soma snapshots
 ```
+
+`soma migrate pai --apply` creates a pre-apply snapshot before writing
+to the Soma home. You can also create one manually with
+`soma snapshot --name before-big-change` and restore it later with
+`soma rollback <snapshot-id>`.
 
 ### Substrate check
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,6 +9,7 @@ export default tseslint.config(
       "dist/**",
       "coverage/**",
       ".worktrees/**",
+      ".tmp-tests/**",
       ".claude/**",
       ".codex/**",
       ".pi/**",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,14 @@ import {
   type ParsedMigrateArgs,
 } from "./cli/migrate";
 import {
+  SNAPSHOT_COMMAND_HELP,
+  parseHistoryArgs,
+  parseRollbackArgs,
+  parseSnapshotArgs,
+  runSnapshotCli,
+  type ParsedSnapshotCommandArgs,
+} from "./cli/snapshots";
+import {
   IMPORT_COMMAND_HELP,
   parseImportArgs,
   runImportCli,
@@ -133,6 +141,7 @@ type ParsedArgs =
   | ParsedPolicyArgs
   | ParsedWritebackArgs
   | ParsedIsaArgs
+  | ParsedSnapshotCommandArgs
   | ParsedToolArgs;
 
 const TOP_LEVEL_COMMANDS = [
@@ -142,6 +151,7 @@ const TOP_LEVEL_COMMANDS = [
   "doctor",
   "export",
   "feedback",
+  "history",
   "import",
   "inference",
   "install",
@@ -157,8 +167,10 @@ const TOP_LEVEL_COMMANDS = [
   "relationship",
   "reproject",
   "result",
+  "rollback",
   "session",
   "stats",
+  "snapshot",
   "telemetry",
   "uninstall",
   "upgrade",
@@ -187,6 +199,7 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
   doctor: ONBOARDING_COMMAND_HELP.doctor,
   import: IMPORT_COMMAND_HELP,
   migrate: MIGRATE_COMMAND_HELP,
+  ...SNAPSHOT_COMMAND_HELP,
   adopt: ONBOARDING_COMMAND_HELP.adopt,
   isa: {
     // Single source of truth lives in `./cli-isa.ts` (Sage round-1 dedup).
@@ -298,6 +311,18 @@ function parseArgs(args: string[]): ParsedArgs {
 
   if (args[0] === "migrate") {
     return parseMigrateArgs(args);
+  }
+
+  if (args[0] === "snapshot") {
+    return parseSnapshotArgs(args);
+  }
+
+  if (args[0] === "history") {
+    return parseHistoryArgs(args);
+  }
+
+  if (args[0] === "rollback") {
+    return parseRollbackArgs(args);
   }
 
   if (args[0] === "adopt") {
@@ -474,6 +499,10 @@ export async function runSomaCli(args: string[]): Promise<string> {
 
   if (parsed.command === "migrate") {
     return runMigrateCli(parsed);
+  }
+
+  if (parsed.command === "snapshot" || parsed.command === "history" || parsed.command === "rollback") {
+    return runSnapshotCli(parsed);
   }
 
   if (isSubstrateLifecycleArgs(parsed)) {

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -16,6 +16,7 @@ import {
   REASON_PREFIX_SLASH_COMMAND,
 } from "../claude-skills-migrator";
 import { createProgressEmitter } from "../claude-skills-progress";
+import { createSomaSnapshot } from "../snapshots";
 import type {
   ClaudeSkillOutcome,
   ClaudeSkillsMigrationManifest,
@@ -962,6 +963,12 @@ export async function runMigrateCli(parsed: ParsedMigrateArgs): Promise<string> 
         await planClaudeSkillsMigration(claudeOptions),
       );
     }
+    await createSomaSnapshot({
+      homeDir: claudeOptions.homeDir,
+      somaHome: claudeOptions.somaHome,
+      name: "before-migrate-claude-skills",
+      trigger: "migrate-claude-skills",
+    });
     const csResult = await migrateClaudeSkills(claudeOptions);
     const formatted = formatClaudeSkillsMigrationResult(csResult);
     // #118 — apply mode: surface a non-zero exit code when any skill
@@ -1009,6 +1016,12 @@ export async function runMigrateCli(parsed: ParsedMigrateArgs): Promise<string> 
     }
     return formatted;
   }
+  await createSomaSnapshot({
+    homeDir: parsed.options.homeDir,
+    somaHome: parsed.options.somaHome,
+    name: "before-migrate-pai",
+    trigger: "migrate-pai",
+  });
   const result = await migratePai(parsed.options);
   const formatted = formatPaiMigrationResult(result, parsed.verbose);
   // #97 — AC-4: exit non-zero only when a pack outcome is

--- a/src/cli/snapshots.ts
+++ b/src/cli/snapshots.ts
@@ -1,0 +1,159 @@
+import {
+  createSomaSnapshot,
+  listSomaSnapshots,
+  rollbackSomaSnapshot,
+} from "../snapshots";
+import type {
+  SomaSnapshotListOptions,
+  SomaSnapshotOptions,
+  SomaSnapshotRollbackOptions,
+} from "../types";
+import { readOption } from "./parse-utils";
+
+export const SNAPSHOT_USAGE =
+  "Usage: soma snapshot [--name <name>] [--trigger <trigger>] [--home-dir <dir>] [--soma-home <dir>]";
+export const HISTORY_USAGE =
+  "Usage: soma history [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]";
+export const ROLLBACK_USAGE =
+  "Usage: soma rollback <snapshot> [--home-dir <dir>] [--soma-home <dir>]";
+
+export const SNAPSHOT_COMMAND_HELP = {
+  snapshot: { usage: SNAPSHOT_USAGE },
+  history: { usage: HISTORY_USAGE },
+  rollback: { usage: ROLLBACK_USAGE },
+} as const;
+
+export interface ParsedSnapshotArgs {
+  command: "snapshot";
+  options: SomaSnapshotOptions;
+}
+
+export interface ParsedHistoryArgs {
+  command: "history";
+  options: SomaSnapshotListOptions;
+}
+
+export interface ParsedRollbackArgs {
+  command: "rollback";
+  options: SomaSnapshotRollbackOptions;
+}
+
+export type ParsedSnapshotCommandArgs = ParsedSnapshotArgs | ParsedHistoryArgs | ParsedRollbackArgs;
+
+export function parseSnapshotArgs(args: string[]): ParsedSnapshotArgs {
+  const [, ...rest] = args;
+  const options: SomaSnapshotOptions = {};
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    switch (arg) {
+      case "--name":
+        options.name = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--trigger":
+        options.trigger = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return { command: "snapshot", options };
+}
+
+export function parseHistoryArgs(args: string[]): ParsedHistoryArgs {
+  const [, ...rest] = args;
+  const options: SomaSnapshotListOptions = {};
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    switch (arg) {
+      case "--limit": {
+        const raw = readOption(rest, index, arg);
+        index += 1;
+        const limit = Number(raw);
+        if (!Number.isInteger(limit) || limit < 1) {
+          throw new Error("--limit must be a positive integer.");
+        }
+        options.limit = limit;
+        break;
+      }
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return { command: "history", options };
+}
+
+export function parseRollbackArgs(args: string[]): ParsedRollbackArgs {
+  const [, snapshot, ...rest] = args;
+  if (!snapshot || snapshot.startsWith("--")) {
+    throw new Error(ROLLBACK_USAGE);
+  }
+  const options: SomaSnapshotRollbackOptions = { snapshot };
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return { command: "rollback", options };
+}
+
+export async function runSnapshotCli(parsed: ParsedSnapshotCommandArgs): Promise<string> {
+  if (parsed.command === "snapshot") {
+    const snapshot = await createSomaSnapshot(parsed.options);
+    return [
+      "soma snapshot — created",
+      `id: ${snapshot.id}`,
+      `name: ${snapshot.name}`,
+      `trigger: ${snapshot.trigger}`,
+      `somaHome: ${snapshot.somaHome}`,
+      "",
+    ].join("\n");
+  }
+  if (parsed.command === "history") {
+    const entries = await listSomaSnapshots(parsed.options);
+    if (entries.length === 0) {
+      return "soma history — no snapshots found\n";
+    }
+    return [
+      "soma history",
+      "",
+      ...entries.map((entry) => `${entry.id.slice(0, 12)}  ${entry.createdAt}  ${entry.name}`),
+      "",
+    ].join("\n");
+  }
+  const rollback = await rollbackSomaSnapshot(parsed.options);
+  return [
+    "soma rollback — restored",
+    `id: ${rollback.id}`,
+    `name: ${rollback.name}`,
+    `somaHome: ${rollback.somaHome}`,
+    "",
+  ].join("\n");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,12 @@ export type {
   SomaProfile,
   SomaRunResult,
   SomaSkill,
+  SomaSnapshotEntry,
+  SomaSnapshotListOptions,
+  SomaSnapshotOptions,
+  SomaSnapshotResult,
+  SomaSnapshotRollbackOptions,
+  SomaSnapshotRollbackResult,
   SomaTask,
   SubstrateId,
   Telos,
@@ -393,6 +399,7 @@ export {
 } from "./lifecycle";
 export { captureSomaFeedback, classifySomaFeedback, maybeSomaFeedbackPrompt } from "./feedback";
 export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from "./memory";
+export { createSomaSnapshot, listSomaSnapshots, rollbackSomaSnapshot } from "./snapshots";
 export { querySomaTelemetryEvents, summarizeSomaTelemetry } from "./observability";
 export {
   listSomaWorkRegistryEntries,

--- a/src/snapshots.ts
+++ b/src/snapshots.ts
@@ -1,0 +1,259 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import packageJson from "../package.json";
+import { createPaths } from "./paths";
+import type {
+  SomaSnapshotEntry,
+  SomaSnapshotListOptions,
+  SomaSnapshotOptions,
+  SomaSnapshotResult,
+  SomaSnapshotRollbackOptions,
+  SomaSnapshotRollbackResult,
+} from "./types";
+
+interface GitResult {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+const SNAPSHOT_GITIGNORE_HEADER = "# Soma snapshot safety ignores";
+const SNAPSHOT_METADATA_FILE = ".soma-snapshot.json";
+const SNAPSHOT_GITIGNORE_RULES = [
+  ".env",
+  ".env.*",
+  "*.pem",
+  "*.key",
+  "*.p12",
+  "*.pfx",
+  "*.crt",
+  "*.cert",
+  "id_rsa",
+  "id_ed25519",
+  ".ssh/",
+  ".aws/",
+  ".azure/",
+  ".config/",
+  ".secrets/",
+  ".tokens/",
+  "secrets/",
+  "tokens/",
+  "**/credentials",
+  "**/credentials.*",
+  "*.token",
+] as const;
+
+interface SnapshotMetadata {
+  ignoredPaths: string[];
+}
+
+function runGit(somaHome: string, args: string[], options: { allowFailure?: boolean } = {}): GitResult {
+  const result = spawnSync("git", args, {
+    cwd: somaHome,
+    encoding: "utf8",
+  });
+  const status = result.status ?? 1;
+  const stdout = result.stdout;
+  const stderr = result.stderr;
+  if (status !== 0 && options.allowFailure !== true) {
+    const detail = (stderr || stdout || `git ${args.join(" ")} failed`).trim();
+    throw new Error(detail);
+  }
+  return { stdout, stderr, status };
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (isEnoent(error)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isEnoent(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT";
+}
+
+function resolveSomaHome(options: { homeDir?: string; somaHome?: string }): string {
+  return createPaths(options).root();
+}
+
+function sanitizeSnapshotLabel(value: string | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : fallback;
+}
+
+async function ensureSnapshotRepo(somaHome: string): Promise<void> {
+  await mkdir(somaHome, { recursive: true });
+  if (!(await pathExists(join(somaHome, ".git")))) {
+    runGit(somaHome, ["init"]);
+  }
+  await ensureSnapshotGitignore(somaHome);
+  runGit(somaHome, ["config", "user.name", "Soma Snapshot"]);
+  runGit(somaHome, ["config", "user.email", "soma-snapshot@localhost"]);
+}
+
+async function ensureSnapshotGitignore(somaHome: string): Promise<void> {
+  const gitignorePath = join(somaHome, ".gitignore");
+  const current = await readTextIfExists(gitignorePath);
+  const lines = current.split(/\r?\n/);
+  const additions = [SNAPSHOT_GITIGNORE_HEADER, ...SNAPSHOT_GITIGNORE_RULES]
+    .filter((line) => !lines.includes(line));
+  if (additions.length === 0) return;
+
+  const prefix = current.trimEnd();
+  const next = [
+    prefix,
+    prefix.length > 0 ? "" : undefined,
+    ...additions,
+    "",
+  ].filter((line) => line !== undefined).join("\n");
+  await writeFile(gitignorePath, next, "utf8");
+}
+
+async function readTextIfExists(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (isEnoent(error)) {
+      return "";
+    }
+    throw error;
+  }
+}
+
+async function writeSnapshotMetadata(somaHome: string): Promise<void> {
+  const metadata: SnapshotMetadata = {
+    ignoredPaths: listIgnoredPaths(somaHome),
+  };
+  await writeFile(join(somaHome, SNAPSHOT_METADATA_FILE), `${JSON.stringify(metadata, null, 2)}\n`, "utf8");
+}
+
+async function readSnapshotMetadata(somaHome: string): Promise<SnapshotMetadata> {
+  const raw = await readTextIfExists(join(somaHome, SNAPSHOT_METADATA_FILE));
+  if (raw.trim() === "") return { ignoredPaths: [] };
+  const parsed = JSON.parse(raw) as unknown;
+  if (typeof parsed !== "object" || parsed === null || !("ignoredPaths" in parsed)) {
+    return { ignoredPaths: [] };
+  }
+  const ignoredPaths = (parsed as { ignoredPaths?: unknown }).ignoredPaths;
+  if (!Array.isArray(ignoredPaths)) return { ignoredPaths: [] };
+  return {
+    ignoredPaths: ignoredPaths.filter((path): path is string => typeof path === "string" && isSafeRelativeGitPath(path)),
+  };
+}
+
+function listIgnoredPaths(somaHome: string): string[] {
+  const result = runGit(somaHome, ["status", "--ignored=matching", "--short", "-z", "--untracked-files=all"], { allowFailure: true });
+  if (result.status !== 0 || result.stdout === "") return [];
+  return result.stdout
+    .split("\0")
+    .filter((entry) => entry.startsWith("!! "))
+    .map((entry) => entry.slice(3))
+    .filter(isSafeRelativeGitPath)
+    .sort();
+}
+
+function isSafeRelativeGitPath(path: string): boolean {
+  return path.length > 0 && !path.startsWith("/") && !path.split(/[\\/]/).includes("..");
+}
+
+function isPreservedIgnoredPath(path: string, preserved: Set<string>): boolean {
+  if (preserved.has(path)) return true;
+  for (const preservedPath of preserved) {
+    if (preservedPath.endsWith("/") && path.startsWith(preservedPath)) return true;
+  }
+  return false;
+}
+
+async function removeIgnoredAdditions(somaHome: string, preservedIgnoredPaths: readonly string[]): Promise<void> {
+  const preserved = new Set(preservedIgnoredPaths);
+  for (const ignoredPath of listIgnoredPaths(somaHome)) {
+    if (isPreservedIgnoredPath(ignoredPath, preserved)) continue;
+    await rm(join(somaHome, ignoredPath), { recursive: true, force: true });
+  }
+}
+
+function assertSafeRevision(snapshot: string): void {
+  if (snapshot.trim() === "" || snapshot.startsWith("-")) {
+    throw new Error("Snapshot id must be a commit id or snapshot ref, not an option.");
+  }
+}
+
+export async function createSomaSnapshot(options: SomaSnapshotOptions = {}): Promise<SomaSnapshotResult> {
+  const somaHome = resolveSomaHome(options);
+  const name = sanitizeSnapshotLabel(options.name, "manual");
+  const trigger = sanitizeSnapshotLabel(options.trigger, "manual");
+  const createdAt = new Date().toISOString();
+
+  await ensureSnapshotRepo(somaHome);
+  await writeSnapshotMetadata(somaHome);
+  runGit(somaHome, ["add", "-A"]);
+  runGit(somaHome, [
+    "commit",
+    "--allow-empty",
+    "-m",
+    `soma snapshot: ${name}`,
+    "-m",
+    `trigger: ${trigger}\ncreated-at: ${createdAt}\nsoma-version: ${packageJson.version}`,
+  ]);
+  const id = runGit(somaHome, ["rev-parse", "HEAD"]).stdout.trim();
+  return { somaHome, id, name, trigger, createdAt };
+}
+
+export async function listSomaSnapshots(options: SomaSnapshotListOptions = {}): Promise<SomaSnapshotEntry[]> {
+  const somaHome = resolveSomaHome(options);
+  if (!(await pathExists(join(somaHome, ".git")))) {
+    return [];
+  }
+  const limit = options.limit === undefined ? 20 : Math.max(1, Math.min(100, Math.trunc(options.limit)));
+  const result = runGit(somaHome, [
+    "log",
+    `--max-count=${limit}`,
+    "--grep=^soma snapshot:",
+    "--format=%H%x1f%cI%x1f%s",
+  ], { allowFailure: true });
+  if (result.status !== 0 || result.stdout.trim() === "") {
+    return [];
+  }
+  return result.stdout
+    .trim()
+    .split("\n")
+    .map((line) => {
+      const [id = "", createdAt = "", subject = ""] = line.split("\x1f");
+      return {
+        id,
+        createdAt,
+        subject,
+        name: subject.replace(/^soma snapshot:\s*/, ""),
+      };
+    });
+}
+
+export async function rollbackSomaSnapshot(options: SomaSnapshotRollbackOptions): Promise<SomaSnapshotRollbackResult> {
+  const somaHome = resolveSomaHome(options);
+  assertSafeRevision(options.snapshot);
+  if (!(await pathExists(join(somaHome, ".git")))) {
+    throw new Error("No Soma snapshot repository exists. Create a snapshot first.");
+  }
+  const rev = `${options.snapshot}^{commit}`;
+  const id = runGit(somaHome, ["rev-parse", "--verify", rev]).stdout.trim();
+  const subject = runGit(somaHome, ["show", "-s", "--format=%s", id]).stdout.trim();
+  if (!subject.startsWith("soma snapshot: ")) {
+    throw new Error(`Refusing to rollback to non-snapshot commit: ${options.snapshot}`);
+  }
+  runGit(somaHome, ["reset", "--hard", id]);
+  const metadata = await readSnapshotMetadata(somaHome);
+  runGit(somaHome, ["clean", "-ffd"]);
+  await removeIgnoredAdditions(somaHome, metadata.ignoredPaths);
+  return {
+    somaHome,
+    id,
+    name: subject.replace(/^soma snapshot:\s*/, ""),
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -393,6 +393,46 @@ export interface SomaPaths {
   resolve(...segments: string[]): string;
 }
 
+export interface SomaSnapshotOptions {
+  homeDir?: string;
+  somaHome?: string;
+  name?: string;
+  trigger?: string;
+}
+
+export interface SomaSnapshotResult {
+  somaHome: string;
+  id: string;
+  name: string;
+  trigger: string;
+  createdAt: string;
+}
+
+export interface SomaSnapshotListOptions {
+  homeDir?: string;
+  somaHome?: string;
+  limit?: number;
+}
+
+export interface SomaSnapshotEntry {
+  id: string;
+  createdAt: string;
+  name: string;
+  subject: string;
+}
+
+export interface SomaSnapshotRollbackOptions {
+  homeDir?: string;
+  somaHome?: string;
+  snapshot: string;
+}
+
+export interface SomaSnapshotRollbackResult {
+  somaHome: string;
+  id: string;
+  name: string;
+}
+
 export interface SomaProfile {
   assistant: AssistantIdentity;
   principal: PrincipalIdentity;

--- a/test/snapshots.test.ts
+++ b/test/snapshots.test.ts
@@ -1,0 +1,143 @@
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { runSomaCli } from "../src/cli";
+import {
+  bootstrapSomaHome,
+  createSomaSnapshot,
+  listSomaSnapshots,
+  rollbackSomaSnapshot,
+} from "../src/index";
+import { writePaiIdentityFixture } from "./fixtures/pai-migration-fixtures";
+
+async function withSnapshotHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const tmpRoot = join(import.meta.dir, "..", ".tmp-tests");
+  await mkdir(tmpRoot, { recursive: true });
+  const homeDir = await mkdtemp(join(tmpRoot, "soma-snapshot-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+test("snapshots restore tracked files and clean post-snapshot additions", async () => {
+  await withSnapshotHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const principalPath = join(somaHome, "profile/principal.md");
+    await writeFile(principalPath, "baseline\n", "utf8");
+    const baseline = await createSomaSnapshot({ homeDir, name: "baseline", trigger: "test" });
+
+    await writeFile(principalPath, "changed\n", "utf8");
+    await mkdir(join(somaHome, "memory/STATE"), { recursive: true });
+    await writeFile(join(somaHome, "memory/STATE/transient.md"), "temporary\n", "utf8");
+
+    const rollback = await rollbackSomaSnapshot({ homeDir, snapshot: baseline.id });
+
+    expect(rollback.name).toBe("baseline");
+    await expect(readFile(principalPath, "utf8")).resolves.toBe("baseline\n");
+    await expect(stat(join(somaHome, "memory/STATE/transient.md"))).rejects.toThrow();
+  });
+});
+
+test("snapshots exclude common secret-bearing files from Git history", async () => {
+  await withSnapshotHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const envPath = join(somaHome, ".env");
+    await writeFile(envPath, "TOKEN=secret\n", "utf8");
+
+    const snapshot = await createSomaSnapshot({ homeDir, name: "with-env", trigger: "test" });
+
+    expect(snapshot.name).toBe("with-env");
+    const history = await runSomaCli(["history", "--home-dir", homeDir]);
+    expect(history).toContain("with-env");
+    await rm(envPath, { force: true });
+    await rollbackSomaSnapshot({ homeDir, snapshot: snapshot.id });
+    await expect(stat(envPath)).rejects.toThrow();
+  });
+});
+
+test("rollback preserves ignored files that existed before the snapshot", async () => {
+  await withSnapshotHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const envPath = join(somaHome, ".env");
+    await writeFile(envPath, "TOKEN=secret\n", "utf8");
+    const snapshot = await createSomaSnapshot({ homeDir, name: "with-env", trigger: "test" });
+
+    await writeFile(envPath, "TOKEN=changed\n", "utf8");
+    await rollbackSomaSnapshot({ homeDir, snapshot: snapshot.id });
+
+    await expect(readFile(envPath, "utf8")).resolves.toBe("TOKEN=changed\n");
+  });
+});
+
+test("rollback removes ignored nested additions as well as untracked files", async () => {
+  await withSnapshotHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const snapshot = await createSomaSnapshot({ homeDir, name: "baseline", trigger: "test" });
+
+    await mkdir(join(somaHome, "secrets/nested"), { recursive: true });
+    await writeFile(join(somaHome, "secrets/nested/api.key"), "secret\n", "utf8");
+
+    await rollbackSomaSnapshot({ homeDir, snapshot: snapshot.id });
+
+    await expect(stat(join(somaHome, "secrets/nested/api.key"))).rejects.toThrow();
+  });
+});
+
+test("snapshot history lists named snapshots newest first", async () => {
+  await withSnapshotHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+
+    await createSomaSnapshot({ homeDir, name: "first", trigger: "test" });
+    await createSomaSnapshot({ homeDir, name: "second", trigger: "test" });
+
+    const snapshots = await listSomaSnapshots({ homeDir });
+
+    expect(snapshots.map((snapshot) => snapshot.name).slice(0, 2)).toEqual(["second", "first"]);
+    expect(snapshots[0]?.subject).toBe("soma snapshot: second");
+  });
+});
+
+test("snapshot, history, and rollback are available through the CLI", async () => {
+  await withSnapshotHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    const principalPath = join(somaHome, "profile/principal.md");
+    await writeFile(principalPath, "cli baseline\n", "utf8");
+
+    const snapshotOutput = await runSomaCli([
+      "snapshot",
+      "--name",
+      "cli-baseline",
+      "--home-dir",
+      homeDir,
+    ]);
+    expect(snapshotOutput).toContain("soma snapshot");
+    expect(snapshotOutput).toContain("cli-baseline");
+
+    const [snapshot] = await listSomaSnapshots({ homeDir });
+    expect(snapshot).toBeDefined();
+    if (!snapshot) throw new Error("expected snapshot");
+    await writeFile(principalPath, "cli changed\n", "utf8");
+
+    const historyOutput = await runSomaCli(["history", "--home-dir", homeDir]);
+    expect(historyOutput).toContain("cli-baseline");
+
+    const rollbackOutput = await runSomaCli(["rollback", snapshot.id.slice(0, 12), "--home-dir", homeDir]);
+    expect(rollbackOutput).toContain("soma rollback");
+    expect(rollbackOutput).toContain("cli-baseline");
+    await expect(readFile(principalPath, "utf8")).resolves.toBe("cli baseline\n");
+  });
+});
+
+test("migrate pai --apply records a pre-apply snapshot", async () => {
+  await withSnapshotHome(async (homeDir) => {
+    await writePaiIdentityFixture(homeDir, { withAlgorithm: true });
+
+    const output = await runSomaCli(["migrate", "pai", "--apply", "--home-dir", homeDir]);
+    const snapshots = await listSomaSnapshots({ homeDir });
+
+    expect(output).toContain("soma migrate pai");
+    expect(snapshots[0]?.name).toBe("before-migrate-pai");
+  });
+});


### PR DESCRIPTION
## Summary

- add Git-backed Soma home snapshots with `soma snapshot`, `soma history`, and `soma rollback`
- create automatic pre-apply snapshots for `migrate pai --apply` and `migrate claude-skills --apply`
- document the snapshot safety net and keep repo-local scratch ignored for tests/lint

Closes #150

## Verification

- `rtk bun run typecheck`
- `rtk bun run lint`
- `TMPDIR=/Users/fischer/work/mf/soma/.worktrees/issue-150-identity-snapshots/.tmp-tests rtk bun test test/snapshots.test.ts test/cli-migrate.test.ts test/cli-migrate-claude-skills.test.ts`
- `TMPDIR=/Users/fischer/work/mf/soma/.worktrees/issue-150-identity-snapshots/.tmp-tests rtk bun test`
