### PR TITLE
docs: working-method vocabulary alignment (checkpoint/intent/Purpose/Verification/VSA) + ADR + strategy/findings

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,7 +52,7 @@ soma install claude-code --apply
 
 The durable, portable assistant body. The thing that gets [[project|projected]] into a [[substrate]].
 
-When you want to speak about "the whole assistant" — its identity, telos, ISA, skills, memory, policy, and learning together — the noun is **Soma**, not `identity`, not `assistant`, not `context`.
+When you want to speak about "the whole assistant" — its identity, purpose, verification, skills, memory, policy, and learning together — the noun is **Soma**, not `identity`, not `assistant`, not `context`.
 
 Examples of correct usage:
 - "Soma projects into substrates."
@@ -93,11 +93,11 @@ One of the seven named subdivisions of [[Soma]]. Each compartment holds a cohere
 The seven compartments:
 
 1. **Identity** — principal profile, assistant profile, voice, personality
-2. **Telos** — goals, principles, commitments, strategies, desired state
-3. **ISA** — ideal-state artifacts (the articulation and verification of work)
+2. **Purpose** — mission, goals, principles, commitments (the source of [[intent]])
+3. **Verification** — the articulation and verification of done; holds [[VSA]]s and [[checkpoint]]s
 4. **Skills** — portable capability folders
 5. **Memory** — work, knowledge, learning, relationship, state stores
-6. **Policy** — security, privacy, permission, verification rules
+6. **Policy** — security, privacy, permission, evidence and audit rules
 7. **Learning** — captured learnings, signals, performance feedback
 
 **Not synonyms:** Do not use `layer`, `store`, `domain`, `component`, `module`, `section`, `part` as glossary terms for these. `compartment` is the only word.
@@ -377,7 +377,7 @@ allows the team and scope.
 
 **Why:** Issue #152 needs shared team capability without violating the
 principal-owned privacy model. An overlay lets team material supplement
-personal Soma while keeping Identity, Telos, Relationship, raw transcripts, and
+personal Soma while keeping Identity, Purpose, Relationship, raw transcripts, and
 security traces private.
 
 ---
@@ -467,7 +467,7 @@ Five verbs for five distinct lifecycle events. No overlap.
 | **uninstall** | Principal (CLI) | Adapter removes its projection from the substrate. |
 
 The lifecycle reads:
-> Principal **installs** Soma into Codex → [[adapter]] **projects** → projection exists on disk. Principal edits Telos → Soma **reprojects** → updated projection on disk. Codex session restarts → substrate **loads** the projection → Soma has fresh presence. New Soma version released → principal runs `soma upgrade codex` → adapter **upgrades** and reprojects. Principal runs `soma uninstall codex` → adapter removes the projection.
+> Principal **installs** Soma into Codex → [[adapter]] **projects** → projection exists on disk. Principal edits Purpose → Soma **reprojects** → updated projection on disk. Codex session restarts → substrate **loads** the projection → Soma has fresh presence. New Soma version released → principal runs `soma upgrade codex` → adapter **upgrades** and reprojects. Principal runs `soma uninstall codex` → adapter removes the projection.
 
 **Not synonyms — killed from glossary:**
 - `sync`, `rebuild`, `refresh`, `regenerate` → `reproject`
@@ -585,7 +585,7 @@ The reverse direction: [[substrate]] → [[Soma]]. Symmetric to [[project|projec
 
 ### The closed loop
 
-> Soma **projects** into the substrate (one-way). The adapter performs the projection. The substrate **loads** the projection into [[context]]. The [[assistant]] gains [[presence]]. During the session, the assistant captures learnings and updates ISA; the adapter **writes back** through the **writeback gate** into Soma. On the next session, Soma reprojects with the new state. Substrate-side state Soma doesn't author is **mirrored** into `MEMORY/STATE/`.
+> Soma **projects** into the substrate (one-way). The adapter performs the projection. The substrate **loads** the projection into [[context]]. The [[assistant]] gains [[presence]]. During the session, the assistant captures learnings and updates its [[VSA]]s; the adapter **writes back** through the **writeback gate** into Soma. On the next session, Soma reprojects with the new state. Substrate-side state Soma doesn't author is **mirrored** into `MEMORY/STATE/`.
 
 This makes Soma a closed loop, not a one-way pipe.
 
@@ -673,14 +673,14 @@ Three adjectives describing how a piece of a [[project|projection]] enters the L
 
 | Tier | Adjective | Behaviour | Typical use |
 | --- | --- | --- | --- |
-| 1 | **eager** | Loaded into context at every session start. | Identity profile, active Telos, current ISA. Cheap, small, identity-defining. |
+| 1 | **eager** | Loaded into context at every session start. | Identity profile, active Purpose, current VSA. Cheap, small, identity-defining. |
 | 2 | **indexed** | A compact **registry** is eager; **bodies** load on demand when invoked. | Skills compartment by default. |
 | 3 | **on-demand** | Nothing loads until the assistant explicitly retrieves it (search, read, query). | Memory archives, past learnings. |
 
 ### Structural nouns
 
 - **registry** — the eager index entry that names what is available without loading the body. (Used in `docs/progressive-skill-loading.md` already.)
-- **body** — the full content of an indexed item, fetched on demand. Examples: "skill body", "ISA body".
+- **body** — the full content of an indexed item, fetched on demand. Examples: "skill body", "VSA body".
 - **resident** — informal: a piece of the projection currently in the LLM context for this session. Used for runtime talk only; not a tier name.
 
 ### Sentence shape
@@ -727,3 +727,81 @@ Three adjectives that classify a piece of Soma or [[project|projection]] data. E
 - "private context surface" → "private projection".
 
 **Why:** Five overlapping adjectives (`private`, `protected`, `principal-only`, `durable`, `generated`) had drifted across three doc files. Each was doing slightly different work but readers couldn't tell which. Locking three orthogonal adjectives (visibility / destructibility / authoritativeness) makes every policy statement falsifiable.
+
+---
+
+## checkpoint
+
+The unit of evidence-gated verification. A **checkpoint** is { criterion, required evidence, typed verdict, completion gate } — [[portable, substrate-neutral, substrate-native|portable]] across substrates, append-only audited, [[Lifecycle verbs: install, reproject, upgrade, load, uninstall|snapshot]]-reversible.
+
+A checkpoint applies on two axes: **done-ness** ("is this task complete?") and [[intent]] ("is this work aligned with where the principal is headed?"). Same machinery, two questions.
+
+The checkpoint is the deterministic spine of Soma's working method: inference may *propose* (a memory reorganization, an alignment judgment, whether to engage), but a checkpoint *disposes* — every proposal is typed, gated, audited, and reversible.
+
+**Not synonyms:**
+- `gate` — already overloaded ([[writeback, write back, writeback gate, mirror|writeback gate]], [[acquisition gate]], [[context-entry gate]], completion gate). A checkpoint *contains* a completion gate; it is not "a gate".
+- `snapshot` — whole-home Git state (`soma snapshot`/`rollback`). A checkpoint is one verified criterion; a snapshot is the entire Soma home at a point in time. Never interchange them.
+- `criterion` — one part of a checkpoint, not the whole.
+- `ISA` / `ISC` — the PAI constructs the checkpoint was extracted from. The [[Verification (compartment, formerly ISA)|Verification]] compartment still *holds* checkpoints (bundled into [[VSA]]s); the Algorithm/effort-tier/euphoric-surprise apparatus is one optional workflow pack over checkpoints, never the canonical primitive name.
+- `assertion` — a claim with no evidence is not a checkpoint.
+
+**Why:** PAI's ISA buried "evidence-gated completion" under five constructs (ISA, ISC, Algorithm phases, effort tiers, euphoric surprise). Extracting it as one primitive — and pointing it at a second axis ([[intent]]) — lets one Soma-native bone underlie what were two Miessler compartments (now [[Verification (compartment, formerly ISA)|Verification]] and [[Purpose (compartment, formerly Telos)|Purpose]]). The code already proves the shape: `IdealStateCriterion { text, status, verification }` is a checkpoint. See ADR on the de-Miessler renames.
+
+---
+
+## intent
+
+The [[principal]]'s checkable directional anchor for a scope of work — what "pointed the right way" means *here*. A [[checkpoint]] on the intent axis scores work against it for alignment or drift.
+
+Intent is *informed by* [[Purpose]] content (mission, goals, principles, commitments) but is none of them individually: it is the directional reading of that content that a checkpoint can actually score. It lives as a domain term, not a struct field.
+
+**Not synonyms:**
+- `mission` — the durable "why," one per principal, too abstract to score a single task against. Intent is scoped and checkable.
+- `goal` — a discrete target (done / not-done), checked on the *done-ness* axis. Intent is *direction*, not a checklist item.
+- `commitment` — an accepted obligation; it feeds intent, it is not intent.
+- `heading` — **banned** as the term for this concept. "Heading" already means a markdown section title across Soma docs; the homonym was rejected. Use `intent`.
+
+**Why:** Keeps the forward-looking alignment value that self-organizing memory systems (e.g. letta) lack, without importing PAI's `telos` schema. Pairs with [[checkpoint]] as the second axis. The directional bone survives; the LifeOS apparatus does not ("PAI, not LifeOS").
+
+---
+
+## Purpose (compartment, formerly Telos)
+
+The [[compartment]] holding the [[principal]]'s forward-looking direction content: mission, goals, principles, commitments. It is the source of [[intent]].
+
+`Purpose` is the English meaning of *telos* (Greek: end, purpose) — the de-branded replacement for the PAI term. The compartment is unchanged in shape and role; only the name moved off Miessler's vocabulary.
+
+**Not synonyms:**
+- `telos` / `Telos` — **killed.** PAI/Miessler term carrying a nine-category LifeOS schema (mission, beliefs, narratives, strategies, problems, challenges, measures). Banned in Soma docs and code. `Purpose` is the only word.
+- `aim`, `direction`, `goals` — `aim` was the runner-up; `direction`/`goals` are too narrow (one field) for the whole compartment.
+- `intent` — the *output* a checkpoint scores against, not the compartment that sources it. Distinct: Purpose (compartment) → intent (the scoped anchor) → checkpoint (scores it).
+
+**Why:** "Telos" was the most Miessler-branded word in the seven-compartment set, and JC's stance is "Personal AI Infrastructure, not a LifeOS." `Purpose` keeps the exact meaning (it *is* the translation of telos) while removing the inherited brand and its schema. Seven compartments stay seven; this is a rename, not a merge. See ADR on the de-Miessler renames.
+
+---
+
+## Verification (compartment, formerly ISA)
+
+The [[compartment]] that articulates what "done" means and verifies work against it — the **done-ness** home (its sibling axis, [[intent]], lives in [[Purpose (compartment, formerly Telos)|Purpose]]). It holds [[VSA]]s and the [[checkpoint]]s inside them, plus the optional Algorithm-run apparatus.
+
+**Not synonyms:**
+- `ISA` (as a compartment name) — **killed.** PAI/Miessler term. `Verification` is the only word for this compartment.
+- `verification` (lowercase, the [[Policy]] sense) — Policy's "evidence and audit rules" govern *security* verification; the Verification *compartment* governs verification of *work/done-ness*. Capitalized `Verification` always means the compartment.
+- `Method`, `Completion`, `Work` — considered. `Method` (zero-collision runner-up) was broader than the verification core; `Completion` overloads the checkpoint's completion gate; `Work` collides with [[work registry]] / Memory work stores.
+
+**Why:** `ISA` was the second Miessler compartment name (after Telos→Purpose). `Verification` names the compartment's actual job — done-ness, established with evidence — and pairs cleanly: Purpose sources intent, Verification houses done-ness, both scored by checkpoints. Renaming the box is cosmetic now that [[checkpoint]] is the extracted primitive. See ADR on the de-Miessler renames.
+
+---
+
+## VSA (Verification State Artifact)
+
+The artifact that defines "done" for a project, task, or work session and carries its [[checkpoint]]s and verdicts across substrates. Lives in the [[Verification (compartment, formerly ISA)|Verification]] compartment.
+
+The de-branded replacement for PAI's **ISA** (Ideal State Artifact): **I**deal → **V**erification, keeping **S**tate **A**rtifact. The swap is one-for-one — every former ISA is a VSA — so the migration is mechanical.
+
+**Not synonyms:**
+- `ISA` (Ideal State Artifact) — **killed.** The PAI name. `VSA` is the only word.
+- `checkpoint` — the unit *inside* a VSA, not the VSA itself. A VSA bundles checkpoints.
+- `spec`, `definition of done` — informal glosses; `VSA` is the canonical artifact noun.
+
+**Why:** completes the de-Miessler pass of the seven-compartment set (Identity · [[Purpose (compartment, formerly Telos)|Purpose]] · [[Verification (compartment, formerly ISA)|Verification]] · Skills · Memory · Policy · Learning). The `VSA` cadence keeps the CLI familiar (`soma isa` → `soma vsa`) and signals deliberate lineage rather than a clean break. See ADR on the de-Miessler renames.

--- a/Plans/2026-06-22-algorithm-runner-prompt-findings.md
+++ b/Plans/2026-06-22-algorithm-runner-prompt-findings.md
@@ -1,0 +1,101 @@
+# Algorithm Runner & Prompt — Findings from 188 Real Runs
+
+**Created:** 2026-06-22
+**Authors:** Jens-Christian Fischer + Ivy
+**Evidence:** 188 run records in `~/.soma/memory/WORK/algorithm-runs/`, 33 `LEARNING/ALGORITHM/*` notes, 4 `REFLECTIONS` rows, 1 PROMOTED critical review. Quantitative aggregation + qualitative corpus sweep.
+
+---
+
+## Headline
+
+The deterministic runner is **ceremony-heavy and its feedback loops are largely abandoned**, and the verify gate **accepts assertion as evidence**. Two numbers tell it:
+
+- **63% of runs stall at OBSERVE** (118/188); only **18% reach `complete`** (33); only **33% are ever verified** (62).
+- The **loop is dead** (68 paused, 0 ran or completed, plateau counter never fired), **reflection capture stopped after 2026-05-07** (4 rows total), and the **effort classifier verdict is never used** (0 runs sourced effort from the classifier; 170/188 explicit).
+
+Read together: the runner asks for *manual advancement work the agent does out-of-band*, so the record goes stale at OBSERVE; and where verification does happen, it is often tautological ("the design says X ∴ X passed"). This is exactly the case for the **checkpoint + inference direction** (`2026-06-22-soma-direction-verification-primitive.md`): the fix is not more gates, it is *the agent proposing real phase-advances and probes, the checkpoint gating them* — not more CLI ceremony.
+
+---
+
+## Quantitative signals (188 runs)
+
+| Signal | Value | Reading |
+| --- | --- | --- |
+| Stall at OBSERVE | 118/188 (63%) | advancement abandoned at phase 1 |
+| Reached `complete` | 33/188 (18%) | low completion |
+| `verified: true` | 62/188 (33%) | most runs never verified |
+| Reached build+ ("deep") | 48/188 (26%) | ¾ never reach execution |
+| Loop status | 68 paused, 0 completed, 0 plateau | loop feature inert |
+| effortSource = classifier | 0 | classifier verdict unused (170 explicit, 16 auto) |
+| substrate unset | 165/188 (88%) | cross-substrate provenance empty in practice |
+| learning array empty | 87/188 (46%) | half capture no learning |
+| schemaVersion missing | 106 (flat ISA) vs 82 (v2) | two incompatible run schemas coexist |
+
+---
+
+## RUNNER fixes (deterministic CLI / state machine)
+
+Ranked by evidence strength × impact.
+
+### R1 — Type the verification evidence: `specified` vs `probed` vs `tested` *(HIGH)*
+The verify command accepts free text and marks `passed`. The PROMOTED review names the failure: *"All 37 ISCs are marked 'passed-design' … tautological verification … should claim 37/37 specified, not verified."* Add an evidence **kind** and split criterion status into `passed-design` vs `passed-verified`. The completion gate requires `probed`/`tested` for behavioral criteria, else forces a `deferred-probe` state. This is the single highest-leverage fix — it attacks hallucinated green, which the 33%-verified number says is rampant.
+
+### R2 — Actually enforce capability invoke-or-remove *(HIGH)*
+~6 learnings: *"Capabilities are data/gate state only … AlgorithmRun.capabilities is string[]."* Selection is recorded, invocation never happens, the gate is unenforced (15 uninvoked selections across the corpus). Either wire selection → skill load, or block `complete` on an uninvoked selection. Today it is theater.
+
+### R3 — Worktree isolation for build/execute *(MED)*
+6 runs carried a hand-rolled criterion like *"unrelated local dirty files are not committed,"* with the recurring lesson *"use a temporary git worktree for PR rescue."* The runner re-pays attention budget guarding dirty state every time. Make build/execute phases offer/auto-create a worktree (Soma already has worktree infra).
+
+### R4 — Schema versioning + migration *(MED)*
+106 runs have no `schemaVersion` and use a flat ISA shape (`isa.phase`, `isa.criteria`); 82 use v2 (`isa.frontmatter`, `isa.sections`). Readers must handle both or rot. (Caveat: the 106 are largely PAI-era imports — partly inherited, not all Soma's bug.) Add a one-time migrate to v2 and make all readers version-aware.
+
+### R5 — Auto-capture substrate *(MED)*
+88% of runs have no substrate. The cross-substrate provenance that is Soma's whole selling point is empty because `--substrate` is manual. Default it from env/session; never require it.
+
+### R6 — Read-only vs build as a phase branch, not a criterion *(MED)*
+The "deepening" flow encodes *"No files are modified"* as a criterion that the user then overrides — it was **dropped mid-run in 6 runs** ("superseded after the user approved implementing"). Model it as an explicit branch (survey → optional build), not a criterion to invalidate.
+
+### R7 — Fix the learning-writer dedup bug *(LOW)*
+Duplicate learning lines written 10s apart (e.g. skill-selection-parity). Minor dedup bug in the learning writer.
+
+### R7b — Port PAI's meta-reflection layer *(MED — corrected 2026-06-22)*
+**Correction:** an earlier draft claimed "reflection capture stopped after 2026-05-07." That was a misread of the PAI→Soma boundary. The `REFLECTIONS/algorithm-reflections.jsonl` is a **PAI-era artifact** (fields `doctrine_fired`, `satisfaction_prediction`, `reflection_q1/q2/q3`); Soma's `src` has **no reflection writer**, and Soma's own `LEARNING/ALGORITHM/*` capture is alive and continuous (2026-05-14 → 2026-06-11). The reflections didn't break — they were never ported.
+
+The real gap: Soma kept *criterion-level* learning ("a lesson from this run") but dropped PAI's *meta-reflection* layer — the per-run self-assessment "a smarter algorithm would have verified current-state earlier / launched Council in parallel." That signal is the highest-value improvement source (it's where P2 came from) and is exactly dream-cycle material. Worth **porting**, substrate-neutral, into Soma's learning capture.
+
+### R8 — Path-segment validation for slugs/manifest fields *(LOW)*
+2 runs: *"every manifest field that becomes a path segment needs a validation rule before implementation."*
+
+---
+
+## PROMPT fixes
+
+### P1 — Verifier prompt: "the doc says X" is NOT evidence *(HIGH, pairs with R1)*
+Instruct the model that a specification/design statement cannot verify a *behavioral* criterion; require an executable probe (test output, curl, grep of running state) or mark `deferred-probe`. This is the prompt half of the tautological-verification fix.
+
+### P2 — OBSERVE current-state-verification floor *(HIGH)*
+The recurring reflection: *"a smarter algorithm would have verified all current-state assumptions before the interview / before planning."* Combined with the 63% OBSERVE stall, the OBSERVE prompt should force probing current-state assumptions (read the repo/system, confirm the named field/flag/route exists) before advancing. Reduces both the stall and the proceed-on-assumption rework.
+
+### P3 — Classifier prompt: tie effort to a current-state floor — or drop it *(MED)*
+The classifier fires on 0 runs and under-scopes (E3 with 34 criteria vs E4 with 8 — no mapping). Decide: improve it so its verdict is trustworthy and *wire it in*, or remove the pretense. A deterministic step nobody trusts is dead weight.
+
+### P4 — Capability prompt: stop implying invocation *(MED, pairs with R2)*
+Until selection → load exists, describe capabilities as *commitments/contracts*, not active invocations, so the prompt stops promising behavior the runner doesn't deliver.
+
+### P5 — Scaffold prompt surfaces the private-path placeholder up front *(LOW)*
+The policy guard blocks first drafts that embed literal private Soma paths (3 runs). Tell the model to use `<soma-home>` in the scaffold prompt, not discover it via a terminal write-block.
+
+---
+
+## Priority (updated 2026-06-22)
+
+**Tier 1 — integrity:**
+1. **R1 + P1 — kill tautological verification** (#330). Highest severity, most recurrent, the integrity of the whole gate. Runner: evidence kinds + `deferred-probe`. Prompt: specified ≠ probed.
+
+**Tier 1 — the meta-reflection pair** (prioritized by JC; both came from PAI's meta-reflection layer):
+2. **R7b — port the meta-reflection layer** (#333). The *generator*. PAI's per-run "a smarter algorithm would have…" self-assessment was never ported. Porting it makes P2-class fixes surface themselves instead of waiting for a manual 188-run dig.
+3. **P2 — OBSERVE current-state floor** (#331). The *first harvested output* of that layer (one recurring `reflection_q2`). Attacks the 63% observe-stall directly.
+
+The causal shape is the point: **R7b is upstream of P2.** P2 is what you get when you read the meta-reflections by hand once; R7b is the loop that produces P2-class improvements continuously. Do P2 now (it's already harvested and cheap), and build R7b as the engine that finds the next ten P2s.
+
+All three feed the checkpoint direction: a `checkpoint` whose verdict carries an evidence *kind* and is *probed not asserted* is the typed primitive; the meta-reflection is the Algorithm's LEARN phase / dream-cycle applied reflexively (the agent proposes, a checkpoint records). These findings are the empirical case for that direction.

--- a/Plans/2026-06-22-letta-af-soma-fieldmap.md
+++ b/Plans/2026-06-22-letta-af-soma-fieldmap.md
@@ -1,0 +1,107 @@
+> **⚠️ DEMOTED TO REFERENCE 2026-06-22 by `2026-06-22-soma-direction-verification-primitive.md`.**
+> The migration spike is dropped — Kyle routed around migration entirely
+> (agent-to-agent via `claude -p`). Keep only the `.af` block envelope (label =
+> typed index, content = free body) as a reference for the memory-manifest shape.
+
+# `.af` ⇆ Soma Compartment Field Map — Integration Spike v0 (REFERENCE ONLY)
+
+**Created:** 2026-06-22
+**Authors:** Jens-Christian Fischer + Ivy, scoping Luna's letta-code recommendation
+**Companion:** `2026-06-22-soma-seam-thesis.md` (this is the "turn posture into a test" artifact)
+**Status:** Spike scope. The field map below either proves the dividing line or breaks it.
+
+---
+
+## Why this doc exists
+
+Luna's call: treat letta-code as the first **hosted content-pack** and the `.af`
+round-trip as **v0 of the seam** — not a feature to match. This map collapses two
+open thesis items (the boundary contract, the lossy-fields register) into one
+concrete integration. If `.af` memory blocks map cleanly onto Soma Memory bodies +
+manifest, the dividing line is real and shipping in production *by someone else*.
+If they don't, the thesis has a hole.
+
+---
+
+## Verified facts (read from source 2026-06-22, not prior knowledge)
+
+`letta-code` (github.com/letta-ai/letta-code), Apache-2.0:
+- **Persistence is git, not a DB.** Uses **MemFS, a git-based VCS**: *"All context
+  (including memory blocks) is tracked via git. Sync context to a custom GitHub
+  repository by setting `/memory-repository set …`."* Local CLI by default; a
+  running `letta server` / Constellation is only for hosted multi-machine access.
+  → **Corrects Luna's "DB-stateful, impedance mismatch" assumption.** letta-code
+  local is git/filesystem-native — the same shape as Soma. The heavy DB connector
+  is only the *hosted server* path, not the default.
+- Memory tooling: `/palace` (view memory), `/doctor` (audit memory quality),
+  `/sleeptime` (periodic "dreaming" / consolidation). Memory blocks drive
+  system-prompt learning + skill learning. By the creators of MemGPT.
+
+`.af` Agent File (github.com/letta-ai/agent-file), Apache-2.0, TS + Python impls:
+- **Top-level components:** system prompt; memory blocks (in-context personality /
+  user info, labeled, agent-editable); tools (source code + JSON schema); tool
+  rules (sequencing/constraints); model config (context-window limit, model name,
+  embedding-model name); message history (with context-window indicators);
+  environment variables.
+- **Excluded:** **Passages (archival memory units) are NOT supported.** Secrets are
+  set to `null` on export.
+  → **The lossy register is partly pre-defined by Letta itself.**
+
+---
+
+## The field map
+
+| `.af` component | → Soma target | Clean / Lossy | Notes |
+|---|---|---|---|
+| **memory blocks** (label + content) | **Memory** compartment: label → typed **manifest**, content → free-form **body** | **CLEAN** | This is the whole thesis. Letta ships Luna's named boundary contract in production: block label = typed index field, block content = assistant-authored body. **v0 lives here.** |
+| **system prompt** | **Identity** + Algorithm/Telos content-pack (assembled into projection) | PARTIAL | Content round-trips; *structure* doesn't — Soma assembles the system prompt from Identity+Telos+pack, `.af` stores one blob. Ingest → store as a body; emit → Soma re-assembles. Lossy on provenance, clean on text. |
+| **tools** (source + schema) | **Skills** compartment (skill tool + manifest) | PARTIAL | Letta tools are inline code+schema; Soma skills are folders. Map 1 tool ⇄ 1 skill-tool. Execution model differs — defer to a later pass, not v0. |
+| **tool rules** (sequencing/constraints) | **Policy** (runtime policy config / governance) | PARTIAL | Maps to Soma policy rules, different shape. Not v0. |
+| **model config** (ctx window, model, embed model) | substrate metadata (NOT Soma-owned) | **LOSSY / out-of-scope** | `docs/boundaries.md`: Soma does not own model provider. Store as opaque metadata, never author. |
+| **message history** | **raw transcript source** / observability events | **LOSSY by design** | Soma does not store full transcripts by default. Drop, or keep a pointer. Never a Soma body. |
+| **environment variables** (secrets `null`) | **Policy** (secrets stay substrate-side) | **LOSSY** | Secrets nulled by `.af` already. Nothing to round-trip. |
+| **archival passages** | Soma archival Memory | **LOSSY — gap is Letta-side** | `.af` excludes Passages entirely. Document as a known boundary; not Soma's to fix. |
+
+---
+
+## v0 interop scope (bounded, per Luna)
+
+- **One pair:** Soma ⇆ letta-code (local, git/MemFS — not Constellation server).
+- **One direction first:** **ingest `.af` → Soma** (memory blocks → bodies+manifest).
+  Emit (Soma → `.af`) is the second milestone, once the manifest shape is fixed.
+- **One component:** **memory blocks only.** Everything else in the table is
+  explicitly out of v0.
+- **Lossy-fields register (v0, frozen):** message history (dropped), model config
+  (metadata only), archival passages (excluded by `.af`), secrets (nulled), tools +
+  tool rules (deferred). This *is* the bounded "lossless" scope the thesis demanded —
+  grounded in a real schema, not an adjective.
+
+**Acceptance test (proves/breaks the dividing line):** ingest a real `.af`
+exported from letta-code; its memory blocks land as Soma Memory bodies, each with a
+typed manifest derived from the block label; the index sees them; re-projecting into
+Claude Code surfaces them as presence — **without any adapter code change**. If the
+block→body+manifest mapping needs an adapter edit, the kernel/content-pack split
+(thesis) has a hole.
+
+---
+
+## Risk register (corrected)
+
+- ~~DB↔git impedance mismatch~~ → **downgraded.** letta-code local is git-native;
+  only the hosted server is DB-backed. v0 targets the local path.
+- **Schema dependency on a VC-backed company.** `.af` evolves on Letta's clock.
+  Acceptable — interop with an adopted format beats a Soma-native format nobody
+  uses — but it's a tracked line, not a freebie. Pin a `.af` schema version in v0.
+- **`/sleeptime` consolidation mutates blocks out-of-band.** If Soma ingests a
+  letta-code git repo that the Letta agent is also editing, define who owns the
+  block between sessions. Writeback-gate concern, flag for the emit milestone.
+
+---
+
+## Next artifact
+
+This doc is the field map. The next step is the **ingest spike**: a `soma import
+af <file>` that lands memory blocks as bodies+manifest and nothing else. One
+direction, one component, the frozen lossy register above. That spike is the
+smallest thing that converts the seam thesis from posture into a passing (or
+failing) test.

--- a/Plans/2026-06-22-soma-direction-verification-primitive.md
+++ b/Plans/2026-06-22-soma-direction-verification-primitive.md
@@ -1,0 +1,194 @@
+# Soma Direction — The Checkpoint
+
+**Created:** 2026-06-22
+**Authors:** Jens-Christian Fischer + Ivy
+**Status:** Direction, approved as the axis. Supersedes `2026-06-22-soma-seam-thesis.md` and demotes `2026-06-22-letta-af-soma-fieldmap.md` to a reference.
+**Method:** First-principles extraction over the PAI/LifeOS critique + Kyle's side-by-side Letta/Soma/PAI usage signal.
+
+---
+
+## One line
+
+Portability is already built. Soma's evolution is **agentic memory consolidation
+that runs inside a deterministic, auditable, reversible gate** — and that gate is a
+single primitive extracted from the two Miessler constructs (Telos, ISA) Soma
+inherited.
+
+---
+
+## What is already done (don't re-sell it)
+
+Being the portable assistant body is **shipped**: five adapters (claude-code,
+codex, cursor, grok, pi-dev) with install/projection/hooks/doctor, plus
+`work-registry.ts`, `observability.ts`, writeback, session-harvester, memory
+promote, provenance. Portability is the platform, not the roadmap. Two earlier
+framings — "compete as the seam" and "import `.af` from Letta" — were re-selling
+the solved problem and chasing demand nobody sized. Retired.
+
+---
+
+## The signal that set the direction (Kyle, runs Letta + Soma + PAI in parallel)
+
+- **The gap, in his words:** *"soma runs purely deterministically... I want to
+  incorporate some inference to classify prompts to trigger it more often."*
+  Determinism is the *limiter*, not the moat.
+- **He bypassed migration:** seeded telos by wiring an agent to Soma and having it
+  talk to his PAI via `claude -p`. Agent-to-agent, not an importer. (Kills the `.af`
+  migration spike.)
+- **The synthesis, handed over:** he rates Letta above PAI for the **dream cycle** +
+  agent-organized memory — but unprompted: *"it could use a telos file... forward-
+  looking info to check alignment between the user's actions and ideal state."*
+  **The one thing Letta lacks is the one thing Soma owns.**
+
+Verified Letta facts (read from source 2026-06-22):
+- **MemFS** — memory as files, git push/pull sync (`/memory-repository set git@…`);
+  "all context including memory blocks tracked via git." = Soma's #146 home
+  replication, *designed not built*. Letta shipped it.
+- **Dream cycle** (`/sleeptime`) — async subagent reviews ~25 recent turns, takes a
+  holistic view, **reorganizes memory as it sees fit**; agent decides structure
+  under guiding principles + progressive disclosure.
+
+---
+
+## First-principles: two Miessler constructs collapse into one bone
+
+Both Telos and ISA are Daniel Miessler's. Strip each to its irreducible function.
+
+**Telos** (Mission/Beliefs/Narratives/Strategies/Problems/Challenges/Measures — a
+life-philosophy schema; the LifeOS weight JC explicitly does not want) reduces to:
+> a checkable statement of intended direction — a **`intent`** — scored for
+> alignment/drift.
+
+**ISA** (Ideal State Artifact / ISC / effort tiers / euphoric surprise / seven-phase
+Algorithm wrapper) reduces to:
+> a checkable **criterion**, with required **evidence**, producing a typed
+> **verdict**, behind a completion **gate**.
+
+These are the **same atom**. The only difference is the axis it points at:
+
+| Axis | Question | Was called |
+|---|---|---|
+| **done-ness** | "is this task complete?" | ISA |
+| **intent** | "is this work aligned with intent?" | Telos (its one bone) |
+
+So Soma keeps neither compartment as inherited. It keeps **one extracted
+primitive** and applies it on two axes.
+
+### The checkpoint (LOCKED term)
+
+> **A `checkpoint` is { criterion, required evidence, typed verdict, completion
+> gate } — portable across substrates, append-only audited, snapshot-reversible.**
+
+Distinct from `snapshot` (whole-home git state, `soma snapshot`/`rollback`): a
+checkpoint is one verified criterion, a snapshot is the entire Soma home at a point
+in time. Never use them interchangeably.
+
+Dropped as inherited apparatus: ISA/ISC/Telos naming, the nine telos categories,
+effort tiers E0–E3, euphoric surprise, the mandatory seven-phase Algorithm wrapper,
+per-project scaffold ceremony. All of that is *one optional workflow pack* over the
+primitive — never the kernel.
+
+Kept: the bone above + cross-substrate carry (Soma's genuine add) + "state the
+target before the work" as a lightweight habit.
+
+---
+
+## The architecture: inference proposes, the primitive disposes
+
+JC's two non-negotiables — *pick the best of telos, move our own way* and *keep the
+deterministic guardrails* — resolve into the same mechanism.
+
+**The checkpoint is the deterministic spine.** Everything agentic only
+ever *proposes into it*:
+
+- **Telos-aware dream cycle** — async subagent reviews recent turns → *proposes* a
+  memory reorganization and consolidation → the proposal passes the **writeback
+  gate** (no private/protected root mutation without policy clearance) → must emit
+  valid typed manifests → writes an **append-only event** → **snapshot-backed, so
+  it's reversible**. And it scores the consolidated work against the **intent**
+  (the extracted telos bone), surfacing alignment/drift. Agency, fully caged.
+- **Inference activation classifier** — *proposes* whether to engage; a
+  deterministic policy decides what engaging may do. Inference can never widen its
+  own permissions. (Replaces the keyword-only mode classifier, #274 — Kyle's
+  literal ask.)
+- **Alignment / done verdicts** — typed (passed / drift / unknown + evidence). A
+  deterministic frame around an inference judgment.
+
+**Dividing line, final form:**
+> Soma is deterministic about movement, trust, gates, and contracts. The model is
+> free to *propose* — engagement, memory organization, alignment and done judgments —
+> but only inside those gates, where every proposal is typed, audited, and reversible.
+
+---
+
+## Why this is Soma's seat (not Letta's, not PAI's)
+
+- **Letta** has the dream cycle but no primitive: it just rewrites your context —
+  agency without an auditable, reversible gate. A non-starter where memory integrity
+  must be inspectable (security, enterprise — JC's domain).
+- **PAI** has the primitive but buried under five layers of construct (ISA/ISC/
+  Algorithm/tiers/euphoric surprise), and no agency.
+- **Soma** extracts the primitive clean, makes it portable and reversible, and puts
+  inference *on top of it*. **Agentic memory inside deterministic, auditable,
+  reversible guardrails** — the combination neither competitor has.
+
+And the **intent** (the telos bone) is the differentiator Letta itself can't
+take: goal-aligned consolidation. Letta won't build it (not their thing); single-
+tool memory can't (no portable goals). Soma already has the intent as first-class state.
+
+---
+
+## Concrete moves (all on primitives already in the tree)
+
+1. **Generalize the checkpoint to two axes.** ISA's done-check exists;
+   add the intent check (alignment/drift against the intent) reusing the same
+   criterion + evidence + verdict machinery. De-brand ISA/Telos to the checkpoint;
+   keep the Algorithm/ISC apparatus as an *optional* pack.
+2. **Intent-aware dream cycle.** Async consolidation pass on recent turns →
+   `session-harvester` + `memory promote` exist → gate via writeback + manifest +
+   append-only event + snapshot. Scores against the intent. The headline.
+3. **Inference activation classifier.** Model-backed engagement decision over the
+   deterministic policy gate. (#274 evolves from keyword to inference.)
+4. **MemFS-parity git memory sync.** Ship #146 home replication as "memory that
+   syncs across machines via git." Letta proved the demand.
+
+---
+
+## Sequencing (honest)
+
+Andreas: **land the Cortex plane first** (federation, onboarding, Signal
+observability, Mission Control). This is the queued Soma evolution direction, not a
+this-sprint pivot. Build order within it: primitive generalization (1) is the
+foundation; the dream cycle (2) is the headline; activation (3) and git sync (4)
+follow.
+
+---
+
+## Locked terms (2026-06-22)
+
+Ready to promote into `CONTEXT.md` as canonical glossary entries:
+
+- **`checkpoint`** — the extracted primitive: { criterion, required evidence, typed
+  verdict, completion gate }, portable, append-only audited, snapshot-reversible.
+  *Not* `gate` (already overloaded: writeback/acquisition/context-entry gates) and
+  *not* `snapshot` (whole-home git state). A checkpoint applies on two axes:
+  **done-ness** and **intent**.
+- **`intent`** — the forward-looking checkable statement of intended direction
+  (the one durable bone extracted from Miessler's Telos). Replaces "telos" as Soma's
+  own term. The dream cycle scores consolidated work against the intent.
+
+Retired words: ISA, ISC, "Ideal State Artifact", effort tiers, euphoric surprise as
+Soma-canonical terms — all demoted to an optional Algorithm workflow pack.
+
+---
+
+## Retired / demoted
+
+- `2026-06-22-soma-seam-thesis.md` — **superseded.** The dividing line was right and
+  is carried forward (final form above). The seam-vs-harness framing was re-selling
+  solved portability; the "stop deepening the harness" conclusion was backwards
+  (a *portable* harness is the differentiated value). Kept for the reasoning trail.
+- `2026-06-22-letta-af-soma-fieldmap.md` — **demoted to reference.** The `.af` block
+  envelope (label = typed index, content = free body) is a useful reference for the
+  memory-manifest shape. The migration spike itself is dropped — Kyle routed around
+  migration entirely.

--- a/Plans/2026-06-22-soma-seam-thesis.md
+++ b/Plans/2026-06-22-soma-seam-thesis.md
@@ -1,0 +1,265 @@
+> **⚠️ SUPERSEDED 2026-06-22 by `2026-06-22-soma-direction-verification-primitive.md`.**
+> The dividing line survives (in final form there). The seam-vs-harness framing
+> re-sold already-shipped portability, and "stop deepening the harness" was
+> backwards — a *portable* harness is the differentiated value. Kept for the
+> reasoning trail only.
+
+# Soma Seam Thesis — Strategy (SUPERSEDED)
+
+**Created:** 2026-06-22
+**Authors:** Jens-Christian Fischer + Ivy
+**Method:** Four-lens dissection (FirstPrinciples, BeCreative, ApertureOscillation, Council) of the PAI→LifeOS rebrand and the MetaFactory Discord critique thread.
+**Status:** Direction proposed. Luna review incorporated 2026-06-22 (see Review log). **Ratify the direction + dividing line; the schedule below is cut to two bets this quarter.**
+
+---
+
+## Thesis
+
+Soma's trap is becoming a *better PAI* — a deeper harness. Its actual moat is being
+the **seam**: the portable assistant body that substrates move through. Lean into
+determinism where it buys portability; loosen structure where it fights the model;
+turn the governance grievance into the product.
+
+> **Epistemic caveat (Luna).** Four analytical lenses produced agreeing
+> conclusions, but they are *not* independent evidence: same authors, one session,
+> one seed thread, shared priors. Their agreement says the framing was *consistent*,
+> not that the conclusion is *correct*. Treat the agreement as a clarity check, not
+> a proof. The dividing line below earns ratification on its own logic and its
+> falsifiable test — not on "the lenses converged."
+
+---
+
+## Origin: what the thread exposed
+
+Daniel Miessler renamed PAI → LifeOS and is pivoting from "clone a `~/.claude`
+directory" to an LLM-driven agentic per-machine installer. The Discord critique
+(Vincent Zontini, Kyle, Robert Chuvala, Andreas Aaström) named the real failures:
+
+- **Brittle monolith** — "one directory, one layout, hope it matches your setup."
+- **Stale harness** — hooks not on current Claude Code API; Algorithm-as-`CLAUDE.md`
+  monolith against best practice; skills not on the Anthropic skill spec.
+- **Rigid memory** — fixed telos/ISA/memory schema; letta's counter-bet is that 2026
+  models self-organize memory better than a prescribed schema.
+- **Governance** — the deepest critique. Ignored PRs, mass-closed issues, "open
+  source in concept." Architecture was never the gating failure; trust and adoption were.
+
+Wishlist (#647): reproducible builds, dependency/API-key docs, lowercase paths,
+foundation/extension repo split, Handlebars-style templating, JSON task slices.
+
+Most of these Soma already answers structurally. The interesting work is the two
+forward-looking tensions: **rigid vs. agent-managed structure**, and
+**deterministic vs. LLM-driven install**.
+
+---
+
+## What the lenses surfaced (consistent framing, not independent proof)
+
+| Claim | FirstPrinciples | Creative | Oscillation | Council |
+|---|---|---|---|---|
+| Deterministic projection/adapters = the moat | HARD atom | proof (#4) | the seam | Mara/Pim |
+| 7-compartment **content schema** is inherited, not load-bearing | INHERITED, drop as requirement | — | tension #2 | concede |
+| Don't out-build letta/beads — consume them | — | exit standard | seam not harness | Devansh |
+| Real gating risk is governance/adoption, not architecture | — | #3/#5 | — | Theo |
+| LLM *diagnoses* install, typed code *commits* | — | #4 | — | Pim |
+
+---
+
+## The dividing line (keystone)
+
+> **Soma is deterministic about *where things go* and *what may move between
+> substrates*. The assistant is free about *what it writes inside a compartment*.**
+> Structure governs movement and trust; the model governs content.
+
+**Stays typed / `git diff`-able / fixture-tested:**
+- projection + adapters
+- install / uninstall
+- Algorithm / ISA phase gates, criterion verification
+- policy ownership, writeback gates
+- compartment *boundaries* — as namespace + policy scope
+
+**Becomes agent-managed (inside the gates):**
+- memory *content and organization* — free-form, assistant-authored, **no field schema**
+- the compartment is a folder + policy, not a struct
+
+### The boundary contract (Luna — the schema didn't vanish, it moved)
+
+"Drop the content schema" and "the index stays typed and eager" are only
+non-contradictory if the boundary is named. A typed index over untyped bodies
+requires a contract *at the seam*:
+
+> **Each loose body emits a minimal typed manifest** (id, compartment, title,
+> created/updated, optional tags/links). The body content is free-form; the
+> manifest is the typed surface the index, projection, and writeback gate read.
+
+So the schema moved from the *body* to a thin *per-body manifest*. That manifest
+is the precise point where letta's "models self-organize" bet meets Soma's
+portability requirement. Name it, version it, fixture-test it. Everything below
+the manifest is the model's; everything at and above it is Soma's.
+
+This satisfies letta's agency critique without surrendering the one property letta
+structurally cannot have — portability. The manifest + index have fixtures; the
+body is just files; a 1.5-FTE team can test all of it.
+
+---
+
+## Highest-leverage structural move: kernel / content-pack split
+
+Split Soma into:
+
+- **Portability kernel** — the 5 load-bearing atoms only: home, projection,
+  writeback, policy, identity contract.
+- **Content-pack layer** — Telos / ISA / Algorithm / compartment-schema as *one
+  default pack among possible packs*.
+
+**Falsifiable acceptance test:** a user installs kernel + zero content schema and
+still gets a recognizable portable assistant; a letta-style self-organizing-memory
+pack and the current structured PAI-derived pack both install over the same kernel
+**without touching adapter code**. If swapping the pack forces adapter changes, the
+split has failed.
+
+This is the architectural form of the dividing line — and what lets Soma *host*
+best-of-breed instead of cloning it. (Scheduled **next quarter**, not this one.)
+
+---
+
+## The reframe: seam, not harness
+
+Stop spending the quality budget deepening Algorithm/ISA — substrates are
+commoditizing exactly that via native `/goal`, memory, and skills. Spend it on the
+seam instead.
+
+### "Lossless" is a destination, not a milestone (Luna)
+
+Bidirectional lossless writeback across letta memory + a beads graph + native
+`/goal` is a CS-hard, unbounded problem — the kind that eats small teams.
+*Deepening Algorithm is bounded; interop is not.* Don't let the reframe invert the
+risk and treat interop as the safe spend.
+
+**Scope a v0 with explicit edges:**
+- **one substrate pair**, **one direction** of writeback
+- an explicit **lossy-fields register** — what does *not* round-trip, named in the doc
+- "lossless across all tools" is the north star, never a sprint goal
+
+### Interop spine: target `.af`, don't author a Soma format (verified 2026-06-22)
+
+letta-code is the reference implementation of the "self-organizing-memory pack" the
+kernel/content-pack test names — so researching it *is* building Exhibit A. Two
+verified facts make it the v0 seam:
+- **letta-code persists via git (MemFS), not a DB** — "all context including memory
+  blocks is tracked via git." The DB-impedance fear is downgraded; local letta-code
+  is Soma's own shape. Only hosted Constellation is DB-backed.
+- **`.af` (Agent File, Apache-2.0) already ships Luna's boundary contract**: memory
+  blocks = label (typed index) + content (free-form body). Don't invent a Soma
+  interchange — **emit/ingest `.af`**. It already excludes archival passages and
+  nulls secrets, so the lossy register is partly pre-defined.
+
+Full mapping + bounded v0 scope: `2026-06-22-letta-af-soma-fieldmap.md`. The `.af`
+ingest spike (memory blocks → Soma bodies+manifest, one direction) is the smallest
+test that proves or breaks the dividing line.
+
+### Position Soma as the Exit / Migration standard
+
+"Data portability for assistants." This inverts the Discord grievance (lock-in,
+mass-closed issues, "open source in concept") into Soma's core promise, already the
+README tagline: *change tools without losing the assistant.*
+
+> **Unvalidated assumption (Luna).** This bet asserts demand it never sizes —
+> the same chicken-and-egg that dinged the Notary and Escrow directions. Portability
+> only has value if users actually churn substrates. **Validate before betting the
+> roadmap on it:** who feels substrate lock-in pain today, how many, how often? If
+> most users live in one substrate, the exit standard is insurance nobody buys. The
+> moat is real; the *market* is assumed. Size it.
+
+---
+
+## Non-negotiable: governance as product
+
+Architecture is moot if two part-time maintainers can't merge community work. The
+decisive differentiator vs PAI is an **explicit, honored contribution + triage
+contract** — and it must be enforced, not aspirational.
+
+**Two concrete CI checks to start (Luna — make it real, not rhetoric):**
+1. **Stale-PR / stale-issue auto-labeling** with a published response SLA timer
+   (e.g. label `needs-maintainer` after N days untouched; surface the count
+   publicly). The opposite of silent backlog.
+2. **Won't-fix register enforcement** — a tracked, public `WONT_FIX.md`; closing an
+   issue as won't-fix requires an entry, and CI fails a close that bypasses it.
+   The opposite of mass-closing without a trace.
+
+Ship this **alongside 0.9**, this quarter. Being-the-exit is only credible if Soma
+visibly runs an open door.
+
+---
+
+## Plan — sequenced by leverage, not listed (Luna)
+
+Six large bets numbered 1–6 is 12+ months for 1.5 FTE wearing a quarter's clothing.
+A plan that ships all six ships none. Forced pick:
+
+### This quarter (ship)
+1. **Distribution leaks** — #302 (`arc install` exposes **no runnable `soma` on
+   PATH**; every README command assumes a binary that isn't installed) and #305
+   (registry serves untagged 0.8.5 as "latest"; `@0.8.4` pin resolves to 0.8.5;
+   install record internally inconsistent). *Verified 2026-06-22.* Trust-critical,
+   cheap, blocks the reproducibility story at its edge. **Do first.**
+2. **Governance contract + won't-fix register + stale-PR CI** (the two checks above).
+
+### Item 0 — dogfood proof (cheapest, possibly the headline)
+Promote the coda. This Claude Code session runs a giant PAI `CLAUDE.md` monolith
+with ~100 eager-loaded skills — the exact anti-pattern the thread mocks. Dogfood
+Soma's indexed-registry / on-demand-body model on Soma's *own* dev env and you
+rebut "open source in concept" with a **running demo instead of a promise**. Likely
+shippable inside the quarter; sequence it before or beside the distribution fix.
+
+### Next quarter
+3. **Kernel / content-pack split** (+ the named manifest boundary contract).
+4. **Loose-memory tier** (assistant-authored bodies, typed manifest + index).
+
+### Backlog (not this half)
+5. **JSON task-graph as ISA-native** — runs are already JSON under
+   `WORK/algorithm-runs/`; make spec→plan→JSON-slice→spawn first-class. Real gap,
+   but not gating.
+6. **`soma doctor` → machine-quirk diagnosing agent.** *Correction (verified):*
+   `src/adapters/doctor.ts` already does per-substrate **projection-drift**
+   diagnosis (codex/claude-code/grok) — it is not a presence-only check. The
+   *extension* is to have an LLM diagnose **machine quirks** doctor doesn't cover
+   (hook API version, paths, OS, case-sensitivity) and *propose* typed adapter
+   config the adapter validates and writes. Beats LifeOS's pure-LLM installer
+   (auditable + reproducible) and PAI's static clone (adaptive).
+
+### Cheap trust sweep (opportunistic, any quarter)
+Per-skill dependency/API-key manifest; lowercase/case-sensitive path normalization
+on `migrate claude-skills` (**unverified — check before scheduling**); document
+foundation/extension separation as the headline advantage it already is.
+
+---
+
+## What NOT to do
+
+- Don't chase LifeOS into LLM-driven install (nondeterministic, unauditable per machine).
+- Don't abandon structure wholesale for letta-style freedom — that throws away the moat.
+- Don't keep deepening Algorithm/ISA as if harness depth is the product.
+- Don't treat "lossless interop" as a milestone, or the exit-standard market as proven.
+
+---
+
+## Divergent directions considered (Creative lens, for the record)
+
+1. **Notary** — cryptographically attest the same assistant ran across N substrates. Too early.
+2. **Escrow for agent labor** — portable ISA + provenance settles trust between strangers' agents. Chicken-and-egg with the network.
+3. **Exit/Migration standard** — *selected, market unvalidated.* Governance grievance inverted into product.
+4. **Differential installer** — LLM diagnoses, code commits. *Carried as proof for #3.*
+5. **Governance-as-code** — posture as product. Not defensible IP alone; folded into the non-negotiable above.
+
+---
+
+## Review log
+
+- **2026-06-22 — Luna (logic review; could not reach repo, did not re-audit code).**
+  Verdict: ratify the seam thesis + dividing line as *direction*; send back four
+  things before they are load-bearing — (a) the convergence framing (cut/caveat),
+  (b) "lossless" scope (bound it), (c) the index/body boundary contract (name it),
+  (d) the quarter plan (cut to two bets). All four incorporated above. Flagged that
+  load-bearing facts were author assertions; **#302, #305, and `doctor.ts` since
+  re-verified against the repo** — #302/#305 confirmed (302 worse than written),
+  the `doctor.ts` "presence-only" claim corrected to projection-drift diagnosis.

--- a/docs/adr/0001-de-miessler-vocabulary.md
+++ b/docs/adr/0001-de-miessler-vocabulary.md
@@ -1,0 +1,85 @@
+---
+status: accepted
+---
+
+# De-Miessler the working-method vocabulary: `checkpoint`, `intent`, `Purpose`, `Verification`, `VSA`
+
+## Context
+
+Soma's working-method vocabulary was inherited wholesale from Daniel Miessler's
+PAI: the **Telos** compartment and the **ISA / ISC / Algorithm / effort-tier /
+euphoric-surprise** apparatus. Two problems. First, the lineage: these are
+Miessler's constructs, and Soma's differentiation argument weakens if its core
+nouns are borrowed. Second, the weight: PAI's Telos is a nine-category LifeOS
+schema (mission, beliefs, narratives, strategies, problems, challenges, measures),
+and JC's explicit stance is *"Personal AI Infrastructure, not a LifeOS."*
+
+First-principles on the two constructs showed both reduce to the **same bone**: a
+checkable criterion + required evidence → typed verdict, behind a completion gate.
+ISA points that bone at *done-ness*; Telos's one durable function points it at
+*direction*. The code already proves the shape — `IdealStateCriterion { text,
+status, verification }` (`src/types.ts`) is exactly the bone, and `Telos` is
+already slimmed to `{ mission, goals, principles, commitments }`.
+
+## Decision
+
+Three canonical terms, locked in `CONTEXT.md`:
+
+- **`checkpoint`** — the extracted evidence-gated verification primitive
+  ({ criterion, evidence, typed verdict, completion gate }), applied on two axes:
+  done-ness and intent. The deterministic spine: *inference proposes, the
+  checkpoint disposes.*
+- **`intent`** — the checkable directional anchor a checkpoint scores work against
+  (the one durable bone of Telos, minus the schema).
+- **`Purpose`** — the compartment formerly named **Telos** (the English meaning of
+  *telos*). Unchanged in shape and role; only the brand moved.
+- **`Verification`** — the compartment formerly named **ISA**. Names its actual job:
+  done-ness, established with evidence. (Policy's descriptor reworded from
+  "verification rules" to "evidence and audit rules" to clear the lowercase collision.)
+- **`VSA` (Verification State Artifact)** — the artifact formerly named **ISA**
+  (Ideal State Artifact). One-for-one swap: Ideal → Verification, keeping State
+  Artifact. `soma isa` → `soma vsa`.
+
+This is a **shared primitive across two existing compartments, not a compartment
+merge** — the seven compartments stay seven (Identity · Purpose · Verification ·
+Skills · Memory · Policy · Learning). The Algorithm/effort-tier/euphoric-surprise
+apparatus remains as an *optional workflow pack* over checkpoints, not the canonical
+primitive name.
+
+## Considered options
+
+- **Direction-anchor name.** `heading` was locked first, then rejected — it
+  collides with markdown section titles, which are ubiquitous in a docs-native
+  repo. `bearing` was rejected — it collides with "load-bearing," pervasive in the
+  architecture prose. `intent` chosen: clarity over the nautical-metaphor cohesion.
+- **Compartment merge vs. shared primitive.** A literal ISA+Telos merge (seven → six)
+  was rejected: it would rewrite `architecture.md`, `soma-home-layout.md`, the home
+  layout, and the `soma isa` CLI while discarding structure (Algorithm runs, phases,
+  reconcile partitions) that is not the primitive.
+- **`Purpose` vs. `Aim`.** `Aim` was the runner-up; `Purpose` won as the literal
+  translation of *telos*, preserving meaning while dropping the brand.
+- **`Verification` vs. `Method`.** `Method` was the zero-collision runner-up but
+  broader than the compartment's verification core; `Verification` chosen, with the
+  Policy descriptor reworded to clear the lowercase collision.
+- **`VSA` vs. `Verifact` / `VA`.** `Verifact` (catchier, full break) and `VA`
+  (overloaded acronym) rejected; `VSA` keeps the ISA cadence so the rename is
+  mechanical.
+- **Killing `ISA` now vs. deferring.** Deferring ISA was initially recommended
+  (descriptive English, large footprint). JC chose to kill it in the same pass for a
+  fully de-Miesslered set; accepted.
+
+## Consequences
+
+- `CONTEXT.md` glossary updated now (this session).
+- **Pending code/doc/path rename** (not done here, larger than the glossary):
+  - Telos → Purpose: `interface Telos` (`src/types.ts`), the `telos/` home path,
+    `~/.claude/rules/soma/TELOS.md` projection, `soma`/migrate references, `docs/`.
+  - ISA → Verification / VSA: `soma isa` → `soma vsa` CLI, `IsaFrontmatter`,
+    `SomaActiveIsaState`, `IsaSection`, `isa-reconcile`, `src/skills/ISA/`, the five
+    `e1`–`e5` example docs, and ISA mentions across `docs/`.
+  Scope as a follow-up task before the terms are load-bearing in code. The CONTEXT.md
+  glossary is the source of truth in the interim.
+- `ISA` / `ISC` / effort tiers / euphoric surprise are retired as *canonical* Soma
+  terms but retained as an optional Algorithm pack — existing VSA docs and CLI keep
+  working under the old names until the rename lands.
+- Reversible only at meaningful cost once the code/path rename lands; hence this record.


### PR DESCRIPTION
Lands the canonical vocabulary decided in a `grill-with-docs` session with JC, plus the strategy and 188-run findings docs.

## Glossary (CONTEXT.md)
- **checkpoint** — extracted evidence-gated verification primitive; two axes (done-ness + intent)
- **intent** — forward-looking directional anchor (telos's one bone, de-schema'd)
- **Purpose** — compartment formerly **Telos**
- **Verification** / **VSA** — compartment + artifact formerly **ISA**
- Policy descriptor reworded ("verification rules" → "evidence and audit rules") to clear the collision
- All seven compartments now Miessler-free: Identity · Purpose · Verification · Skills · Memory · Policy · Learning

## ADR
- `docs/adr/0001-de-miessler-vocabulary.md` — decision, rejected alternatives (heading/bearing, Method, Verifact/VA, merge-vs-shared, defer-vs-kill-ISA), consequences.

## Plans (strategy + evidence)
- `…-soma-direction-verification-primitive.md` — the direction (inference proposes, checkpoint disposes)
- `…-algorithm-runner-prompt-findings.md` — 188-run analysis behind #330/#331/#332/#333
- seam-thesis (superseded) + letta-af-fieldmap (reference) kept for the trail

Docs only — no code. The code/path rename (`interface Telos`→`Purpose`, `soma isa`→`soma vsa`, …) is tracked in #329.

Refs #329