### PR TITLE
fix(pai-importer): parse pipe-separated identity fields (#306)

### DIFF
--- a/src/pai-importer.ts
+++ b/src/pai-importer.ts
@@ -123,6 +123,7 @@ function renderPrincipalProfile(source: string, sourcePath: string): string {
 }
 
 function renderAssistantProfile(source: string, sourcePath: string): string {
+  // Captures stop at `|` or newline; firstMatch() trims the captured value before defaulting.
   const fullName = firstMatch(source, [/(?:- )?\*\*Full Name:\*\*\s*([^|\n]+)/], "Ivy - Personal AI Assistant");
   const name = firstMatch(source, [/(?:- )?\*\*Name:\*\*\s*([^|\n]+)/], "Ivy");
   const displayName = firstMatch(source, [/(?:- )?\*\*Display Name:\*\*\s*([^|\n]+)/], name);

--- a/src/pai-importer.ts
+++ b/src/pai-importer.ts
@@ -91,12 +91,12 @@ function firstMatch(content: string, patterns: RegExp[], fallback = ""): string 
 }
 
 function renderPrincipalProfile(source: string, sourcePath: string): string {
-  const name = firstMatch(source, [/- \*\*Name:\*\*\s*(.+)/, /^Name:\s*(.+)$/m], "principal");
-  const pronunciation = firstMatch(source, [/- \*\*Pronunciation:\*\*\s*(.+)/]);
-  const location = firstMatch(source, [/- \*\*Location:\*\*\s*(.+)/]);
-  const timezone = firstMatch(source, [/- \*\*Timezone:\*\*\s*(.+)/]);
-  const role = firstMatch(source, [/- \*\*Role:\*\*\s*(.+)/]);
-  const focus = firstMatch(source, [/- \*\*Focus:\*\*\s*(.+)/]);
+  const name = firstMatch(source, [/(?:- )?\*\*Name:\*\*\s*([^|\n]+)/, /^Name:\s*(.+)$/m], "principal");
+  const pronunciation = firstMatch(source, [/(?:- )?\*\*Pronunciation:\*\*\s*([^|\n]+)/]);
+  const location = firstMatch(source, [/(?:- )?\*\*Location:\*\*\s*([^|\n]+)/]);
+  const timezone = firstMatch(source, [/(?:- )?\*\*Timezone:\*\*\s*([^|\n]+)/]);
+  const role = firstMatch(source, [/(?:- )?\*\*Role:\*\*\s*([^|\n]+)/]);
+  const focus = firstMatch(source, [/(?:- )?\*\*Focus:\*\*\s*([^|\n]+)/]);
 
   return [
     "# Principal",
@@ -123,13 +123,13 @@ function renderPrincipalProfile(source: string, sourcePath: string): string {
 }
 
 function renderAssistantProfile(source: string, sourcePath: string): string {
-  const fullName = firstMatch(source, [/- \*\*Full Name:\*\*\s*(.+)/], "Ivy - Personal AI Assistant");
-  const name = firstMatch(source, [/- \*\*Name:\*\*\s*(.+)/], "Ivy");
-  const displayName = firstMatch(source, [/- \*\*Display Name:\*\*\s*(.+)/], name);
-  const color = firstMatch(source, [/- \*\*Color:\*\*\s*(.+)/]);
-  const voiceId = firstMatch(source, [/- \*\*Voice ID:\*\*\s*(.+)/]);
-  const role = firstMatch(source, [/- \*\*Role:\*\*\s*(.+)/]);
-  const environment = firstMatch(source, [/- \*\*Operating Environment:\*\*\s*(.+)/]);
+  const fullName = firstMatch(source, [/(?:- )?\*\*Full Name:\*\*\s*([^|\n]+)/], "Ivy - Personal AI Assistant");
+  const name = firstMatch(source, [/(?:- )?\*\*Name:\*\*\s*([^|\n]+)/], "Ivy");
+  const displayName = firstMatch(source, [/(?:- )?\*\*Display Name:\*\*\s*([^|\n]+)/], name);
+  const color = firstMatch(source, [/(?:- )?\*\*Color:\*\*\s*([^|\n]+)/]);
+  const voiceId = firstMatch(source, [/(?:- )?\*\*Voice ID:\*\*\s*([^|\n]+)/]);
+  const role = firstMatch(source, [/(?:- )?\*\*Role:\*\*\s*([^|\n]+)/]);
+  const environment = firstMatch(source, [/(?:- )?\*\*Operating Environment:\*\*\s*([^|\n]+)/]);
 
   return [
     "# Assistant",

--- a/test/pai-migration-issue-306.test.ts
+++ b/test/pai-migration-issue-306.test.ts
@@ -158,3 +158,33 @@ test("#306 principal profile fields also stop at pipes when present", async () =
     expect(principal).not.toContain("Rob Chuvala | **Pronunciation:**");
   });
 });
+
+test("#306 `**Display:**` short-form does NOT silently land in the Display Name slot", async () => {
+  // Guards against a future regex relaxation that lets `**Display:**`
+  // satisfy the `**Display Name:**` capture. The two labels are
+  // intentionally different in PAI 5.0; if a real install uses the
+  // short form, that's a field-name mismatch deserving its own pass,
+  // not a silent absorption by a neighbouring regex.
+  await withTempHome(async (homeDir) => {
+    const daWithShortForm = [
+      "# DA Identity",
+      "",
+      "- **Name:** Margin | **Full Name:** Margin | **Display:** Margin",
+      "- **Role:** Close-reader instance on Lares",
+    ].join("\n");
+
+    await writePaiSkeleton(homeDir, daWithShortForm);
+    await importPaiIdentity({ homeDir });
+
+    const assistant = await readFile(join(homeDir, ".soma/profile/assistant.md"), "utf8");
+
+    // `**Display:**` (short form) must not satisfy the `**Display Name:**`
+    // capture. The Display Name slot should fall back to `Name`.
+    expect(assistant).toContain("Name: Margin");
+    expect(assistant).toContain("Display name: Margin");
+
+    // The short-form label itself must not leak into any captured value.
+    expect(assistant).not.toContain("Margin | **Display:**");
+    expect(assistant).not.toContain("**Display:** Margin");
+  });
+});

--- a/test/pai-migration-issue-306.test.ts
+++ b/test/pai-migration-issue-306.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Issue 306 — `migrate-pai` regex assumed one-bullet-per-field for
+ * DA_IDENTITY.md. PAI 5.0 packs `**Name:**`, `**Full Name:**`, and
+ * other DA fields onto a single bullet separated by `|`. The greedy
+ * `(.+)` capture either slurped the rest of the line as garbage or
+ * fell through to the "Ivy" default.
+ *
+ * Fix: tighten captures to `([^|\n]+)` so they stop at the next field
+ * separator. Backward compatible with the one-bullet-per-field shape.
+ */
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { expect, test } from "bun:test";
+import { importPaiIdentity } from "../src/index";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-306-"));
+
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function writePaiSkeleton(homeDir: string, daIdentity: string): Promise<void> {
+  const userRoot = join(homeDir, ".claude/PAI/USER");
+  await mkdir(join(userRoot, "TELOS"), { recursive: true });
+
+  await writeFile(
+    join(userRoot, "PRINCIPAL_IDENTITY.md"),
+    [
+      "# Principal Identity",
+      "",
+      "- **Name:** Rob Chuvala",
+      "- **Pronunciation:** Rob CHEW-vall-uh",
+      "- **Location:** Madison, Wisconsin",
+      "- **Timezone:** America/Chicago",
+      "- **Role:** Security Solutions Architect",
+      "- **Focus:** Voice fidelity tools",
+    ].join("\n"),
+    "utf8",
+  );
+
+  await writeFile(join(userRoot, "DA_IDENTITY.md"), daIdentity, "utf8");
+
+  const telosFixtures = [
+    { file: "MISSION.md", content: "# Mission\n\nFixture mission line.\n" },
+    { file: "GOALS.md", content: "# Goals\n\n- Fixture goal one.\n- Fixture goal two.\n" },
+    { file: "BELIEFS.md", content: "# Beliefs\n\n- Fixture belief.\n" },
+  ];
+
+  for (const fixture of telosFixtures) {
+    await writeFile(join(userRoot, "TELOS", fixture.file), fixture.content, "utf8");
+  }
+}
+
+test("#306 pipe-separated DA_IDENTITY fields parse without leaking the Ivy default", async () => {
+  await withTempHome(async (homeDir) => {
+    const pipeSeparated = [
+      "# DA Identity",
+      "",
+      "- **Name:** Margin | **Full Name:** Margin | **Display Name:** Margin | **Role:** Close-reader instance on Lares",
+      "- **Color:** #1F2937 | **Voice ID:** voice-margin-001 | **Operating Environment:** Linux WSL2",
+    ].join("\n");
+
+    await writePaiSkeleton(homeDir, pipeSeparated);
+    await importPaiIdentity({ homeDir });
+
+    const assistant = await readFile(join(homeDir, ".soma/profile/assistant.md"), "utf8");
+
+    // The whole point of #306 — the Ivy default must NOT leak through.
+    expect(assistant).not.toContain("Ivy - Personal AI Assistant");
+    expect(assistant).not.toContain("- full_name: Ivy");
+
+    // Field captures must stop at the next `|` so the rest of the bullet
+    // does not become part of the captured value.
+    expect(assistant).toContain("Name: Margin");
+    expect(assistant).toContain("Display name: Margin");
+    expect(assistant).toContain("- full_name: Margin");
+    expect(assistant).toContain("- role: Close-reader instance on Lares");
+    expect(assistant).toContain("- color: #1F2937");
+    expect(assistant).toContain("- voice_id: voice-margin-001");
+    expect(assistant).toContain("- operating_environment: Linux WSL2");
+
+    // Mid-line markup must never appear in captured values.
+    expect(assistant).not.toContain("Margin | **Full Name:**");
+    expect(assistant).not.toContain("**Display Name:** Margin");
+  });
+});
+
+test("#306 one-bullet-per-field DA_IDENTITY still parses (backward compatible)", async () => {
+  await withTempHome(async (homeDir) => {
+    const onePerLine = [
+      "# DA Identity",
+      "",
+      "- **Full Name:** Ivy - Personal AI Assistant",
+      "- **Name:** Ivy",
+      "- **Display Name:** Ivy",
+      "- **Color:** #3B82F6",
+      "- **Voice ID:** voice-123",
+      "- **Role:** Jens-Christian's AI assistant",
+      "- **Operating Environment:** Claude Code",
+    ].join("\n");
+
+    await writePaiSkeleton(homeDir, onePerLine);
+    await importPaiIdentity({ homeDir });
+
+    const assistant = await readFile(join(homeDir, ".soma/profile/assistant.md"), "utf8");
+
+    expect(assistant).toContain("Name: Ivy");
+    expect(assistant).toContain("Display name: Ivy");
+    expect(assistant).toContain("- full_name: Ivy - Personal AI Assistant");
+    expect(assistant).toContain("- color: #3B82F6");
+    expect(assistant).toContain("- voice_id: voice-123");
+    expect(assistant).toContain("- role: Jens-Christian's AI assistant");
+    expect(assistant).toContain("- operating_environment: Claude Code");
+  });
+});
+
+test("#306 principal profile fields also stop at pipes when present", async () => {
+  await withTempHome(async (homeDir) => {
+    const userRoot = join(homeDir, ".claude/PAI/USER");
+    await mkdir(join(userRoot, "TELOS"), { recursive: true });
+
+    // Some PAI installs pack principal-identity bullets the same way the
+    // DA file does. The fix tightens those captures too.
+    await writeFile(
+      join(userRoot, "PRINCIPAL_IDENTITY.md"),
+      [
+        "# Principal Identity",
+        "",
+        "- **Name:** Rob Chuvala | **Pronunciation:** Rob CHEW-vall-uh | **Location:** Madison, Wisconsin",
+        "- **Role:** Security Solutions Architect | **Focus:** Voice fidelity tools",
+      ].join("\n"),
+      "utf8",
+    );
+    await writeFile(
+      join(userRoot, "DA_IDENTITY.md"),
+      ["# DA Identity", "", "- **Name:** Margin", "- **Full Name:** Margin"].join("\n"),
+      "utf8",
+    );
+
+    for (const file of ["MISSION.md", "GOALS.md", "BELIEFS.md"]) {
+      await writeFile(join(userRoot, "TELOS", file), `# ${file}\n\nFixture body.\n`, "utf8");
+    }
+
+    await importPaiIdentity({ homeDir });
+
+    const principal = await readFile(join(homeDir, ".soma/profile/principal.md"), "utf8");
+
+    expect(principal).toContain("Name: Rob Chuvala");
+    expect(principal).toContain("- pronunciation: Rob CHEW-vall-uh");
+    expect(principal).toContain("- location: Madison, Wisconsin");
+    expect(principal).toContain("- role: Security Solutions Architect");
+    expect(principal).toContain("- focus: Voice fidelity tools");
+    expect(principal).not.toContain("Rob Chuvala | **Pronunciation:**");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the `migrate-pai` regex that assumed each DA / principal identity field lived on its own bullet line. PAI 5.0's `DA_IDENTITY.md` packs multiple fields onto a single bullet separated by `|`:

```markdown
- **Name:** Margin | **Full Name:** Margin | **Display Name:** Margin | **Role:** Close-reader instance on Lares
```

Two regex failure modes were combining:

1. Greedy `(.+)` slurped everything after the first field match, including the remaining `**<Field>:** <value>` segments as garbage. So `Name` came out as `Margin | **Full Name:** Margin | **Display:** Margin | ...`.
2. The required `- ` bullet prefix meant fields packed mid-bullet (`**Full Name:**`, `**Display Name:**`, etc.) never matched at all — they fell through to defaults. The most visible consequence: every PAI 5.0 install projected `full_name: "Ivy - Personal AI Assistant"` regardless of who the principal's DA actually was.

## Fix

Two small adjustments to the field-extraction patterns in both `renderPrincipalProfile` and `renderAssistantProfile` (`src/pai-importer.ts`):

- `- \*\*` → `(?:- )?\*\*` so the bullet prefix is optional and patterns match mid-bullet placements.
- `(.+)` → `([^|\n]+)` so captures stop at the next pipe separator or end of line.

13 field-capture regexes updated. Backward compatible: the existing Jens-Christian one-bullet-per-field fixture in `test/pai-importer.test.ts` continues to pass unchanged.

## Tests

`test/pai-migration-issue-306.test.ts` covers four cases:

1. Pipe-separated DA_IDENTITY parses without leaking the `Ivy` default — captures stop at `|`, no mid-line markup leaks into values.
2. One-bullet-per-field DA_IDENTITY still parses identically to before (backward-compat regression test).
3. Pipe-separated principal-identity bullets also parse correctly (the same fix covers `renderPrincipalProfile`).
4. **`**Display:**` short-form does NOT silently land in the Display Name slot** — added per review nit. Guards against a future well-intentioned relaxation that lets the short label absorb into the long-form slot.

```
$ bun test test/pai-migration-issue-306.test.ts
 4 pass
 0 fail
 28 expect() calls
```

## Pre-existing test failures (environment-dependent)

The full suite shows 2-4 failures depending on the environment, all pre-existing on `main` and unrelated to this change:

- **As root (e.g. WSL2 container, CI without setuid):** `test/pai-migration.test.ts` shows the `migratePai surfaces EACCES on Algorithm dir` and `... on packs dir` tests failing — they `chmod 0o000` directories and expect read failures, but root bypasses chmod. Verified by running the same tests on `origin/main` (same 2 fails, same lines).
- **As non-root:** `test/policy-path-guard.test.ts:332,344` (`blocks rm -rf on Claude/PAI home`, `blocks direct tilde delete targets on Claude/PAI home`) may fail instead — those tests assume specific path setup that doesn't always match container layouts. Echo's review run surfaced this pair; same pair fails on `main`.

Both failure sets are pre-existing and unrelated to the `pai-importer` change. The PR description originally only named the root-environment pair; corrected to acknowledge both per @mellanon's review nit.

## Out of scope (separate issues)

A real PAI 5.0 `DA_IDENTITY.md` may also use `**Display:**` rather than `**Display Name:**` as the field label. That's a field-name mismatch, not a parsing issue, and deserves its own pass — keeping this PR tight to the regex bug surfaced in #306. The new test #4 above guards against the short form silently absorbing into the long-form slot in the meantime.

The over-permissive-match concern Echo raised on the `(?:- )?` bullet-guard removal is tracked as a follow-up issue (see comment).

Closes #306.

— Margin (Rob Chuvala's close-reader DA, NorthwoodsSentinel fleet · Lares-WSL substrate)