### PR TITLE
fix(algorithm): type verification evidence (specified/probed/tested) + deferred-probe gate

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,9 @@ OBSERVE -> THINK -> PLAN -> BUILD -> EXECUTE -> VERIFY -> LEARN -> COMPLETE
 
 Each transition has a gate. For example, PLAN requires selected capabilities,
 BUILD requires a criterion-mapped plan, VERIFY requires every plan step to be
-done or blocked, LEARN requires every criterion to be passed or dropped, and
+done or blocked, LEARN requires every criterion to be passed, dropped, or
+deferred-probe and refuses a `passed` criterion whose evidence is
+specification-only (it must be probed/tested or explicitly deferred-probe), and
 COMPLETE rejects structured capability selections that were not invoked or
 removed. This is the part that adds determinism: the LLM can propose content,
 but Soma decides whether the process is allowed to advance.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,10 +51,10 @@ OBSERVE -> THINK -> PLAN -> BUILD -> EXECUTE -> VERIFY -> LEARN -> COMPLETE
 Each transition has a gate. For example, PLAN requires selected capabilities,
 BUILD requires a criterion-mapped plan, VERIFY requires every plan step to be
 done or blocked, LEARN requires every criterion to be passed, dropped, or
-deferred-probe and refuses a `passed` criterion whose evidence is
-specification-only (it must be probed/tested or explicitly deferred-probe), and
-COMPLETE rejects structured capability selections that were not invoked or
-removed. This is the part that adds determinism: the LLM can propose content,
+deferred-probe and refuses a `passed` criterion whose evidence kind is
+explicitly `specified` (it must claim probed/tested, or be marked deferred-probe;
+legacy criteria with no recorded evidence kind are grandfathered), and COMPLETE
+rejects structured capability selections that were not invoked or removed. This is the part that adds determinism: the LLM can propose content,
 but Soma decides whether the process is allowed to advance.
 
 The harness is driven through explicit mutations rather than substrate-specific

--- a/src/algorithm-isa-sync.ts
+++ b/src/algorithm-isa-sync.ts
@@ -37,7 +37,7 @@ import { readAlgorithmRunById, writeAlgorithmRun } from "./algorithm-store";
 import { datePrefixSlug } from "./dated-slug";
 import { getRunPhase } from "./algorithm-lifecycle";
 import { parseIsa, serializeIsa } from "./isa-parse";
-import { getCriteria, getDecisions, getGoal } from "./isa-accessors";
+import { getCriteria, getDecisions, getGoal, isClosedCriterion, isHollowPass } from "./isa-accessors";
 import { promoteAlgorithmRunMemory } from "./memory-promotion";
 import type {
   AlgorithmPhase,
@@ -185,15 +185,12 @@ function phaseIndex(phase: AlgorithmPhase): number {
  * still open — even if the ISA claims `learn`/`complete`.
  */
 function reachableTargetPhase(target: AlgorithmPhase, criteria: readonly IdealStateCriterion[]): AlgorithmPhase {
-  const allClosed =
-    criteria.length > 0 &&
-    criteria.every((c) => c.status === "passed" || c.status === "dropped" || c.status === "deferred-probe");
-  // Mirror the LEARN integrity gate: a `passed` criterion verified by
-  // specification only (e.g. a pass fabricated from a frontmatter progress
-  // counter) cannot clear LEARN, so sync must cap such a run at VERIFY rather
-  // than attempt an advance the gate will reject.
-  const hasHollowPass = criteria.some((c) => c.status === "passed" && c.evidenceKind === "specified");
-  const learnReachable = allClosed && !hasHollowPass;
+  const allClosed = criteria.length > 0 && criteria.every(isClosedCriterion);
+  // Mirror the LEARN integrity gate (shared predicates keep the two in lockstep):
+  // a `passed` criterion verified by specification only (e.g. a pass fabricated
+  // from a frontmatter progress counter) cannot clear LEARN, so sync must cap such
+  // a run at VERIFY rather than attempt an advance the gate will reject.
+  const learnReachable = allClosed && !criteria.some(isHollowPass);
   // `complete` is never a sync target — we stop at `learn`. `complete` requires
   // a learning entry + invoked capabilities, which the LEARN handling provides;
   // but leaving the run at `learn` keeps it resumable rather than terminal.
@@ -261,14 +258,6 @@ function advanceRunToPhase(run: AlgorithmRun, target: AlgorithmPhase, timestamp:
     guard += 1;
   }
   return next;
-}
-
-function isClosedCriterion(
-  criterion: IdealStateCriterion,
-): criterion is IdealStateCriterion & { status: "passed" | "dropped" | "deferred-probe" } {
-  return (
-    criterion.status === "passed" || criterion.status === "dropped" || criterion.status === "deferred-probe"
-  );
 }
 
 function progressCompletedCount(progress: string, total: number): number | null {

--- a/src/algorithm-isa-sync.ts
+++ b/src/algorithm-isa-sync.ts
@@ -37,7 +37,7 @@ import { readAlgorithmRunById, writeAlgorithmRun } from "./algorithm-store";
 import { datePrefixSlug } from "./dated-slug";
 import { getRunPhase } from "./algorithm-lifecycle";
 import { parseIsa, serializeIsa } from "./isa-parse";
-import { getCriteria, getDecisions, getGoal, isClosedCriterion, isHollowPass } from "./isa-accessors";
+import { getCriteria, getDecisions, getGoal, isClosedCriterion, learnGateViolations } from "./isa-accessors";
 import { promoteAlgorithmRunMemory } from "./memory-promotion";
 import type {
   AlgorithmPhase,
@@ -185,12 +185,12 @@ function phaseIndex(phase: AlgorithmPhase): number {
  * still open — even if the ISA claims `learn`/`complete`.
  */
 function reachableTargetPhase(target: AlgorithmPhase, criteria: readonly IdealStateCriterion[]): AlgorithmPhase {
-  const allClosed = criteria.length > 0 && criteria.every(isClosedCriterion);
-  // Mirror the LEARN integrity gate (shared predicates keep the two in lockstep):
+  // Mirror the LEARN integrity gate via the shared rule so the two cannot drift:
   // a `passed` criterion verified by specification only (e.g. a pass fabricated
-  // from a frontmatter progress counter) cannot clear LEARN, so sync must cap such
-  // a run at VERIFY rather than attempt an advance the gate will reject.
-  const learnReachable = allClosed && !criteria.some(isHollowPass);
+  // from a frontmatter progress counter) cannot clear LEARN, so sync caps such a
+  // run at VERIFY rather than attempt an advance the gate will reject.
+  const { unresolved, hollow } = learnGateViolations(criteria);
+  const learnReachable = criteria.length > 0 && unresolved.length === 0 && hollow.length === 0;
   // `complete` is never a sync target — we stop at `learn`. `complete` requires
   // a learning entry + invoked capabilities, which the LEARN handling provides;
   // but leaving the run at `learn` keeps it resumable rather than terminal.
@@ -295,9 +295,12 @@ function reconcileCriteria(
     const verification = isaCriterion.verification?.trim();
     const evidence = verification && verification.length > 0 ? verification : `synced from ISA: ${isaCriterion.text}`;
     // Preserve the markdown-declared evidence kind (`Evidence (probed): ...`).
-    // A bare `Evidence:` carries no kind and stays grandfathered — consistent with
-    // the library boundary — until the ISA-authoring prompt (P1) emits kinds. The
-    // egregious bypass (fabricating passes off a progress counter) is closed below.
+    // That kind is CALLER-ASSERTED, like every surface: an ISA author can write
+    // `Evidence (probed):` with no real probe and clear the gate. The gate does not
+    // close that — it makes a hollow pass an explicit, auditable, declared claim
+    // instead of the silent default. A bare `Evidence:` carries no kind and stays
+    // grandfathered. Only the synthetic progress-counter pass below is forced to
+    // `specified`, because nothing about it is even a claim of observation.
     next = verifyAlgorithmCriterion(
       next,
       isaCriterion.id,

--- a/src/algorithm-isa-sync.ts
+++ b/src/algorithm-isa-sync.ts
@@ -185,12 +185,20 @@ function phaseIndex(phase: AlgorithmPhase): number {
  * still open — even if the ISA claims `learn`/`complete`.
  */
 function reachableTargetPhase(target: AlgorithmPhase, criteria: readonly IdealStateCriterion[]): AlgorithmPhase {
-  const allClosed = criteria.length > 0 && criteria.every((c) => c.status === "passed" || c.status === "dropped");
+  const allClosed =
+    criteria.length > 0 &&
+    criteria.every((c) => c.status === "passed" || c.status === "dropped" || c.status === "deferred-probe");
+  // Mirror the LEARN integrity gate: a `passed` criterion verified by
+  // specification only (e.g. a pass fabricated from a frontmatter progress
+  // counter) cannot clear LEARN, so sync must cap such a run at VERIFY rather
+  // than attempt an advance the gate will reject.
+  const hasHollowPass = criteria.some((c) => c.status === "passed" && c.evidenceKind === "specified");
+  const learnReachable = allClosed && !hasHollowPass;
   // `complete` is never a sync target — we stop at `learn`. `complete` requires
   // a learning entry + invoked capabilities, which the LEARN handling provides;
   // but leaving the run at `learn` keeps it resumable rather than terminal.
   const capped = target === "complete" ? "learn" : target;
-  if (!allClosed && phaseIndex(capped) > phaseIndex("verify")) {
+  if (!learnReachable && phaseIndex(capped) > phaseIndex("verify")) {
     return "verify";
   }
   return capped;
@@ -257,8 +265,10 @@ function advanceRunToPhase(run: AlgorithmRun, target: AlgorithmPhase, timestamp:
 
 function isClosedCriterion(
   criterion: IdealStateCriterion,
-): criterion is IdealStateCriterion & { status: "passed" | "dropped" } {
-  return criterion.status === "passed" || criterion.status === "dropped";
+): criterion is IdealStateCriterion & { status: "passed" | "dropped" | "deferred-probe" } {
+  return (
+    criterion.status === "passed" || criterion.status === "dropped" || criterion.status === "deferred-probe"
+  );
 }
 
 function progressCompletedCount(progress: string, total: number): number | null {
@@ -295,7 +305,19 @@ function reconcileCriteria(
     if (existing.status === isaCriterion.status) continue; // already reconciled — idempotent
     const verification = isaCriterion.verification?.trim();
     const evidence = verification && verification.length > 0 ? verification : `synced from ISA: ${isaCriterion.text}`;
-    next = verifyAlgorithmCriterion(next, isaCriterion.id, isaCriterion.status, evidence, timestamp, { substrate });
+    // Preserve the markdown-declared evidence kind (`Evidence (probed): ...`).
+    // A bare `Evidence:` carries no kind and stays grandfathered — consistent with
+    // the library boundary — until the ISA-authoring prompt (P1) emits kinds. The
+    // egregious bypass (fabricating passes off a progress counter) is closed below.
+    next = verifyAlgorithmCriterion(
+      next,
+      isaCriterion.id,
+      isaCriterion.status,
+      evidence,
+      timestamp,
+      { substrate },
+      isaCriterion.evidenceKind,
+    );
   }
 
   const targetCompleted = frontmatterCompletionCount(isa, isaCriteria);
@@ -309,7 +331,9 @@ function reconcileCriteria(
     if (existing === undefined || isClosedCriterion(existing)) continue;
     const goal = getGoal(isa);
     const evidence = goal ? `synced from ISA progress: ${goal}` : `synced from ISA progress: ${isaCriterion.text}`;
-    next = verifyAlgorithmCriterion(next, isaCriterion.id, "passed", evidence, timestamp, { substrate });
+    // A pass fabricated to match a frontmatter progress counter is specification
+    // grade only — it must not clear the LEARN integrity gate as if probed.
+    next = verifyAlgorithmCriterion(next, isaCriterion.id, "passed", evidence, timestamp, { substrate }, "specified");
     runCriteria = getCriteria(next.isa);
     completed = runCriteria.filter(isClosedCriterion).length;
   }

--- a/src/algorithm-isa-sync.ts
+++ b/src/algorithm-isa-sync.ts
@@ -23,6 +23,7 @@ import { randomUUID } from "node:crypto";
 import {
   advanceAlgorithmRun,
   createAlgorithmRun,
+  learnGateViolations,
   nextAlgorithmPhase,
   recordAlgorithmChange,
   recordAlgorithmLearning,
@@ -37,7 +38,7 @@ import { readAlgorithmRunById, writeAlgorithmRun } from "./algorithm-store";
 import { datePrefixSlug } from "./dated-slug";
 import { getRunPhase } from "./algorithm-lifecycle";
 import { parseIsa, serializeIsa } from "./isa-parse";
-import { getCriteria, getDecisions, getGoal, isClosedCriterion, learnGateViolations } from "./isa-accessors";
+import { getCriteria, getDecisions, getGoal, isClosedCriterion } from "./isa-accessors";
 import { promoteAlgorithmRunMemory } from "./memory-promotion";
 import type {
   AlgorithmPhase,

--- a/src/algorithm-isa-sync.ts
+++ b/src/algorithm-isa-sync.ts
@@ -292,7 +292,12 @@ function reconcileCriteria(
     if (!isClosedCriterion(isaCriterion)) continue;
     const existing = runCriteriaById.get(isaCriterion.id);
     if (existing === undefined) continue;
-    if (existing.status === isaCriterion.status) continue; // already reconciled — idempotent
+    // Idempotent only when BOTH status and the declared evidence kind already
+    // match — otherwise an author upgrading `Evidence:` to `Evidence (specified):`
+    // (to flag an already-passed criterion hollow) would never sync the kind.
+    if (existing.status === isaCriterion.status && existing.evidenceKind === isaCriterion.evidenceKind) {
+      continue;
+    }
     const verification = isaCriterion.verification?.trim();
     const evidence = verification && verification.length > 0 ? verification : `synced from ISA: ${isaCriterion.text}`;
     // Preserve the markdown-declared evidence kind (`Evidence (probed): ...`).

--- a/src/algorithm-store.ts
+++ b/src/algorithm-store.ts
@@ -207,6 +207,7 @@ export function summarizeAlgorithmRun(run: AlgorithmRun, path: string): Algorith
     passed: 0,
     failed: 0,
     dropped: 0,
+    "deferred-probe": 0,
   };
 
   const criteria = getCriteria(run.isa);

--- a/src/algorithm-store.ts
+++ b/src/algorithm-store.ts
@@ -229,6 +229,7 @@ export function summarizeAlgorithmRun(run: AlgorithmRun, path: string): Algorith
     passedCriteria: counts.passed,
     failedCriteria: counts.failed,
     droppedCriteria: counts.dropped,
+    deferredProbeCriteria: counts["deferred-probe"],
     progress: `${completed}/${total}`,
   };
 }

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -19,8 +19,7 @@ import {
   buildIsaArtifact,
   defaultEvidenceKind,
   getCriteria,
-  isClosedCriterion,
-  isHollowPass,
+  learnGateViolations,
   progressFromCriteria,
   updateCriterionWithResult,
   verifiedFromCriteria,
@@ -314,16 +313,15 @@ function assertGate(run: AlgorithmRun, target: AlgorithmPhase): void {
       }
       break;
     case "learn": {
-      const criteria = getCriteria(run.isa);
-      const unresolved = criteria.filter((criterion) => !isClosedCriterion(criterion));
+      const { unresolved, hollow } = learnGateViolations(getCriteria(run.isa));
       if (unresolved.length > 0) {
         throw new Error(
           `Algorithm cannot enter LEARN until every criterion is passed, dropped, or deferred-probe. Unresolved: ${unresolved.map((c) => c.id).join(", ")}.`,
         );
       }
-      // Integrity gate: a 'passed' criterion verified by specification only is not
-      // real verification. Probe it (probed/tested) or mark it deferred-probe.
-      const hollow = criteria.filter(isHollowPass);
+      // Integrity gate: a 'passed' criterion verified by specification only is a
+      // self-attested claim, not a real probe. Probe it (probed/tested) or mark it
+      // deferred-probe.
       if (hollow.length > 0) {
         throw new Error(
           `Algorithm cannot enter LEARN: criteria verified by specification only — probe them (probed/tested) or mark deferred-probe: ${hollow.map((c) => c.id).join(", ")}.`,

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -240,10 +240,11 @@ export function recordAlgorithmLearning(
 export function verifyAlgorithmCriterion(
   run: AlgorithmRun,
   criterionId: string,
-  status: "passed" | "failed" | "dropped",
+  status: "passed" | "failed" | "dropped" | "deferred-probe",
   evidence: string,
   timestamp?: string,
   provenance?: Pick<AlgorithmProvenanceInput, "substrate">,
+  evidenceKind?: IdealStateCriterion["evidenceKind"],
 ): AlgorithmRun {
   assertNonEmpty(evidence, "verification evidence");
 
@@ -252,6 +253,7 @@ export function verifyAlgorithmCriterion(
     criterionId,
     status,
     evidence,
+    evidenceKind,
   );
   const entry = logEntry(getRunPhase(run), `${criterionId}: ${status}. ${evidence}`, timestamp);
   const isaWithRecompute: IdealStateArtifact = {
@@ -310,8 +312,26 @@ function assertGate(run: AlgorithmRun, target: AlgorithmPhase): void {
       break;
     case "learn": {
       const criteria = getCriteria(run.isa);
-      if (!criteria.every((criterion) => criterion.status === "passed" || criterion.status === "dropped")) {
-        throw new Error("Algorithm cannot enter LEARN until every criterion is passed or dropped.");
+      const unresolved = criteria.filter(
+        (criterion) =>
+          criterion.status !== "passed" &&
+          criterion.status !== "dropped" &&
+          criterion.status !== "deferred-probe",
+      );
+      if (unresolved.length > 0) {
+        throw new Error(
+          `Algorithm cannot enter LEARN until every criterion is passed, dropped, or deferred-probe. Unresolved: ${unresolved.map((c) => c.id).join(", ")}.`,
+        );
+      }
+      // Integrity gate: a 'passed' criterion verified by specification only is not
+      // real verification. Probe it (probed/tested) or mark it deferred-probe.
+      const hollow = criteria.filter(
+        (criterion) => criterion.status === "passed" && criterion.evidenceKind === "specified",
+      );
+      if (hollow.length > 0) {
+        throw new Error(
+          `Algorithm cannot enter LEARN: criteria verified by specification only — probe them (probed/tested) or mark deferred-probe: ${hollow.map((c) => c.id).join(", ")}.`,
+        );
       }
       break;
     }

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -19,11 +19,29 @@ import {
   buildIsaArtifact,
   defaultEvidenceKind,
   getCriteria,
-  learnGateViolations,
+  isClosedCriterion,
+  isHollowPass,
   progressFromCriteria,
   updateCriterionWithResult,
   verifiedFromCriteria,
 } from "./isa-accessors";
+
+/**
+ * The criteria that block entry to LEARN, split by reason. Single source of truth
+ * for the Algorithm's LEARN-gate policy — both the assertGate guard and sync's
+ * reachability check call this so the two cannot drift when a future evidence rule
+ * is added. Composes the pure isa-accessor predicates; gate policy lives here in
+ * the Algorithm module, not in the structural accessor layer.
+ */
+export function learnGateViolations(criteria: readonly IdealStateCriterion[]): {
+  unresolved: IdealStateCriterion[];
+  hollow: IdealStateCriterion[];
+} {
+  return {
+    unresolved: criteria.filter((criterion) => !isClosedCriterion(criterion)),
+    hollow: criteria.filter(isHollowPass),
+  };
+}
 import { getRunPhase } from "./algorithm-lifecycle";
 import { DEFAULT_ALGORITHM_LOOP_STATE } from "./algorithm-execution-modes";
 import { appendAlgorithmProvenance } from "./algorithm-provenance";

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -17,7 +17,10 @@ import {
 import { classifyAlgorithmPrompt } from "./algorithm-classifier";
 import {
   buildIsaArtifact,
+  defaultEvidenceKind,
   getCriteria,
+  isClosedCriterion,
+  isHollowPass,
   progressFromCriteria,
   updateCriterionWithResult,
   verifiedFromCriteria,
@@ -312,12 +315,7 @@ function assertGate(run: AlgorithmRun, target: AlgorithmPhase): void {
       break;
     case "learn": {
       const criteria = getCriteria(run.isa);
-      const unresolved = criteria.filter(
-        (criterion) =>
-          criterion.status !== "passed" &&
-          criterion.status !== "dropped" &&
-          criterion.status !== "deferred-probe",
-      );
+      const unresolved = criteria.filter((criterion) => !isClosedCriterion(criterion));
       if (unresolved.length > 0) {
         throw new Error(
           `Algorithm cannot enter LEARN until every criterion is passed, dropped, or deferred-probe. Unresolved: ${unresolved.map((c) => c.id).join(", ")}.`,
@@ -325,9 +323,7 @@ function assertGate(run: AlgorithmRun, target: AlgorithmPhase): void {
       }
       // Integrity gate: a 'passed' criterion verified by specification only is not
       // real verification. Probe it (probed/tested) or mark it deferred-probe.
-      const hollow = criteria.filter(
-        (criterion) => criterion.status === "passed" && criterion.evidenceKind === "specified",
-      );
+      const hollow = criteria.filter(isHollowPass);
       if (hollow.length > 0) {
         throw new Error(
           `Algorithm cannot enter LEARN: criteria verified by specification only — probe them (probed/tested) or mark deferred-probe: ${hollow.map((c) => c.id).join(", ")}.`,
@@ -472,7 +468,7 @@ export function applyAlgorithmBatch(
           operation.evidence,
           timestamp,
           provenance,
-          operation.evidenceKind ?? (operation.status === "passed" ? "specified" : undefined),
+          defaultEvidenceKind(operation.evidenceKind, operation.status),
         );
       case "capability":
         return selectAlgorithmCapability(current, {

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -465,7 +465,15 @@ export function applyAlgorithmBatch(
       case "step":
         return updateAlgorithmPlanStep(current, operation.stepId, operation.status, operation.evidence, timestamp);
       case "verify":
-        return verifyAlgorithmCriterion(current, operation.criterionId, operation.status, operation.evidence, timestamp, provenance);
+        return verifyAlgorithmCriterion(
+          current,
+          operation.criterionId,
+          operation.status,
+          operation.evidence,
+          timestamp,
+          provenance,
+          operation.evidenceKind ?? (operation.status === "passed" ? "specified" : undefined),
+        );
       case "capability":
         return selectAlgorithmCapability(current, {
           name: operation.capability,

--- a/src/cli/algorithm.ts
+++ b/src/cli/algorithm.ts
@@ -23,7 +23,7 @@ import { registerSomaHomeAlgorithmCapabilities } from "../algorithm-capabilities
 import { syncAlgorithmRunFromIsa, formatSyncResult } from "../algorithm-isa-sync";
 import { algorithmTouchedBy } from "../algorithm-provenance";
 import { datePrefixSlug } from "../dated-slug";
-import { getCriteria, getGoal } from "../isa-accessors";
+import { defaultEvidenceKind, getCriteria, getGoal } from "../isa-accessors";
 import { getRunPhase } from "../algorithm-lifecycle";
 import { readOption } from "./parse-utils";
 import { parseSubstrate } from "./substrate";
@@ -723,10 +723,14 @@ export async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<stri
     const criterionId = options.criterionId;
     const criterionStatus = options.criterionStatus;
     const evidence = options.evidence;
-    // At the user surface, a 'passed' with no explicit kind defaults to the weak
-    // 'specified' — the completion gate then forces an honest probe or deferred-probe.
-    const evidenceKind =
-      options.evidenceKind ?? (criterionStatus === "passed" ? "specified" : undefined);
+    if (options.evidenceKind !== undefined && criterionStatus !== "passed") {
+      throw new Error("--evidence-kind only applies to --status passed.");
+    }
+    // A 'passed' with no explicit kind defaults to the weak 'specified', which the
+    // LEARN gate refuses. The kind is caller-asserted: the gate forces an explicit
+    // probed/tested claim (or deferred-probe), making a hollow pass auditable — it
+    // does not verify the probe actually happened.
+    const evidenceKind = defaultEvidenceKind(options.evidenceKind, criterionStatus);
     return updateAndReportAlgorithmRun(options, (run) =>
       verifyAlgorithmCriterion(run, criterionId, criterionStatus, evidence, undefined, { substrate: options.substrate }, evidenceKind),
     );

--- a/src/cli/algorithm.ts
+++ b/src/cli/algorithm.ts
@@ -34,6 +34,7 @@ import type {
   AlgorithmPlanStep,
   AlgorithmRun,
   AlgorithmRunInput,
+  EvidenceKind,
   SubstrateId,
 } from "../types";
 
@@ -105,7 +106,7 @@ interface AlgorithmCliOptions {
   criterionId?: string;
   criterionStatus?: "passed" | "failed" | "dropped" | "deferred-probe";
   evidence?: string;
-  evidenceKind?: "specified" | "probed" | "tested";
+  evidenceKind?: EvidenceKind;
   substrate?: SubstrateId;
   untilPhase?: AlgorithmPhase;
   batchOperations?: AlgorithmBatchOperation[];
@@ -173,7 +174,7 @@ function parseCriterionStatus(value: string): "passed" | "failed" | "dropped" | 
   throw new Error("--status must be one of passed, failed, dropped, or deferred-probe.");
 }
 
-function parseEvidenceKind(value: string): "specified" | "probed" | "tested" {
+function parseEvidenceKind(value: string): EvidenceKind {
   if (value === "specified" || value === "probed" || value === "tested") {
     return value;
   }

--- a/src/cli/algorithm.ts
+++ b/src/cli/algorithm.ts
@@ -74,7 +74,7 @@ export const ALGORITHM_COMMAND_HELP: { usage: string; subcommands: Record<Algori
     decision: "Usage: soma algorithm decision --id <run-id> --text <text> [--home-dir <dir>] [--soma-home <dir>]",
     change: "Usage: soma algorithm change --id <run-id> --text <text> [--home-dir <dir>] [--soma-home <dir>]",
     step: "Usage: soma algorithm step --id <run-id> --step-id <id> --status <open|done|blocked> [--evidence <text>]",
-    verify: "Usage: soma algorithm verify --id <run-id> --criterion-id <id> --status <passed|failed|dropped> --evidence <text> [--substrate <id>]",
+    verify: "Usage: soma algorithm verify --id <run-id> --criterion-id <id> --status <passed|failed|dropped|deferred-probe> --evidence <text> [--evidence-kind <specified|probed|tested>] [--substrate <id>]",
     learn: "Usage: soma algorithm learn --id <run-id> --text <text> [--substrate <id>] [--home-dir <dir>] [--soma-home <dir>]",
     advance: "Usage: soma algorithm advance --id <run-id> [--substrate <id>] [--home-dir <dir>] [--soma-home <dir>]",
     resume: "Usage: soma algorithm resume --id <run-id> --until-phase <phase> [--substrate <id>] [--home-dir <dir>] [--soma-home <dir>]",
@@ -103,8 +103,9 @@ interface AlgorithmCliOptions {
   stepId?: string;
   stepStatus?: AlgorithmPlanStep["status"];
   criterionId?: string;
-  criterionStatus?: "passed" | "failed" | "dropped";
+  criterionStatus?: "passed" | "failed" | "dropped" | "deferred-probe";
   evidence?: string;
+  evidenceKind?: "specified" | "probed" | "tested";
   substrate?: SubstrateId;
   untilPhase?: AlgorithmPhase;
   batchOperations?: AlgorithmBatchOperation[];
@@ -164,12 +165,20 @@ function parseStepStatus(value: string): AlgorithmPlanStep["status"] {
   throw new Error("--status must be one of open, done, or blocked.");
 }
 
-function parseCriterionStatus(value: string): "passed" | "failed" | "dropped" {
-  if (value === "passed" || value === "failed" || value === "dropped") {
+function parseCriterionStatus(value: string): "passed" | "failed" | "dropped" | "deferred-probe" {
+  if (value === "passed" || value === "failed" || value === "dropped" || value === "deferred-probe") {
     return value;
   }
 
-  throw new Error("--status must be one of passed, failed, or dropped.");
+  throw new Error("--status must be one of passed, failed, dropped, or deferred-probe.");
+}
+
+function parseEvidenceKind(value: string): "specified" | "probed" | "tested" {
+  if (value === "specified" || value === "probed" || value === "tested") {
+    return value;
+  }
+
+  throw new Error("--evidence-kind must be one of specified, probed, or tested.");
 }
 
 function parsePlanStep(value: string): AlgorithmPlanStep {
@@ -417,6 +426,10 @@ export function parseAlgorithmArgs(args: string[]): ParsedAlgorithmArgs {
         break;
       case "--evidence":
         options.evidence = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--evidence-kind":
+        options.evidenceKind = parseEvidenceKind(readOption(rest, index, arg));
         index += 1;
         break;
       case "--op":
@@ -710,8 +723,12 @@ export async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<stri
     const criterionId = options.criterionId;
     const criterionStatus = options.criterionStatus;
     const evidence = options.evidence;
+    // At the user surface, a 'passed' with no explicit kind defaults to the weak
+    // 'specified' — the completion gate then forces an honest probe or deferred-probe.
+    const evidenceKind =
+      options.evidenceKind ?? (criterionStatus === "passed" ? "specified" : undefined);
     return updateAndReportAlgorithmRun(options, (run) =>
-      verifyAlgorithmCriterion(run, criterionId, criterionStatus, evidence, undefined, { substrate: options.substrate }),
+      verifyAlgorithmCriterion(run, criterionId, criterionStatus, evidence, undefined, { substrate: options.substrate }, evidenceKind),
     );
   }
 

--- a/src/isa-accessors.ts
+++ b/src/isa-accessors.ts
@@ -3,6 +3,8 @@ import type {
   AlgorithmLogEntry,
   AlgorithmMode,
   AlgorithmPhase,
+  CriterionStatus,
+  EvidenceKind,
   IdealStateArtifact,
   IdealStateCriterion,
   IsaSection,
@@ -129,6 +131,21 @@ export function isHollowPass(criterion: IdealStateCriterion): boolean {
 }
 
 /**
+ * The criteria that block entry to LEARN, split by reason. Single source of truth
+ * for the gate rule — both the assertGate guard and sync's reachability check call
+ * this so the two cannot drift when a future evidence rule is added.
+ */
+export function learnGateViolations(criteria: readonly IdealStateCriterion[]): {
+  unresolved: IdealStateCriterion[];
+  hollow: IdealStateCriterion[];
+} {
+  return {
+    unresolved: criteria.filter((criterion) => !isClosedCriterion(criterion)),
+    hollow: criteria.filter(isHollowPass),
+  };
+}
+
+/**
  * The evidence kind to record for a verification. A `passed` with no explicit
  * kind defaults to the weak, self-attested `specified` so it cannot silently
  * clear the LEARN gate; non-passed statuses carry no evidence kind.
@@ -139,9 +156,9 @@ export function isHollowPass(criterion: IdealStateCriterion): boolean {
  * deferred-probe"; it makes a hollow pass explicit and auditable, not impossible.
  */
 export function defaultEvidenceKind(
-  kind: IdealStateCriterion["evidenceKind"],
-  status: IdealStateCriterion["status"],
-): IdealStateCriterion["evidenceKind"] {
+  kind: EvidenceKind | undefined,
+  status: CriterionStatus,
+): EvidenceKind | undefined {
   return kind ?? (status === "passed" ? "specified" : undefined);
 }
 

--- a/src/isa-accessors.ts
+++ b/src/isa-accessors.ts
@@ -111,6 +111,40 @@ export function updateCriterionWithResult(
   return { isa: setCriteria(isa, updated), criteria: updated };
 }
 
+/** A criterion that no longer needs work: verified, dropped, or honestly deferred. */
+export function isClosedCriterion(
+  criterion: IdealStateCriterion,
+): criterion is IdealStateCriterion & { status: "passed" | "dropped" | "deferred-probe" } {
+  return (
+    criterion.status === "passed" || criterion.status === "dropped" || criterion.status === "deferred-probe"
+  );
+}
+
+/**
+ * A `passed` criterion whose evidence is a specification/design claim only.
+ * It is self-attested, not a real probe, so it must not clear the LEARN gate.
+ */
+export function isHollowPass(criterion: IdealStateCriterion): boolean {
+  return criterion.status === "passed" && criterion.evidenceKind === "specified";
+}
+
+/**
+ * The evidence kind to record for a verification. A `passed` with no explicit
+ * kind defaults to the weak, self-attested `specified` so it cannot silently
+ * clear the LEARN gate; non-passed statuses carry no evidence kind.
+ *
+ * NOTE: the kind is caller-asserted. Soma records the claim — it does NOT verify
+ * that a `probed`/`tested` label corresponds to a real probe or test. The gate
+ * raises the bar from "any text passes" to "declare a probe/test or accept
+ * deferred-probe"; it makes a hollow pass explicit and auditable, not impossible.
+ */
+export function defaultEvidenceKind(
+  kind: IdealStateCriterion["evidenceKind"],
+  status: IdealStateCriterion["status"],
+): IdealStateCriterion["evidenceKind"] {
+  return kind ?? (status === "passed" ? "specified" : undefined);
+}
+
 export function updateCriterion(
   isa: IdealStateArtifact,
   criterionId: string,

--- a/src/isa-accessors.ts
+++ b/src/isa-accessors.ts
@@ -131,21 +131,6 @@ export function isHollowPass(criterion: IdealStateCriterion): boolean {
 }
 
 /**
- * The criteria that block entry to LEARN, split by reason. Single source of truth
- * for the gate rule — both the assertGate guard and sync's reachability check call
- * this so the two cannot drift when a future evidence rule is added.
- */
-export function learnGateViolations(criteria: readonly IdealStateCriterion[]): {
-  unresolved: IdealStateCriterion[];
-  hollow: IdealStateCriterion[];
-} {
-  return {
-    unresolved: criteria.filter((criterion) => !isClosedCriterion(criterion)),
-    hollow: criteria.filter(isHollowPass),
-  };
-}
-
-/**
  * The evidence kind to record for a verification. A `passed` with no explicit
  * kind defaults to the weak, self-attested `specified` so it cannot silently
  * clear the LEARN gate; non-passed statuses carry no evidence kind.

--- a/src/isa-accessors.ts
+++ b/src/isa-accessors.ts
@@ -92,6 +92,7 @@ export function updateCriterionWithResult(
   criterionId: string,
   status: IdealStateCriterion["status"],
   verification?: string,
+  evidenceKind?: IdealStateCriterion["evidenceKind"],
 ): UpdateCriterionResult {
   const criteria = getCriteria(isa);
   if (!criteria.some((criterion) => criterion.id === criterionId)) {
@@ -99,7 +100,12 @@ export function updateCriterionWithResult(
   }
   const updated = criteria.map((criterion) =>
     criterion.id === criterionId
-      ? { ...criterion, status, verification: verification ?? criterion.verification }
+      ? {
+          ...criterion,
+          status,
+          verification: verification ?? criterion.verification,
+          evidenceKind: evidenceKind ?? criterion.evidenceKind,
+        }
       : criterion,
   );
   return { isa: setCriteria(isa, updated), criteria: updated };
@@ -154,8 +160,8 @@ function canonicalInsertIndex(sections: readonly IsaSection[], name: string): nu
   return sections.length;
 }
 
-const CRITERION_LINE = /^- \[([ x\-_!])\]\s+([^:]+):\s*(.+)$/;
-const EVIDENCE_LINE = /^\s{2,}Evidence:\s*(.+)$/;
+const CRITERION_LINE = /^- \[([ x\-_!~])\]\s+([^:]+):\s*(.+)$/;
+const EVIDENCE_LINE = /^\s{2,}Evidence(?:\s*\((specified|probed|tested)\))?:\s*(.+)$/;
 
 export function parseCriteriaMarkdown(content: string): IdealStateCriterion[] {
   const out: IdealStateCriterion[] = [];
@@ -164,7 +170,11 @@ export function parseCriteriaMarkdown(content: string): IdealStateCriterion[] {
     const evidenceMatch = EVIDENCE_LINE.exec(rawLine);
     const last = out.at(-1);
     if (evidenceMatch !== null && last !== undefined) {
-      last.verification = evidenceMatch[1].trim();
+      const kind = evidenceMatch[1];
+      last.verification = evidenceMatch[2].trim();
+      if (kind === "specified" || kind === "probed" || kind === "tested") {
+        last.evidenceKind = kind;
+      }
       continue;
     }
     const criterion = parseCriterionLine(line.trim());
@@ -192,6 +202,8 @@ function criterionStatusFromMark(mark: string): IdealStateCriterion["status"] {
       return "dropped";
     case "!":
       return "failed";
+    case "~":
+      return "deferred-probe";
     default:
       return "open";
   }
@@ -205,6 +217,8 @@ function criterionStatusMark(status: IdealStateCriterion["status"]): string {
       return "-";
     case "failed":
       return "!";
+    case "deferred-probe":
+      return "~";
     default:
       return " ";
   }
@@ -228,7 +242,8 @@ export function renderCriteriaMarkdown(criteria: readonly IdealStateCriterion[])
         return head;
       }
       assertSingleLine("verification", criterion.id, criterion.verification);
-      return `${head}\n  Evidence: ${criterion.verification}`;
+      const kindTag = criterion.evidenceKind ? ` (${criterion.evidenceKind})` : "";
+      return `${head}\n  Evidence${kindTag}: ${criterion.verification}`;
     })
     .join("\n");
 }

--- a/src/isa-reconcile.ts
+++ b/src/isa-reconcile.ts
@@ -293,10 +293,12 @@ function statusRank(status: IdealStateCriterion["status"]): number {
       return 0;
     case "failed":
       return 1;
-    case "passed":
+    case "deferred-probe":
       return 2;
-    case "dropped":
+    case "passed":
       return 3;
+    case "dropped":
+      return 4;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,8 +25,16 @@ export interface Telos {
 export interface IdealStateCriterion {
   id: string;
   text: string;
-  status: "open" | "passed" | "failed" | "dropped";
+  status: "open" | "passed" | "failed" | "dropped" | "deferred-probe";
   verification?: string;
+  /**
+   * How the verification evidence was obtained.
+   * - `specified`: design/spec claim only ("the doc says X") — weak, blocks completion.
+   * - `probed`: behaviour observed at runtime (curl, grep of running state).
+   * - `tested`: covered by an automated test.
+   * Undefined on legacy/pre-feature criteria (grandfathered by the LEARN gate).
+   */
+  evidenceKind?: "specified" | "probed" | "tested";
 }
 
 export type AlgorithmPhase = "observe" | "think" | "plan" | "build" | "execute" | "verify" | "learn" | "complete" | "abandoned";
@@ -331,7 +339,7 @@ export type AlgorithmBatchOperation =
   | {
       kind: "verify";
       criterionId: string;
-      status: "passed" | "failed" | "dropped";
+      status: "passed" | "failed" | "dropped" | "deferred-probe";
       evidence: string;
     }
   | {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,22 +22,26 @@ export interface Telos {
   commitments: string[];
 }
 
+/**
+ * What the verifier CLAIMS about how the evidence was obtained. A caller-asserted
+ * label, NOT a machine-verified fact — Soma records the claim and gates on it, but
+ * does not confirm a `probed`/`tested` label corresponds to a real probe or test
+ * on any surface (CLI, ISA markdown, or library).
+ * - `specified`: a design/spec claim only ("the doc says X") — weak; blocks the LEARN gate.
+ * - `probed`: caller asserts behaviour was observed at runtime (curl, grep of running state).
+ * - `tested`: caller asserts coverage by an automated test.
+ */
+export type EvidenceKind = "specified" | "probed" | "tested";
+
+export type CriterionStatus = "open" | "passed" | "failed" | "dropped" | "deferred-probe";
+
 export interface IdealStateCriterion {
   id: string;
   text: string;
-  status: "open" | "passed" | "failed" | "dropped" | "deferred-probe";
+  status: CriterionStatus;
   verification?: string;
-  /**
-   * What the verifier CLAIMS about how the evidence was obtained. This is a
-   * caller-asserted label, not a machine-verified fact — Soma records the claim
-   * and gates on it, but does not confirm a `probed`/`tested` label corresponds
-   * to a real probe or test.
-   * - `specified`: a design/spec claim only ("the doc says X") — weak; blocks the LEARN gate.
-   * - `probed`: caller asserts behaviour was observed at runtime (curl, grep of running state).
-   * - `tested`: caller asserts coverage by an automated test.
-   * Undefined on legacy/pre-feature criteria (grandfathered by the LEARN gate).
-   */
-  evidenceKind?: "specified" | "probed" | "tested";
+  /** See {@link EvidenceKind}. Undefined on legacy/pre-feature criteria (grandfathered by the LEARN gate). */
+  evidenceKind?: EvidenceKind;
 }
 
 export type AlgorithmPhase = "observe" | "think" | "plan" | "build" | "execute" | "verify" | "learn" | "complete" | "abandoned";
@@ -345,7 +349,7 @@ export type AlgorithmBatchOperation =
       criterionId: string;
       status: "passed" | "failed" | "dropped" | "deferred-probe";
       evidence: string;
-      evidenceKind?: "specified" | "probed" | "tested";
+      evidenceKind?: EvidenceKind;
     }
   | {
       kind: "capability";

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,10 +28,13 @@ export interface IdealStateCriterion {
   status: "open" | "passed" | "failed" | "dropped" | "deferred-probe";
   verification?: string;
   /**
-   * How the verification evidence was obtained.
-   * - `specified`: design/spec claim only ("the doc says X") — weak, blocks completion.
-   * - `probed`: behaviour observed at runtime (curl, grep of running state).
-   * - `tested`: covered by an automated test.
+   * What the verifier CLAIMS about how the evidence was obtained. This is a
+   * caller-asserted label, not a machine-verified fact — Soma records the claim
+   * and gates on it, but does not confirm a `probed`/`tested` label corresponds
+   * to a real probe or test.
+   * - `specified`: a design/spec claim only ("the doc says X") — weak; blocks the LEARN gate.
+   * - `probed`: caller asserts behaviour was observed at runtime (curl, grep of running state).
+   * - `tested`: caller asserts coverage by an automated test.
    * Undefined on legacy/pre-feature criteria (grandfathered by the LEARN gate).
    */
   evidenceKind?: "specified" | "probed" | "tested";

--- a/src/types.ts
+++ b/src/types.ts
@@ -298,6 +298,7 @@ export interface AlgorithmRunSummary {
   passedCriteria: number;
   failedCriteria: number;
   droppedCriteria: number;
+  deferredProbeCriteria: number;
   progress: string;
 }
 
@@ -341,6 +342,7 @@ export type AlgorithmBatchOperation =
       criterionId: string;
       status: "passed" | "failed" | "dropped" | "deferred-probe";
       evidence: string;
+      evidenceKind?: "specified" | "probed" | "tested";
     }
   | {
       kind: "capability";

--- a/test/algorithm-isa-sync.test.ts
+++ b/test/algorithm-isa-sync.test.ts
@@ -325,10 +325,14 @@ test("reconciles frontmatter progress when ISA checkboxes remain unticked", asyn
     const result = await syncAlgorithmRunFromIsa({ isaPath, substrate: "claude-code", somaHome });
     expect(result.criteriaPassed).toBe(3);
     expect(result.criteriaTotal).toBe(3);
-    expect(result.phase).toBe("learn");
+    // Passes fabricated from a frontmatter progress counter are specification-grade
+    // only, so the LEARN integrity gate caps the run at VERIFY despite the ISA
+    // frontmatter claiming `learn`. Reconciliation still marks the criteria passed.
+    expect(result.phase).toBe("verify");
 
     const { run } = await readAlgorithmRunById(result.runId!, { somaHome });
     expect(getCriteria(run.isa).map((c) => c.status)).toEqual(["passed", "passed", "passed"]);
+    expect(getCriteria(run.isa).every((c) => c.evidenceKind === "specified")).toBe(true);
     expect(run.verification.map((entry) => entry.text)).toContain(
       "ISC-1: passed. synced from ISA progress: Honor frontmatter completion",
     );

--- a/test/algorithm-verification-evidence.test.ts
+++ b/test/algorithm-verification-evidence.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test";
+import {
+  addAlgorithmCapabilities,
+  advanceAlgorithmRun,
+  createAlgorithmRun,
+  getCriteria,
+  getRunPhase,
+  setAlgorithmPlan,
+  updateAlgorithmPlanStep,
+  verifyAlgorithmCriterion,
+} from "../src/index";
+
+// Fast-forward a fresh run to the VERIFY phase with one criterion C1.
+function toVerify(): ReturnType<typeof createAlgorithmRun> {
+  let run = createAlgorithmRun({
+    id: "evidence-kind-test",
+    timestamp: "2026-06-22T10:00:00.000Z",
+    prompt: "Exercise verification evidence kinds",
+    intent: "Close the tautological-verification hole.",
+    currentState: "Verify gate accepts assertion as evidence.",
+    goal: "Behavioral criteria require a probe.",
+    criteria: [{ id: "C1", text: "Endpoint returns 200 under test." }],
+  });
+  run = advanceAlgorithmRun(run, "2026-06-22T10:01:00.000Z"); // observe -> think
+  run = addAlgorithmCapabilities(run, ["sequential-analysis"], "2026-06-22T10:02:00.000Z");
+  run = advanceAlgorithmRun(run, "2026-06-22T10:03:00.000Z"); // think -> plan
+  run = setAlgorithmPlan(
+    run,
+    [{ id: "P1", text: "Implement + test.", criteriaIds: ["C1"], status: "open" }],
+    "2026-06-22T10:04:00.000Z",
+  );
+  run = advanceAlgorithmRun(run, "2026-06-22T10:05:00.000Z"); // plan -> build
+  run = {
+    ...run,
+    changelog: [{ timestamp: "2026-06-22T10:06:00.000Z", phase: "build", text: "Implemented." }],
+  };
+  run = advanceAlgorithmRun(run, "2026-06-22T10:07:00.000Z"); // build -> execute
+  run = updateAlgorithmPlanStep(run, "P1", "done", "Tests pass.", "2026-06-22T10:08:00.000Z");
+  run = advanceAlgorithmRun(run, "2026-06-22T10:09:00.000Z"); // execute -> verify
+  expect(getRunPhase(run)).toBe("verify");
+  return run;
+}
+
+test("verifyAlgorithmCriterion records the evidence kind on the criterion", () => {
+  let run = toVerify();
+  run = verifyAlgorithmCriterion(run, "C1", "passed", "curl /health -> 200", "2026-06-22T10:10:00.000Z", undefined, "probed");
+  const c1 = getCriteria(run.isa).find((c) => c.id === "C1");
+  expect(c1?.status).toBe("passed");
+  expect(c1?.evidenceKind).toBe("probed");
+});
+
+test("evidence kind round-trips through ISA markdown serialization", () => {
+  let run = toVerify();
+  run = verifyAlgorithmCriterion(run, "C1", "passed", "ran bun test", "2026-06-22T10:10:00.000Z", undefined, "tested");
+  // Re-parse from the serialized ISA sections.
+  const reparsed = getCriteria(run.isa).find((c) => c.id === "C1");
+  expect(reparsed?.evidenceKind).toBe("tested");
+});
+
+test("a passed criterion verified only as 'specified' blocks advance to LEARN", () => {
+  let run = toVerify();
+  run = verifyAlgorithmCriterion(run, "C1", "passed", "the design says it returns 200", "2026-06-22T10:10:00.000Z", undefined, "specified");
+  expect(() => advanceAlgorithmRun(run, "2026-06-22T10:11:00.000Z")).toThrow(/C1/);
+  expect(() => advanceAlgorithmRun(run, "2026-06-22T10:11:00.000Z")).toThrow(/probe|specified|deferred/i);
+});
+
+test("a probed pass advances to LEARN", () => {
+  let run = toVerify();
+  run = verifyAlgorithmCriterion(run, "C1", "passed", "curl -> 200", "2026-06-22T10:10:00.000Z", undefined, "probed");
+  run = advanceAlgorithmRun(run, "2026-06-22T10:11:00.000Z");
+  expect(getRunPhase(run)).toBe("learn");
+});
+
+test("deferred-probe is an honest resolved state accepted by the LEARN gate", () => {
+  let run = toVerify();
+  run = verifyAlgorithmCriterion(run, "C1", "deferred-probe", "design-only; real probe deferred to follow-up", "2026-06-22T10:10:00.000Z");
+  const c1 = getCriteria(run.isa).find((c) => c.id === "C1");
+  expect(c1?.status).toBe("deferred-probe");
+  // verified should NOT be true when a criterion is only deferred-probe.
+  expect(run.isa.frontmatter.verified).toBe(false);
+  run = advanceAlgorithmRun(run, "2026-06-22T10:11:00.000Z");
+  expect(getRunPhase(run)).toBe("learn");
+});
+
+test("legacy passed verification without an evidence kind is grandfathered", () => {
+  let run = toVerify();
+  // old call signature: no evidenceKind -> undefined, not 'specified'
+  run = verifyAlgorithmCriterion(run, "C1", "passed", "verified", "2026-06-22T10:10:00.000Z");
+  run = advanceAlgorithmRun(run, "2026-06-22T10:11:00.000Z");
+  expect(getRunPhase(run)).toBe("learn");
+});

--- a/test/algorithm-verification-evidence.test.ts
+++ b/test/algorithm-verification-evidence.test.ts
@@ -60,8 +60,15 @@ test("evidence kind round-trips through ISA markdown serialization", () => {
 test("a passed criterion verified only as 'specified' blocks advance to LEARN", () => {
   let run = toVerify();
   run = verifyAlgorithmCriterion(run, "C1", "passed", "the design says it returns 200", "2026-06-22T10:10:00.000Z", undefined, "specified");
-  expect(() => advanceAlgorithmRun(run, "2026-06-22T10:11:00.000Z")).toThrow(/C1/);
-  expect(() => advanceAlgorithmRun(run, "2026-06-22T10:11:00.000Z")).toThrow(/probe|specified|deferred/i);
+  let thrown: unknown;
+  try {
+    advanceAlgorithmRun(run, "2026-06-22T10:11:00.000Z");
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(Error);
+  expect((thrown as Error).message).toMatch(/C1/);
+  expect((thrown as Error).message).toMatch(/probe|specified|deferred/i);
 });
 
 test("a probed pass advances to LEARN", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -534,6 +534,8 @@ test("cli drives Algorithm runs through gated mutations", async () => {
       "passed",
       "--evidence",
       "CLI commands advanced through gates.",
+      "--evidence-kind",
+      "probed",
     ]);
     const output = await runSomaCli(["algorithm", "advance", "--home-dir", homeDir, "--id", "cli-run"]);
 


### PR DESCRIPTION
Closes #330. Hardens the top failure mode found across 188 real runs (analysis in #334 / `Plans/2026-06-22-algorithm-runner-prompt-findings.md`): the LEARN gate accepted "the design says X ∴ passed" as evidence.

## What it does — and what it honestly does NOT
The evidence kind is **caller-asserted on every surface** (CLI, ISA markdown, library). Soma records and gates on the claim; it does **not** verify that a `probed`/`tested` label corresponds to a real probe or test. So this is **necessary, not sufficient**: it converts a silent-default hollow pass into an **explicit, auditable, declared** claim, and flips the default from "any text passes" to "declare probed/tested or accept deferred-probe." Real probe enforcement (evidence↔artifact linkage) is future work.

## What changed
- **Type** — `IdealStateCriterion` gains `evidenceKind` (`EvidenceKind` = specified|probed|tested) and a new `deferred-probe` status (`CriterionStatus`). Both round-trip through ISA markdown (`~` checkbox mark, `Evidence (kind): …`).
- **LEARN gate** (`learnGateViolations`, in algorithm.ts) — every criterion must be passed/dropped/deferred-probe, AND no `passed` criterion may carry an **explicit** `specified` kind. Composed once; assertGate and sync's `reachableTargetPhase` both call it so they can't drift.
- **Sync** (`algorithm-isa-sync.ts`) — synthetic passes fabricated from a frontmatter progress counter are forced to `specified` (so they **cap the run at VERIFY** instead of clearing LEARN); `reachableTargetPhase` mirrors the gate; markdown-authored kinds thread through; `deferred-probe` honored in the closed/cap checks.
- **Batch** — verify op gains optional `evidenceKind`; a `passed` op with no kind defaults to `specified`.
- **CLI** — `verify` gains `--evidence-kind` (rejected on non-passed status) and accepts `--status deferred-probe`; a `passed` with no kind defaults to `specified`.
- **Reconcile** — `statusRank` reordered to place `deferred-probe` between failed and passed.
- **Summary** — `deferredProbeCriteria` added so the breakdown sums to total.

## Back-compat (precise)
- **Library / bare-`Evidence:` markdown** — a `passed` with **undefined** evidence kind is **grandfathered** (legacy data can't be retroactively probed); only an **explicit** `specified` blocks.
- **Synthetic frontmatter-progress passes are NOT grandfathered** — they are forced to `specified`, so a legacy run that previously reached LEARN purely off a progress counter now **correctly stalls at VERIFY** (the integrity fix; the sync test asserts `phase === "verify"`). This is a deliberate behavioral change, not a regression.
- Full enforcement (reject bare `passed`) is gated on the P1 ISA-authoring prompt emitting `Evidence (probed/tested):` — tracked with #331.

## Verification
- `test/algorithm-verification-evidence.test.ts` + updated sync test; **1419 pass / 0 fail**, typecheck clean, changed files lint clean.
- Repo lint has a **pre-existing baseline failure** (grok/doctor/bun-probe, present on clean `main`, #244-class) — unrelated; my files are clean.

Reviewed across 4 Sage rounds (0 blockers throughout); findings converged to claim-accuracy, addressed here.