### PR TITLE
Fix #316: reject ephemeral /tmp bun path in hook config

### DIFF
--- a/src/bun-probe.ts
+++ b/src/bun-probe.ts
@@ -14,6 +14,8 @@
  * fire time. Both probes now always invoke `which bun`.
  */
 import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { sep } from "node:path";
 
 /**
  * Locate the bun binary on PATH. Returns the resolved path, or null
@@ -54,23 +56,75 @@ export function requireBunInPath(): void {
 }
 
 /**
- * Resolve a bun binary path for embedding in a hook's runtime
- * config. Order:
- *   1. `SOMA_BUN_PATH` env override
- *   2. `which bun`
- *   3. `process.execPath` when soma itself runs under Bun
- *      (last-resort fallback — keeps tests that set neither env
- *      nor PATH working when running via `bun test`)
+ * True when `execPath` points at an ephemeral Bun binary that will not
+ * survive a reboot, so it must never be embedded in a persistent hook
+ * command (soma#316).
  *
- * Throws when none resolve. Adopters should have called
- * `requireBunInPath` before getting here.
+ * When Bun runs a single script (`bun run …`) or as a standalone
+ * compiled executable, it extracts its runtime to a temp directory
+ * named like `/tmp/bun-node-<hash>/bun`. The reporter's
+ * `soma install claude-code --apply` embedded exactly such a path into
+ * `settings.json`; it works until the temp dir is cleaned and then the
+ * hook silently breaks. Either a `bun-node-*` path segment or any
+ * location under the OS temp dir is treated as ephemeral.
+ */
+export function isEphemeralBunPath(execPath: string): boolean {
+  if (!execPath) return false;
+  if (execPath.split(/[/\\]/).some((segment) => segment.startsWith("bun-node-"))) {
+    return true;
+  }
+  const tmp = tmpdir();
+  const tmpPrefix = tmp.endsWith(sep) ? tmp : tmp + sep;
+  return execPath === tmp || execPath.startsWith(tmpPrefix);
+}
+
+/**
+ * Pure resolution core (testable without touching the real env/PATH).
+ * Order:
+ *   1. `SOMA_BUN_PATH` override
+ *   2. `which bun` (PATH)
+ *   3. `process.execPath` when running under Bun — but only when it is a
+ *      durable path. An ephemeral `/tmp/bun-node-<hash>/bun` is rejected
+ *      (soma#316): embedding it would break the hook after a reboot, so
+ *      we fail loudly with remediation instead.
+ *
+ * Throws when none resolve.
+ */
+export function chooseBunExecutable(inputs: {
+  somaBunPath?: string;
+  fromPath: string | null;
+  runningUnderBun: boolean;
+  execPath: string;
+}): string {
+  if (inputs.somaBunPath) return inputs.somaBunPath;
+  if (inputs.fromPath !== null) return inputs.fromPath;
+  if (inputs.runningUnderBun && inputs.execPath && !isEphemeralBunPath(inputs.execPath)) {
+    return inputs.execPath;
+  }
+  const ephemeral = Boolean(inputs.execPath) && isEphemeralBunPath(inputs.execPath);
+  throw new Error(
+    [
+      "soma#73/#316: unable to resolve a durable Bun executable for the hook config.",
+      "",
+      ephemeral
+        ? `The only Bun found (${inputs.execPath}) is an ephemeral extraction that will not survive a reboot.`
+        : "Bun could not be located on PATH.",
+      "Install Bun (https://bun.sh) so `which bun` resolves, or set SOMA_BUN_PATH to an absolute, persistent bun path.",
+    ].join("\n"),
+  );
+}
+
+/**
+ * Resolve a bun binary path for embedding in a hook's runtime config.
+ * Thin wrapper over {@link chooseBunExecutable} that reads the real
+ * environment. Adopters should have called `requireBunInPath` before
+ * getting here.
  */
 export function resolveBunExecutable(): string {
-  if (process.env.SOMA_BUN_PATH) return process.env.SOMA_BUN_PATH;
-  const fromPath = locateBunOnPath();
-  if (fromPath !== null) return fromPath;
-  if ((process.versions as Record<string, string | undefined>).bun && process.execPath) {
-    return process.execPath;
-  }
-  throw new Error("soma#73: unable to resolve a Bun executable for the codex hook config.");
+  return chooseBunExecutable({
+    somaBunPath: process.env.SOMA_BUN_PATH,
+    fromPath: locateBunOnPath(),
+    runningUnderBun: Boolean((process.versions as Record<string, string | undefined>).bun),
+    execPath: process.execPath,
+  });
 }

--- a/src/bun-probe.ts
+++ b/src/bun-probe.ts
@@ -81,12 +81,14 @@ export function isEphemeralBunPath(execPath: string): boolean {
 /**
  * Pure resolution core (testable without touching the real env/PATH).
  * Order:
- *   1. `SOMA_BUN_PATH` override
- *   2. `which bun` (PATH)
- *   3. `process.execPath` when running under Bun — but only when it is a
- *      durable path. An ephemeral `/tmp/bun-node-<hash>/bun` is rejected
- *      (soma#316): embedding it would break the hook after a reboot, so
- *      we fail loudly with remediation instead.
+ *   1. `SOMA_BUN_PATH` override (explicit; honored verbatim)
+ *   2. `which bun` (PATH) — rejected if ephemeral
+ *   3. `process.execPath` when running under Bun — rejected if ephemeral
+ *
+ * Both auto-detected candidates (2 and 3) are screened: an ephemeral
+ * `/tmp/bun-node-<hash>/bun` is rejected (soma#316) because embedding it
+ * would break the hook after a reboot, so we fail loudly with
+ * remediation instead.
  *
  * Throws when none resolve.
  */
@@ -96,18 +98,31 @@ export function chooseBunExecutable(inputs: {
   runningUnderBun: boolean;
   execPath: string;
 }): string {
+  // SOMA_BUN_PATH is an explicit, deliberate override — honored verbatim.
   if (inputs.somaBunPath) return inputs.somaBunPath;
-  if (inputs.fromPath !== null) return inputs.fromPath;
+  // Both auto-detected sources (PATH, then the under-Bun execPath
+  // fallback) are screened for ephemerality (soma#316): `which bun` can
+  // itself resolve to a temp extraction, so the screen cannot be limited
+  // to execPath.
+  if (inputs.fromPath !== null && !isEphemeralBunPath(inputs.fromPath)) {
+    return inputs.fromPath;
+  }
   if (inputs.runningUnderBun && inputs.execPath && !isEphemeralBunPath(inputs.execPath)) {
     return inputs.execPath;
   }
-  const ephemeral = Boolean(inputs.execPath) && isEphemeralBunPath(inputs.execPath);
+  let ephemeralCandidate: string | undefined;
+  for (const candidate of [inputs.fromPath, inputs.execPath]) {
+    if (candidate && isEphemeralBunPath(candidate)) {
+      ephemeralCandidate = candidate;
+      break;
+    }
+  }
   throw new Error(
     [
       "soma#73/#316: unable to resolve a durable Bun executable for the hook config.",
       "",
-      ephemeral
-        ? `The only Bun found (${inputs.execPath}) is an ephemeral extraction that will not survive a reboot.`
+      ephemeralCandidate
+        ? `The only Bun found (${ephemeralCandidate}) is an ephemeral extraction that will not survive a reboot.`
         : "Bun could not be located on PATH.",
       "Install Bun (https://bun.sh) so `which bun` resolves, or set SOMA_BUN_PATH to an absolute, persistent bun path.",
     ].join("\n"),

--- a/src/bun-probe.ts
+++ b/src/bun-probe.ts
@@ -122,7 +122,7 @@ export function chooseBunExecutable(inputs: {
       "soma#73/#316: unable to resolve a durable Bun executable for the hook config.",
       "",
       ephemeralCandidate
-        ? `The only Bun found (${ephemeralCandidate}) is an ephemeral extraction that will not survive a reboot.`
+        ? `A candidate Bun (${ephemeralCandidate}) is an ephemeral extraction that will not survive a reboot.`
         : "Bun could not be located on PATH.",
       "Install Bun (https://bun.sh) so `which bun` resolves, or set SOMA_BUN_PATH to an absolute, persistent bun path.",
     ].join("\n"),

--- a/src/bun-probe.ts
+++ b/src/bun-probe.ts
@@ -60,13 +60,11 @@ export function requireBunInPath(): void {
  * survive a reboot, so it must never be embedded in a persistent hook
  * command (soma#316).
  *
- * When Bun runs a single script (`bun run …`) or as a standalone
- * compiled executable, it extracts its runtime to a temp directory
- * named like `/tmp/bun-node-<hash>/bun`. The reporter's
- * `soma install claude-code --apply` embedded exactly such a path into
- * `settings.json`; it works until the temp dir is cleaned and then the
- * hook silently breaks. Either a `bun-node-*` path segment or any
- * location under the OS temp dir is treated as ephemeral.
+ * In the soma#316 report, `soma install claude-code --apply` embedded
+ * `/tmp/bun-node-<hash>/bun` into `settings.json` — a temp extraction of
+ * Bun's runtime that works until the temp dir is cleaned, after which the
+ * hook silently breaks. We classify as ephemeral anything with a
+ * `bun-node-*` path segment or located under the OS temp dir.
  */
 export function isEphemeralBunPath(execPath: string): boolean {
   if (!execPath) return false;

--- a/test/bun-probe.test.ts
+++ b/test/bun-probe.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { chooseBunExecutable, isEphemeralBunPath } from "../src/bun-probe";
+
+describe("isEphemeralBunPath (soma#316)", () => {
+  test("flags bun's temp self-extraction dir", () => {
+    expect(isEphemeralBunPath("/tmp/bun-node-0d9b296af/bun")).toBe(true);
+    expect(isEphemeralBunPath("/home/u/.cache/bun-node-abc123/bun")).toBe(true);
+  });
+
+  test("flags any path under the OS temp dir", () => {
+    expect(isEphemeralBunPath(join(tmpdir(), "whatever", "bun"))).toBe(true);
+  });
+
+  test("does not flag a durable install path", () => {
+    expect(isEphemeralBunPath("/home/u/.bun/bin/bun")).toBe(false);
+    expect(isEphemeralBunPath("/opt/homebrew/bin/bun")).toBe(false);
+    expect(isEphemeralBunPath("/usr/local/bin/bun")).toBe(false);
+  });
+
+  test("empty path is not ephemeral", () => {
+    expect(isEphemeralBunPath("")).toBe(false);
+  });
+});
+
+describe("chooseBunExecutable (soma#316)", () => {
+  test("SOMA_BUN_PATH override wins, even over an ephemeral execPath", () => {
+    expect(
+      chooseBunExecutable({
+        somaBunPath: "/custom/bun",
+        fromPath: null,
+        runningUnderBun: true,
+        execPath: "/tmp/bun-node-x/bun",
+      }),
+    ).toBe("/custom/bun");
+  });
+
+  test("PATH-resolved bun wins over an ephemeral execPath", () => {
+    expect(
+      chooseBunExecutable({
+        fromPath: "/home/u/.bun/bin/bun",
+        runningUnderBun: true,
+        execPath: "/tmp/bun-node-x/bun",
+      }),
+    ).toBe("/home/u/.bun/bin/bun");
+  });
+
+  test("falls back to a durable execPath when nothing else resolves", () => {
+    expect(
+      chooseBunExecutable({
+        fromPath: null,
+        runningUnderBun: true,
+        execPath: "/home/u/.bun/bin/bun",
+      }),
+    ).toBe("/home/u/.bun/bin/bun");
+  });
+
+  test("rejects an ephemeral execPath instead of embedding it (the bug)", () => {
+    expect(() =>
+      chooseBunExecutable({
+        fromPath: null,
+        runningUnderBun: true,
+        execPath: "/tmp/bun-node-0d9b296af/bun",
+      }),
+    ).toThrow(/ephemeral|reboot|SOMA_BUN_PATH/);
+  });
+
+  test("throws when no bun resolves at all", () => {
+    expect(() =>
+      chooseBunExecutable({ fromPath: null, runningUnderBun: false, execPath: "" }),
+    ).toThrow(/SOMA_BUN_PATH|PATH/);
+  });
+});

--- a/test/bun-probe.test.ts
+++ b/test/bun-probe.test.ts
@@ -56,6 +56,26 @@ describe("chooseBunExecutable (soma#316)", () => {
     ).toBe("/home/u/.bun/bin/bun");
   });
 
+  test("rejects an ephemeral PATH result (which bun can resolve to /tmp)", () => {
+    expect(() =>
+      chooseBunExecutable({
+        fromPath: "/tmp/bun-node-x/bun",
+        runningUnderBun: false,
+        execPath: "",
+      }),
+    ).toThrow(/ephemeral|reboot|SOMA_BUN_PATH/);
+  });
+
+  test("skips an ephemeral PATH result but accepts a durable execPath", () => {
+    expect(
+      chooseBunExecutable({
+        fromPath: "/tmp/bun-node-x/bun",
+        runningUnderBun: true,
+        execPath: "/home/u/.bun/bin/bun",
+      }),
+    ).toBe("/home/u/.bun/bin/bun");
+  });
+
   test("rejects an ephemeral execPath instead of embedding it (the bug)", () => {
     expect(() =>
       chooseBunExecutable({


### PR DESCRIPTION
Closes #316.

## Problem
After `soma install claude-code --apply`, `~/.claude/settings.json` contained a hook command using an absolute bun path:
```
'/tmp/bun-node-0d9b296af/bun' '/home/.../soma-claude-code-hook.mjs' session-start
```
`/tmp/bun-node-*/bun` is Bun's ephemeral self-extraction (created when Bun runs a single script / as a standalone executable). It works initially but is deleted when the temp dir is cleaned, so the hook breaks after a reboot.

## Root cause
`resolveBunExecutable()` resolution order was: `SOMA_BUN_PATH` → `which bun` → `process.execPath`. On the reporter's machine `which bun` did not resolve from the install's spawn environment, so it fell to `process.execPath` — which, running under `bun run`, is the ephemeral `/tmp/bun-node-*` path.

## Fix
Keeps the soma#73 decision (embed an explicit absolute bun path rather than a bare `env bun`, which was found unreliable at hook-fire time). The auto-detected candidates are hardened, not removed:
- `SOMA_BUN_PATH` — explicit override, honored verbatim.
- `which bun` (PATH) — **rejected if ephemeral** (`which bun` can itself resolve to a temp extraction).
- `process.execPath` under Bun — **rejected if ephemeral**.

When no durable bun resolves, soma fails loudly with remediation (install bun on PATH, or set `SOMA_BUN_PATH`) instead of embedding a path that won't survive a reboot.

Resolution is refactored into a pure, injectable `chooseBunExecutable` core plus `isEphemeralBunPath` (a `bun-node-*` path segment, or any location under the OS temp dir, is ephemeral).

## Scope of the guarantee
Both auto-detected sources (PATH and the execPath fallback) are screened for ephemerality. `SOMA_BUN_PATH` is intentionally **not** screened — it is an explicit, deliberate operator override (the documented escape hatch); screening it would defeat its purpose.

## Verification
- `test/bun-probe.test.ts` (11 cases): `isEphemeralBunPath` classification; `chooseBunExecutable` precedence (override > PATH > durable execPath); rejects ephemeral PATH result; skips ephemeral PATH but accepts durable execPath; rejects ephemeral execPath; throws with remediation when nothing resolves
- `bun run lint` clean, `bun run typecheck` clean
- Full suite: 1265 pass / 0 fail

## Note on `which bun` failing
Why `which bun` failed in the report (PATH differences in the install spawn env) is environment-specific and out of scope here; this PR ensures that even when it does fail, no ephemeral path is embedded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification evidence (captured)
```
$ bun run lint
$ eslint .
   (no output — clean)

$ bun run typecheck
$ tsc --noEmit
   (no output — clean)

$ bun test test/bun-probe.test.ts
 11 pass
 0 fail
 14 expect() calls

$ bun test
 1265 pass
 0 fail
 4519 expect() calls
Ran 1265 tests across 86 files. [48.97s]
```
