### PR TITLE
fix(install): first install lists the ISA skill in skills.md

### DIFF
--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -5,7 +5,7 @@ import { defaultSomaRepoPath } from "../../repo-path";
 import { resolveBunExecutable } from "../../bun-probe";
 import { readCodexHookAsset, renderCodexPolicyHook, renderCodexPolicyTargets } from "./hooks/assets";
 import { renderFeedbackHookModule } from "../shared/feedback-helper";
-import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
+import { projectableSkillFiles, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
 import { activeIsaBundleFile } from "../../adapter-active-isa";
 import { somaPolicyPrivateMarkers } from "../../policy";
 import { somaMemoryPrivateRoots, somaProjectionPrivateRoots } from "../../projection-private-roots";
@@ -443,7 +443,7 @@ export function projectCodex(input: ProjectionInput): Projection {
 
 export function projectCodexHome(input: ProjectionInput, somaHome: string, homeDir?: string, somaRepoPath = defaultSomaRepoPath()): Projection {
   const instructions = renderHomeRules(input, somaHome);
-  const portableSkillFiles = input.profile.skills.flatMap((skill) =>
+  const portableSkillFiles = projectableSkillFiles(input.profile.skills).flatMap((skill) =>
     (skill.files ?? []).map((file) => ({
       path: `skills/${skill.name}/${file.path}`,
       content: rewriteSubstrateProjectionContent({

--- a/src/adapters/pi-dev/adapter.ts
+++ b/src/adapters/pi-dev/adapter.ts
@@ -3,7 +3,7 @@ import { renderFeedbackHookHelper } from "../shared/feedback-helper";
 import { renderPathGuardExtension } from "./path-guard";
 import { renderSomaAlgorithmExtension } from "./extensions/soma-algorithm";
 import { buildPiDevPortableSkillFiles } from "./skill-projection";
-import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
+import { projectableSkillFiles, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
 import { activeIsaBundleFile } from "../../adapter-active-isa";
 import { SOMA_VERSION } from "../../version";
 
@@ -468,7 +468,7 @@ export function projectPiDev(input: ProjectionInput): Projection {
 
 export function projectPiDevHome(input: ProjectionInput, somaHome: string): Projection {
   const instructions = renderInstructions(input);
-  const portableSkillFiles = buildPiDevPortableSkillFiles(input.profile.skills);
+  const portableSkillFiles = buildPiDevPortableSkillFiles(projectableSkillFiles(input.profile.skills));
 
   return {
     substrate: "pi-dev",

--- a/src/adapters/shared/index.ts
+++ b/src/adapters/shared/index.ts
@@ -1,5 +1,19 @@
-import type { ProjectionInput } from "../../types";
+import type { ProjectionInput, SomaSkill } from "../../types";
 import { getCriteria, getGoal } from "../../isa-accessors";
+import { ISA_SKILL_NAME } from "../../isa-skill-installer";
+
+/**
+ * The portable skills a home projection should emit files for. `skills.md`
+ * (renderSkills) still lists every skill, but the ISA skill is excluded here:
+ * it has a dedicated, managed per-substrate projection (installIsaSkillProjection
+ * — baseline tracking, drift detection, skillNameOverride), so re-emitting its
+ * files through the generic portable-skill loop would double-write the same
+ * bytes that installer owns. Without this, a first install (which reloads the
+ * Soma home after writing the ISA baseline) would project ISA twice.
+ */
+export function projectableSkillFiles(skills: SomaSkill[]): SomaSkill[] {
+  return skills.filter((skill) => skill.name !== ISA_SKILL_NAME);
+}
 
 export function formatList(items: string[]): string {
   return items.length === 0 ? "- None declared" : items.map((item) => `- ${item}`).join("\n");

--- a/src/install.ts
+++ b/src/install.ts
@@ -11,7 +11,7 @@ import type { ClaudeCodeInstallOptions } from "./adapters/claude-code/install-op
 import { buildSomaStartupContext, runSomaLifecycleAlgorithmUpdated } from "./lifecycle";
 import { SOMA_MEMORY_CATEGORIES } from "./memory-readmes";
 import { defaultSomaRepoPath } from "./repo-path";
-import { bootstrapSomaHome } from "./soma-home";
+import { bootstrapSomaHome, loadSomaHome } from "./soma-home";
 import { installIsaSkillProjection } from "./isa-skill-installer";
 import { loadActiveIsaForBundle } from "./adapter-active-isa";
 import { isEnoent } from "./fs-errors";
@@ -128,6 +128,14 @@ async function installSomaForSubstrate(
     somaHome: somaHome.somaHome,
     somaRepoPath,
   });
+  // bootstrapSomaHome captured its context snapshot BEFORE the ISA skill
+  // baseline above existed, so its skill list is empty on a first install.
+  // Re-read the Soma home now that <somaHome>/skills/ISA is on disk: without
+  // this, the first install projects a skills.md that reads "No Soma skills
+  // were declared." and only the second install converges. Reloading makes
+  // the very first projection already list the ISA skill — install #1 is
+  // correct and byte-identical to every re-run.
+  const projectionContext = await loadSomaHome(somaHome.somaHome);
   const projectionOptions = {
     homeDir: options.homeDir,
     somaHome: options.somaHome,
@@ -153,7 +161,7 @@ async function installSomaForSubstrate(
   // Populate the projection input with the active ISA so each
   // substrate writes its `active-isa.md` file (#37 AC-1/AC-2).
   const contextWithActiveIsa: ProjectionInput = {
-    ...somaHome.context,
+    ...projectionContext,
     activeIsa: (await loadActiveIsaForBundle({ somaHome: somaHome.somaHome })) ?? undefined,
   };
   const substrateHome = await installHomeProjectionFor(substrate, contextWithActiveIsa, projectionOptions);

--- a/src/isa-skill-installer.ts
+++ b/src/isa-skill-installer.ts
@@ -18,7 +18,12 @@ interface InternalIsaSkillInstallOptions extends IsaSkillInstallOptions {
   projectionSubstrate?: SubstrateId;
 }
 
-const SKILL_NAME = "ISA";
+// The canonical ISA skill directory name under <somaHome>/skills. Exported so
+// home-projection adapters can recognize the ISA skill and delegate its file
+// projection to this dedicated installer instead of double-emitting it through
+// the generic portable-skill loop.
+export const ISA_SKILL_NAME = "ISA";
+const SKILL_NAME = ISA_SKILL_NAME;
 const SOURCE_SUBPATH = `src/skills/${SKILL_NAME}`;
 const RUNTIME_SUBPATH = `skills/${SKILL_NAME}`;
 const BASELINES_SUBPATH = "memory/STATE/skill-baselines.json";

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -228,6 +228,9 @@ test("pi.dev home projection normalizes portable skill paths and frontmatter nam
         ...portableProjectionInput.profile,
         skills: [
           {
+            // The canonical ISA skill has a dedicated, managed projection
+            // (installIsaSkillProjection); the generic portable-skill loop
+            // delegates it and must NOT also emit its files here.
             name: "ISA",
             path: "skills/ISA",
             description: "Ideal State Artifact.",
@@ -236,6 +239,20 @@ test("pi.dev home projection normalizes portable skill paths and frontmatter nam
               {
                 path: "SKILL.md",
                 content: "---\nname: ISA\n---\n\n# ISA\n",
+              },
+            ],
+          },
+          {
+            // A non-dedicated uppercase skill exercises the general
+            // name/path normalization (FAQ -> faq) through the portable loop.
+            name: "FAQ",
+            path: "skills/FAQ",
+            description: "Frequently asked questions.",
+            triggers: ["faq"],
+            files: [
+              {
+                path: "SKILL.md",
+                content: "---\nname: FAQ\n---\n\n# FAQ\n",
               },
             ],
           },
@@ -269,15 +286,18 @@ test("pi.dev home projection normalizes portable skill paths and frontmatter nam
     { homeDir: "/tmp/soma-test-home" },
   );
 
-  const isa = projection.bundle.files.find((file) => file.path === "agent/skills/isa/SKILL.md");
+  const faq = projection.bundle.files.find((file) => file.path === "agent/skills/faq/SKILL.md");
   const ledger = projection.bundle.files.find((file) => file.path === "agent/skills/ledger-update/SKILL.md");
   const bodyExample = projection.bundle.files.find((file) => file.path === "agent/skills/body-example/SKILL.md");
 
-  expect(isa?.content).toContain("name: isa");
-  expect(isa?.content).not.toContain("name: ISA");
+  expect(faq?.content).toContain("name: faq");
+  expect(faq?.content).not.toContain("name: FAQ");
   expect(ledger?.content).toContain("name: ledger-update");
   expect(bodyExample?.content).toContain("name: Body Example");
   expect(bodyExample?.content).not.toContain("name: body-example");
+  // The dedicated ISA skill is delegated to installIsaSkillProjection and is
+  // not double-emitted through the portable-skill loop (neither cased form).
+  expect(projection.bundle.files.map((file) => file.path)).not.toContain("agent/skills/isa/SKILL.md");
   expect(projection.bundle.files.map((file) => file.path)).not.toContain("agent/skills/ISA/SKILL.md");
 });
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -363,6 +363,28 @@ test("install preserves existing soma profile edits before projecting to codex",
   });
 });
 
+test("first install already converges: skills.md lists ISA and the file set matches a re-install", async () => {
+  await withTempHome(async (homeDir) => {
+    const skillsPath = join(homeDir, ".codex/memories/soma/skills.md");
+
+    // The canonical ISA skill is written to <somaHome>/skills/ISA during
+    // this same install. The projection must already reflect it on the very
+    // first run — not render "No Soma skills were declared." and only
+    // converge on the second install (the context was previously snapshotted
+    // before the ISA baseline existed).
+    const first = await installSomaForCodex({ homeDir });
+    const afterFirst = await readFile(skillsPath, "utf8");
+    expect(afterFirst).toContain("## ISA");
+    expect(afterFirst).not.toContain("No Soma skills were declared.");
+
+    // Already converged: a second install reports the same file set and
+    // produces byte-identical skills.md. install #1 == install #2.
+    const second = await installSomaForCodex({ homeDir });
+    expect(first.substrateHome.files).toHaveLength(second.substrateHome.files.length);
+    expect(await readFile(skillsPath, "utf8")).toBe(afterFirst);
+  });
+});
+
 test("installed codex hook denies private Soma source writes to public destinations", async () => {
   await withTempHome(async (homeDir) => {
     await installSomaForCodex({ homeDir });


### PR DESCRIPTION
Fixes #310

## Problem

A first `soma install <substrate>` rendered `skills.md` as "No Soma skills were declared." even though the ISA skill was installed alongside it; the skill only appeared on the second install. `bootstrapSomaHome` captures its context snapshot (which feeds `skills.md`) **before** `installSomaForSubstrate` writes the canonical ISA skill to `<somaHome>/skills/ISA`, so the first projection rendered from an empty skill list and only converged on re-run.

## Fix

Reload the Soma home context after the canonical ISA baseline is written, so the very first projection already lists the ISA skill: **install #1 == install #2**.

One subtlety: reloading puts the ISA skill into `profile.skills`, which would make the generic portable-skill file loop *also* emit the ISA skill's files — on top of its dedicated, managed projection (`installIsaSkillProjection`: baseline tracking, drift detection, `skillNameOverride`). That double-write is redundant (identical bytes) and would break the file-set contract. So the ISA skill is now delegated: a shared `projectableSkillFiles()` filter excludes it from the portable file loop in the adapters that project skill files (codex, pi-dev), while `renderSkills` still lists it in `skills.md`. The ISA skill is projected exactly once, by its dedicated installer.

## Result

- `skills.md` lists the ISA skill from the first install.
- **install #1 == install #2** — same reported file count and a byte-identical `skills.md` across the two installs (asserted by the new regression test below).
- The ISA skill is projected **exactly once**: the portable-skill loop no longer emits its files (asserted in `home-projection.test.ts`), leaving only the dedicated managed projection — no double-write.
- The existing dry-run/apply install tests (e.g. `cli dry-runs and applies pi.dev install`) are untouched and stay green; this PR does not change the dry-run==apply contract.

## Verification

- `bun run typecheck` clean.
- New regression test — *"first install already converges: skills.md lists ISA and the file set matches a re-install"* — fails before the fix, passes after.
- `test/home-projection.test.ts`: the pi-dev normalization test now uses a non-dedicated uppercase skill (FAQ) and asserts the ISA skill is excluded from the portable bundle.
- **A/B failure-set diff vs `upstream/main` on the same machine** (touched test files `install.test.ts` + `home-projection.test.ts`): identical pre-existing failure set, zero regressions, plus exactly one new passing test. Reproducible transcript (commands, environment, output) posted in a comment below.
- **Platform scope:** verified on Windows 11 (typecheck + the tests and A/B above). The fix is substrate-neutral shared-core with no OS-specific code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
