### PR TITLE
Fix OBSERVE ISA sync run slugs

### DIFF
--- a/docs/algorithm-execution-modes.md
+++ b/docs/algorithm-execution-modes.md
@@ -34,7 +34,9 @@ isolation, and result consolidation remain substrate or orchestration concerns.
 
 New Algorithm runs created without an explicit `--id` use date-prefixed ids.
 This keeps repeated same-day tasks sortable and avoids collisions when several
-substrates start similar work. Existing explicit run ids are preserved.
+substrates start similar work. Existing explicit run ids are preserved. ISA
+files written back from substrate OBSERVE hooks are normalized through the
+same date-prefixing helper so bare ISA slugs do not bypass run identity rules.
 
 Algorithm mutations can also record per-hop substrate provenance. CLI paths
 such as phase advance, criterion verification, capability invocation, and

--- a/src/algorithm-isa-sync.ts
+++ b/src/algorithm-isa-sync.ts
@@ -34,8 +34,9 @@ import {
   selectAlgorithmCapability,
 } from "./algorithm-capabilities";
 import { readAlgorithmRunById, writeAlgorithmRun } from "./algorithm-store";
+import { datePrefixSlug } from "./dated-slug";
 import { getRunPhase } from "./algorithm-lifecycle";
-import { parseIsa } from "./isa-parse";
+import { parseIsa, serializeIsa } from "./isa-parse";
 import { getCriteria, getDecisions, getGoal } from "./isa-accessors";
 import { promoteAlgorithmRunMemory } from "./memory-promotion";
 import type {
@@ -340,6 +341,27 @@ function buildRunFromIsa(isa: IdealStateArtifact, slug: string, substrate: Subst
   });
 }
 
+async function normalizeIsaSlugInPlace(
+  isa: IdealStateArtifact,
+  slug: string,
+  path: string,
+): Promise<IdealStateArtifact> {
+  if (isa.slug === slug) return isa;
+  const normalized: IdealStateArtifact = {
+    ...isa,
+    slug,
+    frontmatter: {
+      ...isa.frontmatter,
+      custom: {
+        ...(isa.frontmatter.custom ?? {}),
+        slug,
+      },
+    },
+  };
+  await writeFile(path, serializeIsa(normalized), "utf8");
+  return normalized;
+}
+
 async function loadOrCreateRun(
   somaHome: string,
   slug: string,
@@ -396,14 +418,15 @@ async function syncAlgorithmRunFromIsaInner(
   }
 
   const isa = parseIsa(markdown, options.isaPath);
-  const slug = isa.slug;
+  const slug = datePrefixSlug(isa.slug, timestamp);
   const isaCriteria = getCriteria(isa);
   // A real ISA has a frontmatter slug AND criteria. Reject non-ISA markdown.
-  if (!isValidSlug(slug) || isaCriteria.length === 0 || getGoal(isa) === null) {
+  if (!isValidSlug(isa.slug) || isaCriteria.length === 0 || getGoal(isa) === null) {
     return noopResult();
   }
 
-  const { run: baseRun, created } = await loadOrCreateRun(somaHome, slug, isa, options.substrate, timestamp);
+  const normalizedIsa = await normalizeIsaSlugInPlace(isa, slug, options.isaPath);
+  const { run: baseRun, created } = await loadOrCreateRun(somaHome, slug, normalizedIsa, options.substrate, timestamp);
 
   let run = baseRun;
   const before = snapshot(run);

--- a/test/algorithm-isa-sync.test.ts
+++ b/test/algorithm-isa-sync.test.ts
@@ -77,10 +77,15 @@ test("creates a soma run from an ISA, keyed by slug, mapping goal + criteria", a
       }),
     );
 
-    const result = await syncAlgorithmRunFromIsa({ isaPath, substrate: "claude-code", somaHome });
+    const result = await syncAlgorithmRunFromIsa({
+      isaPath,
+      substrate: "claude-code",
+      somaHome,
+      timestamp: "2026-06-02T10:00:00.000Z",
+    });
 
     expect(result.created).toBe(true);
-    expect(result.slug).toBe("demo-create");
+    expect(result.slug).toBe("2026-06-02-demo-create");
     expect(result.runId).toBeTruthy();
     expect(result.criteriaTotal).toBe(2);
 
@@ -94,6 +99,96 @@ test("creates a soma run from an ISA, keyed by slug, mapping goal + criteria", a
     expect(criteria.map((c) => c.id)).toEqual(["ISC-1", "ISC-2"]);
     // Advanced forward to match ISA phase `think`.
     expect(getRunPhase(run)).toBe("think");
+  });
+});
+
+test("normalizes bare OBSERVE ISA slugs through dated Algorithm run ids", async () => {
+  await withSomaHome(async (somaHome, dir) => {
+    const isaPath = await writeIsaFile(
+      dir,
+      "switch-phish-to-learn",
+      isaMarkdown({
+        slug: "switch-phish-to-learn",
+        phase: "observe",
+        goal: "Learn from the phishing switch",
+        criteria: [{ id: "ISC-1", text: "the run id is date-prefixed" }],
+      }),
+    );
+
+    const result = await syncAlgorithmRunFromIsa({
+      isaPath,
+      substrate: "claude-code",
+      somaHome,
+      timestamp: "2026-06-02T11:30:00.000Z",
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.slug).toBe("2026-06-02-switch-phish-to-learn");
+    expect(result.runId).toBe("2026-06-02-switch-phish-to-learn");
+
+    const { run } = await readAlgorithmRunById(result.runId!, { somaHome });
+    expect(run.id).toBe("2026-06-02-switch-phish-to-learn");
+    expect(run.isa.slug).toBe("2026-06-02-switch-phish-to-learn");
+
+    const rewritten = await readFile(isaPath, "utf8");
+    expect(rewritten).toContain("slug: 2026-06-02-switch-phish-to-learn");
+  });
+});
+
+test("resumes a normalized bare ISA when edited on a later date", async () => {
+  await withSomaHome(async (somaHome, dir) => {
+    const isaPath = await writeIsaFile(
+      dir,
+      "long-lived-bare",
+      isaMarkdown({
+        slug: "long-lived-bare",
+        phase: "observe",
+        goal: "Keep one run across edits",
+        criteria: [{ id: "ISC-1", text: "the run remains stable" }],
+      }),
+    );
+
+    const first = await syncAlgorithmRunFromIsa({
+      isaPath,
+      substrate: "claude-code",
+      somaHome,
+      timestamp: "2026-06-02T11:30:00.000Z",
+    });
+    const second = await syncAlgorithmRunFromIsa({
+      isaPath,
+      substrate: "claude-code",
+      somaHome,
+      timestamp: "2026-06-03T11:30:00.000Z",
+    });
+
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(false);
+    expect(second.runId).toBe("2026-06-02-long-lived-bare");
+  });
+});
+
+test("keeps already dated OBSERVE ISA slugs stable on sync", async () => {
+  await withSomaHome(async (somaHome, dir) => {
+    const isaPath = await writeIsaFile(
+      dir,
+      "2026-06-02-already-dated",
+      isaMarkdown({
+        slug: "2026-06-02-already-dated",
+        phase: "observe",
+        goal: "Do not double-prefix",
+        criteria: [{ id: "ISC-1", text: "the run id is stable" }],
+      }),
+    );
+
+    const result = await syncAlgorithmRunFromIsa({
+      isaPath,
+      substrate: "claude-code",
+      somaHome,
+      timestamp: "2026-06-03T11:30:00.000Z",
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.runId).toBe("2026-06-02-already-dated");
   });
 });
 
@@ -141,9 +236,14 @@ test("corrupt run index starts fresh and emits bounded debug output", async () =
       return true;
     });
     try {
-      const result = await syncAlgorithmRunFromIsa({ isaPath, substrate: "claude-code", somaHome });
+      const result = await syncAlgorithmRunFromIsa({
+        isaPath,
+        substrate: "claude-code",
+        somaHome,
+        timestamp: "2026-06-02T10:00:00.000Z",
+      });
       expect(result.created).toBe(true);
-      expect(result.slug).toBe("demo-corrupt-index");
+      expect(result.slug).toBe("2026-06-02-demo-corrupt-index");
     } finally {
       stderrSpy.mockRestore();
     }

--- a/test/claude-code-install.test.ts
+++ b/test/claude-code-install.test.ts
@@ -18,6 +18,7 @@ import {
   uninstallSomaForClaudeCode,
 } from "../src/index";
 import { unpatchClaudeCodeModeClassifierSettings } from "../src/adapters/claude-code/hooks";
+import { datePrefixSlug } from "../src/dated-slug";
 import { portableProjectionInput } from "./fixtures";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
@@ -573,6 +574,7 @@ test("hook bridge: editing an ISA file via writeback-tool mirrors it into a soma
       "utf8",
     );
 
+    const expectedSlug = datePrefixSlug(slug);
     runClaudeHook(homeDir, "writeback-tool", {
       session_id: "claude-session-hook-bridge",
       hook_event_name: "PostToolUse",
@@ -581,11 +583,11 @@ test("hook bridge: editing an ISA file via writeback-tool mirrors it into a soma
       tool_input: { file_path: isaPath, content: "..." },
     });
 
-    expect(await waitForRunFile(homeDir, slug)).toBe(true);
+    expect(await waitForRunFile(homeDir, expectedSlug)).toBe(true);
     const run = await readJson<{ id: string; substrate: string }>(
-      join(homeDir, ".soma/memory/WORK/algorithm-runs", `${slug}.json`),
+      join(homeDir, ".soma/memory/WORK/algorithm-runs", `${expectedSlug}.json`),
     );
-    expect(run.id).toBe(slug);
+    expect(run.id).toBe(expectedSlug);
     expect(run.substrate).toBe("claude-code");
   });
 });


### PR DESCRIPTION
## Summary

- Route `sync-from-isa` run identity through the same dated slug helper used by `soma algorithm new`.
- Add OBSERVE sync regressions for bare slugs and already dated slugs.
- Update the Claude hook bridge test and docs for dated sync-created run ids.

Closes #291

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test`
