### PR TITLE
Add Algorithm handoff resume boundary

### DIFF
--- a/docs/algorithm-execution-modes.md
+++ b/docs/algorithm-execution-modes.md
@@ -45,6 +45,11 @@ that provenance as structured metadata, and `soma algorithm show --id <run-id>`
 surfaces a compact `touched by:` summary for handoff across Codex, Claude Code,
 Pi.dev, Cursor, Cortex, or daemon-driven work.
 
+Cross-substrate relays should use `soma algorithm resume --until-phase <phase>`
+when a hop owns only part of the run. `resume` repeatedly applies the normal
+phase gates, stops exactly at the requested phase, and leaves later phases for
+the next substrate.
+
 ## Ideate And Optimize Parameters
 
 Soma defines portable parameter schemas and presets:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,7 +58,9 @@ but Soma decides whether the process is allowed to advance.
 The harness is driven through explicit mutations rather than substrate-specific
 conversation tricks. The portable command surface covers `new`, `list`, `show`,
 `classify`, `capabilities`, `invoke`, `remove-capability`, `plan`, `decision`,
-`change`, `step`, `verify`, `learn`, and `advance`. `classify` is Soma's
+`change`, `step`, `verify`, `learn`, `advance`, and `resume`. `resume` accepts
+an explicit `--until-phase` handoff boundary so a relay substrate can stop
+before consuming downstream phases. `classify` is Soma's
 UserPromptSubmit mode classifier: it chooses MINIMAL, NATIVE, or ALGORITHM and
 maps Algorithm prompts to E1-E5 before a run is created. This adapts the useful
 part of PAI's Algorithm tool while leaving Claude-only PRD parsing, prompt

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -367,6 +367,33 @@ export function advanceAlgorithmRun(
   });
 }
 
+export function advanceAlgorithmRunUntil(
+  run: AlgorithmRun,
+  untilPhase: AlgorithmPhase,
+  timestamp = new Date().toISOString(),
+  provenance?: Pick<AlgorithmProvenanceInput, "substrate">,
+): AlgorithmRun {
+  const targetIndex = PHASES.indexOf(untilPhase);
+  if (targetIndex === -1 || untilPhase === "abandoned") {
+    throw new Error(`Algorithm handoff boundary must be one of ${PHASES.join(", ")}.`);
+  }
+
+  const currentIndex = PHASES.indexOf(getRunPhase(run));
+  if (currentIndex === -1) {
+    throw new Error("Algorithm run was abandoned and cannot advance.");
+  }
+  if (currentIndex > targetIndex) {
+    throw new Error(`Algorithm run is already past handoff boundary ${untilPhase}.`);
+  }
+
+  let next = run;
+  while (PHASES.indexOf(getRunPhase(next)) < targetIndex) {
+    next = advanceAlgorithmRun(next, timestamp, provenance);
+  }
+
+  return next;
+}
+
 export function updateAlgorithmPlanStep(
   run: AlgorithmRun,
   stepId: string,

--- a/src/cli/algorithm.ts
+++ b/src/cli/algorithm.ts
@@ -1,5 +1,6 @@
 import {
   applyAlgorithmBatch,
+  advanceAlgorithmRunUntil,
   advanceAlgorithmRun,
   algorithmPhaseOrder,
   classifyAlgorithmPrompt,
@@ -52,6 +53,7 @@ export const ALGORITHM_ACTIONS = [
   "learn",
   "batch",
   "advance",
+  "resume",
   "sync-from-isa",
 ] as const;
 
@@ -75,6 +77,7 @@ export const ALGORITHM_COMMAND_HELP: { usage: string; subcommands: Record<Algori
     verify: "Usage: soma algorithm verify --id <run-id> --criterion-id <id> --status <passed|failed|dropped> --evidence <text> [--substrate <id>]",
     learn: "Usage: soma algorithm learn --id <run-id> --text <text> [--substrate <id>] [--home-dir <dir>] [--soma-home <dir>]",
     advance: "Usage: soma algorithm advance --id <run-id> [--substrate <id>] [--home-dir <dir>] [--soma-home <dir>]",
+    resume: "Usage: soma algorithm resume --id <run-id> --until-phase <phase> [--substrate <id>] [--home-dir <dir>] [--soma-home <dir>]",
     "sync-from-isa":
       "Usage: soma algorithm sync-from-isa --isa <path> --substrate <id> [--soma-home <dir>] [--home-dir <dir>] [--promote-on-complete]",
   },
@@ -103,6 +106,7 @@ interface AlgorithmCliOptions {
   criterionStatus?: "passed" | "failed" | "dropped";
   evidence?: string;
   substrate?: SubstrateId;
+  untilPhase?: AlgorithmPhase;
   batchOperations?: AlgorithmBatchOperation[];
   json?: boolean;
   isaPath?: string;
@@ -288,13 +292,13 @@ function parseBatchOperationsJson(value: string): AlgorithmBatchOperation[] {
   });
 }
 
-function parseAlgorithmPhase(value: string): AlgorithmPhase {
+function parseAlgorithmPhase(value: string, optionName = "--phase"): AlgorithmPhase {
   const phases = algorithmPhaseOrder();
   if (phases.includes(value as AlgorithmPhase)) {
     return value as AlgorithmPhase;
   }
 
-  throw new Error(`--phase must be one of ${phases.join(", ")}.`);
+  throw new Error(`${optionName} must be one of ${phases.join(", ")}.`);
 }
 
 export function parseAlgorithmArgs(args: string[]): ParsedAlgorithmArgs {
@@ -371,6 +375,10 @@ export function parseAlgorithmArgs(args: string[]): ParsedAlgorithmArgs {
         break;
       case "--phase":
         options.capabilityPhase = parseAlgorithmPhase(readOption(rest, index, arg));
+        index += 1;
+        break;
+      case "--until-phase":
+        options.untilPhase = parseAlgorithmPhase(readOption(rest, index, arg), arg);
         index += 1;
         break;
       case "--reason":
@@ -730,6 +738,15 @@ export async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<stri
       promoteOnComplete: options.promoteOnComplete === true,
     });
     return formatSyncResult(result);
+  }
+
+  if (parsed.action === "resume") {
+    if (!options.untilPhase) throw new Error("--until-phase is required.");
+    const untilPhase = options.untilPhase;
+    return updateAndReportAlgorithmRun(options, (run) =>
+      advanceAlgorithmRunUntil(run, untilPhase, undefined, { substrate: options.substrate }),
+      { registerCapabilities: true },
+    );
   }
 
   return updateAndReportAlgorithmRun(options, (run) => advanceAlgorithmRun(run, undefined, { substrate: options.substrate }), {

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,7 @@ export {
   addAlgorithmCapabilities,
   applyAlgorithmBatch,
   advanceAlgorithmRun,
+  advanceAlgorithmRunUntil,
   algorithmPhaseOrder,
   createAlgorithmRun,
   nextAlgorithmPhase,

--- a/test/algorithm.test.ts
+++ b/test/algorithm.test.ts
@@ -5,6 +5,7 @@ import { expect, test } from "bun:test";
 import {
   addAlgorithmCapabilities,
   advanceAlgorithmRun,
+  advanceAlgorithmRunUntil,
   classifyAlgorithmPrompt,
   createAlgorithmRun,
   getCriteria,
@@ -228,6 +229,34 @@ test("enforces Algorithm phase gates", () => {
   );
   run = advanceAlgorithmRun(run, "2026-05-14T10:13:00.000Z");
   expect(getRunPhase(run)).toBe("complete");
+});
+
+test("advances Algorithm runs only to the requested handoff boundary", () => {
+  let run = createAlgorithmRun({
+    id: "handoff-run",
+    timestamp: "2026-06-02T10:00:00.000Z",
+    prompt: "Relay the run",
+    intent: "Advance only to the handoff boundary.",
+    currentState: "Run is at observe.",
+    goal: "Run pauses for the next substrate.",
+    criteria: [{ id: "C1", text: "Boundary is honored." }],
+  });
+
+  run = advanceAlgorithmRun(run, "2026-06-02T10:01:00.000Z");
+  run = selectAlgorithmCapability(run, { name: "sequential-analysis", phase: "think", reason: "Need a relay plan." });
+  run = recordAlgorithmCapabilityInvocation(run, {
+    name: "sequential-analysis",
+    substrate: "codex",
+    evidence: "Used sequential analysis to decide the handoff boundary.",
+  });
+
+  run = advanceAlgorithmRunUntil(run, "plan", "2026-06-02T10:02:00.000Z", { substrate: "codex" });
+  expect(getRunPhase(run)).toBe("plan");
+
+  run = setAlgorithmPlan(run, [{ id: "P1", criteriaIds: ["C1"], text: "Hand off after BUILD.", status: "open" }]);
+  run = advanceAlgorithmRunUntil(run, "build", "2026-06-02T10:03:00.000Z", { substrate: "codex" });
+  expect(getRunPhase(run)).toBe("build");
+  expect(() => advanceAlgorithmRunUntil(run, "plan", "2026-06-02T10:04:00.000Z")).toThrow("already past handoff boundary plan");
 });
 
 test("records structured Algorithm capability selections and invocations", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -541,6 +541,85 @@ test("cli drives Algorithm runs through gated mutations", async () => {
   });
 });
 
+test("cli resume stops at an explicit handoff phase boundary", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli([
+      "algorithm",
+      "new",
+      "--home-dir",
+      homeDir,
+      "--id",
+      "handoff-cli-run",
+      "--prompt",
+      "Relay this run",
+      "--intent",
+      "Resume only to the next substrate boundary.",
+      "--current-state",
+      "Run is at observe.",
+      "--goal",
+      "Run pauses before downstream phases.",
+      "--criterion",
+      "C1:Handoff boundary is honored.",
+    ]);
+
+    await runSomaCli(["algorithm", "advance", "--home-dir", homeDir, "--id", "handoff-cli-run"]);
+    await runSomaCli(["algorithm", "capabilities", "--home-dir", homeDir, "--id", "handoff-cli-run", "--capability", "sequential-analysis"]);
+
+    const planBoundary = await runSomaCli([
+      "algorithm",
+      "resume",
+      "--home-dir",
+      homeDir,
+      "--id",
+      "handoff-cli-run",
+      "--until-phase",
+      "plan",
+      "--substrate",
+      "codex",
+    ]);
+    expect(planBoundary).toContain("phase: plan");
+
+    await runSomaCli([
+      "algorithm",
+      "plan",
+      "--home-dir",
+      homeDir,
+      "--id",
+      "handoff-cli-run",
+      "--step",
+      "P1:C1:Leave execute and verify for another substrate.",
+    ]);
+
+    const buildBoundary = await runSomaCli([
+      "algorithm",
+      "resume",
+      "--home-dir",
+      homeDir,
+      "--id",
+      "handoff-cli-run",
+      "--until-phase",
+      "build",
+      "--substrate",
+      "codex",
+    ]);
+    expect(buildBoundary).toContain("phase: build");
+    expect(buildBoundary).not.toContain("phase: complete");
+
+    await expect(
+      runSomaCli([
+        "algorithm",
+        "resume",
+        "--home-dir",
+        homeDir,
+        "--id",
+        "handoff-cli-run",
+        "--until-phase",
+        "plan",
+      ]),
+    ).rejects.toThrow("already past handoff boundary plan");
+  });
+});
+
 test("cli records substrate provenance and surfaces touched-by summary", async () => {
   await withTempHome(async (homeDir) => {
     await runSomaCli([


### PR DESCRIPTION
## Summary

- Add `advanceAlgorithmRunUntil(...)` for bounded Algorithm phase progression.
- Add `soma algorithm resume --until-phase <phase>` so relay hops can stop at explicit handoff boundaries.
- Cover pure Algorithm and CLI resume behavior with regression tests.
- Document the resume handoff boundary in architecture and execution-mode docs.

Closes #292

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test`
