### PR TITLE
Fix #293: use shared Soma ISA home for Claude scaffolds

### DIFF
--- a/src/adapters/claude-code/hook-runner.mjs
+++ b/src/adapters/claude-code/hook-runner.mjs
@@ -117,13 +117,14 @@ function writebackQueuePath() {
   return join(hookDir(), "soma-claude-code-writeback-queue.jsonl");
 }
 
-// Match PAI ISA files: a basename of `ISA.md` under a `MEMORY/WORK/<slug>/`
-// directory, OR a project-root `ISA.md`. Anything else is ignored so the
-// sync bridge only fires on real ISA edits.
+// Match shared Soma ISA files, legacy PAI ISA files during migration, OR a
+// project-root `ISA.md`. Anything else is ignored so the sync bridge only fires
+// on real ISA edits.
 function isIsaPath(path) {
   if (typeof path !== "string" || path.length === 0) return false;
   const normalized = path.replaceAll("\\", "/");
   if (!normalized.endsWith("/ISA.md") && normalized !== "ISA.md") return false;
+  if (/\/\.soma\/memory\/WORK\/[^/]+\/ISA\.md$/.test(normalized)) return true;
   if (/\/MEMORY\/WORK\/[^/]+\/ISA\.md$/.test(normalized)) return true;
   // Otherwise any `ISA.md` basename (project-root OR nested, e.g. src/ISA.md).
   // Broader than the MEMORY/WORK case by design: false positives are harmless

--- a/src/skills/ISA/Workflows/Scaffold.md
+++ b/src/skills/ISA/Workflows/Scaffold.md
@@ -14,15 +14,17 @@ Generate a fresh ISA from a prompt at a specified effort tier. The output is a p
 |-------|----------|-------------|
 | prompt | yes | The user's request — verbatim or distilled |
 | tier | yes | E1 / E2 / E3 / E4 / E5 |
-| project | no | If task targets a known project from PROJECTS.md, the project ISA path is used; otherwise a task ISA at `MEMORY/WORK/{slug}/ISA.md` |
+| project | no | If task targets a known project from PROJECTS.md, the project ISA path is used; otherwise a task ISA at `<soma-home>/memory/WORK/{slug}/ISA.md` |
 | ephemeral_feature | no | If set, scaffold a feature-file excerpt instead of a full ISA |
 
 ## Output
 
 A markdown file at one of:
 - `<project-root>/ISA.md` — when `project` is supplied (existing project ISA is read-extended, not overwritten)
-- `~/.claude/PAI/MEMORY/WORK/{slug}/ISA.md` — when no project (slug = `YYYYMMDD-HHMMSS_kebab-task-description`)
-- `~/.claude/PAI/MEMORY/WORK/{slug}/_ephemeral/<feature>.md` — when `ephemeral_feature` is set
+- `<soma-home>/memory/WORK/{slug}/ISA.md` — when no project (slug = `YYYYMMDD-HHMMSS_kebab-task-description`)
+- `<soma-home>/memory/WORK/{slug}/_ephemeral/<feature>.md` — when `ephemeral_feature` is set
+
+`<soma-home>` is the configured shared Soma home. Claude Code must write and sync task ISAs there instead of creating a parallel Claude-local work copy.
 
 ## Procedure
 
@@ -118,7 +120,7 @@ When `ephemeral_feature` is set:
    - `## Test Strategy` entries matching those ISCs
    - `## Decisions` filtered to entries mentioning this feature's ISC IDs (optional)
    - Empty `## Verification` section ready to populate
-4. Write to `MEMORY/WORK/{slug}/_ephemeral/<feature>.md`.
+4. Write to `<soma-home>/memory/WORK/{slug}/_ephemeral/<feature>.md`.
 5. Add a header comment: `<!-- EPHEMERAL FEATURE FILE — derived from <master-isa-path>. Reconcile via Skill("ISA", "reconcile <this-path> → <master-path>"). Do not hand-edit master from this file. -->`
 
 ## Failure modes

--- a/test/adapter-active-isa.test.ts
+++ b/test/adapter-active-isa.test.ts
@@ -111,14 +111,13 @@ test("AC-3: non-Claude ISA skill projections rewrite Claude-specific source path
     await installSomaForPiDev({ homeDir });
 
     const claudeHome = "~/" + ".claude";
-    const somaHome = "~/" + ".soma";
     const codexScaffold = await readFile(join(homeDir, ".codex/skills/ISA/Workflows/Scaffold.md"), "utf8");
     const piScaffold = await readFile(join(homeDir, ".pi/agent/skills/isa/Workflows/Scaffold.md"), "utf8");
     const projected = `${codexScaffold}\n${piScaffold}`;
 
     expect(projected).not.toContain(claudeHome);
-    expect(projected).toContain(`${somaHome}/memory/WORK/{slug}/ISA.md`);
-    expect(projected).toContain(`${somaHome}/skills/ISA/Examples/canonical-isa.md`);
+    expect(projected).toContain("<soma-home>/memory/WORK/{slug}/ISA.md");
+    expect(projected).toContain("<soma-home>/memory/WORK/{slug}/_ephemeral/<feature>.md");
   });
 });
 
@@ -141,6 +140,16 @@ test("AC-3: installSomaForClaudeCode projects ISA skill source into ~/.claude/sk
     await installSomaForClaudeCode({ homeDir });
     const skillMd = await readFile(join(homeDir, ".claude/skills/ISA/SKILL.md"), "utf8");
     expect(skillMd).toContain("name: ISA");
+  });
+});
+
+test("AC-3: installSomaForClaudeCode projects shared Soma ISA work-home instructions", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir });
+    const scaffold = await readFile(join(homeDir, ".claude/skills/ISA/Workflows/Scaffold.md"), "utf8");
+    expect(scaffold).toContain("<soma-home>/memory/WORK/{slug}/ISA.md");
+    expect(scaffold).toContain("<soma-home>/memory/WORK/{slug}/_ephemeral/<feature>.md");
+    expect(scaffold).not.toContain("PAI/MEMORY/WORK");
   });
 });
 

--- a/test/claude-code-install.test.ts
+++ b/test/claude-code-install.test.ts
@@ -541,13 +541,14 @@ async function waitForRunFile(homeDir: string, slug: string): Promise<boolean> {
   return false;
 }
 
-test("hook bridge: editing an ISA file via writeback-tool mirrors it into a soma Algorithm run", async () => {
+test("hook bridge: editing a shared Soma ISA file via writeback-tool mirrors it into a soma Algorithm run", async () => {
   await withTempHome(async (homeDir) => {
     await installSomaForClaudeCode({ homeDir });
 
     const slug = "hook-bridge-demo";
-    const isaPath = join(homeDir, "PAI/MEMORY/WORK", slug, "ISA.md");
-    await mkdir(join(homeDir, "PAI/MEMORY/WORK", slug), { recursive: true });
+    const isaDir = join(homeDir, ".soma/memory/WORK", slug);
+    const isaPath = join(isaDir, "ISA.md");
+    await mkdir(isaDir, { recursive: true });
     await writeFile(
       isaPath,
       [
@@ -578,7 +579,7 @@ test("hook bridge: editing an ISA file via writeback-tool mirrors it into a soma
     runClaudeHook(homeDir, "writeback-tool", {
       session_id: "claude-session-hook-bridge",
       hook_event_name: "PostToolUse",
-      cwd: join(homeDir, "PAI/MEMORY/WORK", slug),
+      cwd: isaDir,
       tool_name: "Write",
       tool_input: { file_path: isaPath, content: "..." },
     });


### PR DESCRIPTION
## Summary
- point ISA Scaffold output paths at the configured shared <soma-home>/memory/WORK home instead of Claude-local work storage
- make the Claude hook explicitly recognize shared Soma ISA paths while keeping legacy PAI paths for migration
- cover Claude projection instructions and hook sync from the shared ISA home

Fixes #293.

## Verification
- rtk bun test test/claude-code-install.test.ts test/adapter-active-isa.test.ts
- rtk bun run lint
- rtk bun run typecheck
- rtk bun test