### PR TITLE
fix(export): soma export emits the ISA skill, completing the bundle

### DIFF
--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -5,7 +5,7 @@ import { defaultSomaRepoPath } from "../../repo-path";
 import { resolveBunExecutable } from "../../bun-probe";
 import { readCodexHookAsset, renderCodexPolicyHook, renderCodexPolicyTargets } from "./hooks/assets";
 import { renderFeedbackHookModule } from "../shared/feedback-helper";
-import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
+import { projectableSkillFiles, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
 import { activeIsaBundleFile } from "../../adapter-active-isa";
 import { somaPolicyPrivateMarkers } from "../../policy";
 import { somaMemoryPrivateRoots, somaProjectionPrivateRoots } from "../../projection-private-roots";
@@ -443,7 +443,7 @@ export function projectCodex(input: ProjectionInput): Projection {
 
 export function projectCodexHome(input: ProjectionInput, somaHome: string, homeDir?: string, somaRepoPath = defaultSomaRepoPath()): Projection {
   const instructions = renderHomeRules(input, somaHome);
-  const portableSkillFiles = input.profile.skills.flatMap((skill) =>
+  const portableSkillFiles = projectableSkillFiles(input.profile.skills).flatMap((skill) =>
     (skill.files ?? []).map((file) => ({
       path: `skills/${skill.name}/${file.path}`,
       content: rewriteSubstrateProjectionContent({

--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -5,7 +5,7 @@ import { defaultSomaRepoPath } from "../../repo-path";
 import { resolveBunExecutable } from "../../bun-probe";
 import { readCodexHookAsset, renderCodexPolicyHook, renderCodexPolicyTargets } from "./hooks/assets";
 import { renderFeedbackHookModule } from "../shared/feedback-helper";
-import { projectableSkillFiles, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
+import { projectableSkills, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
 import { activeIsaBundleFile } from "../../adapter-active-isa";
 import { somaPolicyPrivateMarkers } from "../../policy";
 import { somaMemoryPrivateRoots, somaProjectionPrivateRoots } from "../../projection-private-roots";
@@ -443,7 +443,7 @@ export function projectCodex(input: ProjectionInput): Projection {
 
 export function projectCodexHome(input: ProjectionInput, somaHome: string, homeDir?: string, somaRepoPath = defaultSomaRepoPath()): Projection {
   const instructions = renderHomeRules(input, somaHome);
-  const portableSkillFiles = projectableSkillFiles(input.profile.skills).flatMap((skill) =>
+  const portableSkillFiles = projectableSkills(input.profile.skills).flatMap((skill) =>
     (skill.files ?? []).map((file) => ({
       path: `skills/${skill.name}/${file.path}`,
       content: rewriteSubstrateProjectionContent({

--- a/src/adapters/pi-dev/adapter.ts
+++ b/src/adapters/pi-dev/adapter.ts
@@ -3,7 +3,7 @@ import { renderFeedbackHookHelper } from "../shared/feedback-helper";
 import { renderPathGuardExtension } from "./path-guard";
 import { renderSomaAlgorithmExtension } from "./extensions/soma-algorithm";
 import { buildPiDevPortableSkillFiles } from "./skill-projection";
-import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
+import { projectableSkillFiles, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
 import { activeIsaBundleFile } from "../../adapter-active-isa";
 import { SOMA_VERSION } from "../../version";
 
@@ -468,7 +468,7 @@ export function projectPiDev(input: ProjectionInput): Projection {
 
 export function projectPiDevHome(input: ProjectionInput, somaHome: string): Projection {
   const instructions = renderInstructions(input);
-  const portableSkillFiles = buildPiDevPortableSkillFiles(input.profile.skills);
+  const portableSkillFiles = buildPiDevPortableSkillFiles(projectableSkillFiles(input.profile.skills));
 
   return {
     substrate: "pi-dev",

--- a/src/adapters/pi-dev/adapter.ts
+++ b/src/adapters/pi-dev/adapter.ts
@@ -3,7 +3,7 @@ import { renderFeedbackHookHelper } from "../shared/feedback-helper";
 import { renderPathGuardExtension } from "./path-guard";
 import { renderSomaAlgorithmExtension } from "./extensions/soma-algorithm";
 import { buildPiDevPortableSkillFiles } from "./skill-projection";
-import { projectableSkillFiles, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
+import { projectableSkills, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills } from "../shared";
 import { activeIsaBundleFile } from "../../adapter-active-isa";
 import { SOMA_VERSION } from "../../version";
 
@@ -468,7 +468,7 @@ export function projectPiDev(input: ProjectionInput): Projection {
 
 export function projectPiDevHome(input: ProjectionInput, somaHome: string): Projection {
   const instructions = renderInstructions(input);
-  const portableSkillFiles = buildPiDevPortableSkillFiles(projectableSkillFiles(input.profile.skills));
+  const portableSkillFiles = buildPiDevPortableSkillFiles(projectableSkills(input.profile.skills));
 
   return {
     substrate: "pi-dev",

--- a/src/adapters/shared/index.ts
+++ b/src/adapters/shared/index.ts
@@ -1,3 +1,4 @@
+import { basename } from "node:path";
 import type { ProjectionInput, SomaSkill } from "../../types";
 import { getCriteria, getGoal } from "../../isa-accessors";
 import { ISA_SKILL_NAME } from "../../isa-skill-installer";
@@ -10,9 +11,16 @@ import { ISA_SKILL_NAME } from "../../isa-skill-installer";
  * files through the generic portable-skill loop would double-write the same
  * bytes that installer owns. Without this, a first install (which reloads the
  * Soma home after writing the ISA baseline) would project ISA twice.
+ *
+ * The managed ISA skill is identified by BOTH its frontmatter name and its
+ * canonical directory basename (`skills/ISA/`). Matching on name alone would
+ * let a locally renamed SKILL.md frontmatter slip back into the generic loop
+ * and double-write the dedicated projection.
  */
 export function projectableSkills(skills: SomaSkill[]): SomaSkill[] {
-  return skills.filter((skill) => skill.name !== ISA_SKILL_NAME);
+  return skills.filter(
+    (skill) => skill.name !== ISA_SKILL_NAME && basename(skill.path) !== ISA_SKILL_NAME,
+  );
 }
 
 export function formatList(items: string[]): string {

--- a/src/adapters/shared/index.ts
+++ b/src/adapters/shared/index.ts
@@ -11,7 +11,7 @@ import { ISA_SKILL_NAME } from "../../isa-skill-installer";
  * bytes that installer owns. Without this, a first install (which reloads the
  * Soma home after writing the ISA baseline) would project ISA twice.
  */
-export function projectableSkillFiles(skills: SomaSkill[]): SomaSkill[] {
+export function projectableSkills(skills: SomaSkill[]): SomaSkill[] {
   return skills.filter((skill) => skill.name !== ISA_SKILL_NAME);
 }
 

--- a/src/adapters/shared/index.ts
+++ b/src/adapters/shared/index.ts
@@ -1,5 +1,19 @@
-import type { ProjectionInput } from "../../types";
+import type { ProjectionInput, SomaSkill } from "../../types";
 import { getCriteria, getGoal } from "../../isa-accessors";
+import { ISA_SKILL_NAME } from "../../isa-skill-installer";
+
+/**
+ * The portable skills a home projection should emit files for. `skills.md`
+ * (renderSkills) still lists every skill, but the ISA skill is excluded here:
+ * it has a dedicated, managed per-substrate projection (installIsaSkillProjection
+ * — baseline tracking, drift detection, skillNameOverride), so re-emitting its
+ * files through the generic portable-skill loop would double-write the same
+ * bytes that installer owns. Without this, a first install (which reloads the
+ * Soma home after writing the ISA baseline) would project ISA twice.
+ */
+export function projectableSkillFiles(skills: SomaSkill[]): SomaSkill[] {
+  return skills.filter((skill) => skill.name !== ISA_SKILL_NAME);
+}
 
 export function formatList(items: string[]): string {
   return items.length === 0 ? "- None declared" : items.map((item) => `- ${item}`).join("\n");

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -1,3 +1,5 @@
+import { homedir } from "node:os";
+import { join as pathJoin, relative as pathRelative, resolve as pathResolve } from "node:path";
 import { cursorWorkspaceSubstrateHome } from "../adapters/cursor";
 import {
   buildClaudeCodeHomeProjection,
@@ -20,6 +22,8 @@ import {
   type UninstallCursorResult,
 } from "../index";
 import type { ClaudeCodeInstallOptions } from "../adapters/claude-code/install-options";
+import { projectIsaSkillBundleFiles } from "../isa-skill-installer";
+import { installSpecFor } from "../install-spec-registry";
 import type {
   ProjectionInput,
   SomaInstallOptions,
@@ -410,7 +414,35 @@ async function buildExportProjection(
     substrateHome: options.substrateHome,
   };
   const files = projectionFilesFor(substrate, projectionInput, projectionOptions);
-  return files.map((f) => ({ path: f.path, content: f.content }));
+  // The ISA skill has a dedicated managed projection at install
+  // time (installIsaSkillProjection) and is therefore excluded from the
+  // generic portable-skill loop the projection builders run. Export runs
+  // only that loop, so without this the bundle's skills.md lists the ISA
+  // skill while its files are absent — an incomplete projection that does
+  // not match an installed home. Append the same ISA files install writes,
+  // as in-memory bundle entries, so `soma export` is a complete, installable
+  // set.
+  const isaFiles = await buildExportIsaProjection(substrate, options);
+  return [...files, ...isaFiles].map((f) => ({ path: f.path, content: f.content }));
+}
+
+async function buildExportIsaProjection(
+  substrate: InstallSubstrate,
+  options: SomaInstallOptions,
+): Promise<{ path: string; content: string }[]> {
+  const spec = installSpecFor(substrate);
+  // Resolve the substrate root the same way install does, then derive the
+  // ISA destination relative to it so the bundle path matches an installed
+  // home (e.g. codex → `skills/ISA`, cursor → `.cursor/rules/soma/skills/ISA`).
+  const resolvedHomeDir = pathResolve(options.homeDir ?? homedir());
+  const substrateRoot = pathResolve(options.substrateHome ?? pathJoin(resolvedHomeDir, spec.defaultHome));
+  const destinationPrefix = pathRelative(substrateRoot, spec.isaSkillProjection.destinationDir(substrateRoot));
+  return projectIsaSkillBundleFiles({
+    somaRepoPath: options.somaRepoPath,
+    skillNameOverride: spec.isaSkillProjection.skillNameOverride,
+    projectionSubstrate: substrate,
+    destinationPrefix,
+  });
 }
 
 function projectionFilesFor(

--- a/src/install.ts
+++ b/src/install.ts
@@ -11,7 +11,7 @@ import type { ClaudeCodeInstallOptions } from "./adapters/claude-code/install-op
 import { buildSomaStartupContext, runSomaLifecycleAlgorithmUpdated } from "./lifecycle";
 import { SOMA_MEMORY_CATEGORIES } from "./memory-readmes";
 import { defaultSomaRepoPath } from "./repo-path";
-import { bootstrapSomaHome } from "./soma-home";
+import { bootstrapSomaHome, loadSomaHome } from "./soma-home";
 import { installIsaSkillProjection } from "./isa-skill-installer";
 import { loadActiveIsaForBundle } from "./adapter-active-isa";
 import { isEnoent } from "./fs-errors";
@@ -128,6 +128,14 @@ async function installSomaForSubstrate(
     somaHome: somaHome.somaHome,
     somaRepoPath,
   });
+  // bootstrapSomaHome captured its context snapshot BEFORE the ISA skill
+  // baseline above existed, so its skill list is empty on a first install.
+  // Re-read the Soma home now that <somaHome>/skills/ISA is on disk: without
+  // this, the first install projects a skills.md that reads "No Soma skills
+  // were declared." and only the second install converges. Reloading makes
+  // the very first projection already list the ISA skill — install #1 is
+  // correct and byte-identical to every re-run.
+  const projectionContext = await loadSomaHome(somaHome.somaHome);
   const projectionOptions = {
     homeDir: options.homeDir,
     somaHome: options.somaHome,
@@ -153,7 +161,7 @@ async function installSomaForSubstrate(
   // Populate the projection input with the active ISA so each
   // substrate writes its `active-isa.md` file (#37 AC-1/AC-2).
   const contextWithActiveIsa: ProjectionInput = {
-    ...somaHome.context,
+    ...projectionContext,
     activeIsa: (await loadActiveIsaForBundle({ somaHome: somaHome.somaHome })) ?? undefined,
   };
   const substrateHome = await installHomeProjectionFor(substrate, contextWithActiveIsa, projectionOptions);

--- a/src/isa-skill-installer.ts
+++ b/src/isa-skill-installer.ts
@@ -18,7 +18,12 @@ interface InternalIsaSkillInstallOptions extends IsaSkillInstallOptions {
   projectionSubstrate?: SubstrateId;
 }
 
-const SKILL_NAME = "ISA";
+// The canonical ISA skill directory name under <somaHome>/skills. Exported so
+// home-projection adapters can recognize the ISA skill and delegate its file
+// projection to this dedicated installer instead of double-emitting it through
+// the generic portable-skill loop.
+export const ISA_SKILL_NAME = "ISA";
+const SKILL_NAME = ISA_SKILL_NAME;
 const SOURCE_SUBPATH = `src/skills/${SKILL_NAME}`;
 const RUNTIME_SUBPATH = `skills/${SKILL_NAME}`;
 const BASELINES_SUBPATH = "memory/STATE/skill-baselines.json";

--- a/src/isa-skill-installer.ts
+++ b/src/isa-skill-installer.ts
@@ -463,7 +463,11 @@ async function reconcileSameVersion(ctx: ReconcileSameVersionContext): Promise<I
   for (const rel of missingFiles) {
     const dest = join(ctx.runtimeDir, rel);
     // rel comes from sourceFiles, so it is always a contentByRel key.
-    await writeSkillFile(dest, ctx.contentByRel.get(rel)!);
+    const content = ctx.contentByRel.get(rel);
+    if (content === undefined) {
+      throw new Error(`isa-skill-installer: no content for skill file ${rel}`);
+    }
+    await writeSkillFile(dest, content);
     written.push(dest);
   }
   // Handle the pre-baselines runtime case: existing runtime installed before
@@ -547,7 +551,11 @@ async function freshInstall(ctx: FreshInstallContext): Promise<IsaSkillInstallRe
   for (const rel of ctx.sourceFiles) {
     const dest = join(ctx.runtimeDir, rel);
     // rel comes from sourceFiles, so it is always a contentByRel key.
-    await writeSkillFile(dest, ctx.contentByRel.get(rel)!);
+    const content = ctx.contentByRel.get(rel);
+    if (content === undefined) {
+      throw new Error(`isa-skill-installer: no content for skill file ${rel}`);
+    }
+    await writeSkillFile(dest, content);
     written.push(dest);
   }
 

--- a/src/isa-skill-installer.ts
+++ b/src/isa-skill-installer.ts
@@ -92,15 +92,10 @@ async function listSkillFiles(root: string): Promise<string[]> {
   return out.sort();
 }
 
-async function hashSkillFiles(
-  root: string,
-  relativePaths: string[],
-  skillNameOverride?: string,
-  projectionSubstrate?: SubstrateId,
-): Promise<Record<string, string>> {
+function hashEntries(entries: readonly { rel: string; content: string }[]): Record<string, string> {
   const out: Record<string, string> = {};
-  for (const rel of relativePaths) {
-    out[rel] = sha256(transformSkillFileContent(rel, await readFile(join(root, rel), "utf8"), skillNameOverride, projectionSubstrate));
+  for (const { rel, content } of entries) {
+    out[rel] = sha256(content);
   }
   return out;
 }
@@ -183,15 +178,8 @@ async function readSkillFrontmatter(skillMdPath: string): Promise<SkillFrontmatt
   return parseSkillFrontmatter(await readFile(skillMdPath, "utf8"));
 }
 
-async function copySkillFile(
-  source: string,
-  destination: string,
-  relPath: string,
-  skillNameOverride?: string,
-  projectionSubstrate?: SubstrateId,
-): Promise<void> {
+async function writeSkillFile(destination: string, content: string): Promise<void> {
   await mkdir(dirname(destination), { recursive: true });
-  const content = transformSkillFileContent(relPath, await readFile(source, "utf8"), skillNameOverride, projectionSubstrate);
   await writeFile(destination, content, "utf8");
 }
 
@@ -205,6 +193,34 @@ function transformSkillFileContent(
     ? rewriteSubstrateProjectionContent({ substrate: projectionSubstrate, path: relPath, content })
     : content;
   return rewriteSkillNameFrontmatter(relPath, rewritten, skillNameOverride);
+}
+
+/**
+ * The single source of truth for ISA skill file CONTENT. Lists the source
+ * files (sorted) and applies the substrate transform to each, returning
+ * {rel, content} entries. Every ISA projection derives its bytes from here —
+ * the on-disk install writes (freshInstall / reconcileSameVersion), the
+ * baseline hashes, and the in-memory export bundle (projectIsaSkillBundleFiles)
+ * — so install and export cannot drift. Add any content transform HERE, never
+ * in a single caller, or the byte-identity invariant breaks silently.
+ */
+async function computeSourceFileEntries(
+  sourceDir: string,
+  skillNameOverride?: string,
+  projectionSubstrate?: SubstrateId,
+): Promise<{ rel: string; content: string }[]> {
+  const sourceFiles = await listSkillFiles(sourceDir);
+  const entries: { rel: string; content: string }[] = [];
+  for (const rel of sourceFiles) {
+    const content = transformSkillFileContent(
+      rel,
+      await readFile(join(sourceDir, rel), "utf8"),
+      skillNameOverride,
+      projectionSubstrate,
+    );
+    entries.push({ rel, content });
+  }
+  return entries;
 }
 
 interface DetectedDrift {
@@ -264,6 +280,48 @@ export function installIsaSkillProjection(options: InternalIsaSkillInstallOption
   return installIsaSkillInternal(options);
 }
 
+export interface IsaSkillBundleProjectionOptions {
+  somaRepoPath?: string;
+  skillNameOverride?: string;
+  projectionSubstrate?: SubstrateId;
+  /**
+   * Bundle-relative directory the ISA files live under (e.g. `skills/ISA`
+   * or `.cursor/rules/soma/skills/ISA`). Backslashes are normalized to `/`.
+   */
+  destinationPrefix: string;
+}
+
+/**
+ * Pure in-memory projection of the ISA skill for a substrate bundle.
+ *
+ * Returns the same file CONTENT `installIsaSkillProjection` writes under
+ * `<substrateHome>/<destinationPrefix>`, but as {path, content}[] with
+ * bundle-relative (forward-slash) paths and NO disk writes, baseline
+ * tracking, or drift logic. `soma export` uses this so an exported bundle's
+ * file set matches an installed home: the ISA skill has a
+ * dedicated managed projection and is therefore excluded from the generic
+ * portable-skill loop, so without this the bundle's `skills.md` lists the
+ * ISA skill while its files are absent.
+ *
+ * Mirrors a FRESH install — every source file is emitted verbatim (the
+ * drift/upgrade states only apply to a pre-existing on-disk runtime, which a
+ * freshly exported bundle never has). Returns [] when the configured
+ * somaRepoPath ships no skill (same no-op contract as the installer's
+ * "no-source" branch).
+ */
+export async function projectIsaSkillBundleFiles(
+  options: IsaSkillBundleProjectionOptions,
+): Promise<{ path: string; content: string }[]> {
+  const sourceDir = isaSkillSourceDir(resolveSomaRepoPath(options));
+  if (!(await exists(sourceDir))) return [];
+  const prefix = options.destinationPrefix.replace(/\\/g, "/").replace(/\/+$/, "");
+  const entries = await computeSourceFileEntries(sourceDir, options.skillNameOverride, options.projectionSubstrate);
+  return entries.map(({ rel, content }) => {
+    const relPosix = rel.replace(/\\/g, "/");
+    return { path: prefix ? `${prefix}/${relPosix}` : relPosix, content };
+  });
+}
+
 async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions = {}): Promise<IsaSkillInstallResult> {
   const somaHome = resolveSomaHome(options);
   const somaRepoPath = resolveSomaRepoPath(options);
@@ -296,8 +354,10 @@ async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions =
   if (sourceFrontmatter === null) {
     throw new Error(`ISA skill source ${SKILL_MD} missing version or pack-id frontmatter.`);
   }
-  const sourceFiles = await listSkillFiles(sourceDir);
-  const sourceHashes = await hashSkillFiles(sourceDir, sourceFiles, options.skillNameOverride, options.projectionSubstrate);
+  const sourceEntries = await computeSourceFileEntries(sourceDir, options.skillNameOverride, options.projectionSubstrate);
+  const sourceFiles = sourceEntries.map((entry) => entry.rel);
+  const contentByRel = new Map(sourceEntries.map((entry) => [entry.rel, entry.content] as const));
+  const sourceHashes = hashEntries(sourceEntries);
 
   const runtimeFrontmatter = await readSkillFrontmatter(join(runtimeDir, SKILL_MD));
   const baselinesRead = await readBaselines(somaHome);
@@ -311,9 +371,9 @@ async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions =
   if (runtimeFrontmatter === null || options.force === true) {
     return freshInstall({
       somaHome,
-      sourceDir,
       runtimeDir,
       sourceFiles,
+      contentByRel,
       sourceHashes,
       sourceVersion: sourceFrontmatter.version,
       runtimeVersionBefore: runtimeFrontmatter?.version ?? null,
@@ -321,8 +381,6 @@ async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions =
       markerPath,
       userAdditions,
       skillKey,
-      skillNameOverride: options.skillNameOverride,
-      projectionSubstrate: options.projectionSubstrate,
     });
   }
 
@@ -330,9 +388,9 @@ async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions =
   if (comparison <= 0) {
     return reconcileSameVersion({
       somaHome,
-      sourceDir,
       runtimeDir,
       sourceFiles,
+      contentByRel,
       sourceHashes,
       runtimeFiles,
       sourceVersion: sourceFrontmatter.version,
@@ -341,8 +399,6 @@ async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions =
       baseline: baselineForDest,
       userAdditions,
       skillKey,
-      skillNameOverride: options.skillNameOverride,
-      projectionSubstrate: options.projectionSubstrate,
     });
   }
 
@@ -361,9 +417,9 @@ async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions =
 
   return freshInstall({
     somaHome,
-    sourceDir,
     runtimeDir,
     sourceFiles,
+    contentByRel,
     sourceHashes,
     sourceVersion: sourceFrontmatter.version,
     runtimeVersionBefore: runtimeFrontmatter.version,
@@ -372,16 +428,14 @@ async function installIsaSkillInternal(options: InternalIsaSkillInstallOptions =
     userAdditions,
     actionOverride: "upgraded",
     skillKey,
-    skillNameOverride: options.skillNameOverride,
-    projectionSubstrate: options.projectionSubstrate,
   });
 }
 
 interface ReconcileSameVersionContext {
   somaHome: string;
-  sourceDir: string;
   runtimeDir: string;
   sourceFiles: string[];
+  contentByRel: Map<string, string>;
   sourceHashes: Record<string, string>;
   runtimeFiles: string[];
   sourceVersion: string;
@@ -390,8 +444,6 @@ interface ReconcileSameVersionContext {
   baseline: SomaSkillBaseline | undefined;
   userAdditions: string[];
   skillKey: string;
-  skillNameOverride?: string;
-  projectionSubstrate?: SubstrateId;
 }
 
 async function reconcileSameVersion(ctx: ReconcileSameVersionContext): Promise<IsaSkillInstallResult> {
@@ -410,7 +462,8 @@ async function reconcileSameVersion(ctx: ReconcileSameVersionContext): Promise<I
   const written: string[] = [];
   for (const rel of missingFiles) {
     const dest = join(ctx.runtimeDir, rel);
-    await copySkillFile(join(ctx.sourceDir, rel), dest, rel, ctx.skillNameOverride, ctx.projectionSubstrate);
+    // rel comes from sourceFiles, so it is always a contentByRel key.
+    await writeSkillFile(dest, ctx.contentByRel.get(rel)!);
     written.push(dest);
   }
   // Handle the pre-baselines runtime case: existing runtime installed before
@@ -476,9 +529,9 @@ async function writeUpgradeMarker(ctx: UpgradeMarkerContext): Promise<IsaSkillIn
 
 interface FreshInstallContext {
   somaHome: string;
-  sourceDir: string;
   runtimeDir: string;
   sourceFiles: string[];
+  contentByRel: Map<string, string>;
   sourceHashes: Record<string, string>;
   sourceVersion: string;
   runtimeVersionBefore: string | null;
@@ -487,15 +540,14 @@ interface FreshInstallContext {
   userAdditions: string[];
   actionOverride?: "fresh" | "upgraded";
   skillKey: string;
-  skillNameOverride?: string;
-  projectionSubstrate?: SubstrateId;
 }
 
 async function freshInstall(ctx: FreshInstallContext): Promise<IsaSkillInstallResult> {
   const written: string[] = [];
   for (const rel of ctx.sourceFiles) {
     const dest = join(ctx.runtimeDir, rel);
-    await copySkillFile(join(ctx.sourceDir, rel), dest, rel, ctx.skillNameOverride, ctx.projectionSubstrate);
+    // rel comes from sourceFiles, so it is always a contentByRel key.
+    await writeSkillFile(dest, ctx.contentByRel.get(rel)!);
     written.push(dest);
   }
 

--- a/src/isa-skill-installer.ts
+++ b/src/isa-skill-installer.ts
@@ -183,6 +183,26 @@ async function writeSkillFile(destination: string, content: string): Promise<voi
   await writeFile(destination, content, "utf8");
 }
 
+/**
+ * Write a skill file whose `rel` is known to come from the skill's own
+ * source listing, so `contentByRel` must contain it. Returns the written
+ * destination path. Throws if the (invariant-impossible) lookup misses,
+ * documenting the contract without a non-null assertion.
+ */
+async function writeKnownSkillFile(
+  runtimeDir: string,
+  rel: string,
+  contentByRel: Map<string, string>,
+): Promise<string> {
+  const dest = join(runtimeDir, rel);
+  const content = contentByRel.get(rel);
+  if (content === undefined) {
+    throw new Error(`isa-skill-installer: no content for skill file ${rel}`);
+  }
+  await writeSkillFile(dest, content);
+  return dest;
+}
+
 function transformSkillFileContent(
   relPath: string,
   content: string,
@@ -461,14 +481,7 @@ async function reconcileSameVersion(ctx: ReconcileSameVersionContext): Promise<I
   }
   const written: string[] = [];
   for (const rel of missingFiles) {
-    const dest = join(ctx.runtimeDir, rel);
-    // rel comes from sourceFiles, so it is always a contentByRel key.
-    const content = ctx.contentByRel.get(rel);
-    if (content === undefined) {
-      throw new Error(`isa-skill-installer: no content for skill file ${rel}`);
-    }
-    await writeSkillFile(dest, content);
-    written.push(dest);
+    written.push(await writeKnownSkillFile(ctx.runtimeDir, rel, ctx.contentByRel));
   }
   // Handle the pre-baselines runtime case: existing runtime installed before
   // the baseline feature shipped has no baseline entry. Seed one from the
@@ -549,14 +562,7 @@ interface FreshInstallContext {
 async function freshInstall(ctx: FreshInstallContext): Promise<IsaSkillInstallResult> {
   const written: string[] = [];
   for (const rel of ctx.sourceFiles) {
-    const dest = join(ctx.runtimeDir, rel);
-    // rel comes from sourceFiles, so it is always a contentByRel key.
-    const content = ctx.contentByRel.get(rel);
-    if (content === undefined) {
-      throw new Error(`isa-skill-installer: no content for skill file ${rel}`);
-    }
-    await writeSkillFile(dest, content);
-    written.push(dest);
+    written.push(await writeKnownSkillFile(ctx.runtimeDir, rel, ctx.contentByRel));
   }
 
   const baselines = { ...ctx.baselines };

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { join, relative } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import { runSomaCli } from "../src/cli";
@@ -20,6 +20,7 @@ import {
   INSTALL_SUBSTRATES,
   SUBSTRATE_LIFECYCLE_COMMAND_HELP,
 } from "../src/cli/substrate-lifecycle";
+import { installSpecFor } from "../src/install-spec-registry";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-cli-"));
@@ -1972,6 +1973,67 @@ test("cli export emits projection JSON without touching home", async () => {
     await expect(stat(join(homeDir, ".codex"))).rejects.toThrow();
   });
 });
+
+async function walkRelativeFiles(root: string): Promise<string[]> {
+  const out: string[] = [];
+  async function recurse(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const abs = join(dir, entry.name);
+      if (entry.isDirectory()) await recurse(abs);
+      else if (entry.isFile()) out.push(relative(root, abs).replace(/\\/g, "/"));
+    }
+  }
+  await recurse(root);
+  return out.sort();
+}
+
+// `soma export` must produce a COMPLETE bundle for EVERY substrate. The ISA
+// skill has a dedicated managed projection at install time and is excluded
+// from the generic portable-skill loop, so a naive export omits its files
+// while skills.md still lists it. The exported bundle's ISA set must match the
+// installed home byte-for-byte. Run per-substrate because the destination
+// prefix differs (codex/claude-code `skills/ISA`, cursor
+// `.cursor/rules/soma/skills/ISA`, pi-dev a custom dir + lowercase `isa` skill
+// name), so each prefix must be exercised or it could silently diverge. Prefix
+// + installed dir are derived from the install spec, exactly as
+// buildExportIsaProjection does, so the test can't drift from the production
+// prefix logic.
+for (const substrate of INSTALL_SUBSTRATES) {
+  test(`cli export ${substrate} bundle includes the ISA skill files, matching an installed home`, async () => {
+    await withTempHome(async (homeDir) => {
+      const spec = installSpecFor(substrate);
+      const substrateRoot = join(homeDir, spec.defaultHome);
+      const installedIsaDir = spec.isaSkillProjection.destinationDir(substrateRoot);
+      const prefix = relative(substrateRoot, installedIsaDir).replace(/\\/g, "/");
+
+      await runSomaCli(["install", substrate, "--apply", "--home-dir", homeDir]);
+
+      // Installed-home ISA file set (the source of truth for completeness).
+      const installedIsaFiles = await walkRelativeFiles(installedIsaDir);
+      expect(installedIsaFiles).toContain("SKILL.md");
+
+      const output = await runSomaCli(["export", substrate, "--home-dir", homeDir]);
+      const bundle = JSON.parse(output) as { path: string; content: string }[];
+
+      const bundleIsa = bundle
+        .filter((f) => f.path.startsWith(`${prefix}/`))
+        .map((f) => ({ rel: f.path.slice(prefix.length + 1), content: f.content }))
+        // Default code-unit order to match walkRelativeFiles / listSkillFiles.
+        .sort((a, b) => (a.rel < b.rel ? -1 : a.rel > b.rel ? 1 : 0));
+
+      // Same file set as the installed home...
+      expect(bundleIsa.map((f) => f.rel)).toEqual(installedIsaFiles);
+      expect(bundleIsa.length).toBeGreaterThan(0);
+
+      // ...with byte-identical content.
+      for (const { rel, content } of bundleIsa) {
+        const onDisk = await readFile(join(installedIsaDir, rel), "utf8");
+        expect(content).toBe(onDisk);
+      }
+    });
+  });
+}
 
 test("cli export cursor emits Cursor projection JSON", async () => {
   await withTempHome(async (homeDir) => {

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -228,6 +228,9 @@ test("pi.dev home projection normalizes portable skill paths and frontmatter nam
         ...portableProjectionInput.profile,
         skills: [
           {
+            // The canonical ISA skill has a dedicated, managed projection
+            // (installIsaSkillProjection); the generic portable-skill loop
+            // delegates it and must NOT also emit its files here.
             name: "ISA",
             path: "skills/ISA",
             description: "Ideal State Artifact.",
@@ -236,6 +239,20 @@ test("pi.dev home projection normalizes portable skill paths and frontmatter nam
               {
                 path: "SKILL.md",
                 content: "---\nname: ISA\n---\n\n# ISA\n",
+              },
+            ],
+          },
+          {
+            // A non-dedicated uppercase skill exercises the general
+            // name/path normalization (FAQ -> faq) through the portable loop.
+            name: "FAQ",
+            path: "skills/FAQ",
+            description: "Frequently asked questions.",
+            triggers: ["faq"],
+            files: [
+              {
+                path: "SKILL.md",
+                content: "---\nname: FAQ\n---\n\n# FAQ\n",
               },
             ],
           },
@@ -269,15 +286,18 @@ test("pi.dev home projection normalizes portable skill paths and frontmatter nam
     { homeDir: "/tmp/soma-test-home" },
   );
 
-  const isa = projection.bundle.files.find((file) => file.path === "agent/skills/isa/SKILL.md");
+  const faq = projection.bundle.files.find((file) => file.path === "agent/skills/faq/SKILL.md");
   const ledger = projection.bundle.files.find((file) => file.path === "agent/skills/ledger-update/SKILL.md");
   const bodyExample = projection.bundle.files.find((file) => file.path === "agent/skills/body-example/SKILL.md");
 
-  expect(isa?.content).toContain("name: isa");
-  expect(isa?.content).not.toContain("name: ISA");
+  expect(faq?.content).toContain("name: faq");
+  expect(faq?.content).not.toContain("name: FAQ");
   expect(ledger?.content).toContain("name: ledger-update");
   expect(bodyExample?.content).toContain("name: Body Example");
   expect(bodyExample?.content).not.toContain("name: body-example");
+  // The dedicated ISA skill is delegated to installIsaSkillProjection and is
+  // not double-emitted through the portable-skill loop (neither cased form).
+  expect(projection.bundle.files.map((file) => file.path)).not.toContain("agent/skills/isa/SKILL.md");
   expect(projection.bundle.files.map((file) => file.path)).not.toContain("agent/skills/ISA/SKILL.md");
 });
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import { installSomaForCodex, installSomaForPiDev, planSomaForCodexInstall, planSomaForPiDevInstall, somaWorkRegistryPaths } from "../src/index";
@@ -377,11 +377,22 @@ test("first install already converges: skills.md lists ISA and the file set matc
     expect(afterFirst).toContain("## ISA");
     expect(afterFirst).not.toContain("No Soma skills were declared.");
 
-    // Already converged: a second install reports the same file set and
-    // produces byte-identical skills.md. install #1 == install #2.
+    // Snapshot every projected file's bytes after the first install.
+    const resolveFile = (root: string, rel: string) => (isAbsolute(rel) ? rel : join(root, rel));
+    const readAll = async (root: string, files: string[]) =>
+      Object.fromEntries(
+        await Promise.all(
+          files.map(async (f) => [f, await readFile(resolveFile(root, f), "utf8")] as const),
+        ),
+      );
+    const firstBytes = await readAll(first.substrateHome.rootDir, first.substrateHome.files);
+
+    // Already converged: a second install reproduces the EXACT same file set
+    // — identical paths AND byte-identical content for every file, not just
+    // an equal count or a single skills.md spot-check. install #1 == install #2.
     const second = await installSomaForCodex({ homeDir });
-    expect(first.substrateHome.files).toHaveLength(second.substrateHome.files.length);
-    expect(await readFile(skillsPath, "utf8")).toBe(afterFirst);
+    expect([...second.substrateHome.files].sort()).toEqual([...first.substrateHome.files].sort());
+    expect(await readAll(second.substrateHome.rootDir, second.substrateHome.files)).toEqual(firstBytes);
   });
 });
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -363,6 +363,28 @@ test("install preserves existing soma profile edits before projecting to codex",
   });
 });
 
+test("first install already converges: skills.md lists ISA and the file set matches a re-install", async () => {
+  await withTempHome(async (homeDir) => {
+    const skillsPath = join(homeDir, ".codex/memories/soma/skills.md");
+
+    // The canonical ISA skill is written to <somaHome>/skills/ISA during
+    // this same install. The projection must already reflect it on the very
+    // first run — not render "No Soma skills were declared." and only
+    // converge on the second install (the context was previously snapshotted
+    // before the ISA baseline existed).
+    const first = await installSomaForCodex({ homeDir });
+    const afterFirst = await readFile(skillsPath, "utf8");
+    expect(afterFirst).toContain("## ISA");
+    expect(afterFirst).not.toContain("No Soma skills were declared.");
+
+    // Already converged: a second install reports the same file set and
+    // produces byte-identical skills.md. install #1 == install #2.
+    const second = await installSomaForCodex({ homeDir });
+    expect(first.substrateHome.files).toHaveLength(second.substrateHome.files.length);
+    expect(await readFile(skillsPath, "utf8")).toBe(afterFirst);
+  });
+});
+
 test("installed codex hook denies private Soma source writes to public destinations", async () => {
   await withTempHome(async (homeDir) => {
     await installSomaForCodex({ homeDir });


### PR DESCRIPTION
Fixes #312. **Stacked on #311 — draft until that merges.**

> ⚠️ **Depends on #311.** This PR builds on the ISA-exclusion fix in #311, so its branch currently contains **two commits**: #311's (`first install lists the ISA skill in skills.md`) underneath, and this PR's export commit on top. Once #311 merges, GitHub will narrow this PR to the single export commit and I'll mark it ready for review. Reviewing #311 first is the intended order.

## Problem

`soma export <substrate>` ran only the generic projection builders. The ISA skill has a dedicated managed projection at install time (`installIsaSkillProjection` — baseline tracking, drift detection, per-substrate `skillNameOverride` and destination dir) and is excluded from the generic portable-skill loop (#311). So an export bundle listed the ISA skill in `skills.md` but omitted its files — an incomplete projection that does not match an installed home. Every substrate had the same omission.

## Fix

- **`isa-skill-installer.ts`**: new pure `projectIsaSkillBundleFiles` — returns the same content `installIsaSkillProjection` writes, as in-memory `{path, content}[]` with bundle-relative **forward-slash** paths, no disk writes / baseline / drift. Mirrors a fresh install.
- **`substrate-lifecycle.ts`**: `buildExportProjection` appends the ISA projection, deriving the destination prefix per-substrate from the install spec (codex/claude-code `skills/ISA`, cursor `.cursor/rules/soma/skills/ISA`, pi-dev honors its `skillNameOverride`).

## Single content producer (hardening)

Export and the install write loop independently re-listed, re-read, and applied the per-file content transform, so the byte-identity invariant (exported bundle == installed home) rested only on a comment. Extracted one `computeSourceFileEntries(...)` as the single source of truth for ISA file CONTENT: the on-disk install writes, the baseline hashes, and the in-memory export bundle all derive their bytes from it. Behavior-preserving.

## Tests

A per-substrate generated test over `INSTALL_SUBSTRATES` derives each ISA destination prefix from the install spec exactly as `buildExportIsaProjection` does, then asserts the exported bundle's ISA set == the installed home **byte-for-byte**. Covers the non-trivial prefixes (cursor's nested rules dir, pi-dev's custom dir + lowercase skill name) that were otherwise unverified.

## Verification

- `bun run typecheck` clean
- The 4 new per-substrate export tests pass; A/B against the #311 base shows an identical failure set (zero regressions) on the touched test files
- **Platform scope:** verified on Windows 11 (typecheck + the 4 export tests + the A/B above). Export is substrate-neutral shared-core with no OS-specific code paths. Full reproducible evidence (commands, environment, output) will be posted when this flips from draft to ready after #311 merges and the branch narrows to the single export commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
