### PR TITLE
test(#318): lock init home-population with a non-flat Claude skills dir

### DIFF
--- a/test/onboarding-doctor.test.ts
+++ b/test/onboarding-doctor.test.ts
@@ -148,6 +148,35 @@ test("soma init skips Claude skills migration when the skills dir is empty", asy
   });
 });
 
+test("soma init skips a non-flat Claude skills dir yet still populates the home (#318)", async () => {
+  await withTempHome(async (homeDir) => {
+    // soma#318 (reported on 0.8.5): a ~/.claude/skills that is NOT a flat
+    // <Name>/SKILL.md tree must not trigger a migrate step (which refused
+    // with "not a flat skills tree"), and init must still fully populate
+    // the Soma home. The reporter saw an empty home plus a confusing
+    // import warning; fixed by #309. This locks the non-empty/non-flat
+    // variant the empty-dir test above does not cover.
+    await mkdir(join(homeDir, ".claude/skills"), { recursive: true });
+    await writeFile(join(homeDir, ".claude/skills/loose.md"), "not a <Name>/SKILL.md tree\n", "utf8");
+
+    const plan = await planSomaInit({ homeDir });
+    expect(plan.detected.claudeSkillsStatus).toBe("not-importable");
+    expect(plan.steps.map((step) => step.id)).toEqual([
+      "bootstrap-soma-home",
+      "install-codex",
+    ]);
+
+    const output = await runSomaCli(["init", "--apply", "--home-dir", homeDir]);
+    expect(output).toContain("soma init — applied");
+    expect(output).not.toContain("migrate-claude-skills");
+    expect(output).not.toContain("not a flat skills tree");
+    // Home is fully populated — not the empty dir the reporter observed.
+    await expect(stat(join(homeDir, ".soma/profile/principal.md"))).resolves.toBeTruthy();
+    await expect(stat(join(homeDir, ".soma/profile/telos.md"))).resolves.toBeTruthy();
+    await expect(stat(join(homeDir, ".soma/memory/WORK"))).resolves.toBeTruthy();
+  });
+});
+
 test("re-running soma init --apply never overwrites existing Soma home files", async () => {
   await withTempHome(async (homeDir) => {
     // Proves the doc claim in docs/soma-home-layout.md ("existing files are

--- a/test/onboarding-doctor.test.ts
+++ b/test/onboarding-doctor.test.ts
@@ -171,9 +171,20 @@ test("soma init skips a non-flat Claude skills dir yet still populates the home 
     expect(output).not.toContain("migrate-claude-skills");
     expect(output).not.toContain("not a flat skills tree");
     // Home is fully populated — not the empty dir the reporter observed.
-    await expect(stat(join(homeDir, ".soma/profile/principal.md"))).resolves.toBeTruthy();
-    await expect(stat(join(homeDir, ".soma/profile/telos.md"))).resolves.toBeTruthy();
-    await expect(stat(join(homeDir, ".soma/memory/WORK"))).resolves.toBeTruthy();
+    // Assert across every top-level area the bootstrap creates.
+    for (const relative of [
+      "profile/assistant.md",
+      "profile/principal.md",
+      "profile/telos.md",
+      "memory/WORK",
+      "memory/KNOWLEDGE",
+      "skills/README.md",
+      "policy/README.md",
+      "isa/INDEX.md",
+      "projections/README.md",
+    ]) {
+      await expect(stat(join(homeDir, ".soma", relative))).resolves.toBeTruthy();
+    }
   });
 });
 


### PR DESCRIPTION
Closes #318.

## TL;DR
#318 (reported on soma **0.8.5**) is **already fixed on `main` (0.8.6)** by #309. This PR adds the missing regression test for the reporter's specific scenario and closes the issue.

## The report (0.8.5)
`soma init --yes` produced an **empty** `~/.soma` and printed a confusing `soma migrate claude-skills: … is not a flat skills tree` warning; the home files only appeared later during `soma install`.

## Why it's already fixed on main
#309 changed the init flow:
- `planSomaInit` always plans `bootstrap-soma-home` **first**, so init fully populates `~/.soma` (profile, telos, memory taxonomy, skills, policy, isa) up front — independent of any later step.
- `migrate-claude-skills` is gated on `claudeSkillsStatus === "importable"`. A non-flat `~/.claude/skills` classifies as `not-importable`, so the step (and its warning) is skipped.

Reproduced the reporter's exact case (a non-flat `~/.claude/skills` holding a loose file) against `main`:
```
$ soma init --apply --home-dir <tmp> --soma-home <tmp>/.soma --substrate codex
soma init — applied
bootstrap-soma-home: applied (Soma home at <tmp>/.soma)
install-codex: applied (21 files)
# <tmp>/.soma fully populated: profile/, memory/<taxonomy>, policy/, skills/, isa/, projections/
# no migrate-claude-skills step, no "not a flat skills tree" warning
```

## What this PR adds
Existing tests cover the **empty** `~/.claude/skills` case but not the **non-empty / non-flat** case the reporter hit. New regression test in `test/onboarding-doctor.test.ts`:
- a loose-file (non-flat) `~/.claude/skills` classifies as `not-importable`
- the plan is exactly `[bootstrap-soma-home, install-codex]` (no migrate step)
- output contains no `not a flat skills tree` warning
- the Soma home is fully populated (`profile/principal.md`, `profile/telos.md`, `memory/WORK`)

## Verification
```
$ bun run lint        # clean
$ bun run typecheck   # clean
$ bun test
 1266 pass / 0 fail
 Ran 1266 tests across 86 files. [47.45s]
```

Recommend the reporter upgrade to ≥0.8.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)