### PR TITLE
Design #146: Soma home replication

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -577,6 +577,31 @@ This makes Soma a closed loop, not a one-way pipe.
 
 ---
 
+## home replication
+
+The cross-machine exchange of eligible Soma home state between two local Soma
+homes through an explicit remote transport.
+
+Home replication is not [[project|projection]] and not [[writeback]]. Projection
+makes Soma present inside a substrate. Writeback accepts a substrate-originated
+mutation into Soma. Home replication exchanges already-Soma-owned files between
+machines after scope checks, Policy checks, snapshots, and merge/conflict
+rules.
+
+The first transport is Git-backed, but Git is transport and audit history only.
+Soma core owns path eligibility, privacy gates, append-only event merge,
+session-keyed work-state merge, and durable-file conflict reporting.
+
+**Not synonyms:** Do not call the core model `sync`, `bidirectional sync`, or
+`live sync`. Use `replicate` / `home replication`.
+
+**Why:** Issue #146 needs the same assistant to travel between machines without
+turning a remote repository into the source of truth or weakening writeback
+gates. A separate term keeps cross-machine exchange distinct from both
+substrate projection and substrate writeback.
+
+---
+
 ## work registry
 
 The canonical Soma state that records active and historical work across substrates.

--- a/README.md
+++ b/README.md
@@ -404,6 +404,11 @@ substrate's native shape.
 Daemon mode and deeper Cortex/Myelin integration come after the file format,
 writeback gates, and adapter behavior are stable.
 
+Cross-machine use is designed as Soma home replication: a policy-gated,
+snapshot-backed exchange of eligible `~/.soma/` state between machines. It does
+not change projection or writeback semantics. See
+[docs/home-replication.md](docs/home-replication.md).
+
 ---
 
 ## Documentation
@@ -416,6 +421,7 @@ writeback gates, and adapter behavior are stable.
 - [docs/pai-pack-importer.md](docs/pai-pack-importer.md), PAI pack import rules
 - [docs/progressive-skill-loading.md](docs/progressive-skill-loading.md), skill registry and just-in-time loading
 - [docs/mcp-server.md](docs/mcp-server.md), optional read-mostly MCP tool surface
+- [docs/home-replication.md](docs/home-replication.md), cross-machine Soma home replication
 - [docs/writeback-and-policy.md](docs/writeback-and-policy.md), projection, writeback, conflict, and policy semantics
 - [docs/portability-proof.md](docs/portability-proof.md), the first portability proof and evidence contract
 

--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -577,3 +577,63 @@ without returning private excerpts.
   until the confirmation protocol is implemented.
 - Home and workspace projections remain required. MCP is an on-demand
   optimization, not the only way to inhabit Soma.
+
+### DD-11: Cross-machine state uses Soma home replication
+
+**Status:** Decided (2026-05-31)
+
+**Context:** Issue #146 asks for cross-machine access to memory, identity,
+Telos, skills, ISA state, and conflict resolution when a principal works from
+multiple machines. The obvious word is "sync", but Soma already reserves
+precise vocabulary for projection and writeback and rejects fuzzy bidirectional
+sync semantics in `CONTEXT.md`. The implementation needs a transport model
+without weakening DD-1's canonical home, DD-5/DD-6's shared work state, or the
+writeback conflict policy.
+
+Three candidates surfaced:
+- **(a) Treat a remote Git repository as the source of truth.** Every machine
+  pulls and pushes the whole Soma home.
+- **(b) Add a backend-neutral home replication contract.** Use Git first as the
+  transport, while Soma core owns scope eligibility, policy checks, snapshots,
+  deterministic merge rules, and conflict reports.
+- **(c) Defer cross-machine state until daemon mode.** Let a future
+  Cortex/Myelin daemon own shared state and avoid file replication now.
+
+**Decision:** **(b)** — cross-machine state uses **Soma home replication**.
+Each machine keeps a local authoritative Soma home. A remote is an exchange
+surface and audit history, not the canonical source of truth and not a live
+overlay. The first backend should be Git-backed because Soma homes and
+snapshots are already filesystem-native, but backend transport does not own
+merge or privacy semantics.
+
+Replication is scope-based. Identity, Telos, skills, policy, ISA, append-only
+state events, and session-keyed work state are eligible by default, subject to
+path policy and secret guards. Learning and knowledge are opt-in until
+promotion/citation merge rules exist. Relationship is private by default, and
+raw and security scopes are off by default.
+
+Only stores with deterministic merge rules are auto-merged:
+`memory/STATE/events.jsonl` merges by event id, and DD-5/DD-6 work state may
+merge by session id, run id, or pointer filename. Durable profile, Telos,
+skill, policy, ISA body, knowledge, learning, relationship, and work artifacts
+surface conflicts instead of using last-writer-wins. Every pull or exchange
+operation snapshots before applying remote state.
+
+**Rejected:**
+- (a) makes a transport authority over privacy and merge semantics, and would
+  leak private or generated material unless every operation reimplemented Soma
+  Policy.
+- (c) preserves conceptual purity but leaves "one assistant, many substrates"
+  machine-local until a daemon exists. Soma's filesystem-native design should
+  support a safe no-daemon path.
+
+**Implications:**
+- The canonical design is documented in `docs/home-replication.md`.
+- Future CLI work should use `soma replicate ...` rather than `soma sync ...`.
+- The Git backend owns remote transport only. Soma core owns path eligibility,
+  snapshots, event/work-state merge, conflict reporting, and refusal messages.
+- Home replication must not automatically refresh substrate projections.
+- Hosted backends such as S3 or Turso may follow later, but must implement the
+  same privacy, snapshot, and conflict contract.
+
+**Discussion:** issue #146 design pass, 2026-05-31.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,6 +101,11 @@ MEMORY/
 The initial version should avoid requiring a vector database. Search can start
 with filenames, frontmatter, ripgrep, and small deterministic indexes.
 
+Cross-machine Soma state uses **Home replication**, not projection refresh or
+substrate writeback. The design is Git-backed first, policy-gated per scope,
+and only auto-merges stores with deterministic merge semantics. See
+[docs/home-replication.md](./home-replication.md).
+
 ### Policy
 
 Policy covers security, privacy, permission, and verification. Policies should

--- a/docs/home-replication.md
+++ b/docs/home-replication.md
@@ -1,0 +1,202 @@
+# Soma Home Replication
+
+Issue #146 asks for cross-machine access to the same Soma state. The
+implementation term is **home replication**: exchanging eligible Soma home
+state between machines while preserving `~/.soma/` as the local source of truth
+and keeping projection/writeback semantics unchanged.
+
+The issue uses the familiar word "sync", but Soma avoids that as a core term
+because it hides direction, authority, privacy, and conflict behavior. Home
+replication is explicit about what can move, when it can move, and what happens
+when two machines edit the same durable artifact.
+
+## Goals
+
+- Let a principal carry one Soma home across laptop, VM, and future daemon
+  substrates.
+- Preserve the existing filesystem-native home contract: profile, Telos,
+  memory, skills, policy, Algorithm runs, and ISAs remain plain files.
+- Reuse Git history and the snapshot/rollback safety net before applying remote
+  changes.
+- Merge append-only state deterministically where Soma already has merge
+  semantics.
+- Refuse or surface conflicts for durable files that do not yet have a
+  store-specific merge rule.
+- Gate every replicated path through Policy so private compartments and secrets
+  do not leak to a remote by default.
+
+## Non-Goals
+
+- Home replication is not a live overlay, shared filesystem, or substrate
+  projection refresh.
+- Home replication does not let substrates directly edit durable memory stores.
+  Substrate-originated changes still enter through the writeback gate.
+- The first backend does not need S3, Turso, or another hosted service.
+- The first implementation does not automatically reconcile arbitrary Markdown
+  conflicts in `KNOWLEDGE`, `RELATIONSHIP`, `LEARNING`, `WORK`, profile, Telos,
+  skills, policy, or ISA files.
+- Home replication does not copy raw prompts, transcripts, full tool inputs, or
+  command output unless a future policy explicitly allows that path.
+
+## Model
+
+Each machine has a local Soma home and an optional replica identity:
+
+```text
+~/.soma/
+  .git/
+  .soma-replica.json
+  profile/
+  memory/
+  skills/
+  policy/
+  isa/
+```
+
+The local home is authoritative while a machine is running. The remote is an
+exchange surface and audit history, not a daemon and not the global source of
+truth. Replication happens only when a user or substrate invokes a replication
+operation.
+
+The first backend should be Git-backed because Soma homes are already
+filesystem-native and snapshots already initialize safe Git repositories. A
+later cloud backend may implement the same exchange contract, but it must not
+change conflict or privacy semantics.
+
+## Replication Scopes
+
+Replication operates on explicit scopes. The first implementation should expose
+these scopes in status output and config instead of silently pushing the whole
+home.
+
+| Scope | Default | Merge rule |
+| --- | --- | --- |
+| `identity` | eligible | normal file, conflict surfaced |
+| `telos` | eligible | normal file, conflict surfaced |
+| `skills` | eligible | normal file, conflict surfaced |
+| `policy` | eligible | normal file, conflict surfaced |
+| `isa` | eligible | normal file, conflict surfaced, append-only logs can be merged later |
+| `state-events` | eligible | append-only event union by event id |
+| `work-state` | eligible | session-keyed metadata merge for work registry and current-work pointers |
+| `learning` | opt-in | normal file, conflict surfaced until promotion merge rules exist |
+| `knowledge` | opt-in | normal file, conflict surfaced until citation merge rules exist |
+| `relationship` | opt-in | private by default, conflict surfaced |
+| `raw` | off | never replicated by default |
+| `security` | off | never replicated by default |
+
+Eligible does not mean public. It means the scope may be replicated after the
+configured remote, path policy, and secret guard all allow the specific path.
+
+## Privacy Gate
+
+Before a path enters a replication commit or export bundle, Soma runs a
+replication policy check:
+
+1. The path must be inside the Soma home.
+2. The path must match an enabled replication scope.
+3. The path must not match snapshot safety ignores such as `.env`, key files,
+   token files, `.ssh/`, `.aws/`, `.secrets/`, or `secrets/`.
+4. The path must not be generated projection output.
+5. Private scopes such as `relationship`, `raw`, and `security` require an
+   explicit allow rule naming the scope and remote.
+
+Policy refusal fails closed. A replication operation should return a report
+listing refused paths by category without printing secret file contents.
+
+## Operation Flow
+
+The first CLI surface should be:
+
+```bash
+soma replicate init --remote <git-url>
+soma replicate status
+soma replicate pull
+soma replicate push
+soma replicate exchange
+```
+
+`pull`, `push`, and `exchange` must create a Soma snapshot before applying
+remote state. `exchange` is shorthand for pull then push with the same safety
+checks. `status` must show the configured remote, replica id, enabled scopes,
+uncommitted local changes, pending remote changes, refused paths, and conflicts.
+
+No operation should refresh substrate projections automatically. After a
+replication operation changes the home, the user or substrate still runs
+`soma reproject <substrate>` or `soma install <substrate> --apply` when a
+projection refresh is needed.
+
+## Conflict Rules
+
+Home replication has three conflict classes.
+
+### Append-Only State
+
+`memory/STATE/events.jsonl` merges by event id. A merge keeps the first valid
+event for an id, drops exact duplicate ids, preserves malformed rows in a
+conflict report, and writes a deterministic file order:
+
+1. valid events sorted by timestamp when present
+2. ties ordered by event id
+3. rows without timestamps ordered by original replica/source order
+
+This is safe because the writeback gate already treats events as an audit log
+and inbox, not durable learned truth.
+
+### Session-Keyed Work State
+
+`memory/STATE/work.json`, `memory/STATE/session-names.json`, and
+`current-work-*.json` may merge by session id, run id, or pointer filename
+because DD-5 and DD-6 made those files metadata-only continuation state.
+Conflicting values for the same key must be reported, not silently overwritten.
+
+### Durable Memory And Profile Files
+
+Files in profile, Telos, skills, policy, ISA bodies, `KNOWLEDGE`, `LEARNING`,
+`RELATIONSHIP`, and `WORK` are normal durable artifacts. Until a store has a
+specific merge rule, concurrent edits are conflicts. The first implementation
+should keep both sides reachable through Git history and write a bounded
+conflict report under `memory/STATE/replication-conflicts.json` instead of
+choosing last-writer-wins.
+
+## Backend Boundary
+
+The Git backend owns transport:
+
+- initialize or reuse the Soma home repository
+- set and inspect a remote
+- fetch remote refs
+- stage only policy-eligible paths
+- commit replication changes with replica metadata
+- push or pull refs
+
+Soma core owns semantics:
+
+- scope eligibility
+- policy checks
+- snapshot creation before applying remote changes
+- append-only event merge
+- work-state merge
+- conflict reports
+- refusal messages
+
+Hosted backends such as S3 or Turso must implement the same semantic contract.
+They may optimize transport, but they must not invent weaker privacy or
+conflict rules.
+
+## First Implementation Slice
+
+The first code slice should add the Git-backed CLI and library surface without
+attempting full durable-memory auto-merge:
+
+- `soma replicate init --remote <git-url>` stores remote and replica metadata.
+- `soma replicate status` reports scopes, dirty state, pending remote changes,
+  refused paths, and conflicts without mutating files.
+- `soma replicate pull` snapshots first, fetches remote state, merges
+  append-only state events, merges session-keyed work state, and reports
+  durable-file conflicts.
+- `soma replicate push` stages only policy-eligible paths and refuses if
+  unresolved conflicts remain.
+- Tests cover secret refusal, raw/security default refusal, event-log union,
+  work-state keyed conflict reporting, snapshot-before-pull, and no projection
+  refresh side effects.
+

--- a/docs/home-replication.md
+++ b/docs/home-replication.md
@@ -55,8 +55,8 @@ Each machine has a local Soma home and an optional replica identity:
 
 The local home is authoritative while a machine is running. The remote is an
 exchange surface and audit history, not a daemon and not the global source of
-truth. Replication happens only when a user or substrate invokes a replication
-operation.
+truth. Replication happens only when a principal or substrate invokes a
+replication operation.
 
 The first backend should be Git-backed because Soma homes are already
 filesystem-native and snapshots already initialize safe Git repositories. A
@@ -115,13 +115,14 @@ soma replicate push
 soma replicate exchange
 ```
 
-`pull`, `push`, and `exchange` must create a Soma snapshot before applying
-remote state. `exchange` is shorthand for pull then push with the same safety
-checks. `status` must show the configured remote, replica id, enabled scopes,
+`pull` and `exchange` must create a Soma snapshot before applying remote state.
+`push` must create a Soma snapshot before staging and publishing eligible local
+state. `exchange` is shorthand for pull then push with the same safety checks.
+`status` must show the configured remote, replica id, enabled scopes,
 uncommitted local changes, pending remote changes, refused paths, and conflicts.
 
 No operation should refresh substrate projections automatically. After a
-replication operation changes the home, the user or substrate still runs
+replication operation changes the home, the principal or substrate still runs
 `soma reproject <substrate>` or `soma install <substrate> --apply` when a
 projection refresh is needed.
 

--- a/docs/home-replication.md
+++ b/docs/home-replication.md
@@ -12,8 +12,8 @@ when two machines edit the same durable artifact.
 
 ## Goals
 
-- Let a principal carry one Soma home across laptop, VM, and future daemon
-  substrates.
+- Let a principal carry one Soma home across laptop, VM, and future
+  daemon-backed use.
 - Preserve the existing filesystem-native home contract: profile, Telos,
   memory, skills, policy, Algorithm runs, and ISAs remain plain files.
 - Reuse Git history and the snapshot/rollback safety net before applying remote
@@ -199,4 +199,3 @@ attempting full durable-memory auto-merge:
 - Tests cover secret refusal, raw/security default refusal, event-log union,
   work-state keyed conflict reporting, snapshot-before-pull, and no projection
   refresh side effects.
-

--- a/docs/writeback-and-policy.md
+++ b/docs/writeback-and-policy.md
@@ -152,6 +152,12 @@ Until store-specific merge rules exist:
 - No silent promotion from event log to durable stores.
 - No bidirectional projection sync.
 
+Home replication must preserve these conflict rules across machines. It may
+merge append-only `memory/STATE/events.jsonl` entries and session-keyed work
+state, but durable memory, profile, Telos, skill, policy, and ISA body
+conflicts remain explicit conflicts until store-specific merge rules exist. See
+[home-replication.md](./home-replication.md).
+
 If two substrates report conflicting facts, both facts remain events. A later
 consolidator or human review decides what becomes durable memory.
 

--- a/test/home-replication-design.test.ts
+++ b/test/home-replication-design.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "bun:test";
+
+const designDoc = readFileSync("docs/home-replication.md", "utf8");
+const architecture = readFileSync("docs/architecture.md", "utf8");
+const writeback = readFileSync("docs/writeback-and-policy.md", "utf8");
+const decisions = readFileSync("design/design-decisions.md", "utf8");
+const readme = readFileSync("README.md", "utf8");
+const context = readFileSync("CONTEXT.md", "utf8");
+
+test("home replication design keeps Soma home authoritative", () => {
+  expect(designDoc).toContain("home replication");
+  expect(designDoc).toContain("The local home is authoritative while a machine is running.");
+  expect(designDoc).toMatch(/The remote is an\s+exchange surface and audit history/);
+  expect(architecture).toContain("Home replication");
+  expect(context).toContain("## home replication");
+  expect(context).toContain("Do not call the core model `sync`");
+  expect(decisions).toContain("Soma home replication");
+});
+
+test("home replication has explicit privacy and scope gates", () => {
+  for (const scope of ["identity", "telos", "skills", "policy", "isa", "state-events", "relationship", "raw", "security"]) {
+    expect(designDoc).toContain(`\`${scope}\``);
+  }
+  expect(designDoc).toContain("snapshot safety ignores");
+  expect(designDoc).toContain("Private scopes such as `relationship`, `raw`, and `security` require an");
+  expect(decisions).toContain("raw and security scopes are off by default");
+});
+
+test("home replication defines deterministic merge boundaries", () => {
+  expect(designDoc).toContain("`memory/STATE/events.jsonl` merges by event id");
+  expect(designDoc).toContain("Session-Keyed Work State");
+  expect(designDoc).toContain("concurrent edits are conflicts");
+  expect(designDoc).toContain("replication-conflicts.json");
+  expect(writeback).toContain("Home replication must preserve these conflict rules");
+});
+
+test("home replication uses snapshots before applying remote state", () => {
+  expect(designDoc).toContain("must create a Soma snapshot before applying");
+  expect(designDoc).toContain("snapshot-before-pull");
+  expect(decisions).toMatch(/Every pull or exchange\s+operation snapshots before applying remote state/);
+});
+
+test("home replication is linked from public docs", () => {
+  expect(readme).toContain("docs/home-replication.md");
+  expect(architecture).toContain("docs/home-replication.md");
+});


### PR DESCRIPTION
Design gate for #146.

## Summary

- adds `docs/home-replication.md` with the cross-machine Soma home replication contract
- records DD-11 and the `home replication` glossary term so future code avoids fuzzy bidirectional sync semantics
- links the design from README, architecture, and writeback/conflict semantics
- adds a doc contract test for authority, privacy scopes, merge boundaries, snapshot-before-pull, and public links

## Scope

Design slice for #146. This does not implement `soma replicate` yet; it defines the Git-backed first backend, scope policy, privacy gates, event/work-state merge rules, conflict reporting, and the first implementation slice.

## Verification

- `TMPDIR=/Users/fischer/work/mf/soma/.worktrees/issue-146-home-replication/.tmp-tests rtk bun test test/home-replication-design.test.ts`
- `git diff --check`
- `rtk bun run typecheck`
- `rtk bun run lint`
- `TMPDIR=/Users/fischer/work/mf/soma/.worktrees/issue-146-home-replication/.tmp-tests rtk bun test`
