### PR TITLE
Fix #317: codex hooks run under bun, not node

### DIFF
--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -295,7 +295,7 @@ function renderCodexHooksJson(): string {
             hooks: [
               {
                 type: "command",
-                command: "node ~/.codex/hooks/soma-lifecycle.mjs session-start",
+                command: "bun ~/.codex/hooks/soma-lifecycle.mjs session-start",
                 timeout: 30,
                 statusMessage: "Loading Soma lifecycle context",
               },
@@ -307,7 +307,7 @@ function renderCodexHooksJson(): string {
             hooks: [
               {
                 type: "command",
-                command: "node ~/.codex/hooks/soma-lifecycle.mjs prompt-submit",
+                command: "bun ~/.codex/hooks/soma-lifecycle.mjs prompt-submit",
                 timeout: 30,
                 statusMessage: "Classifying Soma Algorithm mode",
               },
@@ -320,7 +320,7 @@ function renderCodexHooksJson(): string {
             hooks: [
               {
                 type: "command",
-                command: "node ~/.codex/hooks/soma-lifecycle.mjs pre-tool-use",
+                command: "bun ~/.codex/hooks/soma-lifecycle.mjs pre-tool-use",
                 timeout: 30,
                 statusMessage: "Checking Soma private context policy",
               },
@@ -333,7 +333,7 @@ function renderCodexHooksJson(): string {
             hooks: [
               {
                 type: "command",
-                command: "node ~/.codex/hooks/soma-lifecycle.mjs algorithm-updated",
+                command: "bun ~/.codex/hooks/soma-lifecycle.mjs algorithm-updated",
                 timeout: 30,
                 statusMessage: "Refreshing Soma work index",
               },
@@ -345,7 +345,7 @@ function renderCodexHooksJson(): string {
             hooks: [
               {
                 type: "command",
-                command: "node ~/.codex/hooks/soma-lifecycle.mjs session-end",
+                command: "bun ~/.codex/hooks/soma-lifecycle.mjs session-end",
                 timeout: 30,
                 statusMessage: "Capturing Soma lifecycle learning",
               },

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -410,6 +410,12 @@ test("installs codex home projection into a substrate home", async () => {
     expect(hooks).toContain("SessionStart");
     expect(hooks).toContain("UserPromptSubmit");
     expect(hooks).toContain("PreToolUse");
+    // soma#317: hook commands must run under bun (Soma's declared runtime),
+    // not node — the README does not list node as a prerequisite, so a
+    // `node …` command would fail on a bun-only machine. Aligns with the
+    // soma#73 `#!/usr/bin/env bun` shebang the hook script already ships.
+    expect(hooks).not.toContain("node ~/.codex/hooks/soma-lifecycle.mjs");
+    expect(hooks).toContain("bun ~/.codex/hooks/soma-lifecycle.mjs session-start");
     // soma#73: hookScript ships verbatim with bun shebang; runtime config in JSON.
     expect(hookScript).toContain("#!/usr/bin/env bun");
     expect(hookScript).toContain("runCodexHook");

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -415,7 +415,15 @@ test("installs codex home projection into a substrate home", async () => {
     // `node …` command would fail on a bun-only machine. Aligns with the
     // soma#73 `#!/usr/bin/env bun` shebang the hook script already ships.
     expect(hooks).not.toContain("node ~/.codex/hooks/soma-lifecycle.mjs");
-    expect(hooks).toContain("bun ~/.codex/hooks/soma-lifecycle.mjs session-start");
+    for (const event of [
+      "session-start",
+      "prompt-submit",
+      "pre-tool-use",
+      "algorithm-updated",
+      "session-end",
+    ]) {
+      expect(hooks).toContain(`bun ~/.codex/hooks/soma-lifecycle.mjs ${event}`);
+    }
     // soma#73: hookScript ships verbatim with bun shebang; runtime config in JSON.
     expect(hookScript).toContain("#!/usr/bin/env bun");
     expect(hookScript).toContain("runCodexHook");


### PR DESCRIPTION
Closes #317.

## Problem
`soma install codex --apply` wrote `~/.codex/hooks.json` whose command entries invoked the hook via **node**:
```json
{ "type": "command", "command": "node ~/.codex/hooks/soma-lifecycle.mjs session-start", ... }
```
Node is not a declared Soma prerequisite — the README and `arc-manifest.yaml` (`runtime.bash.restricted_to: [bun, tsc]`) pin **bun**. On a bun-only machine the hooks fail.

## Root cause
`renderCodexHooksJson()` hardcoded `node …` for all five hook events (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop). This both required an undeclared runtime and bypassed the `#!/usr/bin/env bun` shebang the hook script already ships with (soma#73, `adapter.ts` line ~469).

## Fix
Run all five hook commands under `bun` instead of `node`. This aligns hooks.json with the shebang the script already carries and with Soma's bun-first design. `requireBunInPath` already guards install-time that bun is resolvable.

I kept the codex hook on a PATH-resolved `bun` (matching the soma#73 `#!/usr/bin/env bun` decision for codex), rather than embedding an absolute path — that PATH-vs-absolute choice was deliberate for codex and is orthogonal to this fix.

## Verification
```
$ bun run lint
$ eslint .
   (clean)
$ bun run typecheck
$ tsc --noEmit
   (clean)
$ bun test
 1265 pass / 0 fail
 Ran 1265 tests across 86 files. [48.06s]
```
New regression assertion in `test/home-projection.test.ts`: the codex hooks.json must not contain `node ~/.codex/hooks/soma-lifecycle.mjs` and must contain `bun ~/.codex/hooks/soma-lifecycle.mjs session-start` (fails before the fix, passes after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Runtime-pin evidence
`arc-manifest.yaml` (lines 45-49) restricts the allowed runtimes to bun and tsc — node is not listed:
```yaml
  bash:
    allowed: true
    restricted_to:
      - bun
      - tsc
```
README documents only bun for running soma (no node prerequisite):
```
$ grep -n 'bun install\|bun run soma' README.md
420:bun install
421:bun run soma --help
```