### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soma",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "description": "Substrate-portable Personal AI Assistant core.",


### PR DESCRIPTION
Minor version bump `0.7.1 → 0.8.0`. All four substrate projections (claude-code, codex, pi-dev, cursor) reprojected at 0.8.0 via `soma install <s> --apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)