### PR TITLE
Fix #315: resolve export --out against ARC_INVOCATION_CWD

### DIFF
--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -427,7 +427,15 @@ function defaultSomaHomePath(homeDir?: string): string {
 }
 
 function resolveAbsolute(path: string): string {
-  return path.startsWith("/") ? path : resolveJoin(process.cwd(), path);
+  if (path.startsWith("/")) return path;
+  // soma#315: when soma is launched through an arc-generated shim, the
+  // shim `cd`s into the repo before exec, so process.cwd() is the repo
+  // root — not the directory the user ran `soma export` from. The shim
+  // exports the caller's directory as ARC_INVOCATION_CWD; resolve a
+  // relative --out against it, falling back to process.cwd() for direct
+  // (non-shim) invocations.
+  const base = process.env.ARC_INVOCATION_CWD ?? process.cwd();
+  return resolveJoin(base, path);
 }
 
 async function writeProjectionExportFile(

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1998,6 +1998,28 @@ test("cli export --out writes projection files into the out dir", async () => {
   });
 });
 
+test("cli export --out resolves a relative path against ARC_INVOCATION_CWD (soma#315)", async () => {
+  await withTempHome(async (homeDir) => {
+    await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);
+
+    // The arc shim `cd`s into the repo before exec, overwriting both
+    // process.cwd() and $PWD. It exports the caller's directory as
+    // ARC_INVOCATION_CWD so a relative --out resolves against the user's
+    // shell dir, not the repo root.
+    const previous = process.env.ARC_INVOCATION_CWD;
+    process.env.ARC_INVOCATION_CWD = homeDir;
+    try {
+      const output = await runSomaCli(["export", "codex", "--out", "exported-rel", "--home-dir", homeDir]);
+      const expectedOut = join(homeDir, "exported-rel");
+      expect(output).toContain(`out: ${expectedOut}`);
+      await expect(stat(join(expectedOut, "rules/soma.rules"))).resolves.toBeDefined();
+    } finally {
+      if (previous === undefined) delete process.env.ARC_INVOCATION_CWD;
+      else process.env.ARC_INVOCATION_CWD = previous;
+    }
+  });
+});
+
 test("cli export --out rejects symlink escape from within out dir", async () => {
   await withTempHome(async (homeDir) => {
     await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);


### PR DESCRIPTION
Closes #315. Soma side of a two-PR fix (arc shim is the-metafactory/arc#239).

## Problem
`soma export codex --out ./soma-codex-preview` wrote the projection to `<repo-root>/./soma-codex-preview` instead of `./soma-codex-preview` relative to the directory the user ran it from.

## Root cause
soma is launched through an arc-generated shim:
```bash
#!/bin/bash
cd "<repo>" && exec bun run src/cli.ts "$@"
```
The `cd` overwrites **both** `process.cwd()` and `$PWD` before soma's process starts (verified empirically). So `resolveAbsolute()` resolved a relative `--out` against the repo root. The data needed to do better — the caller's directory — was destroyed before any soma code ran.

## Fix
- arc#239: the shim exports the caller's directory as `ARC_INVOCATION_CWD` **before** the `cd`.
- This PR: `resolveAbsolute()` resolves a relative `--out` against `ARC_INVOCATION_CWD`, falling back to `process.cwd()` when unset (direct, non-shim invocation — unchanged behavior).

Absolute `--out` paths are unaffected.

## Verification
- New regression test: with `ARC_INVOCATION_CWD` set, a relative `--out` resolves under it (fails before the fix, passes after)
- `bun run lint` clean, `bun run typecheck` clean
- Full suite: 1254 pass / 0 fail

## Sequencing / behavior change
Before this PR, soma ignored `ARC_INVOCATION_CWD` entirely; relative `--out` always resolved against `process.cwd()`. After this PR, a relative `--out` resolves against `ARC_INVOCATION_CWD` **whenever that variable is set by any caller** — not only the arc#239 shim. In every current environment the variable is unset (no shim or other caller exports it yet), so the resolved path is identical to today's `process.cwd()` behavior. The change becomes load-bearing only once arc#239 ships. This is a deliberate, documented behavior change for that one env var, not an unconditional no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)