### PR TITLE
fix(bun-probe): validate the frozen bun path and resolve it win32-correctly (#316 sibling)

### DIFF
--- a/src/bun-probe.ts
+++ b/src/bun-probe.ts
@@ -1,63 +1,96 @@
 /**
- * Bun discovery + pre-flight (soma#73 sage r1).
+ * Bun discovery + pre-flight.
  *
  * Two callers in the install/adapter surfaces need the same logic:
  *   - `requireBunInPath` — installer pre-flight; throws + remediation
- *     when `env bun` cannot resolve from the substrate's later
- *     spawn environment
- *   - `resolveBunExecutable` — codex adapter; returns an explicit
- *     bun binary path to embed in the hook's runtime config
+ *     when no spawnable, durable bun can be resolved
+ *   - `resolveBunExecutable` — substrate adapters (codex, claude-code);
+ *     returns the validated bun binary path frozen into hook commands
+ *     and runtime configs
  *
- * Sage r1: the previous `process.versions.bun` shortcut bypassed the
- * `which bun` check when the installer happened to be running under
- * Bun. That proves nothing about whether `env bun` resolves at hook
- * fire time. Both probes now always invoke `which bun`.
+ * Two INDEPENDENT failure classes are guarded here, and both must be —
+ * neither check subsumes the other:
+ *
+ *   - soma#316 (ephemeral): under `bun run`, `process.execPath` (and
+ *     sometimes `which bun`) is `/tmp/bun-node-<hash>/bun`, a temp
+ *     self-extraction of Bun's runtime. It spawns fine NOW but is
+ *     deleted on cleanup, so a hook command frozen with it silently
+ *     breaks after a reboot. Passing a `--version` probe is therefore
+ *     not enough — a candidate must also be DURABLE. `isEphemeralBunPath`
+ *     screens it (kept from #320).
+ *   - win32/MSYS (unspawnable): `which` does not exist on native
+ *     Windows and, under Git Bash/MSYS, answers in a path dialect
+ *     (`/c/Users/...`, forward slashes, no `.exe`) that no native
+ *     Windows spawn can resolve. On a fail-open hook platform a frozen
+ *     unspawnable path is not an error: the hook never launches and the
+ *     policy gate silently disables. So on win32 the resolver probes
+ *     `where` (never `which`), normalizes the MSYS dialect, and every
+ *     candidate is checked on disk + spawn-probed (`<path> --version`)
+ *     before it is frozen.
+ *
+ * An ephemeral path passes the spawn probe; an MSYS-dialect path is not
+ * under the temp dir. Both screens run, on every candidate.
  */
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { sep } from "node:path";
 
-/**
- * Locate the bun binary on PATH. Returns the resolved path, or null
- * when bun is unavailable.
- *
- * Always runs `which bun` — running under bun is NOT evidence that
- * a shebang-resolved `env bun` will succeed in the hook's later
- * spawn environment (different PATH, different shell, restricted
- * env via the substrate, etc.).
- */
-export function locateBunOnPath(): string | null {
-  const which = spawnSync("which", ["bun"], { encoding: "utf8" });
-  if (which.status !== 0) return null;
-  const resolved = which.stdout.trim().split("\n")[0];
-  return resolved.length > 0 ? resolved : null;
-}
+/** Where a candidate bun path came from — named in validation errors. */
+export type BunPathSource = "SOMA_BUN_PATH" | "process.execPath" | "where bun" | "which bun";
 
 /**
- * Installer pre-flight. Throws with remediation when bun is not on
- * PATH; returns silently when it is.
- *
- * `SOMA_BUN_PATH` is accepted as an explicit override for unusual
- * deployments (CI sandboxes, etc.). The hook's shebang is still
- * `#!/usr/bin/env bun`; users with a non-PATH bun must keep the
- * override path resolvable when the hook fires.
+ * Filesystem/spawn seam: production uses the real default; tests inject
+ * a fixture probe to drive every platform/normalization/validation
+ * branch hermetically. Never passed by production callers.
  */
-export function requireBunInPath(): void {
-  if (process.env.SOMA_BUN_PATH) return;
-  if (locateBunOnPath() !== null) return;
-  throw new Error(
-    [
-      "soma adopt: Bun not found in PATH.",
-      "",
-      "Every substrate hook installed by soma runs under Bun (#!/usr/bin/env bun).",
-      "Install Bun (https://bun.sh) and re-run, or set SOMA_BUN_PATH to an absolute path.",
-    ].join("\n"),
-  );
+export interface BunPathProbe {
+  exists(candidate: string): boolean;
+  /** Run `<candidate> --version` (5s timeout). `ok` iff exit 0. */
+  spawnVersion(candidate: string): { ok: boolean; detail: string };
+  /** First PATH hit from `which bun` / `where bun`, or null. */
+  locate(tool: "which" | "where"): string | null;
 }
+
+export interface ResolveBunPathInput {
+  env?: Record<string, string | undefined>;
+  platform?: string;
+  execPath?: string;
+  runningUnderBun?: boolean;
+  probe?: BunPathProbe;
+}
+
+const SPAWN_PROBE_TIMEOUT_MS = 5_000;
+
+const defaultProbe: BunPathProbe = {
+  exists: (candidate) => existsSync(candidate),
+  spawnVersion: (candidate) => {
+    const result = spawnSync(candidate, ["--version"], {
+      encoding: "utf8",
+      timeout: SPAWN_PROBE_TIMEOUT_MS,
+      windowsHide: true,
+    });
+    if (result.error) return { ok: false, detail: String(result.error) };
+    if (result.status !== 0) {
+      const stderr = (result.stderr ?? "").trim();
+      return { ok: false, detail: `exit ${result.status}${stderr ? `: ${stderr}` : ""}` };
+    }
+    return { ok: true, detail: (result.stdout ?? "").trim() };
+  },
+  locate: (tool) => {
+    const result = spawnSync(tool, ["bun"], { encoding: "utf8", windowsHide: true });
+    if (result.error || result.status !== 0) return null;
+    // `where` lists every PATH hit (shims before the real exe is
+    // common under scoop) — take the first; validation makes a wrong
+    // pick loud instead of latent.
+    const first = (result.stdout ?? "").trim().split(/\r?\n/)[0]?.trim() ?? "";
+    return first.length > 0 ? first : null;
+  },
+};
 
 /**
  * True when `execPath` points at an ephemeral Bun binary that will not
- * survive a reboot, so it must never be embedded in a persistent hook
+ * survive a reboot, so it must never be frozen into a persistent hook
  * command (soma#316).
  *
  * In the soma#316 report, `soma install claude-code --apply` embedded
@@ -77,67 +110,184 @@ export function isEphemeralBunPath(execPath: string): boolean {
 }
 
 /**
- * Pure resolution core (testable without touching the real env/PATH).
- * Order:
- *   1. `SOMA_BUN_PATH` override (explicit; honored verbatim)
- *   2. `which bun` (PATH) — rejected if ephemeral
- *   3. `process.execPath` when running under Bun — rejected if ephemeral
- *
- * Both auto-detected candidates (2 and 3) are screened: an ephemeral
- * `/tmp/bun-node-<hash>/bun` is rejected (soma#316) because embedding it
- * would break the hook after a reboot, so we fail loudly with
- * remediation instead.
- *
- * Throws when none resolve.
+ * MSYS/Git Bash answers paths in a dialect native Windows spawns
+ * cannot resolve: `/c/Users/.../bun` (forward slashes, drive as a
+ * root directory, no `.exe`). Normalize to `C:\Users\...\bun.exe`
+ * BEFORE validation so a Git Bash-driven install succeeds with a
+ * correct value rather than freezing a poisoned one.
  */
-export function chooseBunExecutable(inputs: {
-  somaBunPath?: string;
-  fromPath: string | null;
-  runningUnderBun: boolean;
-  execPath: string;
-}): string {
-  // SOMA_BUN_PATH is an explicit, deliberate override — honored verbatim.
-  if (inputs.somaBunPath) return inputs.somaBunPath;
-  // Both auto-detected sources (PATH, then the under-Bun execPath
-  // fallback) are screened for ephemerality (soma#316): `which bun` can
-  // itself resolve to a temp extraction, so the screen cannot be limited
-  // to execPath.
-  if (inputs.fromPath !== null && !isEphemeralBunPath(inputs.fromPath)) {
-    return inputs.fromPath;
+function normalizeWin32Candidate(raw: string, probe: BunPathProbe): string {
+  let candidate = raw.trim();
+  const msys = /^\/(?:cygdrive\/)?([A-Za-z])\/(.*)$/.exec(candidate);
+  if (msys) candidate = `${msys[1].toUpperCase()}:\\${msys[2].replace(/\//g, "\\")}`;
+  if (!candidate.toLowerCase().endsWith(".exe") && !probe.exists(candidate) && probe.exists(`${candidate}.exe`)) {
+    candidate = `${candidate}.exe`;
   }
-  if (inputs.runningUnderBun && inputs.execPath && !isEphemeralBunPath(inputs.execPath)) {
-    return inputs.execPath;
-  }
-  let ephemeralCandidate: string | undefined;
-  for (const candidate of [inputs.fromPath, inputs.execPath]) {
-    if (candidate && isEphemeralBunPath(candidate)) {
-      ephemeralCandidate = candidate;
-      break;
-    }
-  }
-  throw new Error(
+  return candidate;
+}
+
+function validationError(input: { raw: string; candidate: string; source: BunPathSource; failure: string }): Error {
+  const rawNote = input.raw === input.candidate ? "" : ` (raw value "${input.raw}")`;
+  return new Error(
     [
-      "soma#73/#316: unable to resolve a durable Bun executable for the hook config.",
+      "soma: refusing to freeze an unspawnable Bun path.",
       "",
-      ephemeralCandidate
-        ? `A candidate Bun (${ephemeralCandidate}) is an ephemeral extraction that will not survive a reboot.`
-        : "Bun could not be located on PATH.",
-      "Install Bun (https://bun.sh) so `which bun` resolves, or set SOMA_BUN_PATH to an absolute, persistent bun path.",
+      `  candidate: ${input.candidate}${rawNote}`,
+      `  source:    ${input.source}`,
+      `  failure:   ${input.failure}`,
+      "",
+      "This value would be frozen into substrate hook commands; on a fail-open",
+      "hook platform an unlaunchable hook silently disables Soma's policy gate.",
+      "Set SOMA_BUN_PATH to the absolute native path of the bun binary",
+      "(Windows: C:\\...\\bun.exe) or ensure `bun` resolves on PATH, then re-run.",
+    ].join("\n"),
+  );
+}
+
+function ephemeralError(input: { candidate: string; source: BunPathSource }): Error {
+  return new Error(
+    [
+      "soma#316: refusing to freeze an ephemeral Bun path.",
+      "",
+      `  candidate: ${input.candidate}`,
+      `  source:    ${input.source}`,
+      "",
+      "This is Bun's temporary self-extraction (a `bun-node-*` dir under the OS",
+      "temp dir). It spawns now but is deleted on cleanup, so a frozen hook command",
+      "would silently break after a reboot — on a fail-open hook platform that also",
+      "disables Soma's policy gate.",
+      "Set SOMA_BUN_PATH to a durable, absolute bun path (Windows: C:\\...\\bun.exe),",
+      "or install Bun (https://bun.sh) so a persistent `bun` resolves on PATH.",
+    ].join("\n"),
+  );
+}
+
+function bunNotFoundError(platform: string): Error {
+  const probeName = platform === "win32" ? "`where bun`" : "`which bun`";
+  return new Error(
+    [
+      "soma: Bun not found.",
+      "",
+      `No SOMA_BUN_PATH override, not running under Bun, and ${probeName} found nothing.`,
+      "Every substrate hook installed by soma runs under Bun.",
+      "Install Bun (https://bun.sh) and re-run, or set SOMA_BUN_PATH to an absolute path.",
     ].join("\n"),
   );
 }
 
 /**
- * Resolve a bun binary path for embedding in a hook's runtime config.
- * Thin wrapper over {@link chooseBunExecutable} that reads the real
- * environment. Adopters should have called `requireBunInPath` before
- * getting here.
+ * Resolve and VALIDATE the bun binary path frozen into substrate
+ * configs. Resolution order:
+ *   - win32: SOMA_BUN_PATH -> process.execPath when running under bun
+ *     (always a spawn-valid native path, immune to the MSYS dialect by
+ *     construction) -> `where bun` first hit. `which` is never invoked
+ *     on win32.
+ *   - POSIX (unchanged order): SOMA_BUN_PATH -> `which bun` ->
+ *     process.execPath when running under bun.
+ *
+ * Each PRESENT candidate is normalized (win32 MSYS form), then screened:
+ *   1. soma#316 ephemeral — a `/tmp/bun-node-*` path is durable-unsafe.
+ *      An explicit SOMA_BUN_PATH set to one fails loudly (the user named
+ *      it); an auto-detected one is SKIPPED so a durable source (e.g.
+ *      `where bun`) can still win, exactly as #320 intended.
+ *   2. existsSync + a `--version` spawn probe. A present-but-broken
+ *      candidate throws (naming the candidate and source) rather than
+ *      falling through — silent fallthrough is how a wrong path goes
+ *      latent.
+ * No candidate at all throws the install-bun remediation (mentioning the
+ * ephemeral hit if that was the only thing seen).
+ */
+export function resolveValidatedBunPath(input: ResolveBunPathInput = {}): string {
+  const env = input.env ?? process.env;
+  const platform = input.platform ?? process.platform;
+  const probe = input.probe ?? defaultProbe;
+  const execPath = input.execPath ?? process.execPath;
+  const runningUnderBun =
+    input.runningUnderBun ?? Boolean((process.versions as Record<string, string | undefined>).bun);
+
+  const fromEnv = (): string | null => {
+    const value = env.SOMA_BUN_PATH;
+    return value && value.trim().length > 0 ? value : null;
+  };
+  const fromExecPath = (): string | null => (runningUnderBun && execPath ? execPath : null);
+  const fromLocate = (tool: "which" | "where") => (): string | null => probe.locate(tool);
+
+  const producers: Array<{ source: BunPathSource; explicit?: boolean; get: () => string | null }> =
+    platform === "win32"
+      ? [
+          { source: "SOMA_BUN_PATH", explicit: true, get: fromEnv },
+          { source: "process.execPath", get: fromExecPath },
+          { source: "where bun", get: fromLocate("where") },
+        ]
+      : [
+          { source: "SOMA_BUN_PATH", explicit: true, get: fromEnv },
+          { source: "which bun", get: fromLocate("which") },
+          { source: "process.execPath", get: fromExecPath },
+        ];
+
+  let ephemeralSeen: { candidate: string; source: BunPathSource } | null = null;
+
+  for (const producer of producers) {
+    const raw = producer.get();
+    if (raw === null) continue;
+    const candidate = platform === "win32" ? normalizeWin32Candidate(raw, probe) : raw.trim();
+
+    if (isEphemeralBunPath(candidate)) {
+      // An explicit override that is ephemeral is a loud error (the user
+      // pointed at a doomed path on purpose); an auto-detected one is
+      // skipped so a durable source can still win (soma#316/#320).
+      if (producer.explicit) throw ephemeralError({ candidate, source: producer.source });
+      ephemeralSeen = { candidate, source: producer.source };
+      continue;
+    }
+
+    if (!probe.exists(candidate)) {
+      throw validationError({ raw, candidate, source: producer.source, failure: "not found on disk (existsSync)" });
+    }
+    const version = probe.spawnVersion(candidate);
+    if (!version.ok) {
+      throw validationError({
+        raw,
+        candidate,
+        source: producer.source,
+        failure: `spawn probe \`${candidate} --version\` failed: ${version.detail}`,
+      });
+    }
+    return candidate;
+  }
+
+  if (ephemeralSeen) throw ephemeralError(ephemeralSeen);
+  throw bunNotFoundError(platform);
+}
+
+// One spawn probe per process per SOMA_BUN_PATH value: the resolver is
+// called from several freeze sites per install and from test batteries
+// thousands of times; re-probing an already-validated path only adds
+// Windows spawn pressure. Failures are never cached.
+const validatedByEnvOverride = new Map<string, string>();
+
+/**
+ * Resolve the validated bun binary path for embedding in substrate hook
+ * commands and runtime configs. Memoized per process (keyed on the
+ * SOMA_BUN_PATH override value). Throws when no durable, spawnable bun
+ * resolves — adopters get the same error from `requireBunInPath`.
  */
 export function resolveBunExecutable(): string {
-  return chooseBunExecutable({
-    somaBunPath: process.env.SOMA_BUN_PATH,
-    fromPath: locateBunOnPath(),
-    runningUnderBun: Boolean((process.versions as Record<string, string | undefined>).bun),
-    execPath: process.execPath,
-  });
+  const key = process.env.SOMA_BUN_PATH ?? "";
+  const cached = validatedByEnvOverride.get(key);
+  if (cached !== undefined) return cached;
+  const resolved = resolveValidatedBunPath();
+  validatedByEnvOverride.set(key, resolved);
+  return resolved;
+}
+
+/**
+ * Installer pre-flight. Throws with remediation when no VALIDATED bun
+ * resolves; returns silently when one does. A set-but-broken
+ * `SOMA_BUN_PATH` now fails here (it used to be trusted verbatim — an
+ * MSYS-dialect or ephemeral override reproduces the exact fail-open
+ * incidents the validation exists to prevent).
+ */
+export function requireBunInPath(): void {
+  resolveBunExecutable();
 }

--- a/test/bun-probe.test.ts
+++ b/test/bun-probe.test.ts
@@ -1,7 +1,48 @@
-import { describe, test, expect } from "bun:test";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { chooseBunExecutable, isEphemeralBunPath } from "../src/bun-probe";
+import { describe, expect, test } from "bun:test";
+import {
+  type BunPathProbe,
+  isEphemeralBunPath,
+  requireBunInPath,
+  resolveBunExecutable,
+  resolveValidatedBunPath,
+} from "../src/bun-probe";
+
+// Hermetic probe fixture: a tiny in-memory filesystem + spawn table so
+// every platform/normalization/validation branch runs without touching
+// the real disk or spawning anything. `calls` records which PATH
+// locators ran and which candidates were spawn-probed — the "which is
+// never invoked on win32" and "no silent fallthrough" assertions hang
+// off it.
+function fixtureProbe(input: {
+  files?: string[];
+  spawnFails?: string[];
+  located?: Partial<Record<"which" | "where", string | null>>;
+}): { probe: BunPathProbe; calls: { locate: string[]; spawned: string[] } } {
+  const files = new Set(input.files ?? []);
+  const spawnFails = new Set(input.spawnFails ?? []);
+  const calls = { locate: [] as string[], spawned: [] as string[] };
+  const probe: BunPathProbe = {
+    exists: (candidate) => files.has(candidate),
+    spawnVersion: (candidate) => {
+      calls.spawned.push(candidate);
+      return spawnFails.has(candidate)
+        ? { ok: false, detail: "exit 1: fixture failure" }
+        : { ok: true, detail: "1.2.3" };
+    },
+    locate: (tool) => {
+      calls.locate.push(tool);
+      return input.located?.[tool] ?? null;
+    },
+  };
+  return { probe, calls };
+}
+
+const WIN_BUN = "C:\\Users\\kyle\\scoop\\apps\\bun\\current\\bun.exe";
+const WIN_WHERE_BUN = "C:\\Users\\kyle\\scoop\\shims\\bun.exe";
+const POSIX_BUN = "/home/kyle/.bun/bin/bun";
 
 describe("isEphemeralBunPath (soma#316)", () => {
   test("flags bun's temp self-extraction dir", () => {
@@ -24,71 +65,262 @@ describe("isEphemeralBunPath (soma#316)", () => {
   });
 });
 
-describe("chooseBunExecutable (soma#316)", () => {
+// The #320 ephemeral guarantees, re-expressed against the validating
+// resolver that replaces the old pure `chooseBunExecutable`. A frozen
+// path must be DURABLE, not merely spawnable — these lock that in.
+describe("resolveValidatedBunPath — soma#316 ephemeral screening", () => {
   test("SOMA_BUN_PATH override wins, even over an ephemeral execPath", () => {
+    const { probe } = fixtureProbe({ files: ["/custom/bun"] });
     expect(
-      chooseBunExecutable({
-        somaBunPath: "/custom/bun",
-        fromPath: null,
-        runningUnderBun: true,
+      resolveValidatedBunPath({
+        env: { SOMA_BUN_PATH: "/custom/bun" },
+        platform: "linux",
         execPath: "/tmp/bun-node-x/bun",
+        runningUnderBun: true,
+        probe,
       }),
     ).toBe("/custom/bun");
   });
 
   test("PATH-resolved bun wins over an ephemeral execPath", () => {
+    const { probe } = fixtureProbe({ files: [POSIX_BUN], located: { which: POSIX_BUN } });
     expect(
-      chooseBunExecutable({
-        fromPath: "/home/u/.bun/bin/bun",
-        runningUnderBun: true,
+      resolveValidatedBunPath({
+        env: {},
+        platform: "linux",
         execPath: "/tmp/bun-node-x/bun",
+        runningUnderBun: true,
+        probe,
       }),
-    ).toBe("/home/u/.bun/bin/bun");
+    ).toBe(POSIX_BUN);
   });
 
   test("falls back to a durable execPath when nothing else resolves", () => {
+    const { probe } = fixtureProbe({ files: [POSIX_BUN] });
     expect(
-      chooseBunExecutable({
-        fromPath: null,
-        runningUnderBun: true,
-        execPath: "/home/u/.bun/bin/bun",
-      }),
-    ).toBe("/home/u/.bun/bin/bun");
-  });
-
-  test("rejects an ephemeral PATH result (which bun can resolve to /tmp)", () => {
-    expect(() =>
-      chooseBunExecutable({
-        fromPath: "/tmp/bun-node-x/bun",
-        runningUnderBun: false,
-        execPath: "",
-      }),
-    ).toThrow(/ephemeral|reboot|SOMA_BUN_PATH/);
+      resolveValidatedBunPath({ env: {}, platform: "linux", execPath: POSIX_BUN, runningUnderBun: true, probe }),
+    ).toBe(POSIX_BUN);
   });
 
   test("skips an ephemeral PATH result but accepts a durable execPath", () => {
+    const { probe } = fixtureProbe({ files: [POSIX_BUN], located: { which: "/tmp/bun-node-x/bun" } });
     expect(
-      chooseBunExecutable({
-        fromPath: "/tmp/bun-node-x/bun",
-        runningUnderBun: true,
-        execPath: "/home/u/.bun/bin/bun",
-      }),
-    ).toBe("/home/u/.bun/bin/bun");
+      resolveValidatedBunPath({ env: {}, platform: "linux", execPath: POSIX_BUN, runningUnderBun: true, probe }),
+    ).toBe(POSIX_BUN);
   });
 
-  test("rejects an ephemeral execPath instead of embedding it (the bug)", () => {
+  test("rejects an ephemeral execPath instead of freezing it (the bug)", () => {
+    const { probe } = fixtureProbe({});
     expect(() =>
-      chooseBunExecutable({
-        fromPath: null,
-        runningUnderBun: true,
+      resolveValidatedBunPath({
+        env: {},
+        platform: "linux",
         execPath: "/tmp/bun-node-0d9b296af/bun",
+        runningUnderBun: true,
+        probe,
       }),
-    ).toThrow(/ephemeral|reboot|SOMA_BUN_PATH/);
+    ).toThrow(/ephemeral|reboot/);
   });
 
-  test("throws when no bun resolves at all", () => {
+  test("rejects an ephemeral PATH result when no durable source remains", () => {
+    const { probe } = fixtureProbe({ located: { which: "/tmp/bun-node-x/bun" } });
     expect(() =>
-      chooseBunExecutable({ fromPath: null, runningUnderBun: false, execPath: "" }),
-    ).toThrow(/SOMA_BUN_PATH|PATH/);
+      resolveValidatedBunPath({ env: {}, platform: "linux", execPath: "", runningUnderBun: false, probe }),
+    ).toThrow(/ephemeral|reboot/);
+  });
+
+  test("an explicit ephemeral SOMA_BUN_PATH fails loudly (the user named a doomed path)", () => {
+    const { probe, calls } = fixtureProbe({});
+    const attempt = () =>
+      resolveValidatedBunPath({ env: { SOMA_BUN_PATH: "/tmp/bun-node-x/bun" }, platform: "linux", probe });
+    expect(attempt).toThrow(/ephemeral|reboot/);
+    expect(attempt).toThrow(/SOMA_BUN_PATH/);
+    expect(calls.spawned).toEqual([]); // rejected before any spawn probe
+  });
+});
+
+describe("resolveValidatedBunPath — win32/MSYS resolution + validation", () => {
+  test("win32: execPath-under-bun wins when no env override; which is never invoked", () => {
+    const { probe, calls } = fixtureProbe({ files: [WIN_BUN, WIN_WHERE_BUN], located: { where: WIN_WHERE_BUN } });
+    const resolved = resolveValidatedBunPath({
+      env: {},
+      platform: "win32",
+      execPath: WIN_BUN,
+      runningUnderBun: true,
+      probe,
+    });
+    expect(resolved).toBe(WIN_BUN);
+    expect(calls.locate).toEqual([]); // execPath won before any PATH probe
+    expect(calls.spawned).toEqual([WIN_BUN]);
+  });
+
+  test("win32: `where bun` is the fallback when not running under bun; which is never invoked", () => {
+    const { probe, calls } = fixtureProbe({ files: [WIN_WHERE_BUN], located: { where: WIN_WHERE_BUN } });
+    const resolved = resolveValidatedBunPath({
+      env: {},
+      platform: "win32",
+      execPath: "C:\\Program Files\\nodejs\\node.exe",
+      runningUnderBun: false,
+      probe,
+    });
+    expect(resolved).toBe(WIN_WHERE_BUN);
+    expect(calls.locate).toEqual(["where"]);
+    expect(calls.locate).not.toContain("which");
+  });
+
+  test("win32: validated SOMA_BUN_PATH override beats execPath", () => {
+    const override = "C:\\tools\\bun\\bun.exe";
+    const { probe, calls } = fixtureProbe({ files: [override, WIN_BUN] });
+    const resolved = resolveValidatedBunPath({
+      env: { SOMA_BUN_PATH: override },
+      platform: "win32",
+      execPath: WIN_BUN,
+      runningUnderBun: true,
+      probe,
+    });
+    expect(resolved).toBe(override);
+    expect(calls.spawned).toEqual([override]);
+  });
+
+  test("win32: MSYS-form SOMA_BUN_PATH normalizes to the native .exe form before validation", () => {
+    // The exact 2026-06-10 incident shape: Git Bash dialect, no .exe.
+    const { probe } = fixtureProbe({ files: [WIN_BUN] });
+    const resolved = resolveValidatedBunPath({
+      env: { SOMA_BUN_PATH: "/c/Users/kyle/scoop/apps/bun/current/bun" },
+      platform: "win32",
+      runningUnderBun: false,
+      probe,
+    });
+    expect(resolved).toBe(WIN_BUN);
+  });
+
+  test("win32: MSYS-form `where` output (Git Bash where shim) normalizes too", () => {
+    const { probe } = fixtureProbe({
+      files: [WIN_WHERE_BUN],
+      located: { where: "/c/Users/kyle/scoop/shims/bun" },
+    });
+    const resolved = resolveValidatedBunPath({
+      env: {},
+      platform: "win32",
+      runningUnderBun: false,
+      probe,
+    });
+    expect(resolved).toBe(WIN_WHERE_BUN);
+  });
+
+  test("win32: broken SOMA_BUN_PATH throws naming the candidate and source — no silent fallthrough", () => {
+    // execPath and where would both be valid; a present-but-broken
+    // override must still abort the install, not fall through.
+    const { probe, calls } = fixtureProbe({ files: [WIN_BUN, WIN_WHERE_BUN], located: { where: WIN_WHERE_BUN } });
+    const attempt = () =>
+      resolveValidatedBunPath({
+        env: { SOMA_BUN_PATH: "C:\\nope\\bun.exe" },
+        platform: "win32",
+        execPath: WIN_BUN,
+        runningUnderBun: true,
+        probe,
+      });
+    expect(attempt).toThrow(/SOMA_BUN_PATH/);
+    expect(attempt).toThrow(/C:\\nope\\bun\.exe/);
+    expect(attempt).toThrow(/not found on disk/);
+    expect(attempt).toThrow(/fail-open/);
+    expect(calls.spawned).toEqual([]); // never reached the spawn probe, never tried another candidate
+  });
+
+  test("MSYS-form override that still fails validation throws with the raw value in the message", () => {
+    const { probe } = fixtureProbe({ files: [] });
+    const attempt = () =>
+      resolveValidatedBunPath({
+        env: { SOMA_BUN_PATH: "/c/gone/bun" },
+        platform: "win32",
+        runningUnderBun: false,
+        probe,
+      });
+    expect(attempt).toThrow(/C:\\gone\\bun/);
+    expect(attempt).toThrow(/\/c\/gone\/bun/);
+  });
+
+  test("spawn-probe failure throws naming the source and the probe command", () => {
+    const { probe } = fixtureProbe({ files: [WIN_BUN], spawnFails: [WIN_BUN] });
+    const attempt = () =>
+      resolveValidatedBunPath({
+        env: {},
+        platform: "win32",
+        execPath: WIN_BUN,
+        runningUnderBun: true,
+        probe,
+      });
+    expect(attempt).toThrow(/process\.execPath/);
+    expect(attempt).toThrow(/--version/);
+    expect(attempt).toThrow(/exit 1: fixture failure/);
+  });
+
+  test("POSIX: order preserved — which bun beats execPath-under-bun", () => {
+    const { probe, calls } = fixtureProbe({ files: [POSIX_BUN, "/proc/self/exe-bun"], located: { which: POSIX_BUN } });
+    const resolved = resolveValidatedBunPath({
+      env: {},
+      platform: "linux",
+      execPath: "/proc/self/exe-bun",
+      runningUnderBun: true,
+      probe,
+    });
+    expect(resolved).toBe(POSIX_BUN);
+    expect(calls.locate).toEqual(["which"]);
+  });
+
+  test("POSIX: SOMA_BUN_PATH first, and it too is validated", () => {
+    const { probe } = fixtureProbe({ files: [POSIX_BUN], located: { which: POSIX_BUN } });
+    const attempt = () =>
+      resolveValidatedBunPath({ env: { SOMA_BUN_PATH: "/opt/missing/bun" }, platform: "linux", probe });
+    expect(attempt).toThrow(/SOMA_BUN_PATH/);
+    expect(attempt).toThrow(/\/opt\/missing\/bun/);
+  });
+
+  test("POSIX: execPath-under-bun remains the last-resort fallback", () => {
+    const { probe } = fixtureProbe({ files: ["/bun/bin/bun"] });
+    const resolved = resolveValidatedBunPath({
+      env: {},
+      platform: "linux",
+      execPath: "/bun/bin/bun",
+      runningUnderBun: true,
+      probe,
+    });
+    expect(resolved).toBe("/bun/bin/bun");
+  });
+
+  test("no candidate at all: loud install-bun remediation naming the platform's locator", () => {
+    const { probe } = fixtureProbe({});
+    const win = () => resolveValidatedBunPath({ env: {}, platform: "win32", runningUnderBun: false, probe });
+    expect(win).toThrow(/where bun/);
+    expect(win).toThrow(/SOMA_BUN_PATH/);
+    const posix = () => resolveValidatedBunPath({ env: {}, platform: "linux", runningUnderBun: false, probe });
+    expect(posix).toThrow(/which bun/);
+  });
+
+  test("empty SOMA_BUN_PATH is treated as unset, not validated as a path", () => {
+    const { probe } = fixtureProbe({ files: [WIN_BUN] });
+    const resolved = resolveValidatedBunPath({
+      env: { SOMA_BUN_PATH: "  " },
+      platform: "win32",
+      execPath: WIN_BUN,
+      runningUnderBun: true,
+      probe,
+    });
+    expect(resolved).toBe(WIN_BUN);
+  });
+});
+
+// Integration: this suite itself runs under bun, so the production path
+// (real probe, real spawn) must resolve and validate — pinned
+// SOMA_BUN_PATH or not.
+describe("resolveBunExecutable / requireBunInPath (real probe)", () => {
+  test("resolveBunExecutable resolves a real, existing bun on this machine", () => {
+    const resolved = resolveBunExecutable();
+    expect(existsSync(resolved)).toBe(true);
+    expect(resolved).toBe(resolveBunExecutable()); // memoized: same value, no re-probe
+  });
+
+  test("requireBunInPath passes on this machine", () => {
+    expect(() => requireBunInPath()).not.toThrow();
   });
 });

--- a/test/claude-code-install.test.ts
+++ b/test/claude-code-install.test.ts
@@ -463,8 +463,17 @@ test("issue #236: uninstall removes settings entries using the installed Bun pat
     const config = await readJson<{ bunPath: string }>(configPath);
     const oldBunPath = "/tmp/soma-test-old-bun";
     await writeFile(configPath, `${JSON.stringify({ ...config, bunPath: oldBunPath }, null, 2)}\n`, "utf8");
-    const settings = await readFile(settingsPath, "utf8");
-    await writeFile(settingsPath, settings.replaceAll(config.bunPath, oldBunPath), "utf8");
+    // Rewrite the frozen bun path inside settings.json as decoded JSON
+    // string values, not raw file text: a raw replaceAll silently no-ops
+    // when the resolved path is a native Windows path (C:\...), whose
+    // backslashes are JSON-escaped on disk.
+    const settings = await readJson<unknown>(settingsPath);
+    const rewritten = JSON.stringify(
+      settings,
+      (_key, value) => (typeof value === "string" ? value.replaceAll(config.bunPath, oldBunPath) : value),
+      2,
+    );
+    await writeFile(settingsPath, `${rewritten}\n`, "utf8");
 
     await uninstallSomaForClaudeCode({ homeDir });
 


### PR DESCRIPTION
Fixes #323.

### Problem

`resolveBunExecutable()` (`src/bun-probe.ts`) freezes an absolute bun path into substrate
hook commands and runtime configs. #316/#320 hardened it against ephemeral `/tmp/bun-node-*`
paths, but the PATH probe is still `which bun` on every platform. On native Windows `which`
does not exist, and under Git Bash/MSYS it answers in a dialect — `/c/Users/.../bun`
(forward slashes, no `.exe`) — that no native Windows spawn can resolve. The resolver freezes
that value unvalidated.

Reproduction on `main` @ `4ea8af8` (Windows 11, Git Bash, Bun 1.3.5):

```
$ bun -e 'import {resolveBunExecutable} from "./src/bun-probe.ts"; console.log(JSON.stringify(resolveBunExecutable()))'
"/c/Users/KyleLittle/scoop/persist/bun/bin/bun"
```

A native Windows process cannot launch the `/c/...` dialect form, so the value frozen into the
hook command is unspawnable. On any hook whose absence does not block the tool call (fail-open),
an unlaunchable hook means the policy gate does not fire. This is the win32/MSYS **sibling** of
#316 — an ephemeral path passes a spawn probe and an MSYS path is not under `/tmp`, so the
two checks are independent.

### Fix (`src/bun-probe.ts`)

- **win32 resolution order**: `SOMA_BUN_PATH` → `process.execPath` under bun (a native path
  by construction) → `where bun`. `which` is never invoked on win32. POSIX order unchanged
  (`SOMA_BUN_PATH` → `which bun` → execPath).
- **MSYS normalization**: `/c/Users/.../bun` → `C:\Users\...\bun.exe` before validation.
- **Validation**: every winning candidate — including `SOMA_BUN_PATH` — must pass `existsSync`
  + a `<path> --version` spawn probe, or the install aborts loudly naming the candidate and
  its source. No present-but-broken value falls through silently.
- **#316 preserved**: `isEphemeralBunPath` still screens every candidate; an auto-detected
  ephemeral path is skipped so a durable source can win; an explicit ephemeral
  `SOMA_BUN_PATH` now fails loudly (new behavior — the user named a doomed path).
- Resolution is injectable (`probe`/`platform`/`env` seam) so tests drive every branch
  hermetically. `resolveBunExecutable` is memoized per `SOMA_BUN_PATH` value.

The internal-only `chooseBunExecutable`/`locateBunOnPath` (no consumers outside this file +
its test) are replaced by `resolveValidatedBunPath`; the two production exports
(`resolveBunExecutable`, `requireBunInPath`) keep their signatures.

### Tests

- `test/bun-probe.test.ts`: #316's `isEphemeralBunPath` block is unchanged; its
  ephemeral-resolution cases are re-expressed against the new core (so the #316 guarantees
  stay covered); added a win32/MSYS/POSIX hermetic suite (injected probe fixture) covering
  the resolution order, MSYS normalization of both `SOMA_BUN_PATH` and `where` output,
  validated/broken overrides, spawn-probe failure, and the "`which` never invoked on win32"
  assertion.
- `test/claude-code-install.test.ts` (test-only): the existing test *"issue #236: uninstall
  removes settings entries using the installed Bun path"* simulated a prior install by
  `replaceAll`-ing the frozen path in **raw** `settings.json` text. With a native Windows
  path the on-disk backslashes are JSON-escaped, so the decoded-string replace silently
  no-ops and the simulated state never lands. Rewritten to edit the path on parsed JSON
  values (separator-agnostic). Production removal already matches on the parsed command and
  is unaffected.

### Verification

Windows 11, Bun 1.3.5, Git Bash. No `SOMA_BUN_PATH` pin (this branch resolves bun natively,
so the pin that bare `main` needs on this box is no longer required).

Deterministic:
- `bun run typecheck` — clean (exit 0).
- `bun test test/bun-probe.test.ts` — **26 pass / 0 fail**.
- `resolveBunExecutable()` on this branch returns `C:\Users\KyleLittle\scoop\persist\bun\bin\bun.exe`
  (native; `existsSync` true); on bare `main` it returns `/c/Users/KyleLittle/scoop/persist/bun/bin/bun`
  (`existsSync` false from a native process).
- The test fixed above: `issue #236: uninstall removes settings entries using the installed
  Bun path` — fails 3/3 on this branch before the test fix, passes 3/3 on bare `main`, passes
  3/3 after the fix.

A/B on the touched consumer suite (`test/claude-code-install.test.ts`), same box — **illustrative,
not load-bearing**, because the suite is non-deterministic. One representative run was branch
**19 pass / 3 fail** vs bare `main` **17 pass / 5 fail**, with all 3 branch failures present in
`main`'s set. Those residual failures are a Windows environmental baseline shared with `main`
(a Windows-incompatible `chmod`-based test, HOME-sensitive install tests, and Bun spawn jitter —
exact counts vary run to run), not introduced here. The load-bearing result is deterministic: the
`#236` uninstall test goes red → green (above), and the resolver change introduced no new failure
in the suites I ran (`bun-probe`, `codex-adapter`, `claude-code-install`) — the only test it broke,
`#236`, is now fixed.

**Platform scope: verified on Windows 11 only.** The change is shared-core with explicit
win32/POSIX branches; the POSIX path preserves the prior resolution order and is exercised by
the hermetic suite, but I have not run the suite on macOS or Linux. CI not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
