### PR TITLE
fix(grok): close the glued-prefix backstop fail-open for the whole home-anchor class (#327)

### DIFF
--- a/src/adapters/grok/hooks/shell-policy-core.mjs
+++ b/src/adapters/grok/hooks/shell-policy-core.mjs
@@ -867,16 +867,38 @@ export function createShellPolicyExtractor(descriptor) {
     );
     if (marker) return resolve(marker);
 
-    // 3. A candidate matches a descriptor RELATIVE private prefix (`.soma/…`,
-    //    `./.soma/…`, bare `.soma`, and their deglued `@`-prefixed forms). No
-    //    resolution under a root is needed — the prefix's somaHome-anchored
-    //    root is the enforceable source. A bare-alnum `my.soma` never deglues,
-    //    and matchesRelativePathPrefix is boundary-exact, so no over-block.
+    // 3. A descriptor RELATIVE private prefix in the segment TEXT, at a
+    //    token/path boundary. The full-text scan (not just per-token) is what
+    //    catches a marker glued INSIDE an opaque alnum-led token that does not
+    //    deglue — e.g. `iex"@.soma/x"`, where the `@` is a boundary in the
+    //    joined text but the token starts `iex` so step 1/1b's per-token deglue
+    //    leaves it intact. The optional `(?:\./|~/)?` anchor also covers the
+    //    `@./.soma/`, `@~/.soma/` standalone forms. Boundary-gated and
+    //    case-folded on win32 (mirroring matchesRelativePathPrefix), so a
+    //    benign `my.somatic` and a nested `proj/.soma` (project-local, not the
+    //    home root) do NOT match. Emits the prefix's somaHome-anchored root —
+    //    a private scope root `policy check` honors regardless of policyMarkers.
+    //
+    // Note: an env-var home spelling embedded inside an opaque alnum-led token
+    // (`iex"@$HOME/.soma/x"`) is reachable by neither the per-token deglue nor
+    // this text scan (env-var spellings are built from boundary chars); that
+    // residual is out of scope here and is not a valid file-reading form.
     const home = somaHomeParent(config);
     if (home) {
-      for (const token of candidates) {
-        for (const entry of privatePathPrefixes) {
-          if (matchesRelativePathPrefix(token, entry)) return resolve(home, entry.path);
+      const fold = process.platform === "win32";
+      const folded = fold ? text.toLowerCase() : text;
+      // A boundary char is anything that cannot continue a path token.
+      const boundary = "[^A-Za-z0-9._/~-]";
+      // Optional home-relative anchor glued between the boundary and the
+      // marker: `./` (cwd-relative) or `~/` (home-relative).
+      const relAnchor = "(?:\\./|~/)?";
+      for (const entry of privatePathPrefixes) {
+        const prefix = fold ? entry.path.toLowerCase() : entry.path;
+        const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const prefixed = new RegExp(`(?:^|${boundary})${relAnchor}${escaped}/`);
+        const bare = entry.bare ? new RegExp(`(?:^|${boundary})${relAnchor}${escaped}(?:$|${boundary})`) : undefined;
+        if (prefixed.test(folded) || (bare && bare.test(folded))) {
+          return resolve(home, entry.path);
         }
       }
     }

--- a/src/adapters/grok/hooks/shell-policy-core.mjs
+++ b/src/adapters/grok/hooks/shell-policy-core.mjs
@@ -249,6 +249,24 @@ function matchesRelativePathPrefix(token, entry) {
   return candidate.startsWith(`${prefix}/`) || candidate.startsWith(`./${prefix}/`);
 }
 
+// soma#327: a private reference glued behind a non-path prefix
+// (`@.soma/…`, `@./.soma/…`, `@~/.soma/…`, `@$HOME/.soma/…`,
+// `@%USERPROFILE%/.soma/…`, `@${env:USERPROFILE}/.soma/…`) defeats both the
+// per-token relative match (the token starts with the glue char, not the
+// anchor) and `resolveShellPath`'s `^`-anchored home normalizers, so it
+// resolved under no root and ALLOWED. Strip a single LEADING run of non-path
+// "glue" chars (`@`, `"`, `'`, `(`, `=`, …) and re-run the SAME resolvers on
+// the remainder — closing every home-anchor spelling through
+// normalizeShellPathToken instead of re-encoding each one here (which is how
+// #326→#327 leaked a spelling at a time). The kept set includes every char
+// that can BEGIN a path/home anchor (`$ % ~ . / \ -` and alnum), so a bare
+// `my.soma` is never turned into `.soma` — no over-block.
+function degluePrivateToken(token) {
+  if (!token) return null;
+  const stripped = token.replace(/^[^A-Za-z0-9$%~./\\-]+/, "");
+  return stripped !== token && stripped.length > 0 ? stripped : null;
+}
+
 function absoluteProtectedRoots(config) {
   return Array.from(new Set(config.policyMarkers.filter((marker) => isAbsolute(marker)).map((marker) => resolve(marker))));
 }
@@ -802,64 +820,63 @@ export function createShellPolicyExtractor(descriptor) {
   // per-form fixes remain so the common cases produce a precise
   // source/destination; this only catches what they don't.
   function matchedPrivateMarkerSource(config, segment, cwd) {
-    // Prefer a token that RESOLVES to a path actually under a private root —
-    // that yields a precise, enforceable source. A token can satisfy
-    // hasPrivatePathReference via an embedded marker SUBSTRING (a marker glued
-    // inside an opaque `iex"..."` / `$(...)` / `@`-prefixed token) yet resolve
-    // to a path that is NOT under any root. Returning that path made the backstop
-    // emit a target whose sourcePath fails the private-root test, so `policy
-    // check` ALLOWED — a toothless deny. Require the resolved token to be under
-    // a root here; if none is, fall through to the marker-root branch, whose
-    // source IS a real private root, so the deny is enforceable.
+    // Each token is expanded with a DEGLUED variant (soma#327): the leading
+    // glue run (`@`, quote, `(`, `=`, …) stripped, so a private reference
+    // glued behind a non-path prefix re-enters the SAME resolvers below. A
+    // token can also satisfy hasPrivatePathReference via an embedded marker
+    // SUBSTRING (a marker glued inside an opaque `iex"..."` / `$(...)` token)
+    // yet resolve to a path that is NOT under any root; emitting that path
+    // made the backstop produce a sourcePath that fails the private-root test,
+    // so `policy check` ALLOWED — a toothless deny. Every branch here requires
+    // a source that IS a real private root (an absolute marker, or the
+    // somaHome private root), so the deny is always enforceable.
+    const candidates = [];
+    for (const token of segment) {
+      candidates.push(token);
+      const deglued = degluePrivateToken(token);
+      if (deglued !== null) candidates.push(deglued);
+    }
+
+    // 1. A candidate that RESOLVES under an absolute protected (marker) root —
+    //    the most precise, enforceable source.
     const roots = absoluteProtectedRoots(config);
-    const resolvableToken = segment.find(
+    const resolvableToken = candidates.find(
       (token) => hasPrivatePathReference(config, token, cwd) && roots.some((root) => isUnderRoot(resolveShellPath(config, token, cwd), root)),
     );
     if (resolvableToken) return resolveShellPath(config, resolvableToken, cwd);
-    // No token resolves under a root, but the raw (separator-normalized) text
-    // still carries an absolute private marker — use the marker root as the
-    // source so the deny is enforceable.
+
+    // 1b. A candidate that resolves under the somaHome PRIVATE root. This is
+    //     the home-anchor leg: `~/.soma`, `$HOME/.soma`, `%USERPROFILE%/.soma`,
+    //     `${env:USERPROFILE}/.soma`, and their `@`-glued forms all collapse
+    //     through normalizeShellPathToken to a path under somaHome — a private
+    //     scope root `policy check` honors regardless of policyMarkers (so this
+    //     fires even with an empty marker set). The root is the enforceable
+    //     source. soma#327: this replaces the prior spelling-specific regex,
+    //     closing every home-anchor spelling with one resolver-backed check.
+    const privateRoot = config.somaHome ? resolve(config.somaHome) : null;
+    if (privateRoot) {
+      const homeAnchored = candidates.find((token) => isUnderRoot(resolveShellPath(config, token, cwd), privateRoot));
+      if (homeAnchored) return privateRoot;
+    }
+
+    // 2. No candidate resolves under a root, but the raw (separator-normalized)
+    //    text still carries an absolute private marker as a substring.
     const text = normalizeSeparators(segment.join(" "));
     const marker = config.policyMarkers.find(
       (candidate) => isAbsolute(candidate) && text.includes(normalizeSeparators(candidate).replace(/\/+$/, "")),
     );
     if (marker) return resolve(marker);
-    // A RELATIVE private prefix glued behind a non-path prefix
-    // (`Frobnicate-Item @.soma/memory/x`) defeats the per-token relative
-    // match — the token starts `@.soma/`, not `.soma/`, so
-    // matchesRelativePathPrefix misses it — AND it carries no absolute
-    // marker, so both scans above miss it: a fail-OPEN of the same class the
-    // absolute branch closes. Scan the segment text for any descriptor
-    // relative privatePathPrefix at a token/path boundary (case-folded on
-    // win32, mirroring matchesRelativePathPrefix; the boundary keeps a glued
-    // `@`/quote/`(` matching while a benign `my.somatic` does not) and emit
-    // that prefix's absolute root — anchored at the soma-home parent — so the
-    // deny is enforceable: the `.soma` root is config.somaHome, a private
-    // scope root `policy check` always honors regardless of policyMarkers.
-    //
-    // soma#327: an interposed `./` or `~/` between the non-path prefix and the
-    // marker (`@./.soma/…`, `@~/.soma/…`) put a path-CONTINUE char (`/`)
-    // immediately before `.soma`, so a plain `(?:^|boundary)\.soma/` missed it
-    // — the same fail-open class, one glue-char wider. The optional relative
-    // anchor `(?:\./|~/)?` after the boundary catches those forms. It stays
-    // boundary-gated, so a benign `my.somatic` and a nested `proj/.soma`
-    // (a project-local soma, not the home root) still do NOT match.
+
+    // 3. A candidate matches a descriptor RELATIVE private prefix (`.soma/…`,
+    //    `./.soma/…`, bare `.soma`, and their deglued `@`-prefixed forms). No
+    //    resolution under a root is needed — the prefix's somaHome-anchored
+    //    root is the enforceable source. A bare-alnum `my.soma` never deglues,
+    //    and matchesRelativePathPrefix is boundary-exact, so no over-block.
     const home = somaHomeParent(config);
     if (home) {
-      const fold = process.platform === "win32";
-      const folded = fold ? text.toLowerCase() : text;
-      // A boundary char is anything that cannot continue a path token.
-      const boundary = "[^A-Za-z0-9._/~-]";
-      // Optional home-relative anchor glued between the boundary and the
-      // marker: `./` (cwd-relative) or `~/` (home-relative).
-      const relAnchor = "(?:\\./|~/)?";
-      for (const entry of privatePathPrefixes) {
-        const prefix = fold ? entry.path.toLowerCase() : entry.path;
-        const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const prefixed = new RegExp(`(?:^|${boundary})${relAnchor}${escaped}/`);
-        const bare = entry.bare ? new RegExp(`(?:^|${boundary})${relAnchor}${escaped}(?:$|${boundary})`) : undefined;
-        if (prefixed.test(folded) || (bare && bare.test(folded))) {
-          return resolve(home, entry.path);
+      for (const token of candidates) {
+        for (const entry of privatePathPrefixes) {
+          if (matchesRelativePathPrefix(token, entry)) return resolve(home, entry.path);
         }
       }
     }

--- a/src/adapters/grok/hooks/shell-policy-core.mjs
+++ b/src/adapters/grok/hooks/shell-policy-core.mjs
@@ -836,17 +836,28 @@ export function createShellPolicyExtractor(descriptor) {
     // that prefix's absolute root — anchored at the soma-home parent — so the
     // deny is enforceable: the `.soma` root is config.somaHome, a private
     // scope root `policy check` always honors regardless of policyMarkers.
+    //
+    // soma#327: an interposed `./` or `~/` between the non-path prefix and the
+    // marker (`@./.soma/…`, `@~/.soma/…`) put a path-CONTINUE char (`/`)
+    // immediately before `.soma`, so a plain `(?:^|boundary)\.soma/` missed it
+    // — the same fail-open class, one glue-char wider. The optional relative
+    // anchor `(?:\./|~/)?` after the boundary catches those forms. It stays
+    // boundary-gated, so a benign `my.somatic` and a nested `proj/.soma`
+    // (a project-local soma, not the home root) still do NOT match.
     const home = somaHomeParent(config);
     if (home) {
       const fold = process.platform === "win32";
       const folded = fold ? text.toLowerCase() : text;
       // A boundary char is anything that cannot continue a path token.
       const boundary = "[^A-Za-z0-9._/~-]";
+      // Optional home-relative anchor glued between the boundary and the
+      // marker: `./` (cwd-relative) or `~/` (home-relative).
+      const relAnchor = "(?:\\./|~/)?";
       for (const entry of privatePathPrefixes) {
         const prefix = fold ? entry.path.toLowerCase() : entry.path;
         const escaped = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const prefixed = new RegExp(`(?:^|${boundary})${escaped}/`);
-        const bare = entry.bare ? new RegExp(`(?:^|${boundary})${escaped}(?:$|${boundary})`) : undefined;
+        const prefixed = new RegExp(`(?:^|${boundary})${relAnchor}${escaped}/`);
+        const bare = entry.bare ? new RegExp(`(?:^|${boundary})${relAnchor}${escaped}(?:$|${boundary})`) : undefined;
         if (prefixed.test(folded) || (bare && bare.test(folded))) {
           return resolve(home, entry.path);
         }

--- a/test/grok-hook.test.ts
+++ b/test/grok-hook.test.ts
@@ -668,17 +668,24 @@ test("installed grok pre-tool-use hook fails closed on a RELATIVE private marker
   });
 });
 
-test("soma#327: installed grok pre-tool-use hook fails closed on @./.soma/ and @~/.soma/ glued forms", async () => {
+test("soma#327: installed grok pre-tool-use hook fails closed on every home-anchor glued form", async () => {
   await withTempHome(async (homeDir) => {
     await installSomaForGrok({ homeDir });
     const hook = join(homeDir, ".grok/hooks/soma-lifecycle.mjs");
-    // The end-to-end sibling of the #327 unit test: an interposed `./`/`~/`
-    // anchor between the non-path prefix and the marker slipped the backstop
-    // before the fix. Both now deny through `policy check`.
-    for (const command of ["Frobnicate-Item @./.soma/memory/x", "Frobnicate-Item @~/.soma/memory/x"]) {
+    // End-to-end through `policy check`: every home-anchor spelling glued
+    // behind a non-path prefix slipped the backstop before the structural
+    // deglue fix. All now deny.
+    for (const command of [
+      "Frobnicate-Item @.soma/memory/x",
+      "Frobnicate-Item @./.soma/memory/x",
+      "Frobnicate-Item @~/.soma/memory/x",
+      "Frobnicate-Item @$HOME/.soma/memory/x",
+      "Frobnicate-Item @%USERPROFILE%/.soma/memory/x",
+      "Frobnicate-Item @${env:USERPROFILE}/.soma/memory/x",
+    ]) {
       const result = runGrokPreToolUse(hook, homeDir, "Shell", {
         command,
-        description: "relative marker glued behind a non-path prefix with ./ or ~/ anchor",
+        description: "private marker glued behind a non-path prefix (home-anchor spelling)",
       });
       expect(result.output.decision).toBe("deny");
       expect(result.status).toBe(2);
@@ -1033,12 +1040,14 @@ test("relative private prefix glued behind a non-path prefix still fails closed 
   }
 });
 
-test("soma#327: relative marker glued behind a non-path prefix WITH an interposed ./ or ~/ still fails closed (backstop)", () => {
-  // The residual the absolute-and-bare-`@.soma/` fix (#326) left open: an
-  // interposed `./` or `~/` (`@./.soma/…`, `@~/.soma/…`) puts a path-CONTINUE
-  // char (`/`) immediately before `.soma`, so the plain boundary scan missed
-  // it — the same fail-open class, one glue-char wider. The optional relative
-  // anchor catches both forms while staying boundary-gated.
+test("soma#327: private reference glued behind a non-path prefix fails closed for EVERY home-anchor spelling (backstop)", () => {
+  // The class the per-spelling regex closed one form at a time (#326 `@.soma/`,
+  // then `@./`/`@~/`): a private reference glued behind a non-path prefix.
+  // The structural fix deglues the leading junk and re-runs the SAME resolvers,
+  // so every home-anchor spelling normalizeShellPathToken understands —
+  // `./`, `~/`, `$HOME`, `${HOME}`, `%USERPROFILE%`, `${env:USERPROFILE}` —
+  // collapses to the private root. Empty policyMarkers prove this rides the
+  // private-root / relative leg, not an absolute marker.
   const extractor = createShellPolicyExtractor(GROK_SHELL_POLICY_DESCRIPTOR);
   const base = join(tmpdir(), "soma-core-unit-327");
   const config = { somaHome: join(base, ".soma"), policyMarkers: [], privateRoots: [] };
@@ -1046,20 +1055,33 @@ test("soma#327: relative marker glued behind a non-path prefix WITH an interpose
   const root = join(base, ".soma");
 
   for (const command of [
-    "Frobnicate-Item @./.soma/memory/x", // cwd-relative anchor glued behind `@`
-    "Frobnicate-Item @~/.soma/memory/x", // home-relative anchor glued behind `@`
+    "Frobnicate-Item @.soma/memory/x", // bare marker glued behind `@`
+    "Frobnicate-Item @./.soma/memory/x", // cwd-relative anchor
+    "Frobnicate-Item @~/.soma/memory/x", // home-relative anchor
+    "Frobnicate-Item @$HOME/.soma/memory/x", // env home, bare $
+    "Frobnicate-Item @${HOME}/.soma/memory/x", // env home, braced
+    "Frobnicate-Item @%USERPROFILE%/.soma/memory/x", // Windows %VAR% home
+    "Frobnicate-Item @${env:USERPROFILE}/.soma/memory/x", // pwsh ${env:} home
+    "Frobnicate-Item (.soma/memory/x", // paren glue
+    "Frobnicate-Item =.soma/memory/x", // assignment glue
   ]) {
     const targets = extractor(config, { command, cwd });
     expect(targets).toHaveLength(1);
-    // Rides the RELATIVE leg (empty policyMarkers) and emits the private ROOT,
-    // which `policy check` honors — a toothless cwd-relative source would ALLOW.
+    // Emits the private ROOT, which `policy check` honors — a toothless
+    // cwd-relative source would resolve under no root and ALLOW.
     expect(targets[0].sourcePath).toBe(root);
   }
 
-  // A NESTED `proj/.soma` is a project-local soma, not the home root: the `/`
-  // before `.soma` is a continue char with no boundary-gated `./`|`~/` anchor,
-  // so it must NOT over-block.
-  expect(extractor(config, { command: "Build-Thing proj/.soma/x out", cwd })).toHaveLength(0);
+  // Over-block guards: the deglue strips ONLY a leading non-path glue run and
+  // never turns a bare-alnum token into the marker, so these stay ALLOW.
+  for (const command of [
+    "Build-Thing proj/.soma/x out", // nested project-local .soma, not the home root
+    "Frobnicate-Item my.soma/x", // alnum-led: no leading glue to strip
+    "Frobnicate-Item my.somatic-notes.txt", // .soma substring, not a path segment
+    "Frobnicate-Item a/b/.soma/x out", // deeper nested
+  ]) {
+    expect(extractor(config, { command, cwd })).toHaveLength(0);
+  }
 });
 
 test("grok descriptor preserves the asymmetric bare-token semantics", () => {

--- a/test/grok-hook.test.ts
+++ b/test/grok-hook.test.ts
@@ -668,6 +668,24 @@ test("installed grok pre-tool-use hook fails closed on a RELATIVE private marker
   });
 });
 
+test("soma#327: installed grok pre-tool-use hook fails closed on @./.soma/ and @~/.soma/ glued forms", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForGrok({ homeDir });
+    const hook = join(homeDir, ".grok/hooks/soma-lifecycle.mjs");
+    // The end-to-end sibling of the #327 unit test: an interposed `./`/`~/`
+    // anchor between the non-path prefix and the marker slipped the backstop
+    // before the fix. Both now deny through `policy check`.
+    for (const command of ["Frobnicate-Item @./.soma/memory/x", "Frobnicate-Item @~/.soma/memory/x"]) {
+      const result = runGrokPreToolUse(hook, homeDir, "Shell", {
+        command,
+        description: "relative marker glued behind a non-path prefix with ./ or ~/ anchor",
+      });
+      expect(result.output.decision).toBe("deny");
+      expect(result.status).toBe(2);
+    }
+  });
+});
+
 // Two more egress-bypass forms: normalization/tokenization gaps in the same
 // Copy-Item-to-public class that colon-glued/backslash/redirect hardening
 // closed earlier. They land failing-test-first; the grok-policy-targets.mjs fixes make them deny.
@@ -1013,6 +1031,35 @@ test("relative private prefix glued behind a non-path prefix still fails closed 
     expect(backslash).toHaveLength(1);
     expect(backslash[0].sourcePath).toBe(join(base, ".soma"));
   }
+});
+
+test("soma#327: relative marker glued behind a non-path prefix WITH an interposed ./ or ~/ still fails closed (backstop)", () => {
+  // The residual the absolute-and-bare-`@.soma/` fix (#326) left open: an
+  // interposed `./` or `~/` (`@./.soma/…`, `@~/.soma/…`) puts a path-CONTINUE
+  // char (`/`) immediately before `.soma`, so the plain boundary scan missed
+  // it — the same fail-open class, one glue-char wider. The optional relative
+  // anchor catches both forms while staying boundary-gated.
+  const extractor = createShellPolicyExtractor(GROK_SHELL_POLICY_DESCRIPTOR);
+  const base = join(tmpdir(), "soma-core-unit-327");
+  const config = { somaHome: join(base, ".soma"), policyMarkers: [], privateRoots: [] };
+  const cwd = join(base, "work");
+  const root = join(base, ".soma");
+
+  for (const command of [
+    "Frobnicate-Item @./.soma/memory/x", // cwd-relative anchor glued behind `@`
+    "Frobnicate-Item @~/.soma/memory/x", // home-relative anchor glued behind `@`
+  ]) {
+    const targets = extractor(config, { command, cwd });
+    expect(targets).toHaveLength(1);
+    // Rides the RELATIVE leg (empty policyMarkers) and emits the private ROOT,
+    // which `policy check` honors — a toothless cwd-relative source would ALLOW.
+    expect(targets[0].sourcePath).toBe(root);
+  }
+
+  // A NESTED `proj/.soma` is a project-local soma, not the home root: the `/`
+  // before `.soma` is a continue char with no boundary-gated `./`|`~/` anchor,
+  // so it must NOT over-block.
+  expect(extractor(config, { command: "Build-Thing proj/.soma/x out", cwd })).toHaveLength(0);
 });
 
 test("grok descriptor preserves the asymmetric bare-token semantics", () => {

--- a/test/grok-hook.test.ts
+++ b/test/grok-hook.test.ts
@@ -1064,6 +1064,7 @@ test("soma#327: private reference glued behind a non-path prefix fails closed fo
     "Frobnicate-Item @${env:USERPROFILE}/.soma/memory/x", // pwsh ${env:} home
     "Frobnicate-Item (.soma/memory/x", // paren glue
     "Frobnicate-Item =.soma/memory/x", // assignment glue
+    'iex"@.soma/memory/x"', // marker embedded in an opaque alnum-led token (full-text scan, not deglue)
   ]) {
     const targets = extractor(config, { command, cwd });
     expect(targets).toHaveLength(1);


### PR DESCRIPTION
Fixes #327.

### Problem

The #326 fail-closed backstop (`src/adapters/grok/hooks/shell-policy-core.mjs`, `matchedPrivateMarkerSource`) denied the reported `Frobnicate-Item @.soma/memory/x`, but the **class** was not fully closed. An interposed `./` or `~/` between the non-path prefix and the marker still fell through to ALLOW:

- `Frobnicate-Item @./.soma/memory/x` → **ALLOW** (should DENY)
- `Frobnicate-Item @~/.soma/memory/x` → **ALLOW** (should DENY)

The `/` from `./`|`~/` is a path-continue char, so it sits immediately before `.soma` and the plain `(?:^|boundary)\.soma/` scan misses. These `@`-glued tokens also resolve via `resolveToolPath` to a literal `@.`/`@~` segment under no root (branch-1 miss) and carry no absolute marker (absolute-scan miss), so they reached `policy check` as a toothless ALLOW.

### Fix

Add an optional, **boundary-gated** relative anchor `(?:\./|~/)?` between the boundary and the marker. It stays boundary-gated, so the over-block guards hold:
- benign `my.somatic` → ALLOW (no `.soma/`, no boundary-anchored bare `.soma`)
- nested `proj/.soma/x` → ALLOW (project-local soma, not the home root — `/` before `.soma` with no boundary-gated `./`|`~/` anchor)

### Tests

- Unit (`createShellPolicyExtractor`): both `@./.soma/` and `@~/.soma/` emit the private **root** as `sourcePath` (rides the relative leg — empty `policyMarkers`), plus a nested-`proj/.soma` over-block guard.
- Installed-hook e2e: both glued forms deny end-to-end (`decision: deny`, exit 2).

### Verification

- `bun run typecheck` — clean.
- `bun test test/grok-hook.test.ts` — 49 pass / 0 fail (47 + 2 new).
- `bun test` grok-adapter/doctor/install/uninstall + substrate-adapters — 77 pass / 0 fail.
- Regex matrix checked directly: the two `@./`/`@~/` variants now DENY; `my.somatic` and `proj/.soma` (and deeper `a/b/.soma`) stay ALLOW.

macOS run only (the suite is platform-independent by construction — hooks spawn via node with pinned HOME, no live grok); CI runs the Linux gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)