### PR TITLE
Fix fresh-install onboarding: init bootstraps Soma home, handles empty Claude skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Fresh-machine onboarding story: `soma init` now creates the Soma home
+  skeleton itself (`bootstrap-soma-home` is the first plan step), so a machine
+  with no Claude Code / PAI installation gets identity, telos, memory, skills,
+  and policy files even when a later step fails or is skipped. The dry-run
+  plan explains that init imports from detected sources and notes when it
+  starts from the starter profile.
+- `docs/soma-home-layout.md`: what `soma init` creates on disk, where the
+  Soma-native Algorithm and ISA implementations live
+  (`~/.soma/memory/WORK/algorithm-runs/`, `~/.soma/isa/`), and which init
+  steps run when. Linked from the README quickstart and Documentation index.
+
+### Changed
+- `soma init --apply` is the canonical execute flag, aligning init with
+  `install`/`adopt`/`migrate`/`import`. `--yes` remains accepted for one
+  release as a deprecated alias with a stderr warning.
+
+### Fixed
+- A fresh Claude Code install ships an empty `~/.claude/skills/`; `soma init`
+  no longer plans a `migrate-claude-skills` step for it (and `soma doctor` no
+  longer suggests one), instead reporting "empty — nothing to import".
+  Direct `soma migrate claude-skills` runs now distinguish a missing or empty
+  `--from` tree from a genuinely non-flat layout instead of misreporting
+  "not a flat skills tree".
+
 ## [0.8.3] - 2026-06-03
 
 ### Fixed

--- a/ISA.md
+++ b/ISA.md
@@ -1,12 +1,12 @@
 ---
-task: Extract portable Personal AI Assistant core
-slug: soma
-effort: e3
+task: "Extract portable Personal AI Assistant core"
+effort: E3
 phase: verify
 progress: 30/30
-mode: design
 started: 2026-05-14
 updated: 2026-05-14
+verified: true
+slug: 2026-06-12-soma
 ---
 
 ## Problem
@@ -188,6 +188,14 @@ Pi.dev, Claude Code, and Cortex/Myelin.
   implemented, and policy enforcement remains substrate-specific.
 - 2026-05-14: Added CLI dry-run as the default operational path for Codex
   install; live writes require `--apply`.
+- 2026-06-12: First-external-user feedback (Vincent Zontini) drove the
+  fresh-machine onboarding story: `soma init` now bootstraps the Soma home as
+  its own first step instead of deferring it to `soma install`, skips the
+  Claude-skills migration when `~/.claude/skills` is empty, and reports
+  missing/empty/non-flat `--from` trees with distinct messages.
+- 2026-06-12: Standardized `--apply` as the execute flag on `soma init`
+  (matching install/adopt/migrate/import); `--yes` kept one release as a
+  deprecated alias with a stderr warning.
 
 ## Changelog
 

--- a/ISA.md
+++ b/ISA.md
@@ -1,12 +1,12 @@
 ---
-task: "Extract portable Personal AI Assistant core"
-effort: E3
+task: Extract portable Personal AI Assistant core
+slug: soma
+effort: e3
 phase: verify
 progress: 30/30
+mode: design
 started: 2026-05-14
-updated: 2026-05-14
-verified: true
-slug: 2026-06-12-soma
+updated: 2026-06-12
 ---
 
 ## Problem

--- a/README.md
+++ b/README.md
@@ -116,8 +116,12 @@ Soma.
 # 1. Install Soma (Arc, or from source - see Install below)
 arc install @metafactory/soma
 
-# 2. Create your Soma home (identity, telos, memory, skills, policy)
-soma init --yes
+# 2. Create your Soma home (identity, telos, memory, skills, policy).
+#    If an existing Claude Code / PAI installation is found, init also
+#    imports its skills and identity. On a fresh machine (no Claude at
+#    all) it starts from the starter profile — run `soma init` without
+#    --apply first to see the dry-run plan.
+soma init --apply
 
 # 3. Project that core into Codex
 soma install codex --apply
@@ -151,6 +155,13 @@ show --id <run-id>` reports which substrates have touched the run. Phase
 advances, criterion verification, capability invocation, and learning
 promotion all append substrate provenance when the caller supplies
 `--substrate`.
+
+The Algorithm and ISA are implemented by Soma itself — `soma algorithm` and
+`soma isa` work on any substrate, with run state in
+`~/.soma/memory/WORK/algorithm-runs/` and ISAs in `~/.soma/isa/`. See
+[The Algorithm](#the-algorithm) and [ISA](#isa) below, and
+[docs/soma-home-layout.md](docs/soma-home-layout.md) for the full on-disk
+layout `soma init` creates.
 
 That run, your identity, telos, and anything learned now travel with you to the
 next host. Switch to Claude Code or Cursor (`soma install claude-code --apply`)
@@ -463,6 +474,7 @@ writeback boundaries as substrate sessions. See
 ## Documentation
 
 - [CONTEXT.md](CONTEXT.md), the shared Soma vocabulary used by docs, CLI, and ISA
+- [docs/soma-home-layout.md](docs/soma-home-layout.md), what `soma init` creates and where Algorithm/ISA state lives
 - [docs/architecture.md](docs/architecture.md), the core/adapters/runtime model
 - [docs/boundaries.md](docs/boundaries.md), exactly what Soma owns and does not own
 - [docs/substrate-adapters.md](docs/substrate-adapters.md), adapter behavior by host

--- a/docs/soma-home-layout.md
+++ b/docs/soma-home-layout.md
@@ -15,7 +15,7 @@ directory is the portable source of truth for your assistant. Substrate homes
 │   ├── telos.md            # mission, goals, principles, commitments
 │   └── imports/            # provenance of migrated PAI/Claude identity
 ├── skills/                 # portable skill folders (<name>/SKILL.md)
-├── memory/                 # PAI v5 memory taxonomy (WORK, KNOWLEDGE, LEARNING, …)
+├── memory/                 # Soma memory taxonomy (WORK, KNOWLEDGE, LEARNING, …)
 │   ├── WORK/
 │   │   └── algorithm-runs/ # Algorithm run state, one <run-id>.json per run
 │   └── STATE/

--- a/docs/soma-home-layout.md
+++ b/docs/soma-home-layout.md
@@ -2,8 +2,10 @@
 
 `soma init --apply` creates `~/.soma/` (override with `--soma-home`). This
 directory is the portable source of truth for your assistant. Substrate homes
-(`~/.codex`, `~/.claude`, …) are generated projections of it; everything in
-`~/.soma` is plain, readable files you can edit directly.
+(`~/.codex`, `~/.claude`, …) are generated projections of it. Everything in
+`~/.soma` is plain, readable files; profile, skills, memory, ISAs, and policy
+are yours to edit directly, while `projections/` holds generated caches that
+re-projection rewrites.
 
 ## Layout
 
@@ -45,7 +47,7 @@ substrate being installed:
   `memory/WORK/algorithm-runs/`; ISAs are markdown files under `isa/`, with
   the active ISA recorded in `memory/STATE/active.json`.
 - **Projection:** substrate adapters surface the active ISA and Algorithm
-  context into each substrate (for Claude Code: `~/.claude/rules/soma/`).
+  state into each substrate (for Claude Code: `~/.claude/rules/soma/`).
 
 ## How the home gets populated
 

--- a/docs/soma-home-layout.md
+++ b/docs/soma-home-layout.md
@@ -1,0 +1,68 @@
+# The Soma home: what `soma init` creates
+
+`soma init --apply` creates `~/.soma/` (override with `--soma-home`). This
+directory is the portable source of truth for your assistant. Substrate homes
+(`~/.codex`, `~/.claude`, …) are generated projections of it; everything in
+`~/.soma` is plain, readable files you can edit directly.
+
+## Layout
+
+```text
+~/.soma/
+├── profile/
+│   ├── assistant.md        # assistant identity (name, traits)
+│   ├── principal.md        # who the assistant works for
+│   ├── telos.md            # mission, goals, principles, commitments
+│   └── imports/            # provenance of migrated PAI/Claude identity
+├── skills/                 # portable skill folders (<name>/SKILL.md)
+├── memory/                 # PAI v5 memory taxonomy (WORK, KNOWLEDGE, LEARNING, …)
+│   ├── WORK/
+│   │   └── algorithm-runs/ # Algorithm run state, one <run-id>.json per run
+│   └── STATE/
+│       └── active.json     # active ISA pointer
+├── isa/                    # Ideal State Artifacts, one <slug>.md per project/task
+│   └── .templates/         # ISA scaffolding templates
+├── policy/                 # substrate policy declarations
+├── imports/                # migration manifests and portability reports
+└── projections/            # cached generated projections (codex, claude-code, …)
+```
+
+On a fresh machine the profile files start as a **starter profile**
+(`status: starter-profile` in `principal.md`). Replace them with your own
+content, or import an existing installation (see below). `soma doctor` warns
+while the starter profile is still in place.
+
+## Where the Algorithm and ISA live
+
+Soma ships its own, substrate-neutral implementation of the Algorithm work
+harness and Ideal State Artifacts — they do not depend on PAI or any host
+substrate being installed:
+
+- **Implementation:** the `soma algorithm ...` and `soma isa ...` CLI commands
+  (see [README — The Algorithm](../README.md#the-algorithm) and
+  [README — ISA](../README.md#isa)).
+- **State on disk:** Algorithm runs persist as JSON under
+  `memory/WORK/algorithm-runs/`; ISAs are markdown files under `isa/`, with
+  the active ISA recorded in `memory/STATE/active.json`.
+- **Projection:** substrate adapters surface the active ISA and Algorithm
+  context into each host (for Claude Code: `~/.claude/rules/soma/`).
+
+## How the home gets populated
+
+`soma init` runs up to four steps, shown by the dry-run plan (`soma init`
+without `--apply`):
+
+1. `bootstrap-soma-home` — always. Creates the skeleton above; idempotent,
+   existing files are never overwritten.
+2. `migrate-claude-skills` — only when `~/.claude/skills` exists **and**
+   contains at least one importable `<Name>/SKILL.md`. A fresh Claude Code
+   install ships an empty skills directory; the plan reports it as
+   "empty — nothing to import" and skips the step.
+3. `migrate-pai` — only when a PAI installation (`~/.claude/PAI`) is detected.
+   Imports identity, Telos, Algorithm context, memory, and docs.
+4. `install-<substrate>` — projects the Soma home into the selected substrate
+   (default `codex`; choose with `--substrate`).
+
+No Claude Code, no PAI? Steps 2 and 3 simply do not appear; you get a working
+Soma home from the starter profile. Re-running `soma init --apply` later, after
+installing Claude Code or PAI, picks the migrations up.

--- a/docs/soma-home-layout.md
+++ b/docs/soma-home-layout.md
@@ -35,7 +35,7 @@ while the starter profile is still in place.
 ## Where the Algorithm and ISA live
 
 Soma ships its own, substrate-neutral implementation of the Algorithm work
-harness and Ideal State Artifacts — they do not depend on PAI or any host
+harness and Ideal State Artifacts — they do not depend on PAI or any
 substrate being installed:
 
 - **Implementation:** the `soma algorithm ...` and `soma isa ...` CLI commands
@@ -45,7 +45,7 @@ substrate being installed:
   `memory/WORK/algorithm-runs/`; ISAs are markdown files under `isa/`, with
   the active ISA recorded in `memory/STATE/active.json`.
 - **Projection:** substrate adapters surface the active ISA and Algorithm
-  context into each host (for Claude Code: `~/.claude/rules/soma/`).
+  context into each substrate (for Claude Code: `~/.claude/rules/soma/`).
 
 ## How the home gets populated
 

--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -1845,9 +1845,6 @@ export async function migrateClaudeSkills(
   let applyWriteMs = 0;
   let smokeVerifyMs = 0;
 
-  // Ensure imports/claude-skills/ exists so manifest + report writes
-  // succeed even on a fully empty Soma home.
-  await mkdir(join(somaHome, "imports/claude-skills"), { recursive: true });
   const manifestPath = join(somaHome, MANIFEST_RELATIVE);
   const reportPath = join(somaHome, REPORT_RELATIVE);
 
@@ -1876,6 +1873,13 @@ export async function migrateClaudeSkills(
       `soma migrate claude-skills: ${await describeFlatTreeRefusal(from)}`,
     );
   }
+
+  // Ensure imports/claude-skills/ exists so manifest + report writes
+  // succeed even on a fully empty Soma home. Deliberately AFTER the
+  // flat-tree gate: a refused run must not leave a stray imports dir
+  // behind (that stray dir was all a fresh-install user found in
+  // ~/.soma after the pre-fix failure — user feedback, 2026-06-12).
+  await mkdir(join(somaHome, "imports/claude-skills"), { recursive: true });
 
   // Holly R1 nit — thread the buildPlanCore reads into the apply path
   // so we don't re-read every skill from disk a second time. Plan phase

--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -764,6 +764,21 @@ async function readSourceSkill(
 }
 
 /**
+ * Structured refusal from `listFlatSkillNames` so callers classify by
+ * reason instead of matching message text (sage cycle 4 on #309: message
+ * coupling lets copy edits silently change onboarding classification).
+ */
+class FlatSkillsSourceError extends Error {
+  constructor(
+    message: string,
+    readonly reason: "symlinked-root" | "not-a-directory",
+  ) {
+    super(message);
+    this.name = "FlatSkillsSourceError";
+  }
+}
+
+/**
  * Refuse the apply path if the source isn't a flat skills tree. A flat
  * tree has at least one `<Name>/SKILL.md` direct child. Anything else
  * (Packs/ layout, empty dir, file-at-root) is rejected loud so the
@@ -775,10 +790,10 @@ async function listFlatSkillNames(fromDir: string): Promise<string[]> {
   }
   const fromStat = await lstat(fromDir);
   if (fromStat.isSymbolicLink()) {
-    throw new Error("soma migrate claude-skills refused symlinked --from root.");
+    throw new FlatSkillsSourceError("soma migrate claude-skills refused symlinked --from root.", "symlinked-root");
   }
   if (!fromStat.isDirectory()) {
-    throw new Error(`soma migrate claude-skills: --from is not a directory: ${fromDir}`);
+    throw new FlatSkillsSourceError(`soma migrate claude-skills: --from is not a directory: ${fromDir}`, "not-a-directory");
   }
   const entries = await readdir(fromDir, { withFileTypes: true });
   const names: string[] = [];
@@ -842,10 +857,10 @@ async function classifyFlatSkillsSource(fromDir: string): Promise<FlatSkillsSour
     const visible = entries.filter((entry) => !entry.name.startsWith("."));
     return visible.length === 0 ? "empty" : "not-flat";
   } catch (error) {
-    // listFlatSkillNames throws structured refusals for symlinked-root and
-    // file-at-path sources — those are structural verdicts, not read
-    // failures. Anything else (EACCES and friends) is `unreadable`.
-    if (error instanceof Error && /symlinked --from root|not a directory/.test(error.message)) {
+    // Only the migrator's explicit structured refusals (symlinked root,
+    // file-at-path) are structural verdicts; generic fs failures
+    // (ENOTDIR from a racing change, EACCES, …) are `unreadable`.
+    if (error instanceof FlatSkillsSourceError) {
       return "not-flat";
     }
     return "unreadable";

--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -815,20 +815,21 @@ async function listFlatSkillNames(fromDir: string): Promise<string[]> {
 }
 
 /**
- * Onboarding-facing probe classifying a Claude skills source dir. Never
- * throws — `soma init` uses this to decide whether to plan a
- * `migrate-claude-skills` step and how to label the source; a direct
- * `soma migrate claude-skills` run still surfaces the full error.
+ * Single internal classifier for a Claude skills source tree (sage cycle 3
+ * on #309: one set of structural rules, mapped to either an onboarding
+ * status or a refusal message — never duplicated).
  *
  * - `importable`: at least one `<Name>/SKILL.md` direct child
  * - `empty`: directory exists with no visible entries (fresh Claude Code)
  * - `missing`: directory does not exist
- * - `not-importable`: structurally wrong — non-flat layout, symlinked
- *   root, file-at-path (sage review on #309: must NOT read as "empty")
- * - `unreadable`: the probe could not read the source at all (sage cycle 2:
- *   an access failure must NOT read as a structural verdict)
+ * - `not-flat`: structurally wrong — non-flat layout, symlinked root,
+ *   file-at-path (sage review on #309: must NOT read as "empty")
+ * - `unreadable`: the source could not be read at all (sage cycle 2: an
+ *   access failure must NOT read as a structural verdict)
  */
-export async function probeClaudeSkillsSource(fromDir: string): Promise<ClaudeSkillsSourceStatus> {
+type FlatSkillsSourceClass = "importable" | "empty" | "missing" | "not-flat" | "unreadable";
+
+async function classifyFlatSkillsSource(fromDir: string): Promise<FlatSkillsSourceClass> {
   try {
     if (!(await pathExists(fromDir))) {
       return "missing";
@@ -839,41 +840,46 @@ export async function probeClaudeSkillsSource(fromDir: string): Promise<ClaudeSk
     }
     const entries = await readdir(fromDir, { withFileTypes: true });
     const visible = entries.filter((entry) => !entry.name.startsWith("."));
-    return visible.length === 0 ? "empty" : "not-importable";
+    return visible.length === 0 ? "empty" : "not-flat";
   } catch (error) {
     // listFlatSkillNames throws structured refusals for symlinked-root and
     // file-at-path sources — those are structural verdicts, not read
     // failures. Anything else (EACCES and friends) is `unreadable`.
     if (error instanceof Error && /symlinked --from root|not a directory/.test(error.message)) {
-      return "not-importable";
+      return "not-flat";
     }
     return "unreadable";
   }
 }
 
 /**
+ * Onboarding-facing probe. Never throws — `soma init` uses this to decide
+ * whether to plan a `migrate-claude-skills` step and how to label the
+ * source; a direct `soma migrate claude-skills` run still surfaces the
+ * full error.
+ */
+export async function probeClaudeSkillsSource(fromDir: string): Promise<ClaudeSkillsSourceStatus> {
+  const sourceClass = await classifyFlatSkillsSource(fromDir);
+  return sourceClass === "not-flat" ? "not-importable" : sourceClass;
+}
+
+/**
  * Accurate refusal reason for a source tree that produced zero flat skill
  * names. A fresh Claude Code install ships an EMPTY `~/.claude/skills/` —
  * calling that "not a flat skills tree" misdiagnoses the situation
- * (user feedback, 2026-06-12). Distinguish missing / empty / non-flat.
+ * (user feedback, 2026-06-12).
  */
 async function describeFlatTreeRefusal(fromDir: string): Promise<string> {
-  if (!(await pathExists(fromDir))) {
-    return `--from ${fromDir} does not exist.`;
+  switch (await classifyFlatSkillsSource(fromDir)) {
+    case "missing":
+      return `--from ${fromDir} does not exist.`;
+    case "empty":
+      return `--from ${fromDir} is empty — no skills to import.`;
+    case "unreadable":
+      return `--from ${fromDir} could not be read (not a directory, or permission denied).`;
+    default:
+      return `--from ${fromDir} is not a flat skills tree (no <Name>/SKILL.md direct children).`;
   }
-  // Guarded so a file-at-path or permission failure surfaces the intended
-  // refusal message instead of a raw fs error (sage cycle 2 on #309).
-  let entries;
-  try {
-    entries = await readdir(fromDir, { withFileTypes: true });
-  } catch {
-    return `--from ${fromDir} could not be read (not a directory, or permission denied).`;
-  }
-  const visible = entries.filter((entry) => !entry.name.startsWith("."));
-  if (visible.length === 0) {
-    return `--from ${fromDir} is empty — no skills to import.`;
-  }
-  return `--from ${fromDir} is not a flat skills tree (no <Name>/SKILL.md direct children).`;
 }
 
 async function readExistingManifest(

--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -72,6 +72,7 @@ import type {
   ClaudeSkillsMigrationPlan,
   ClaudeSkillsMigrationResult,
   ClaudeSkillsSmokeSubstrate,
+  ClaudeSkillsSourceStatus,
   DescriptionStatus,
   RewriteDescriptionsAgent,
   RewriteDispatchOverride,
@@ -822,12 +823,11 @@ async function listFlatSkillNames(fromDir: string): Promise<string[]> {
  * - `importable`: at least one `<Name>/SKILL.md` direct child
  * - `empty`: directory exists with no visible entries (fresh Claude Code)
  * - `missing`: directory does not exist
- * - `not-importable`: anything else — non-flat layout, symlinked root,
- *   file-at-path, unreadable dir (sage review on #309: this must NOT be
- *   reported as "empty")
+ * - `not-importable`: structurally wrong — non-flat layout, symlinked
+ *   root, file-at-path (sage review on #309: must NOT read as "empty")
+ * - `unreadable`: the probe could not read the source at all (sage cycle 2:
+ *   an access failure must NOT read as a structural verdict)
  */
-export type ClaudeSkillsSourceStatus = "importable" | "empty" | "missing" | "not-importable";
-
 export async function probeClaudeSkillsSource(fromDir: string): Promise<ClaudeSkillsSourceStatus> {
   try {
     if (!(await pathExists(fromDir))) {
@@ -840,8 +840,14 @@ export async function probeClaudeSkillsSource(fromDir: string): Promise<ClaudeSk
     const entries = await readdir(fromDir, { withFileTypes: true });
     const visible = entries.filter((entry) => !entry.name.startsWith("."));
     return visible.length === 0 ? "empty" : "not-importable";
-  } catch {
-    return "not-importable";
+  } catch (error) {
+    // listFlatSkillNames throws structured refusals for symlinked-root and
+    // file-at-path sources — those are structural verdicts, not read
+    // failures. Anything else (EACCES and friends) is `unreadable`.
+    if (error instanceof Error && /symlinked --from root|not a directory/.test(error.message)) {
+      return "not-importable";
+    }
+    return "unreadable";
   }
 }
 
@@ -855,7 +861,14 @@ async function describeFlatTreeRefusal(fromDir: string): Promise<string> {
   if (!(await pathExists(fromDir))) {
     return `--from ${fromDir} does not exist.`;
   }
-  const entries = await readdir(fromDir, { withFileTypes: true });
+  // Guarded so a file-at-path or permission failure surfaces the intended
+  // refusal message instead of a raw fs error (sage cycle 2 on #309).
+  let entries;
+  try {
+    entries = await readdir(fromDir, { withFileTypes: true });
+  } catch {
+    return `--from ${fromDir} could not be read (not a directory, or permission denied).`;
+  }
   const visible = entries.filter((entry) => !entry.name.startsWith("."));
   if (visible.length === 0) {
     return `--from ${fromDir} is empty — no skills to import.`;

--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -813,6 +813,39 @@ async function listFlatSkillNames(fromDir: string): Promise<string[]> {
   return names;
 }
 
+/**
+ * Onboarding-facing probe: does `fromDir` contain at least one importable
+ * `<Name>/SKILL.md` direct child? Swallows structural errors (symlinked
+ * root, file-at-path) and reports `false` — `soma init` uses this to decide
+ * whether to plan a `migrate-claude-skills` step at all; a direct
+ * `soma migrate claude-skills` run still surfaces the full error.
+ */
+export async function hasImportableClaudeSkills(fromDir: string): Promise<boolean> {
+  try {
+    return (await listFlatSkillNames(fromDir)).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Accurate refusal reason for a source tree that produced zero flat skill
+ * names. A fresh Claude Code install ships an EMPTY `~/.claude/skills/` —
+ * calling that "not a flat skills tree" misdiagnoses the situation
+ * (user feedback, 2026-06-12). Distinguish missing / empty / non-flat.
+ */
+async function describeFlatTreeRefusal(fromDir: string): Promise<string> {
+  if (!(await pathExists(fromDir))) {
+    return `--from ${fromDir} does not exist.`;
+  }
+  const entries = await readdir(fromDir, { withFileTypes: true });
+  const visible = entries.filter((entry) => !entry.name.startsWith("."));
+  if (visible.length === 0) {
+    return `--from ${fromDir} is empty — no skills to import.`;
+  }
+  return `--from ${fromDir} is not a flat skills tree (no <Name>/SKILL.md direct children).`;
+}
+
 async function readExistingManifest(
   somaHome: string,
 ): Promise<ClaudeSkillsMigrationManifest | null> {
@@ -1106,6 +1139,7 @@ export async function planClaudeSkillsMigration(
     from,
     somaHome,
     isFlatSkillsTree,
+    flatTreeRefusalReason: isFlatSkillsTree ? undefined : await describeFlatTreeRefusal(from),
     outcomes,
     includeClaudeSpecific,
     smokeSubstrates,
@@ -1839,7 +1873,7 @@ export async function migrateClaudeSkills(
 
   if (!isFlatSkillsTree) {
     throw new Error(
-      `soma migrate claude-skills: --from ${from} is not a flat skills tree (no <Name>/SKILL.md direct children).`,
+      `soma migrate claude-skills: ${await describeFlatTreeRefusal(from)}`,
     );
   }
 

--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -815,9 +815,9 @@ async function listFlatSkillNames(fromDir: string): Promise<string[]> {
 
 /**
  * Onboarding-facing probe: does `fromDir` contain at least one importable
- * `<Name>/SKILL.md` direct child? Swallows structural errors (symlinked
- * root, file-at-path) and reports `false` — `soma init` uses this to decide
- * whether to plan a `migrate-claude-skills` step at all; a direct
+ * `<Name>/SKILL.md` direct child? Swallows ALL errors (symlinked root,
+ * file-at-path, unreadable dir) and reports `false` — `soma init` uses this
+ * to decide whether to plan a `migrate-claude-skills` step at all; a direct
  * `soma migrate claude-skills` run still surfaces the full error.
  */
 export async function hasImportableClaudeSkills(fromDir: string): Promise<boolean> {

--- a/src/claude-skills-migrator.ts
+++ b/src/claude-skills-migrator.ts
@@ -814,17 +814,34 @@ async function listFlatSkillNames(fromDir: string): Promise<string[]> {
 }
 
 /**
- * Onboarding-facing probe: does `fromDir` contain at least one importable
- * `<Name>/SKILL.md` direct child? Swallows ALL errors (symlinked root,
- * file-at-path, unreadable dir) and reports `false` — `soma init` uses this
- * to decide whether to plan a `migrate-claude-skills` step at all; a direct
+ * Onboarding-facing probe classifying a Claude skills source dir. Never
+ * throws — `soma init` uses this to decide whether to plan a
+ * `migrate-claude-skills` step and how to label the source; a direct
  * `soma migrate claude-skills` run still surfaces the full error.
+ *
+ * - `importable`: at least one `<Name>/SKILL.md` direct child
+ * - `empty`: directory exists with no visible entries (fresh Claude Code)
+ * - `missing`: directory does not exist
+ * - `not-importable`: anything else — non-flat layout, symlinked root,
+ *   file-at-path, unreadable dir (sage review on #309: this must NOT be
+ *   reported as "empty")
  */
-export async function hasImportableClaudeSkills(fromDir: string): Promise<boolean> {
+export type ClaudeSkillsSourceStatus = "importable" | "empty" | "missing" | "not-importable";
+
+export async function probeClaudeSkillsSource(fromDir: string): Promise<ClaudeSkillsSourceStatus> {
   try {
-    return (await listFlatSkillNames(fromDir)).length > 0;
+    if (!(await pathExists(fromDir))) {
+      return "missing";
+    }
+    const names = await listFlatSkillNames(fromDir);
+    if (names.length > 0) {
+      return "importable";
+    }
+    const entries = await readdir(fromDir, { withFileTypes: true });
+    const visible = entries.filter((entry) => !entry.name.startsWith("."));
+    return visible.length === 0 ? "empty" : "not-importable";
   } catch {
-    return false;
+    return "not-importable";
   }
 }
 

--- a/src/cli/deprecated-flags.ts
+++ b/src/cli/deprecated-flags.ts
@@ -15,3 +15,12 @@ export function warnDeprecatedSubstrateFlag(): void {
     "Warning: --include-substrate-specific is deprecated; use --include-unrecognized.\n",
   );
 }
+
+/**
+ * `soma init --yes` was the only mutating command not using the
+ * `--dry-run`/`--apply` pair (user feedback, 2026-06-12). `--apply` is
+ * canonical now; `--yes` stays accepted for one release with this warning.
+ */
+export function warnDeprecatedYesFlag(): void {
+  process.stderr.write("Warning: --yes is deprecated; use --apply.\n");
+}

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -738,7 +738,7 @@ function formatClaudeSkillsMigrationPlan(plan: ClaudeSkillsMigrationPlan): strin
       `from: ${plan.from}`,
       `somaHome: ${plan.somaHome}`,
       "",
-      "Refused: --from is not a flat skills tree (no <Name>/SKILL.md direct children).",
+      `Refused: ${plan.flatTreeRefusalReason ?? "--from is not a flat skills tree (no <Name>/SKILL.md direct children)."}`,
       "Point --from at an installed `.claude/skills/` tree (e.g. ~/.claude/skills or ~/work/PAI/Releases/v5.0.0/.claude/skills).",
       "",
     ].join("\n");

--- a/src/cli/onboarding.ts
+++ b/src/cli/onboarding.ts
@@ -188,15 +188,24 @@ export async function runOnboardingCli(parsed: ParsedOnboardingArgs): Promise<st
 }
 
 function formatClaudeSkillsDetection(plan: SomaInitPlan): string {
-  if (!plan.detected.claudeSkillsDir) return "not found";
-  if (!plan.detected.claudeSkillsImportable) {
-    return `${plan.detected.claudeSkillsDir} (empty — nothing to import)`;
+  const dir = plan.detected.claudeSkillsDir;
+  if (!dir) return "not found";
+  switch (plan.detected.claudeSkillsStatus) {
+    case "importable":
+      return dir;
+    case "empty":
+      return `${dir} (empty — nothing to import)`;
+    default:
+      // sage review on #309: a non-flat/unreadable tree must not be
+      // labeled "empty" — point at the command that explains why.
+      return `${dir} (found, but not an importable flat skills tree — run \`soma migrate claude-skills --from ${dir}\` for details)`;
   }
-  return plan.detected.claudeSkillsDir;
 }
 
 function formatSomaInitPlan(plan: SomaInitPlan): string {
-  const freshMachine = !plan.detected.paiInstall && !plan.detected.claudeSkillsImportable;
+  const claudeSkillsStatus = plan.detected.claudeSkillsStatus;
+  const freshMachine =
+    !plan.detected.paiInstall && (claudeSkillsStatus === "missing" || claudeSkillsStatus === "empty");
   return [
     `soma init — ${plan.mode === "apply" ? "apply plan" : "plan (dry-run; pass --apply to execute)"}`,
     "",
@@ -223,7 +232,7 @@ function formatSomaInitPlan(plan: SomaInitPlan): string {
     `  - Algorithm skill: ${plan.soma.algorithmSkillPresent ? "present" : "missing"}`,
     "",
     "Steps:",
-    ...plan.steps.map((step, index) => `${index + 1}. ${step.command}`),
+    ...plan.steps.map((step, index) => `${index + 1}. ${step.kind === "command" ? step.command : step.action}`),
     "",
   ].join("\n");
 }

--- a/src/cli/onboarding.ts
+++ b/src/cli/onboarding.ts
@@ -14,6 +14,7 @@ import {
   parseOnboardingSubstrate,
 } from "./substrate-lifecycle";
 import { readOption } from "./parse-utils";
+import { warnDeprecatedYesFlag } from "./deprecated-flags";
 
 export interface ParsedInitArgs {
   command: "init";
@@ -38,7 +39,7 @@ export type ParsedOnboardingArgs = ParsedInitArgs | ParsedDoctorArgs | ParsedAdo
 const ADOPT_CLAUDE_USAGE =
   "Usage: soma adopt claude [--dry-run] [--apply] [--uninstall] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 const INIT_USAGE =
-  "Usage: soma init [--dry-run] [--yes] [--home-dir <dir>] [--soma-home <dir>] [--substrate <codex|pi-dev|claude-code|cursor>]";
+  "Usage: soma init [--dry-run] [--apply] [--home-dir <dir>] [--soma-home <dir>] [--substrate <codex|pi-dev|claude-code|cursor>]";
 const DOCTOR_USAGE =
   "Usage: soma doctor [--home-dir <dir>] [--soma-home <dir>] [--substrate <codex|claude-code>]";
 
@@ -60,7 +61,11 @@ export function parseInitArgs(args: string[]): ParsedInitArgs {
   let apply = false;
   const optionArgs: string[] = [];
   for (const arg of rest) {
-    if (arg === "--yes") {
+    if (arg === "--apply") {
+      apply = true;
+    } else if (arg === "--yes") {
+      // Deprecated alias — `--apply` aligns init with install/adopt/migrate.
+      warnDeprecatedYesFlag();
       apply = true;
     } else if (arg === "--dry-run") {
       apply = false;
@@ -182,18 +187,34 @@ export async function runOnboardingCli(parsed: ParsedOnboardingArgs): Promise<st
   return formatInstallResult(await installSomaForClaudeCode(parsed.options));
 }
 
+function formatClaudeSkillsDetection(plan: SomaInitPlan): string {
+  if (!plan.detected.claudeSkillsDir) return "not found";
+  if (!plan.detected.claudeSkillsImportable) {
+    return `${plan.detected.claudeSkillsDir} (empty — nothing to import)`;
+  }
+  return plan.detected.claudeSkillsDir;
+}
+
 function formatSomaInitPlan(plan: SomaInitPlan): string {
+  const freshMachine = !plan.detected.paiInstall && !plan.detected.claudeSkillsImportable;
   return [
-    `soma init — ${plan.mode === "apply" ? "apply plan" : "plan (dry-run; pass --yes to execute)"}`,
+    `soma init — ${plan.mode === "apply" ? "apply plan" : "plan (dry-run; pass --apply to execute)"}`,
+    "",
+    "Creates the Soma home (identity, telos, memory, skills, policy) and",
+    "imports context from an existing Claude Code / PAI installation when one",
+    "is detected.",
     "",
     `Home:       ${plan.homeDir}`,
     `Soma home:  ${plan.somaHome}`,
     `Substrate:  ${plan.substrate}`,
     "",
-    "Detected:",
+    "Detected import sources:",
     `  - PAI install:    ${plan.detected.paiInstall ?? "not found"}`,
-    `  - Claude skills:  ${plan.detected.claudeSkillsDir ?? "not found"}`,
+    `  - Claude skills:  ${formatClaudeSkillsDetection(plan)}`,
     `  - CORE_USER:      ${plan.detected.coreUserDir ?? "not found"}`,
+    ...(freshMachine
+      ? ["", "No existing installation to import — starting from the Soma starter profile."]
+      : []),
     "",
     "Soma state:",
     `  - exists:          ${plan.soma.exists ? "yes" : "no"}`,

--- a/src/cli/onboarding.ts
+++ b/src/cli/onboarding.ts
@@ -195,9 +195,12 @@ function formatClaudeSkillsDetection(plan: SomaInitPlan): string {
       return dir;
     case "empty":
       return `${dir} (empty — nothing to import)`;
+    case "unreadable":
+      // sage cycle 2 on #309: a read failure is not a structural verdict.
+      return `${dir} (could not be read — check permissions, then run \`soma migrate claude-skills --from ${dir}\` for details)`;
     default:
-      // sage review on #309: a non-flat/unreadable tree must not be
-      // labeled "empty" — point at the command that explains why.
+      // sage review on #309: a non-flat tree must not be labeled
+      // "empty" — point at the command that explains why.
       return `${dir} (found, but not an importable flat skills tree — run \`soma migrate claude-skills --from ${dir}\` for details)`;
   }
 }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -170,7 +170,7 @@ export async function planSomaInit(options: SomaOnboardingOptions & { apply?: bo
     id: installStepId(detected.substrate),
     kind: "command",
     command: `${installCommand(detected.substrate, apply)} ${sharedPathFlags(detected)}`,
-    description: "Project the Soma home into the selected host substrate.",
+    description: "Project the Soma home into the selected substrate.",
   });
 
   return {

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { DOCTOR_UNSUPPORTED_DRIFT_MESSAGE, diagnoseProjectionDrift } from "./adapters/doctor";
 import { installSomaForClaudeCode, installSomaForCodex, installSomaForCursor, installSomaForPiDev } from "./install";
-import { hasImportableClaudeSkills, migrateClaudeSkills } from "./claude-skills-migrator";
+import { migrateClaudeSkills, probeClaudeSkillsSource } from "./claude-skills-migrator";
 import { bootstrapSomaHome } from "./soma-home";
 import { migratePai } from "./pai-migration";
 import { isEnoent, pathExists, pathMtimeMs } from "./fs-utils";
@@ -92,14 +92,14 @@ async function detectOnboarding(options: SomaOnboardingOptions): Promise<Omit<So
     paiPresent,
     paiUserPresent,
     claudeSkillsPresent,
-    claudeSkillsImportable,
+    claudeSkillsStatus,
     coreUserPresent,
     somaExists,
   ] = await Promise.all([
     pathExists(join(paiInstall, "PAI")),
     pathExists(paiUserDir),
     pathExists(claudeSkillsDir),
-    hasImportableClaudeSkills(claudeSkillsDir),
+    probeClaudeSkillsSource(claudeSkillsDir),
     pathExists(coreUserDir),
     pathExists(somaHome),
   ]);
@@ -119,7 +119,7 @@ async function detectOnboarding(options: SomaOnboardingOptions): Promise<Omit<So
       paiInstall: paiPresent ? paiInstall : null,
       paiUserDir: paiUserPresent ? paiUserDir : null,
       claudeSkillsDir: claudeSkillsPresent ? claudeSkillsDir : null,
-      claudeSkillsImportable,
+      claudeSkillsStatus,
       coreUserDir: coreUserPresent ? coreUserDir : null,
     },
     soma: {
@@ -143,13 +143,15 @@ export async function planSomaInit(options: SomaOnboardingOptions & { apply?: bo
   // Idempotent: existing files are preserved (`wx` writes).
   steps.push({
     id: "bootstrap-soma-home",
-    command: `create Soma home skeleton at ${shellQuote(detected.somaHome)} (identity, telos, memory, skills, policy)`,
+    kind: "builtin",
+    action: `create Soma home skeleton at ${shellQuote(detected.somaHome)} (identity, telos, memory, skills, policy)`,
     description: "Performed by soma init itself; idempotent, existing files preserved.",
   });
 
-  if (detected.detected.claudeSkillsDir && detected.detected.claudeSkillsImportable) {
+  if (detected.detected.claudeSkillsDir && detected.detected.claudeSkillsStatus === "importable") {
     steps.push({
       id: "migrate-claude-skills",
+      kind: "command",
       command: `soma migrate claude-skills --from ${shellQuote(detected.detected.claudeSkillsDir)} ${modeFlag} ${sharedPathFlags(detected)}`,
       description: "Import portable Claude skills into the Soma skills tree.",
     });
@@ -158,6 +160,7 @@ export async function planSomaInit(options: SomaOnboardingOptions & { apply?: bo
   if (detected.detected.paiInstall) {
     steps.push({
       id: "migrate-pai",
+      kind: "command",
       command: `soma migrate pai --pai-install ${shellQuote(detected.detected.paiInstall)} ${modeFlag} ${sharedPathFlags(detected)}`,
       description: "Import PAI identity, Algorithm, memory, docs, and pack surfaces that are present.",
     });
@@ -165,6 +168,7 @@ export async function planSomaInit(options: SomaOnboardingOptions & { apply?: bo
 
   steps.push({
     id: installStepId(detected.substrate),
+    kind: "command",
     command: `${installCommand(detected.substrate, apply)} ${sharedPathFlags(detected)}`,
     description: "Project the Soma home into the selected host substrate.",
   });
@@ -263,7 +267,7 @@ export async function diagnoseSomaDoctor(options: SomaOnboardingOptions = {}): P
     });
   }
 
-  if (detected.detected.claudeSkillsDir && detected.detected.claudeSkillsImportable && !(await pathExists(join(detected.somaHome, "imports/claude-skills/.manifest.json")))) {
+  if (detected.detected.claudeSkillsDir && detected.detected.claudeSkillsStatus === "importable" && !(await pathExists(join(detected.somaHome, "imports/claude-skills/.manifest.json")))) {
     findings.push({
       id: "claude-skills-not-migrated",
       severity: "warning",

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -3,7 +3,8 @@ import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import { DOCTOR_UNSUPPORTED_DRIFT_MESSAGE, diagnoseProjectionDrift } from "./adapters/doctor";
 import { installSomaForClaudeCode, installSomaForCodex, installSomaForCursor, installSomaForPiDev } from "./install";
-import { migrateClaudeSkills } from "./claude-skills-migrator";
+import { hasImportableClaudeSkills, migrateClaudeSkills } from "./claude-skills-migrator";
+import { bootstrapSomaHome } from "./soma-home";
 import { migratePai } from "./pai-migration";
 import { isEnoent, pathExists, pathMtimeMs } from "./fs-utils";
 import type {
@@ -91,12 +92,14 @@ async function detectOnboarding(options: SomaOnboardingOptions): Promise<Omit<So
     paiPresent,
     paiUserPresent,
     claudeSkillsPresent,
+    claudeSkillsImportable,
     coreUserPresent,
     somaExists,
   ] = await Promise.all([
     pathExists(join(paiInstall, "PAI")),
     pathExists(paiUserDir),
     pathExists(claudeSkillsDir),
+    hasImportableClaudeSkills(claudeSkillsDir),
     pathExists(coreUserDir),
     pathExists(somaHome),
   ]);
@@ -116,6 +119,7 @@ async function detectOnboarding(options: SomaOnboardingOptions): Promise<Omit<So
       paiInstall: paiPresent ? paiInstall : null,
       paiUserDir: paiUserPresent ? paiUserDir : null,
       claudeSkillsDir: claudeSkillsPresent ? claudeSkillsDir : null,
+      claudeSkillsImportable,
       coreUserDir: coreUserPresent ? coreUserDir : null,
     },
     soma: {
@@ -133,7 +137,17 @@ export async function planSomaInit(options: SomaOnboardingOptions & { apply?: bo
   const modeFlag = apply ? "--apply" : "--dry-run";
   const steps: SomaInitStep[] = [];
 
-  if (detected.detected.claudeSkillsDir) {
+  // The Soma home skeleton is created by init itself (not deferred to
+  // `soma install`), so a failed or skipped later step never strands the
+  // principal without identity/telos/memory/skills/policy files.
+  // Idempotent: existing files are preserved (`wx` writes).
+  steps.push({
+    id: "bootstrap-soma-home",
+    command: `create Soma home skeleton at ${shellQuote(detected.somaHome)} (identity, telos, memory, skills, policy)`,
+    description: "Performed by soma init itself; idempotent, existing files preserved.",
+  });
+
+  if (detected.detected.claudeSkillsDir && detected.detected.claudeSkillsImportable) {
     steps.push({
       id: "migrate-claude-skills",
       command: `soma migrate claude-skills --from ${shellQuote(detected.detected.claudeSkillsDir)} ${modeFlag} ${sharedPathFlags(detected)}`,
@@ -179,7 +193,10 @@ export async function applySomaInit(options: SomaOnboardingOptions = {}): Promis
   const plan = await planSomaInit({ ...options, apply: true });
   const steps: SomaInitApplyResult["steps"] = [];
   for (const step of plan.steps) {
-    if (step.id === "migrate-claude-skills" && plan.detected.claudeSkillsDir) {
+    if (step.id === "bootstrap-soma-home") {
+      const result = await bootstrapSomaHome({ somaHome: plan.somaHome });
+      steps.push({ id: step.id, status: "applied", detail: `Soma home at ${result.somaHome}` });
+    } else if (step.id === "migrate-claude-skills" && plan.detected.claudeSkillsDir) {
       const result = await migrateClaudeSkills({
         from: plan.detected.claudeSkillsDir,
         homeDir: plan.homeDir,
@@ -246,7 +263,7 @@ export async function diagnoseSomaDoctor(options: SomaOnboardingOptions = {}): P
     });
   }
 
-  if (detected.detected.claudeSkillsDir && !(await pathExists(join(detected.somaHome, "imports/claude-skills/.manifest.json")))) {
+  if (detected.detected.claudeSkillsDir && detected.detected.claudeSkillsImportable && !(await pathExists(join(detected.somaHome, "imports/claude-skills/.manifest.json")))) {
     findings.push({
       id: "claude-skills-not-migrated",
       severity: "warning",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1553,15 +1553,17 @@ export interface SomaOnboardingOptions {
   substrate?: Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor">;
 }
 
-export interface SomaInitStep {
-  id: SomaInitStepId;
-  // Copy-paste shell command for steps that map to a standalone CLI
-  // invocation (migrate-*, install-*). Built-in steps performed by
-  // `soma init` itself (bootstrap-soma-home) carry a descriptive action
-  // string instead — do not assume every command is shell-executable.
-  command: string;
-  description: string;
-}
+// Classification of a detected Claude skills source dir (sage review on
+// #309): `not-importable` (non-flat layout, unreadable, file-at-path) must
+// never be conflated with `empty` in user-facing output.
+export type ClaudeSkillsSourceStatus = "importable" | "empty" | "missing" | "not-importable";
+
+// Discriminated: `command` steps are copy-paste shell commands that map to
+// a standalone CLI invocation (migrate-*, install-*); `builtin` steps are
+// performed by `soma init` itself and carry a human-readable action.
+export type SomaInitStep =
+  | { id: SomaInitStepId; kind: "command"; command: string; description: string }
+  | { id: SomaInitStepId; kind: "builtin"; action: string; description: string };
 
 export interface SomaInitPlan {
   mode: "dry-run" | "apply";
@@ -1572,10 +1574,10 @@ export interface SomaInitPlan {
     paiInstall: string | null;
     paiUserDir: string | null;
     claudeSkillsDir: string | null;
-    // True only when `claudeSkillsDir` contains at least one importable
-    // `<Name>/SKILL.md` child. A fresh Claude Code install ships an empty
-    // skills dir — init must not plan a migrate step that would refuse.
-    claudeSkillsImportable: boolean;
+    // Classification of the skills source. A fresh Claude Code install
+    // ships an `empty` skills dir — init must not plan a migrate step that
+    // would refuse, and must not label a `not-importable` tree as empty.
+    claudeSkillsStatus: ClaudeSkillsSourceStatus;
     coreUserDir: string | null;
   };
   soma: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1554,9 +1554,10 @@ export interface SomaOnboardingOptions {
 }
 
 // Classification of a detected Claude skills source dir (sage review on
-// #309): `not-importable` (non-flat layout, unreadable, file-at-path) must
-// never be conflated with `empty` in user-facing output.
-export type ClaudeSkillsSourceStatus = "importable" | "empty" | "missing" | "not-importable";
+// #309): `not-importable` (non-flat layout, file-at-path) and `unreadable`
+// (probe could not read the source at all) must never be conflated with
+// `empty` in user-facing output.
+export type ClaudeSkillsSourceStatus = "importable" | "empty" | "missing" | "not-importable" | "unreadable";
 
 // Discriminated: `command` steps are copy-paste shell commands that map to
 // a standalone CLI invocation (migrate-*, install-*); `builtin` steps are

--- a/src/types.ts
+++ b/src/types.ts
@@ -1555,6 +1555,10 @@ export interface SomaOnboardingOptions {
 
 export interface SomaInitStep {
   id: SomaInitStepId;
+  // Copy-paste shell command for steps that map to a standalone CLI
+  // invocation (migrate-*, install-*). Built-in steps performed by
+  // `soma init` itself (bootstrap-soma-home) carry a descriptive action
+  // string instead — do not assume every command is shell-executable.
   command: string;
   description: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1379,6 +1379,10 @@ export interface ClaudeSkillsMigrationPlan {
   // (i.e. at least one `<Name>/SKILL.md` direct child). When false,
   // `outcomes` is empty and the formatter renders a hard refusal.
   isFlatSkillsTree: boolean;
+  // Present only when `isFlatSkillsTree` is false: the accurate reason
+  // (missing dir / empty dir / non-flat layout) so the formatter does
+  // not misdiagnose a fresh, empty `~/.claude/skills/` as "not flat".
+  flatTreeRefusalReason?: string;
   // One outcome per source `<Name>/SKILL.md`. Always ordered by
   // `sourceName` so the report and CLI rendering are deterministic.
   outcomes: ClaudeSkillOutcome[];
@@ -1526,6 +1530,7 @@ export interface ClaudeSkillsMigrationManifest {
 }
 
 export type SomaInitStepId =
+  | "bootstrap-soma-home"
   | "migrate-claude-skills"
   | "migrate-pai"
   | "install-codex"
@@ -1563,6 +1568,10 @@ export interface SomaInitPlan {
     paiInstall: string | null;
     paiUserDir: string | null;
     claudeSkillsDir: string | null;
+    // True only when `claudeSkillsDir` contains at least one importable
+    // `<Name>/SKILL.md` child. A fresh Claude Code install ships an empty
+    // skills dir — init must not plan a migrate step that would refuse.
+    claudeSkillsImportable: boolean;
     coreUserDir: string | null;
   };
   soma: {

--- a/test/claude-skills-migrator.test.ts
+++ b/test/claude-skills-migrator.test.ts
@@ -229,6 +229,22 @@ test("planClaudeSkillsMigration on non-flat tree → isFlatSkillsTree=false", as
     });
     expect(plan.isFlatSkillsTree).toBe(false);
     expect(plan.outcomes).toEqual([]);
+    // Empty dir gets the accurate "empty" reason, not "not flat".
+    expect(plan.flatTreeRefusalReason).toContain("is empty — no skills to import");
+  });
+});
+
+test("planClaudeSkillsMigration distinguishes non-flat layout from empty dir", async () => {
+  await withTempHome(async (home) => {
+    // Children present, but none has a <Name>/SKILL.md — a Packs/-style tree.
+    const fromDir = join(home, "Packs");
+    await mkdir(join(fromDir, "SomePack/nested"), { recursive: true });
+    const plan = await planClaudeSkillsMigration({
+      from: fromDir,
+      homeDir: home,
+    });
+    expect(plan.isFlatSkillsTree).toBe(false);
+    expect(plan.flatTreeRefusalReason).toContain("not a flat skills tree");
   });
 });
 
@@ -515,10 +531,20 @@ test("migrateClaudeSkills handles mixed tree: per-skill routing is independent",
   });
 });
 
-test("migrateClaudeSkills refuses non-flat tree on apply", async () => {
+test("migrateClaudeSkills refuses empty tree on apply with accurate reason", async () => {
   await withTempHome(async (home) => {
     const fromDir = join(home, "empty");
     await mkdir(fromDir, { recursive: true });
+    await expect(
+      migrateClaudeSkills({ from: fromDir, somaHome: join(home, "soma") }),
+    ).rejects.toThrow(/is empty — no skills to import/);
+  });
+});
+
+test("migrateClaudeSkills refuses non-flat tree on apply", async () => {
+  await withTempHome(async (home) => {
+    const fromDir = join(home, "packs");
+    await mkdir(join(fromDir, "SomePack/nested"), { recursive: true });
     await expect(
       migrateClaudeSkills({ from: fromDir, somaHome: join(home, "soma") }),
     ).rejects.toThrow(/not a flat skills tree/);

--- a/test/claude-skills-migrator.test.ts
+++ b/test/claude-skills-migrator.test.ts
@@ -28,6 +28,7 @@ import {
   classifySkillPortability,
   migrateClaudeSkills,
   planClaudeSkillsMigration,
+  probeClaudeSkillsSource,
   readClaudeSkillsMigrationStatus,
 } from "../src/claude-skills-migrator";
 import type { ClaudeSkillsMigrationManifest } from "../src/types";
@@ -231,6 +232,30 @@ test("planClaudeSkillsMigration on non-flat tree → isFlatSkillsTree=false", as
     expect(plan.outcomes).toEqual([]);
     // Empty dir gets the accurate "empty" reason, not "not flat".
     expect(plan.flatTreeRefusalReason).toContain("is empty — no skills to import");
+  });
+});
+
+test("probeClaudeSkillsSource classifies missing, empty, non-flat, file-at-path", async () => {
+  await withTempHome(async (home) => {
+    expect(await probeClaudeSkillsSource(join(home, "nope"))).toBe("missing");
+
+    const emptyDir = join(home, "empty");
+    await mkdir(emptyDir, { recursive: true });
+    expect(await probeClaudeSkillsSource(emptyDir)).toBe("empty");
+
+    const packsDir = join(home, "packs");
+    await mkdir(join(packsDir, "SomePack/nested"), { recursive: true });
+    expect(await probeClaudeSkillsSource(packsDir)).toBe("not-importable");
+
+    const filePath = join(home, "file.txt");
+    await writeFile(filePath, "not a dir\n", "utf8");
+    // Structural verdict, not a read failure (sage cycle 2 on #309).
+    expect(await probeClaudeSkillsSource(filePath)).toBe("not-importable");
+
+    const flatDir = join(home, "flat");
+    await mkdir(join(flatDir, "Portable"), { recursive: true });
+    await writeFile(join(flatDir, "Portable/SKILL.md"), "---\nname: Portable\ndescription: ok\n---\n# P\n", "utf8");
+    expect(await probeClaudeSkillsSource(flatDir)).toBe("importable");
   });
 });
 

--- a/test/claude-skills-migrator.test.ts
+++ b/test/claude-skills-migrator.test.ts
@@ -538,6 +538,9 @@ test("migrateClaudeSkills refuses empty tree on apply with accurate reason", asy
     await expect(
       migrateClaudeSkills({ from: fromDir, somaHome: join(home, "soma") }),
     ).rejects.toThrow(/is empty — no skills to import/);
+    // A refused run must not leave a stray imports dir behind — that
+    // stray dir was all a fresh-install user found in ~/.soma.
+    await expect(readdir(join(home, "soma"))).rejects.toThrow();
   });
 });
 

--- a/test/onboarding-doctor.test.ts
+++ b/test/onboarding-doctor.test.ts
@@ -39,12 +39,15 @@ test("planSomaInit orders PAI migrant commands as dry-run copy-paste steps", asy
     expect(plan.detected.claudeSkillsDir).toBe(join(homeDir, ".claude/skills"));
     expect(plan.detected.coreUserDir).toBe(join(homeDir, ".config/pai/CORE_USER"));
     expect(plan.soma.starterProfile).toBe(false);
+    expect(plan.detected.claudeSkillsImportable).toBe(true);
     expect(plan.steps.map((step) => step.id)).toEqual([
+      "bootstrap-soma-home",
       "migrate-claude-skills",
       "migrate-pai",
       "install-codex",
     ]);
     expect(plan.steps.map((step) => step.command)).toEqual([
+      `create Soma home skeleton at ${join(homeDir, ".soma")} (identity, telos, memory, skills, policy)`,
       `soma migrate claude-skills --from ${join(homeDir, ".claude/skills")} --dry-run --home-dir ${homeDir} --soma-home ${join(homeDir, ".soma")}`,
       `soma migrate pai --pai-install ${join(homeDir, ".claude")} --dry-run --home-dir ${homeDir} --soma-home ${join(homeDir, ".soma")}`,
       `soma install codex --dry-run --home-dir ${homeDir} --soma-home ${join(homeDir, ".soma")}`,
@@ -62,25 +65,90 @@ test("planSomaInit shell-quotes paths in copy-paste commands", async () => {
       somaHome: join(homeDir, "soma home"),
     });
 
-    expect(plan.steps[0]?.command).toContain(`--from '${join(homeDir, ".claude/skills")}'`);
-    expect(plan.steps[0]?.command).toContain(`--home-dir '${homeDir}'`);
-    expect(plan.steps[0]?.command).toContain(`--soma-home '${join(homeDir, "soma home")}'`);
+    expect(plan.steps[0]?.command).toContain(`'${join(homeDir, "soma home")}'`);
+    expect(plan.steps[1]?.command).toContain(`--from '${join(homeDir, ".claude/skills")}'`);
+    expect(plan.steps[1]?.command).toContain(`--home-dir '${homeDir}'`);
+    expect(plan.steps[1]?.command).toContain(`--soma-home '${join(homeDir, "soma home")}'`);
   });
 });
 
-test("soma init --yes applies detected migration phases", async () => {
+test("soma init --apply applies detected migration phases", async () => {
   await withTempHome(async (homeDir) => {
     await writeMinimalPaiInstall(homeDir);
 
-    const output = await runSomaCli(["init", "--yes", "--home-dir", homeDir]);
+    const output = await runSomaCli(["init", "--apply", "--home-dir", homeDir]);
 
     expect(output).toContain("soma init — applied");
+    expect(output).toContain("bootstrap-soma-home: applied");
     expect(output).toContain("migrate-claude-skills: applied");
     expect(output).toContain("migrate-pai: applied");
     expect(output).toContain("install-codex: applied");
     await expect(stat(join(homeDir, ".soma/imports/claude-skills/.manifest.json"))).resolves.toBeTruthy();
     await expect(stat(join(homeDir, ".soma/profile/imports/claude/MIGRATION.md"))).resolves.toBeTruthy();
     await expect(stat(join(homeDir, ".codex/rules/soma.rules"))).resolves.toBeTruthy();
+  });
+});
+
+test("soma init --yes still works as a deprecated alias for --apply", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeMinimalPaiInstall(homeDir);
+
+    const output = await runSomaCli(["init", "--yes", "--home-dir", homeDir]);
+
+    expect(output).toContain("soma init — applied");
+    expect(output).toContain("install-codex: applied");
+  });
+});
+
+test("soma init on a fresh machine (no Claude install) bootstraps the Soma home", async () => {
+  await withTempHome(async (homeDir) => {
+    const plan = await planSomaInit({ homeDir });
+    expect(plan.detected.paiInstall).toBeNull();
+    expect(plan.detected.claudeSkillsDir).toBeNull();
+    expect(plan.steps.map((step) => step.id)).toEqual([
+      "bootstrap-soma-home",
+      "install-codex",
+    ]);
+
+    const output = await runSomaCli(["init", "--apply", "--home-dir", homeDir]);
+    expect(output).toContain("bootstrap-soma-home: applied");
+    expect(output).not.toContain("migrate-claude-skills");
+    const principal = await readFile(join(homeDir, ".soma/profile/principal.md"), "utf8");
+    expect(principal).toContain("status: starter-profile");
+    await expect(stat(join(homeDir, ".soma/profile/telos.md"))).resolves.toBeTruthy();
+    await expect(stat(join(homeDir, ".soma/memory"))).resolves.toBeTruthy();
+  });
+});
+
+test("soma init skips Claude skills migration when the skills dir is empty", async () => {
+  await withTempHome(async (homeDir) => {
+    // A fresh Claude Code install ships an EMPTY ~/.claude/skills — init
+    // must not plan a migrate step that would refuse (user feedback,
+    // 2026-06-12).
+    await mkdir(join(homeDir, ".claude/skills"), { recursive: true });
+
+    const plan = await planSomaInit({ homeDir });
+    expect(plan.detected.claudeSkillsDir).toBe(join(homeDir, ".claude/skills"));
+    expect(plan.detected.claudeSkillsImportable).toBe(false);
+    expect(plan.steps.map((step) => step.id)).toEqual([
+      "bootstrap-soma-home",
+      "install-codex",
+    ]);
+
+    const output = await runSomaCli(["init", "--apply", "--home-dir", homeDir]);
+    expect(output).toContain("soma init — applied");
+    expect(output).not.toContain("migrate-claude-skills");
+    await expect(stat(join(homeDir, ".soma/profile/principal.md"))).resolves.toBeTruthy();
+  });
+});
+
+test("soma doctor does not suggest skills migration for an empty Claude skills dir", async () => {
+  await withTempHome(async (homeDir) => {
+    await mkdir(join(homeDir, ".claude/skills"), { recursive: true });
+    await runSomaCli(["init", "--apply", "--home-dir", homeDir]);
+
+    const diagnosis = await diagnoseSomaDoctor({ homeDir });
+    expect(diagnosis.findings.map((finding) => finding.id)).not.toContain("claude-skills-not-migrated");
   });
 });
 
@@ -146,7 +214,7 @@ test("soma init surfaces broken Soma skills paths", async () => {
   });
 });
 
-test("soma init --yes fails when Claude skills migration has refused errors", async () => {
+test("soma init --apply fails when Claude skills migration has refused errors", async () => {
   await withTempHome(async (homeDir) => {
     await writeMinimalPaiInstall(homeDir);
     await mkdir(join(homeDir, ".claude/skills/EmbeddedGit/.git"), { recursive: true });
@@ -157,7 +225,7 @@ test("soma init --yes fails when Claude skills migration has refused errors", as
     );
     await writeFile(join(homeDir, ".claude/skills/EmbeddedGit/.git/config"), "[core]\n", "utf8");
 
-    await expect(runSomaCli(["init", "--yes", "--home-dir", homeDir])).rejects.toThrow(
+    await expect(runSomaCli(["init", "--apply", "--home-dir", homeDir])).rejects.toThrow(
       "soma init migrate-claude-skills failed",
     );
   });
@@ -167,7 +235,7 @@ test("soma doctor reports ok after init applies the detected plan", async () => 
   await withTempHome(async (homeDir) => {
     await writeMinimalPaiInstall(homeDir);
 
-    await runSomaCli(["init", "--yes", "--home-dir", homeDir]);
+    await runSomaCli(["init", "--apply", "--home-dir", homeDir]);
     const output = await runSomaCli(["doctor", "--home-dir", homeDir]);
 
     expect(output).toContain("soma doctor — ok");

--- a/test/onboarding-doctor.test.ts
+++ b/test/onboarding-doctor.test.ts
@@ -148,6 +148,26 @@ test("soma init skips Claude skills migration when the skills dir is empty", asy
   });
 });
 
+test("re-running soma init --apply never overwrites existing Soma home files", async () => {
+  await withTempHome(async (homeDir) => {
+    // Proves the doc claim in docs/soma-home-layout.md ("existing files are
+    // never overwritten") at the init level (sage cycle 3 on #309).
+    await runSomaCli(["init", "--apply", "--home-dir", homeDir]);
+
+    const principalPath = join(homeDir, ".soma/profile/principal.md");
+    const telosPath = join(homeDir, ".soma/profile/telos.md");
+    const customPrincipal = "# Principal\n\nName: Jens-Christian\n\n## Profile\n\n- status: customized\n";
+    const customTelos = "# Telos\n\nMission: My own mission.\n";
+    await writeFile(principalPath, customPrincipal, "utf8");
+    await writeFile(telosPath, customTelos, "utf8");
+
+    await runSomaCli(["init", "--apply", "--home-dir", homeDir]);
+
+    expect(await readFile(principalPath, "utf8")).toBe(customPrincipal);
+    expect(await readFile(telosPath, "utf8")).toBe(customTelos);
+  });
+});
+
 test("soma init labels a non-flat skills tree as not importable, never empty", async () => {
   await withTempHome(async (homeDir) => {
     // Children present, but no <Name>/SKILL.md — e.g. a Packs/-style tree.

--- a/test/onboarding-doctor.test.ts
+++ b/test/onboarding-doctor.test.ts
@@ -39,19 +39,20 @@ test("planSomaInit orders PAI migrant commands as dry-run copy-paste steps", asy
     expect(plan.detected.claudeSkillsDir).toBe(join(homeDir, ".claude/skills"));
     expect(plan.detected.coreUserDir).toBe(join(homeDir, ".config/pai/CORE_USER"));
     expect(plan.soma.starterProfile).toBe(false);
-    expect(plan.detected.claudeSkillsImportable).toBe(true);
+    expect(plan.detected.claudeSkillsStatus).toBe("importable");
     expect(plan.steps.map((step) => step.id)).toEqual([
       "bootstrap-soma-home",
       "migrate-claude-skills",
       "migrate-pai",
       "install-codex",
     ]);
-    expect(plan.steps.map((step) => step.command)).toEqual([
+    expect(plan.steps.map((step) => (step.kind === "command" ? step.command : step.action))).toEqual([
       `create Soma home skeleton at ${join(homeDir, ".soma")} (identity, telos, memory, skills, policy)`,
       `soma migrate claude-skills --from ${join(homeDir, ".claude/skills")} --dry-run --home-dir ${homeDir} --soma-home ${join(homeDir, ".soma")}`,
       `soma migrate pai --pai-install ${join(homeDir, ".claude")} --dry-run --home-dir ${homeDir} --soma-home ${join(homeDir, ".soma")}`,
       `soma install codex --dry-run --home-dir ${homeDir} --soma-home ${join(homeDir, ".soma")}`,
     ]);
+    expect(plan.steps.map((step) => step.kind)).toEqual(["builtin", "command", "command", "command"]);
   });
 });
 
@@ -65,10 +66,15 @@ test("planSomaInit shell-quotes paths in copy-paste commands", async () => {
       somaHome: join(homeDir, "soma home"),
     });
 
-    expect(plan.steps[0]?.command).toContain(`'${join(homeDir, "soma home")}'`);
-    expect(plan.steps[1]?.command).toContain(`--from '${join(homeDir, ".claude/skills")}'`);
-    expect(plan.steps[1]?.command).toContain(`--home-dir '${homeDir}'`);
-    expect(plan.steps[1]?.command).toContain(`--soma-home '${join(homeDir, "soma home")}'`);
+    const stepText = (index: number): string => {
+      const step = plan.steps[index];
+      if (!step) return "";
+      return step.kind === "command" ? step.command : step.action;
+    };
+    expect(stepText(0)).toContain(`'${join(homeDir, "soma home")}'`);
+    expect(stepText(1)).toContain(`--from '${join(homeDir, ".claude/skills")}'`);
+    expect(stepText(1)).toContain(`--home-dir '${homeDir}'`);
+    expect(stepText(1)).toContain(`--soma-home '${join(homeDir, "soma home")}'`);
   });
 });
 
@@ -129,7 +135,7 @@ test("soma init skips Claude skills migration when the skills dir is empty", asy
 
     const plan = await planSomaInit({ homeDir });
     expect(plan.detected.claudeSkillsDir).toBe(join(homeDir, ".claude/skills"));
-    expect(plan.detected.claudeSkillsImportable).toBe(false);
+    expect(plan.detected.claudeSkillsStatus).toBe("empty");
     expect(plan.steps.map((step) => step.id)).toEqual([
       "bootstrap-soma-home",
       "install-codex",
@@ -139,6 +145,26 @@ test("soma init skips Claude skills migration when the skills dir is empty", asy
     expect(output).toContain("soma init — applied");
     expect(output).not.toContain("migrate-claude-skills");
     await expect(stat(join(homeDir, ".soma/profile/principal.md"))).resolves.toBeTruthy();
+  });
+});
+
+test("soma init labels a non-flat skills tree as not importable, never empty", async () => {
+  await withTempHome(async (homeDir) => {
+    // Children present, but no <Name>/SKILL.md — e.g. a Packs/-style tree.
+    // sage review on #309: this must NOT be reported as "empty".
+    await mkdir(join(homeDir, ".claude/skills/SomePack/nested"), { recursive: true });
+
+    const plan = await planSomaInit({ homeDir });
+    expect(plan.detected.claudeSkillsStatus).toBe("not-importable");
+    expect(plan.steps.map((step) => step.id)).toEqual([
+      "bootstrap-soma-home",
+      "install-codex",
+    ]);
+
+    const output = await runSomaCli(["init", "--home-dir", homeDir]);
+    expect(output).toContain("not an importable flat skills tree");
+    expect(output).not.toContain("empty — nothing to import");
+    expect(output).not.toContain("No existing installation to import");
   });
 });
 


### PR DESCRIPTION
## Problem

First-external-user feedback (Vincent Zontini, 2026-06-12). On a fresh machine:

1. Claude Code creates an **empty** `~/.claude/skills`; `soma init --yes` planned a `migrate-claude-skills` step for it, which refused with the misleading error `--from ... is not a flat skills tree (no <Name>/SKILL.md direct children)`.
2. The refusal fired **before** the `install-*` step — the only place `bootstrapSomaHome` ran — so the user ended up with `~/.soma` containing nothing but an empty imports directory, despite the README promising init "creates your Soma home".
3. `soma init --yes` was the only mutating command not using the `--dry-run`/`--apply` pair.
4. Nothing in the docs said where Soma's own Algorithm/ISA implementation lives.

## Changes

- **init owns home creation**: new `bootstrap-soma-home` step runs first in plan and apply (`src/onboarding.ts`); idempotent, existing files preserved. A failed or skipped later step can no longer strand the user without identity/telos/memory/skills/policy.
- **Empty skills dir handled**: `detectOnboarding` probes importability via new `hasImportableClaudeSkills`; init plans no migrate step for an empty dir (plan shows `(empty — nothing to import)`), and `soma doctor` no longer suggests a migration that would refuse.
- **Accurate migrate refusals**: `describeFlatTreeRefusal` distinguishes missing / empty / genuinely non-flat `--from` trees in both the apply error and the dry-run plan (`flatTreeRefusalReason` on `ClaudeSkillsMigrationPlan`).
- **Flag terminology**: `soma init --apply` is canonical; `--yes` accepted one release as a deprecated alias with a stderr warning (`warnDeprecatedYesFlag`).
- **Story in output + docs**: init dry-run plan explains it creates the home and imports detected Claude/PAI sources, notes starter-profile fallback on fresh machines. New `docs/soma-home-layout.md` maps the `~/.soma` layout and documents that the Algorithm/ISA implementations are Soma-native (`soma algorithm`/`soma isa`, state in `memory/WORK/algorithm-runs/` and `isa/`). README quickstart updated.

## Verification

- `bun test`: 1246 pass, 0 fail (new tests: fresh machine, empty skills dir, `--apply`, `--yes` alias, empty-vs-non-flat refusals, doctor gating)
- `tsc --noEmit` and eslint clean
- Live CLI replay of the reported scenario: dry-run plan, apply, populated `~/.soma`, accurate migrate error on empty dir, fresh machine with no `.claude` at all



## Live replay transcripts (sage cycle 4: evidence for the verification claims)

### A. Empty Claude skills dir (the reported scenario)
```
$ mkdir -p $HOME/.claude/skills   # fresh Claude Code ships this empty
$ soma init --home-dir $HOME
soma init — plan (dry-run; pass --apply to execute)

Creates the Soma home (identity, telos, memory, skills, policy) and
imports context from an existing Claude Code / PAI installation when one
is detected.

Home:       $HOME
Soma home:  $HOME/.soma
Substrate:  codex

Detected import sources:
  - PAI install:    not found
  - Claude skills:  $HOME/.claude/skills (empty — nothing to import)
  - CORE_USER:      not found

No existing installation to import — starting from the Soma starter profile.

Soma state:
  - exists:          no
  - starter profile: no
  - skills:          empty
  - Algorithm skill: missing

Steps:
1. create Soma home skeleton at $HOME/.soma (identity, telos, memory, skills, policy)
2. soma install codex --dry-run --home-dir $HOME --soma-home $HOME/.soma

$ soma init --apply --home-dir $HOME
soma init — applied

bootstrap-soma-home: applied (Soma home at $HOME/.soma)
install-codex: applied (21 files)

$ ls $HOME/.soma
isa
memory
policy
profile
projections
skills
$ soma migrate claude-skills --from $HOME/.claude/skills --apply
soma migrate claude-skills: --from $HOME/.claude/skills is empty — no skills to import.
```

### B. Fresh machine, no `.claude` at all
```
$ soma init --apply --home-dir $HOME
soma init — applied

bootstrap-soma-home: applied (Soma home at $HOME/.soma)
install-codex: applied (21 files)

$ head -8 $HOME/.soma/profile/principal.md
# Principal

Name: principal
Preferred name: Principal

## Profile

- status: starter-profile
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
