### PR TITLE
Design #149 daemon mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,11 @@ read-only team overlays. A team overlay supplements one principal's Soma home;
 it does not make the home multi-principal or share private Identity, Telos, or
 Relationship state. See [docs/team-overlays.md](docs/team-overlays.md).
 
+Daemon mode is designed as a long-lived Soma process that consumes Myelin-owned
+contracts through Cortex, routes centrally, and preserves the same policy and
+writeback boundaries as substrate sessions. See
+[docs/daemon-mode.md](docs/daemon-mode.md).
+
 ---
 
 ## Documentation
@@ -428,6 +433,7 @@ Relationship state. See [docs/team-overlays.md](docs/team-overlays.md).
 - [docs/mcp-server.md](docs/mcp-server.md), optional read-mostly MCP tool surface
 - [docs/home-replication.md](docs/home-replication.md), cross-machine Soma home replication
 - [docs/team-overlays.md](docs/team-overlays.md), read-only team overlays and shared-state boundaries
+- [docs/daemon-mode.md](docs/daemon-mode.md), daemon mode ownership and Myelin contract boundaries
 - [docs/writeback-and-policy.md](docs/writeback-and-policy.md), projection, writeback, conflict, and policy semantics
 - [docs/portability-proof.md](docs/portability-proof.md), the first portability proof and evidence contract
 

--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -693,3 +693,52 @@ organizational process.
   approval, provenance, and conflict reports exist.
 
 **Discussion:** issue #152 design pass, 2026-05-31.
+
+### DD-13: Daemon mode consumes Myelin contracts without owning the bus
+
+**Status:** Decided (2026-05-31)
+
+**Context:** Issue #149 asks for `soma daemon`: a long-lived process that
+subscribes to Myelin subjects, keeps assistant presence alive without an active
+substrate session, and routes work before spawning substrate sessions. Existing
+Soma docs define daemon as a runtime mode, while `docs/boundaries.md` says
+Cortex/Myelin own daemon, bus, and envelope mechanics.
+
+Three candidates surfaced:
+- **(a) Make Soma own Myelin subjects and envelope schemas.** Fast to implement
+  locally, but it duplicates Myelin protocol authority inside Soma.
+- **(b) Treat daemon as a Soma runtime mode that consumes imported
+  Cortex/Myelin contracts.** Soma owns assistant state, policy, route decisions,
+  and writeback. Myelin owns subject names, envelope semantics, credentials,
+  acknowledgements, and retries.
+- **(c) Defer daemon mode until Cortex provides an entire runner.** Avoids
+  premature protocol guesses, but leaves no local health or dry-run surface for
+  Soma readiness.
+
+**Decision:** **(b)** — daemon mode consumes Myelin contracts without owning
+the bus. Soma may run as a standalone Cortex agent and route work using Soma
+identity, memory, ISA, policy, and skill registry state. It must import or be
+configured with Myelin-owned subject/envelope contracts before subscribing to
+live bus traffic.
+
+The first implementation slice should add `soma daemon --dry-run` and
+`soma daemon --health` only. Live subscription, work claiming, substrate
+spawning, and result publication come after the owning Myelin/Cortex contracts
+are available.
+
+**Rejected:**
+- (a) violates the source-of-truth boundary and risks incompatible protocol
+  drift.
+- (c) is too passive; Soma can safely validate readiness and expose health
+  before live bus integration.
+
+**Implications:**
+- The canonical design is documented in `docs/daemon-mode.md`.
+- `soma daemon` with no flags can remain the reserved placeholder until live
+  subscribe semantics exist.
+- Daemon routing must preserve personal policy, team overlay privacy, and the
+  normal writeback gate.
+- Tests for the first implementation should use mock Myelin contracts, not a
+  live bus.
+
+**Discussion:** issue #149 design pass, 2026-05-31.

--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -699,10 +699,11 @@ organizational process.
 **Status:** Decided (2026-05-31)
 
 **Context:** Issue #149 asks for `soma daemon`: a long-lived process that
-subscribes to Myelin subjects, keeps assistant presence alive without an active
-substrate session, and routes work before spawning substrate sessions. Existing
-Soma docs define daemon as a runtime mode, while `docs/boundaries.md` says
-Cortex/Myelin own daemon, bus, and envelope mechanics.
+subscribes to Myelin subjects, keeps assistant availability alive without an
+active substrate session, and routes work before spawning substrate sessions.
+Existing Soma docs define daemon as a runtime mode, while
+`docs/boundaries.md` says Cortex/Myelin own daemon, bus, and envelope
+mechanics.
 
 Three candidates surfaced:
 - **(a) Make Soma own Myelin subjects and envelope schemas.** Fast to implement

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,6 +174,11 @@ workspace projections.
 Soma runs as a long-lived process, subscribes to Myelin subjects, owns state,
 and publishes envelopes. No substrate involved.
 
+Daemon mode consumes Cortex/Myelin contracts rather than defining bus semantics
+inside Soma. It should start with dry-run and health surfaces, then add live
+subscription only after Myelin subject and envelope contracts are imported from
+their owning packages. See [docs/daemon-mode.md](./daemon-mode.md).
+
 ### export
 
 Generate projection bytes (stdout or a tarball) without writing anywhere or

--- a/docs/boundaries.md
+++ b/docs/boundaries.md
@@ -39,6 +39,10 @@ Factory systems without absorbing their responsibilities. Glossary lives in
 - Team overlays supplement personal Soma state. They must not become a shared
   personal home, and they must not contain personal Identity, Telos,
   Relationship, raw transcript, or security-trace compartments.
+- Daemon mode is a Soma runtime mode, not a new bus contract. Soma may route and
+  publish assistant work as a Cortex agent, but Myelin-owned subject names,
+  envelope schemas, credentials, acknowledgements, and retries stay outside
+  Soma. See [daemon-mode.md](./daemon-mode.md).
 
 ## Naming Rules
 

--- a/docs/boundaries.md
+++ b/docs/boundaries.md
@@ -40,9 +40,8 @@ Factory systems without absorbing their responsibilities. Glossary lives in
   personal home, and they must not contain personal Identity, Telos,
   Relationship, raw transcript, or security-trace compartments.
 - Daemon mode is a Soma runtime mode, not a new bus contract. Soma may route and
-  publish assistant work as a Cortex agent, but Myelin-owned subject names,
-  envelope schemas, credentials, acknowledgements, and retries stay outside
-  Soma. See [daemon-mode.md](./daemon-mode.md).
+  publish assistant work as a Cortex agent, while detailed Myelin ownership
+  terms stay canonical in [daemon-mode.md](./daemon-mode.md).
 
 ## Naming Rules
 

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -46,7 +46,7 @@ not a new ecosystem coordinator.
 
 ## Myelin Contract Shape
 
-Soma should integrate through a narrow adapter that consumes Myelin-owned
+Soma should integrate through a narrow contract consumer for Myelin-owned
 contracts. The design uses logical subject classes here; exact subject names,
 wire versions, credentials, and retry policy must come from Myelin/Cortex
 configuration or packages.

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -1,0 +1,113 @@
+# Daemon Mode
+
+Issue #149 asks for `soma daemon`: a long-lived Soma process that can subscribe
+to Myelin subjects, keep assistant presence alive without an active substrate
+session, and route work before a substrate session is spawned.
+
+Daemon mode does not make Soma the bus, collaboration surface, or process
+supervisor. Soma owns the portable personal assistant core and the routing
+decisions derived from that core. Cortex owns the collaboration surface, Myelin
+owns transport and envelope semantics, and Spawn owns isolated execution.
+
+## Goals
+
+- Keep Soma identity, memory, ISA, policy, and skill routing available without
+  requiring Codex, Claude Code, Pi.dev, Cursor, or another substrate session to
+  already be active.
+- Let Cortex/Myelin address a standalone Soma Cortex agent through approved
+  Myelin envelopes.
+- Route centrally before spawning or addressing substrate sessions, using the
+  same progressive skill registry and policy checks as other runtime modes.
+- Publish presence, health, route decisions, work-state updates, and result
+  events with clear provenance.
+- Start with a dry-run and health surface before subscribing to live subjects.
+
+## Non-Goals
+
+- Soma daemon mode does not define Myelin protocol semantics, subject names,
+  acknowledgements, retries, or credentials.
+- Soma daemon mode does not replace Cortex as the collaboration surface.
+- Soma daemon mode does not replace Spawn for sandboxed execution.
+- Soma daemon mode does not make team overlays writable or multi-principal.
+- The first implementation does not execute arbitrary envelopes from the bus.
+
+## Ownership Boundary
+
+| Area | Owner | Soma daemon role |
+| --- | --- | --- |
+| Assistant identity, Telos, ISA, memory, policy, and skill registry | Soma | Read and update through the normal Soma home contracts. |
+| Myelin subject names, envelope schemas, ack/retry semantics, credentials | Myelin | Consume imported contracts; never invent incompatible wire semantics. |
+| Collaboration routing, work queues, task assignment | Cortex | Let Cortex address or discover the Soma Cortex agent. |
+| Isolated execution lifecycle | Spawn | Request execution when a task needs an isolated runtime. |
+| Observability backends | Signal | Emit structured Soma events that Signal can collect. |
+
+This boundary keeps daemon mode as a runtime mode for the same assistant body,
+not a new ecosystem coordinator.
+
+## Myelin Contract Shape
+
+Soma should integrate through a narrow adapter that consumes Myelin-owned
+contracts. The design uses logical subject classes here; exact subject names,
+wire versions, credentials, and retry policy must come from Myelin/Cortex
+configuration or packages.
+
+| Logical subject class | Direction | Daemon behavior |
+| --- | --- | --- |
+| Presence/health | publish | Announce daemon identity, version, enabled scopes, and readiness. |
+| Task or route request | subscribe | Validate envelope provenance and decide whether Soma can route or claim it. |
+| Skill-route request | subscribe/reply | Return selected skills, source paths, and context budget without loading unrelated bodies. |
+| Work-state event | publish | Mirror accepted task state into Soma `memory/STATE/` and publish a bus-visible update. |
+| Result or refusal | publish | Report routed result metadata, refusal reason, or handoff target. |
+
+Every inbound envelope is policy-checked before it can affect memory, skills,
+ISA state, Algorithm runs, or substrate spawning. Unauthorized or malformed
+envelopes fail closed and produce a refusal event instead of partial work.
+
+## Routing Flow
+
+1. Start `soma daemon` with a principal-selected Soma home and Cortex/Myelin
+   configuration.
+2. Load the Soma kernel: identity summary, active work/ISA, policy, skill
+   registry, and team overlays that are enabled for daemon use.
+3. Publish presence and health.
+4. Receive a Myelin envelope.
+5. Verify envelope provenance, principal/team scope, requested capability, and
+   policy.
+6. Route against the progressive skill registry and active work state.
+7. Either refuse with a structured reason, handle a read-only/library request
+   locally, or request a substrate/Spawn execution path with selected context.
+8. Record route decisions, loaded paths, policy decisions, and result metadata
+   as append-only Soma events.
+
+The daemon must preserve the same writeback gate used by substrate sessions.
+Bus-visible events can mirror state, but they do not bypass Soma policy or
+write directly into private compartments.
+
+## First Implementation Slice
+
+The first code slice should expose a non-subscribing surface:
+
+- `soma daemon --dry-run` validates Soma home, enabled daemon scopes, and
+  Cortex/Myelin configuration presence without connecting to the bus.
+- `soma daemon --health` prints daemon readiness as JSON for supervisors.
+- The CLI should keep the existing no-argument placeholder until live subscribe
+  semantics are implemented.
+- Health output should include Soma version, selected home, enabled scopes,
+  configured Myelin source, and warnings for missing optional pieces.
+- Tests should use a mock Myelin contract; no live bus is required.
+
+The second slice can add read-only subscription to route and health subjects.
+Claiming work, spawning substrate sessions, and publishing results should wait
+until Myelin envelope contracts and credential handling are imported from the
+owning packages.
+
+## Safety Rules
+
+- The daemon never relaxes personal policy; team overlay policy can only add
+  restrictions.
+- The daemon must not expose Identity, Telos, Relationship, raw transcripts, or
+  security traces through team or bus-facing surfaces.
+- The daemon records provenance for every accepted envelope and every selected
+  skill or ISA.
+- A bus envelope cannot become an unreviewed writeback operation.
+- Live subscription must be opt-in and visible in health output.

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -1,8 +1,8 @@
 # Daemon Mode
 
 Issue #149 asks for `soma daemon`: a long-lived Soma process that can subscribe
-to Myelin subjects, keep assistant presence alive without an active substrate
-session, and route work before a substrate session is spawned.
+to Myelin subjects, keep assistant availability alive without an active
+substrate session, and route work before a substrate session is spawned.
 
 Daemon mode does not make Soma the bus, collaboration surface, or process
 supervisor. Soma owns the portable personal assistant core and the routing
@@ -18,7 +18,7 @@ owns transport and envelope semantics, and Spawn owns isolated execution.
   Myelin envelopes.
 - Route centrally before spawning or addressing substrate sessions, using the
   same progressive skill registry and policy checks as other runtime modes.
-- Publish presence, health, route decisions, work-state updates, and result
+- Publish readiness, health, route decisions, work-state updates, and result
   events with clear provenance.
 - Start with a dry-run and health surface before subscribing to live subjects.
 
@@ -53,7 +53,7 @@ configuration or packages.
 
 | Logical subject class | Direction | Daemon behavior |
 | --- | --- | --- |
-| Presence/health | publish | Announce daemon identity, version, enabled scopes, and readiness. |
+| Readiness/health | publish | Announce daemon identity, version, enabled scopes, and readiness. |
 | Task or route request | subscribe | Validate envelope provenance and decide whether Soma can route or claim it. |
 | Skill-route request | subscribe/reply | Return selected skills, source paths, and context budget without loading unrelated bodies. |
 | Work-state event | publish | Mirror accepted task state into Soma `memory/STATE/` and publish a bus-visible update. |
@@ -69,7 +69,7 @@ envelopes fail closed and produce a refusal event instead of partial work.
    configuration.
 2. Load the Soma kernel: identity summary, active work/ISA, policy, skill
    registry, and team overlays that are enabled for daemon use.
-3. Publish presence and health.
+3. Publish readiness and health.
 4. Receive a Myelin envelope.
 5. Verify envelope provenance, principal/team scope, requested capability, and
    policy.
@@ -88,7 +88,7 @@ write directly into private compartments.
 The first code slice should expose a non-subscribing surface:
 
 - `soma daemon --dry-run` validates Soma home, enabled daemon scopes, and
-  Cortex/Myelin configuration presence without connecting to the bus.
+  Cortex/Myelin configuration availability without connecting to the bus.
 - `soma daemon --health` prints daemon readiness as JSON for supervisors.
 - The CLI should keep the existing no-argument placeholder until live subscribe
   semantics are implemented.

--- a/docs/progressive-skill-loading.md
+++ b/docs/progressive-skill-loading.md
@@ -238,6 +238,10 @@ substrate session. The daemon can send a Myelin envelope containing the selected
 skill manifests and source paths, then let the substrate adapter materialize the
 right context shape.
 
+The ownership and safety contract for this runtime lives in
+[daemon-mode.md](./daemon-mode.md). Soma owns route decisions and selected
+context provenance; Myelin owns the wire protocol and envelope semantics.
+
 ## Context Budget Rules
 
 - Every projection should report estimated token cost for kernel, registry, and

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -190,8 +190,7 @@ The daemon shape should follow the existing standalone Cortex agent pattern:
 
 Daemon ownership and Myelin contract boundaries are documented in
 [daemon-mode.md](./daemon-mode.md). The adapter may consume Myelin-owned
-contracts, but it must not make Soma the owner of subject naming, envelope
-schema, credentials, acknowledgements, or retry policy.
+contracts, but it must not make Soma the owner of bus protocol details.
 
 When a Cortex/Myelin agent drives a Soma Algorithm run, capability names must
 come from Soma's registry or the run's adapter-provided capability definitions.

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -188,6 +188,11 @@ The daemon shape should follow the existing standalone Cortex agent pattern:
 - NATS credentials issued by Cortex
 - capabilities registered on startup
 
+Daemon ownership and Myelin contract boundaries are documented in
+[daemon-mode.md](./daemon-mode.md). The adapter may consume Myelin-owned
+contracts, but it must not make Soma the owner of subject naming, envelope
+schema, credentials, acknowledgements, or retry policy.
+
 When a Cortex/Myelin agent drives a Soma Algorithm run, capability names must
 come from Soma's registry or the run's adapter-provided capability definitions.
 Agents can register startup capabilities on the run with

--- a/test/daemon-mode-design.test.ts
+++ b/test/daemon-mode-design.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { expect, test } from "bun:test";
+
+const daemonDoc = readFileSync("docs/daemon-mode.md", "utf8");
+const readme = readFileSync("README.md", "utf8");
+const architecture = readFileSync("docs/architecture.md", "utf8");
+const boundaries = readFileSync("docs/boundaries.md", "utf8");
+const progressiveLoading = readFileSync("docs/progressive-skill-loading.md", "utf8");
+const substrateAdapters = readFileSync("docs/substrate-adapters.md", "utf8");
+const decisions = readFileSync("design/design-decisions.md", "utf8");
+
+test("daemon design keeps Myelin protocol ownership outside Soma", () => {
+  expect(daemonDoc).toMatch(/Myelin\s+owns transport and envelope semantics/);
+  expect(daemonDoc).toMatch(/exact subject names,\s+wire versions, credentials, and retry policy must come from Myelin\/Cortex/);
+  expect(boundaries).toContain("Myelin-owned subject names");
+  expect(decisions).toMatch(/daemon mode consumes Myelin contracts without owning\s+the bus/);
+});
+
+test("daemon design defines a dry-run and health first slice before live subscription", () => {
+  expect(daemonDoc).toContain("soma daemon --dry-run");
+  expect(daemonDoc).toContain("soma daemon --health");
+  expect(daemonDoc).toContain("The second slice can add read-only subscription");
+  expect(decisions).toContain("Live subscription, work claiming, substrate");
+});
+
+test("daemon design preserves policy, writeback, and private compartments", () => {
+  expect(daemonDoc).toContain("Every inbound envelope is policy-checked");
+  expect(daemonDoc).toContain("same writeback gate used by substrate sessions");
+  expect(daemonDoc).toContain("must not expose Identity, Telos, Relationship, raw transcripts, or");
+});
+
+test("daemon design is linked from architecture and routing docs", () => {
+  expect(readme).toContain("docs/daemon-mode.md");
+  expect(architecture).toContain("docs/daemon-mode.md");
+  expect(progressiveLoading).toContain("daemon-mode.md");
+  expect(substrateAdapters).toContain("daemon-mode.md");
+});

--- a/test/daemon-mode-design.test.ts
+++ b/test/daemon-mode-design.test.ts
@@ -12,7 +12,8 @@ const decisions = readFileSync("design/design-decisions.md", "utf8");
 test("daemon design keeps Myelin protocol ownership outside Soma", () => {
   expect(daemonDoc).toMatch(/Myelin\s+owns transport and envelope semantics/);
   expect(daemonDoc).toMatch(/exact subject names,\s+wire versions, credentials, and retry policy must come from Myelin\/Cortex/);
-  expect(boundaries).toContain("Myelin-owned subject names");
+  expect(boundaries).toContain("not a new bus contract");
+  expect(boundaries).toContain("daemon-mode.md");
   expect(decisions).toMatch(/daemon mode consumes Myelin contracts without owning\s+the bus/);
 });
 


### PR DESCRIPTION
Design gate for #149.

## Summary
- Adds `docs/daemon-mode.md` defining daemon mode ownership, logical Myelin contract classes, routing flow, and safety rules.
- Records DD-13: daemon mode consumes Myelin contracts without owning the bus.
- Links the design from README, architecture, boundaries, progressive loading, and substrate adapter docs.
- Adds a focused design test for Myelin ownership, dry-run/health-first implementation scope, policy/writeback safety, and documentation links.

## Scope
- This does not implement live Myelin subscription yet.
- The issue should remain open for the implementation slice.

## Verification
- `TMPDIR=/Users/fischer/work/mf/soma/.worktrees/issue-149-soma-daemon/.tmp-tests rtk bun test test/daemon-mode-design.test.ts`
- `git diff --check`
- `rtk bun run typecheck`
- `rtk bun run lint`
- `TMPDIR=/Users/fischer/work/mf/soma/.worktrees/issue-149-soma-daemon/.tmp-tests rtk bun test`
