### PR TITLE
Design #152 team overlays

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -361,6 +361,27 @@ Pairs with [[assistant]]: principal ↔ assistant = the human and the named bein
 
 ---
 
+## team overlay
+
+A policy-scoped shared Soma layer that supplements one principal's local Soma
+home with team skills, team knowledge, team work artifacts, team ISAs, and
+team policy restrictions.
+
+Team overlays do not make a Soma home multi-principal. The personal Soma home
+still has exactly one [[principal]]. Team overlay material is mounted beside
+that home, read with explicit team provenance, and projected only when Policy
+allows the team and scope.
+
+**Not synonyms:** Do not call this `multi-principal home`, `shared home`, or
+`team identity`. The canonical term is `team overlay`.
+
+**Why:** Issue #152 needs shared team capability without violating the
+principal-owned privacy model. An overlay lets team material supplement
+personal Soma while keeping Identity, Telos, Relationship, raw transcripts, and
+security traces private.
+
+---
+
 ## adapter
 
 The actor that performs a [[project|projection]]. One adapter per [[substrate]]: Codex adapter, Pi.dev adapter, Claude Code adapter, Cortex adapter.

--- a/README.md
+++ b/README.md
@@ -409,6 +409,11 @@ snapshot-backed exchange of eligible `~/.soma/` state between machines. It does
 not change projection or writeback semantics. See
 [docs/home-replication.md](docs/home-replication.md).
 
+Team-shared skills, knowledge, work artifacts, and ISAs are designed as
+read-only team overlays. A team overlay supplements one principal's Soma home;
+it does not make the home multi-principal or share private Identity, Telos, or
+Relationship state. See [docs/team-overlays.md](docs/team-overlays.md).
+
 ---
 
 ## Documentation
@@ -422,6 +427,7 @@ not change projection or writeback semantics. See
 - [docs/progressive-skill-loading.md](docs/progressive-skill-loading.md), skill registry and just-in-time loading
 - [docs/mcp-server.md](docs/mcp-server.md), optional read-mostly MCP tool surface
 - [docs/home-replication.md](docs/home-replication.md), cross-machine Soma home replication
+- [docs/team-overlays.md](docs/team-overlays.md), read-only team overlays and shared-state boundaries
 - [docs/writeback-and-policy.md](docs/writeback-and-policy.md), projection, writeback, conflict, and policy semantics
 - [docs/portability-proof.md](docs/portability-proof.md), the first portability proof and evidence contract
 

--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -637,3 +637,59 @@ operation snapshots before applying remote state.
   same privacy, snapshot, and conflict contract.
 
 **Discussion:** issue #146 design pass, 2026-05-31.
+
+### DD-12: Shared team state uses read-only team overlays
+
+**Status:** Decided (2026-05-31)
+
+**Context:** Issue #152 asks for shared skill registries, team memory overlays,
+team ISAs, and a permission model for organizations. Soma is intentionally a
+personal assistant core: Identity, Telos, Relationship, Policy, and Memory are
+rooted in one principal. A direct multi-principal home would weaken the trust
+model and make it unclear which principal owns profile facts, private memory,
+policy approvals, and writeback decisions. The design also intersects with Arc
+and Compass: Arc owns distribution, and Compass owns SOPs and governance.
+
+Three candidates surfaced:
+- **(a) Make `~/.soma/` multi-principal.** Add several principals to one shared
+  home and let permissions decide which parts each principal can see.
+- **(b) Use read-only team overlays.** Keep each personal Soma home
+  single-principal, then mount shared team skills, team knowledge/work, team
+  ISAs, and team policy restrictions as explicit overlays with provenance.
+- **(c) Defer team support to Cortex/Myelin.** Keep Soma purely personal and
+  let collaboration surfaces handle all team state.
+
+**Decision:** **(b)** — shared team state uses read-only **team overlays**. A
+personal Soma home remains single-principal. Team material supplements that
+home after Policy checks the team, source, scopes, and provenance. Identity,
+Telos, Relationship, raw transcripts, and security traces are never mounted
+from a team overlay.
+
+Team overlays start read-only. They may expose team skills, team
+`memory/KNOWLEDGE`, team `memory/WORK`, team ISAs, and team policy restrictions.
+Team policy can add restrictions or metadata requirements, but it must not relax
+personal policy. Search and projection must cite team/source/version
+provenance, and personal and team memory result groups remain separate.
+
+Arc remains the distribution source of truth for team skill packs and
+Arc-installable team overlay bundles. Compass remains the source of truth for
+SOPs and governance; Soma can reference Compass ids but does not redefine
+organizational process.
+
+**Rejected:**
+- (a) makes privacy and authority ambiguous. A shared home would invite
+  accidental sharing of personal Identity, Telos, Relationship, raw
+  transcripts, and security traces.
+- (c) is clean but too narrow: teams can safely share read-only skills,
+  knowledge, work artifacts, and ISAs before a daemon or bus is required.
+
+**Implications:**
+- The canonical design is documented in `docs/team-overlays.md`.
+- Future CLI work should use `soma team ...` for overlay management.
+- The first implementation slice should add read-only overlay install/list,
+  team-provenanced memory search, team skill registry entries, and explicit
+  team ISA selection.
+- Collaborative team writes are deferred until team-specific merge rules,
+  approval, provenance, and conflict reports exist.
+
+**Discussion:** issue #152 design pass, 2026-05-31.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,6 +85,11 @@ MCP-capable substrates may use the optional
 memory, ISA, Algorithm, and identity context. The server remains a core/library
 access surface; adapters only configure substrate-native MCP clients.
 
+Team-shared skills use **team overlays** rather than multi-principal Soma
+homes. A team overlay can supplement skill routing with team-provenanced skill
+registries, while the personal Soma home remains owned by one principal. See
+[docs/team-overlays.md](./team-overlays.md).
+
 ### Memory
 
 Memory is structured as files first:
@@ -105,6 +110,11 @@ Cross-machine Soma state uses **Home replication**, not projection refresh or
 substrate writeback. The design is Git-backed first, policy-gated per scope,
 and only auto-merges stores with deterministic merge semantics. See
 [docs/home-replication.md](./home-replication.md).
+
+Team `KNOWLEDGE`, `WORK`, and ISA material can be read through a team overlay,
+but it stays namespaced and cited separately from personal memory. Team
+overlays are read-only in the first slice and must not expose personal Identity,
+Telos, Relationship, raw transcript, or security-trace compartments.
 
 ### Policy
 

--- a/docs/boundaries.md
+++ b/docs/boundaries.md
@@ -14,6 +14,8 @@ Factory systems without absorbing their responsibilities. Glossary lives in
 | Project ISA | Project repository | Reads and summarizes local `ISA.md`; does not centralize every project task. |
 | Personal/task ISA | Soma memory | Owns personal assistant tasks that do not belong to one project repo. |
 | Skills as portable capability folders | Soma | Owns portable skill metadata and discovery contract. |
+| Team skill distribution | Arc | Soma can mount Arc-installed skill packs as team overlays; Arc owns package lifecycle and version resolution. |
+| Team SOPs and governance | Compass | Soma can reference Compass ids in team overlays; Compass remains the governance authority. |
 | Claude Code skills | Claude Code adapter | A Soma skill's Claude Code projection. |
 | Codex instructions | Codex adapter | A Soma skill's Codex projection (Codex instruction). |
 | SOPs and governance | Compass | Soma references Compass rules; it does not redefine org process. |
@@ -34,6 +36,9 @@ Factory systems without absorbing their responsibilities. Glossary lives in
 - Substrate → Soma flow is **writeback** only, gated by Policy
   (see [writeback-and-policy.md](./writeback-and-policy.md)). Substrate-side
   state Soma does not author is **mirrored** into `MEMORY/STATE/`.
+- Team overlays supplement personal Soma state. They must not become a shared
+  personal home, and they must not contain personal Identity, Telos,
+  Relationship, raw transcript, or security-trace compartments.
 
 ## Naming Rules
 

--- a/docs/team-overlays.md
+++ b/docs/team-overlays.md
@@ -1,0 +1,156 @@
+# Team Overlays
+
+Issue #152 asks for shared skills, team memory, team ISAs, and a permission
+model without leaking personal Identity, Telos, or Relationship state. The
+implementation term is **team overlay**: a policy-scoped shared Soma layer that
+supplements one principal's local Soma home.
+
+Team overlays do not make a Soma home multi-principal. A Soma home remains
+owned by exactly one principal. Team material is mounted beside that home,
+projected into substrates only after Policy allows it, and cited as team
+provenance when it is used.
+
+## Goals
+
+- Let several principals use a team-curated set of Soma skills.
+- Let personal Soma memory read shared team `KNOWLEDGE` and `WORK` without
+  copying private personal stores into the team layer.
+- Let project or team ISAs be visible beside personal/task ISAs.
+- Keep shared state explicitly namespaced by team, source, and permission.
+- Preserve Arc as the package/distribution system and Compass as the SOP and
+  governance authority.
+- Start read-only so shared editing does not bypass writeback, review, or
+  provenance rules.
+
+## Non-Goals
+
+- A team overlay is not a second principal inside the personal Soma home.
+- A team overlay does not share `profile/`, personal Telos, Relationship,
+  private notes, raw transcripts, security traces, or local policy secrets.
+- A team overlay does not replace Arc packages, Compass SOPs, or Cortex/Myelin
+  collaboration.
+- The first implementation does not support collaborative editing of team
+  memory.
+- Team overlay state is not projected into a workspace unless the principal has
+  enabled that team for the workspace.
+
+## Model
+
+Each principal keeps a personal Soma home:
+
+```text
+~/.soma/
+  profile/
+  memory/
+  skills/
+  policy/
+  teams/
+    <team-id>/
+      team-overlay.json
+      skills/
+      memory/
+        KNOWLEDGE/
+        WORK/
+      isa/
+      policy/
+```
+
+The team directory is a local materialization of a shared source. It can be
+installed from an Arc package, a Git-backed team repository, or another future
+backend, but the mounted shape is the same. The overlay manifest names the
+team, source, version, enabled scopes, permission mode, and provenance.
+
+Personal state remains first-class and private. Team overlay data is read as a
+separate source and cited with a team prefix instead of being merged into
+personal files.
+
+## Allowed Compartments
+
+| Area | Team overlay default | Rule |
+| --- | --- | --- |
+| Skills | allowed | Team skills are shared capability folders distributed by Arc or an approved source. |
+| `memory/KNOWLEDGE` | read-only | Shared facts require provenance and stay team-cited. |
+| `memory/WORK` | read-only | Shared project/work artifacts are visible but not silently promoted into personal work. |
+| ISA | read-only | Team ISAs supplement personal/task ISAs and keep team provenance. |
+| Policy | read-only | Team policy may add stricter rules; it must not relax personal policy. |
+| Identity | denied | Personal principal and assistant identity are never sourced from a team overlay. |
+| Telos | denied | Personal goals and commitments are never shared by default. |
+| Relationship | denied | Personal relationship memory is private and never mounted from a team overlay. |
+| Raw/security | denied | Raw transcripts and security traces are not team-overlay material in the first slice. |
+
+## Precedence
+
+Team overlays supplement personal Soma; they do not override it.
+
+1. Personal policy is always evaluated.
+2. Team policy may only add restrictions or metadata requirements.
+3. Personal skills and workspace skills keep their names. A team skill name
+   collision is reported as a conflict unless the principal explicitly aliases
+   one side.
+4. Personal memory search results and team memory search results are separate
+   cited result groups.
+5. A team ISA is selected explicitly by team and slug. It does not replace the
+   active personal ISA unless the principal chooses that team ISA for the
+   current workspace or task.
+
+This avoids hidden last-writer-wins behavior and makes team provenance visible
+in every projected or searched result.
+
+## Permission Model
+
+The first implementation uses a read-only permission model:
+
+```json
+{
+  "schema": "soma-team-overlay-v1",
+  "teamId": "example-team",
+  "source": {
+    "kind": "arc-package",
+    "ref": "@example/soma-team"
+  },
+  "scopes": ["skills", "knowledge", "work", "isa", "policy"],
+  "mode": "read-only"
+}
+```
+
+Policy checks every overlay before use:
+
+- the team id must be a safe identifier
+- the source must be trusted by the principal's personal policy
+- requested scopes must be enabled by the overlay manifest
+- denied compartments must remain absent or unread
+- team policy must not relax personal policy
+- every projected team artifact must retain team/source/version provenance
+
+Malformed or unauthorized overlays fail closed and are omitted from projection,
+memory search, and skill routing.
+
+## Arc And Compass Boundaries
+
+Arc owns distribution. Team skill registries and curated skill packs should be
+Arc packages or Arc-installable references. Soma may read their manifests and
+materialize them into `teams/<team-id>/`, but Arc owns package lifecycle,
+version resolution, and provenance.
+
+Compass owns SOPs and governance. A team overlay may reference Compass SOP ids,
+project governance, or policy requirements, but it must not redefine the
+organization process. Soma uses Compass references as context and policy input.
+
+## First Implementation Slice
+
+The first code slice should implement read-only team overlays:
+
+- `soma team add --from <path-or-arc-ref> --team <team-id>` materializes a
+  local overlay manifest and eligible shared files.
+- `soma team list` reports enabled teams, versions, sources, scopes, and
+  conflicts.
+- Memory search can include team `KNOWLEDGE` and `WORK` results with team
+  provenance, but keeps personal and team result groups separate.
+- Skill registry can include team skills with team prefixes or aliases, but
+  refuses unaliased name collisions.
+- Active ISA commands can show or select a team ISA explicitly by team and slug.
+- Projection code includes only enabled read-only team artifacts and never
+  projects personal-private compartments from a team overlay.
+
+Follow-up work can add reviewed team writeback, but only after team-specific
+merge rules, approval, provenance, and conflict reports exist.

--- a/test/team-overlays-design.test.ts
+++ b/test/team-overlays-design.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "bun:test";
+
+const designDoc = readFileSync("docs/team-overlays.md", "utf8");
+const context = readFileSync("CONTEXT.md", "utf8");
+const architecture = readFileSync("docs/architecture.md", "utf8");
+const boundaries = readFileSync("docs/boundaries.md", "utf8");
+const decisions = readFileSync("design/design-decisions.md", "utf8");
+const readme = readFileSync("README.md", "utf8");
+
+test("team overlay design keeps the personal Soma home single-principal", () => {
+  expect(designDoc).toContain("Team overlays do not make a Soma home multi-principal");
+  expect(designDoc).toMatch(/A Soma home remains\s+owned by exactly one principal/);
+  expect(context).toContain("## team overlay");
+  expect(decisions).toContain("personal Soma home remains single-principal");
+});
+
+test("team overlay design denies personal-private compartments", () => {
+  for (const denied of ["Identity", "Telos", "Relationship", "Raw/security"]) {
+    expect(designDoc).toContain(denied);
+  }
+  expect(designDoc).toContain("Personal relationship memory is private");
+  expect(decisions).toMatch(/Identity,\s+Telos, Relationship, raw transcripts, and security traces are never mounted\s+from a team overlay/);
+});
+
+test("team overlay design starts read-only and keeps provenance", () => {
+  expect(designDoc).toContain('"mode": "read-only"');
+  expect(designDoc).toContain("team/source/version provenance");
+  expect(designDoc).toContain("Follow-up work can add reviewed team writeback");
+  expect(decisions).toContain("Team overlays start read-only");
+});
+
+test("team overlay design preserves Arc and Compass ownership", () => {
+  expect(designDoc).toContain("Arc owns distribution");
+  expect(designDoc).toContain("Compass owns SOPs and governance");
+  expect(boundaries).toContain("Team skill distribution | Arc");
+  expect(boundaries).toContain("Team SOPs and governance | Compass");
+});
+
+test("team overlay design is linked from public architecture docs", () => {
+  expect(readme).toContain("docs/team-overlays.md");
+  expect(architecture).toContain("docs/team-overlays.md");
+});


### PR DESCRIPTION
Design gate for #152.

## Summary
- Adds `docs/team-overlays.md` defining read-only team overlays for shared skills, team knowledge/work, team ISAs, and team policy restrictions.
- Records DD-12 and adds glossary, README, architecture, and boundary links.
- Adds a focused design test proving the single-principal, privacy, provenance, Arc, and Compass constraints stay documented.

## Scope
- This does not implement `soma team ...` yet.
- The issue should remain open for the implementation slice.

## Verification
- `TMPDIR=/Users/fischer/work/mf/soma/.worktrees/issue-152-team-overlays/.tmp-tests rtk bun test test/team-overlays-design.test.ts`
- `git diff --check`
- `rtk bun run typecheck`
- `rtk bun run lint`
- `TMPDIR=/Users/fischer/work/mf/soma/.worktrees/issue-152-team-overlays/.tmp-tests rtk bun test`
