### PR TITLE
docs(vocab): rename ISA → VSA / Verification across docs (#329, slice 2a)

### DIFF
--- a/Plans/2026-05-30-open-issues-sequential-fix-plan.md
+++ b/Plans/2026-05-30-open-issues-sequential-fix-plan.md
@@ -1,0 +1,378 @@
+# Open Issues Sequential Fix Plan
+
+**Created:** 2026-05-30
+
+**Scope:** Work every currently open issue in `the-metafactory/soma`
+sequentially from a clean `main`.
+
+**Issues in scope:** #274, #272, #267, #266, #265, #264, #263, #260, #248,
+#244, #243, #153, #152, #150, #149, #146.
+
+**Operating mode:** one issue at a time. Claim, branch from fresh `main`, TDD,
+implement, run full verification, request Sage review, fix and loop until clean,
+then merge before starting the next issue.
+
+## Queue Order
+
+| Order | Issue | Branch | Type | Why here |
+| --- | --- | --- | --- | --- |
+| 0 | #244 lint baseline failure | `issue-244-close-lint-baseline` | close/update | Already fixed by `c295437`; verify current `main`, comment, and close if still clean. |
+| 1 | #243 path guard delete hardening | `issue-243-path-guard-delete-hardening` | needs-info / hardening | Reporter issue is not reproducible, but defensive direct-API path normalization is small and security-adjacent. |
+| 2 | #260 sync-from-isa debug logging nits | `issue-260-sync-debug-nits` | small cleanup | Low-risk warm-up issue touching known bridge code. |
+| 3 | #267 memory search positional query | `issue-267-memory-search-positional-query` | CLI bug | Small, user-visible CLI fix with clear TDD acceptance criteria. |
+| 4 | #263 install dry-run is silent no-op | `issue-263-install-dry-run-banner` | CLI UX bug | Prevents repeated install confusion; isolated output behavior. |
+| 5 | #265 sync-from-isa honors frontmatter progress | `issue-265-sync-frontmatter-progress` | bridge correctness | Fixes real run reconciliation before provenance work. |
+| 6 | #272 date-prefix run slugs | `issue-272-date-prefixed-run-slugs` | identity/run lifecycle | Prevents future same-task collision; depends on understanding sync/run slug behavior. |
+| 7 | #266 per-hop substrate provenance | `issue-266-substrate-provenance` | Algorithm metadata | Needs stable run identity and sync semantics from #265/#272. |
+| 8 | #264 substrate path rewrites | `issue-264-substrate-path-rewrites` | projection portability | Broader adapter/projection fix; should follow provenance/sync fixes. |
+| 9 | #274 opt-in Claude Code mode classifier | `issue-274-claude-code-mode-classifier` | feature | Builds on projection/install confidence; includes classifier parity tests. |
+| 10 | #248 Sigstore-sign official-tier publishes | `issue-248-sigstore-release-signing` | release process | Human decision plus publish pipeline implementation if decision is yes. |
+| 11 | #153 MCP server tools | `issue-153-mcp-server` | large feature | Needs a design slice first, then implementation slices. |
+| 12 | #150 identity versioning snapshots/rollback | `issue-150-identity-snapshots` | large feature | Safety net that benefits the remaining large stateful work. |
+| 13 | #146 cross-machine memory sync | `issue-146-cross-machine-memory-sync` | architecture feature | Depends on snapshot/rollback and clear state mutation semantics. |
+| 14 | #152 multi-principal support | `issue-152-multi-principal-support` | architecture feature | Depends on sync and strict personal/team boundary design. |
+| 15 | #149 daemon mode with Myelin bus | `issue-149-soma-daemon` | architecture feature | Last: it depends on stable memory, identity, MCP/tool, and multi-principal boundaries. |
+
+## Repeated Runbook
+
+Replace `<N>` and `<slug>` for each issue.
+
+### 1. Claim
+
+```bash
+gh issue comment <N> \
+  --repo the-metafactory/soma \
+  --body "Claiming for implementation. Plan: clean main, isolated branch/worktree, TDD, PR, Sage review loop, merge when clean."
+
+gh issue edit <N> \
+  --repo the-metafactory/soma \
+  --add-assignee @me
+```
+
+If assignment fails, keep the claim comment and continue. For #243, claim only
+after deciding whether to implement defensive hardening despite the
+`needs-info` label.
+
+### 2. Fresh Branch / Worktree
+
+```bash
+git fetch origin
+git switch main
+git pull --ff-only
+mkdir -p .worktrees
+git worktree add .worktrees/issue-<N>-<slug> -b issue-<N>-<slug> origin/main
+cd .worktrees/issue-<N>-<slug>
+bun install
+```
+
+### 3. TDD
+
+Start with focused failing tests derived from the issue body.
+
+```bash
+bun test <focused-test-file>
+# implement smallest useful change
+bun test <focused-test-file>
+```
+
+Before PR:
+
+```bash
+bun run lint
+bun run typecheck
+bun test
+```
+
+### 4. Commit and PR
+
+```bash
+git status --short
+git add <changed-files>
+git commit -m "Fix #<N>: <short summary>"
+git push -u origin issue-<N>-<slug>
+gh pr create \
+  --repo the-metafactory/soma \
+  --base main \
+  --head issue-<N>-<slug> \
+  --title "Fix #<N>: <short summary>" \
+  --body "Closes #<N>
+
+## Summary
+- ...
+
+## Verification
+- bun run lint
+- bun run typecheck
+- bun test"
+```
+
+### 5. Sage Review Loop
+
+```bash
+pilot request-review \
+  --pr the-metafactory/soma#<PR> \
+  --capability code-review.typescript \
+  --title "Fix #<N>: <short summary>" \
+  --note "Please review this Soma issue fix. Focus on repo conventions, adapter boundaries, runtime safety, regression risk, and test coverage." \
+  --wait \
+  --timeout 30m \
+  --json > /private/tmp/soma-review-<N>-cycle-1.json
+```
+
+If Sage reports findings:
+
+```bash
+gh pr view <PR> --repo the-metafactory/soma --comments
+gh pr diff <PR> --repo the-metafactory/soma
+bun test <focused-test-file>
+bun run lint
+bun run typecheck
+bun test
+git add <changed-files>
+git commit -m "Address Sage review for #<N>"
+git push
+```
+
+Repeat Sage review until clean.
+
+### 6. Merge and Cleanup
+
+```bash
+gh pr merge <PR> --repo the-metafactory/soma --squash --delete-branch
+cd <repo-root>
+git fetch origin
+git pull --ff-only
+git worktree remove .worktrees/issue-<N>-<slug>
+```
+
+## Issue Notes and TDD Targets
+
+### #244 Lint Baseline
+
+Current state: fixed by `c295437 Clean ESLint baseline`.
+
+Plan:
+- Verify `bun run lint`, `bun run typecheck`, and `bun test` on current `main`.
+- Comment with the commit and verification.
+- Close #244 if still clean.
+
+### #243 Path Guard Delete Hardening
+
+Current state: labeled `needs-info`; the reported runtime path is not
+reproducible.
+
+Plan:
+- Add a direct `evaluatePathGuard` test for protected memory-root delete input
+  that reaches the lower-level API without shell normalization.
+- Harden the direct API boundary to normalize shorthand and relative targets
+  consistently with shell target extraction.
+- Keep the issue comment clear: this is defensive hardening, not confirmation
+  of the originally reported runtime bypass.
+
+Focused tests:
+- `test/policy-path-guard.test.ts`
+- `test/policy-targets.test.ts` if shell target extraction changes.
+
+### #260 sync-from-isa Debug Nits
+
+Plan:
+- Add a focused test for malformed/corrupt run index handling that asserts no
+  throw and a useful debug signal.
+- Replace empty catch in `algorithm-isa-sync.ts` with bounded debug output.
+- Switch the polling helper to `Bun.sleep` if it remains clearer without
+  increasing flake risk.
+
+Focused tests:
+- `test/algorithm-isa-sync.test.ts`
+- `test/claude-code-install.test.ts`
+
+### #267 Memory Search Positional Query
+
+Plan:
+- Add CLI tests for positional query and existing `--query`.
+- Prefer `--query` if both are provided, or reject mixed query inputs if that
+  matches the surrounding CLI style.
+- Improve missing-query and unknown positional errors.
+
+Focused tests:
+- `test/cli.test.ts`
+- `test/memory.test.ts`
+
+### #263 Install Dry-run Banner
+
+Plan:
+- Add CLI/install tests proving dry-run output says no changes were written and
+  names `--apply`.
+- Add the same footer/header for all install substrates.
+- Keep default dry-run behavior unless the issue is explicitly expanded to
+  default-on apply.
+
+Focused tests:
+- `test/cli.test.ts`
+- `test/install.test.ts`
+
+### #265 sync-from-isa Frontmatter Progress
+
+Plan:
+- Add tests where ISA checkboxes are unticked but frontmatter progress and phase
+  indicate completion.
+- Reconcile criteria up to the strongest trustworthy completion signal.
+- Preserve idempotency and do not regress manually ticked checkbox behavior.
+
+Focused tests:
+- `test/algorithm-isa-sync.test.ts`
+- `test/isa-accessors.test.ts` if parsing frontmatter progress needs helpers.
+
+### #272 Date-prefixed Run Slugs
+
+Plan:
+- Decide same-day collision policy before coding. Default recommendation:
+  `yyyy-mm-dd-<base>` plus `-2`, `-3` suffix when the dated slug already exists.
+- Add tests for `algorithm new` and `isa scaffold` slug derivation.
+- Preserve existing bare slugs; apply only to newly minted slugs.
+- Document that the upstream Claude-side scaffolder must adopt the same
+  convention in its repo.
+
+Focused tests:
+- `test/algorithm.test.ts`
+- `test/cli.test.ts`
+- `test/cli-isa.test.ts`
+- `test/session-naming.test.ts`
+
+### #266 Per-hop Substrate Provenance
+
+Plan:
+- Add append-only provenance entries to Algorithm run mutations.
+- Record substrate for phase advance, criterion verify, capability invoke, and
+  learn/promote operations.
+- Surface a compact `touched by:` line in `algorithm show` and preserve raw
+  provenance in JSON.
+
+Focused tests:
+- `test/algorithm.test.ts`
+- `test/algorithm-isa-sync.test.ts`
+- `test/cli.test.ts`
+- `test/lifecycle.test.ts`
+
+### #264 Substrate Path Rewrites
+
+Plan:
+- Add projection tests showing non-Claude substrate outputs do not contain
+  Claude-specific home paths, hook refs, or Claude-only ISA tool refs.
+- Add adapter-level path normalization for imported Algorithm skill/context
+  payloads.
+- Keep Claude Code projection unchanged where Claude-specific paths are valid.
+
+Focused tests:
+- `test/home-projection.test.ts`
+- `test/substrate-adapters.test.ts`
+- `test/portability-ci.test.ts`
+- `test/skill-entrypoints.test.ts`
+
+### #274 Claude Code Mode Classifier
+
+Plan:
+- First fix classifier parity: port minimal/native behavior into Soma tests.
+- Add an opt-in `soma install claude-code --mode-classifier` flag.
+- Project a `UserPromptSubmit` hook that calls Soma's classifier and emits the
+  tightened no-downshift instruction.
+- Disable conflicting external classifier entries while enabled; uninstall
+  should restore or remove only Soma-owned settings.
+
+Focused tests:
+- `test/algorithm.test.ts`
+- `test/claude-code-install.test.ts`
+- `test/install.test.ts`
+- `test/cli.test.ts`
+
+### #248 Sigstore Release Signing
+
+Plan:
+- Treat as a design+release-pipeline issue.
+- First PR should document the decision in release docs and add a CI/release
+  check or script stub.
+- If signing is approved, implement the publish-time Sigstore step and a local
+  verification command.
+
+Focused tests:
+- `test/release-privacy-guard.test.ts`
+- release script tests if available.
+
+### #153 MCP Server
+
+Plan:
+- Start with a design PR: tool inventory, schema budget, write confirmation
+  model, and adapter/MCP boundary.
+- Implement a small read-only vertical slice first:
+  `soma_memory_search`, `soma_isa_active`, `soma_algorithm_classify`.
+- Add write tools only after per-call confirmation semantics are explicit.
+
+Focused tests:
+- New MCP server tests.
+- `test/memory.test.ts`, `test/isa.test.ts`, `test/algorithm.test.ts`.
+
+### #150 Identity Versioning
+
+Plan:
+- Decide snapshot backend first. Git-backed snapshots are the default
+  recommendation because Soma state is file-native and diffs matter.
+- Implement `soma snapshot`, `soma history`, and `soma rollback <snapshot>`.
+- Add auto-snapshot hooks before migrations/upgrades/bulk imports.
+
+Focused tests:
+- New snapshot tests.
+- `test/cli.test.ts`
+- `test/pai-migration.test.ts`
+- `test/isa-skill-installer.test.ts`
+
+### #146 Cross-machine Memory Sync
+
+Plan:
+- Design the sync model before implementation: git remote vs cloud backend,
+  conflict handling, and personal-compartment policy.
+- Implement a minimal git-backed `soma sync status/pull/push` first.
+- Keep append-only JSONL conflict handling explicit and tested.
+
+Focused tests:
+- New sync tests.
+- `test/memory.test.ts`
+- `test/work-registry.test.ts`
+- `test/policy.test.ts`
+
+### #152 Multi-principal Support
+
+Plan:
+- Design personal vs team compartments before writing runtime code.
+- Add read-only shared skill registry overlay first.
+- Add team memory only after the privacy model is enforced by policy tests.
+
+Focused tests:
+- New multi-principal tests.
+- `test/home-projection.test.ts`
+- `test/memory.test.ts`
+- `test/policy.test.ts`
+
+### #149 Daemon Mode
+
+Plan:
+- Start with a design PR around Myelin subject contracts and what Soma may own.
+- Implement `soma daemon --dry-run` / health surface first.
+- Add Myelin subscription and routing only after the contracts are explicit.
+
+Focused tests:
+- New daemon tests.
+- `test/cli.test.ts`
+- `test/lifecycle.test.ts`
+- integration tests behind a mock Myelin bus.
+
+## Completion Definition
+
+All issues are considered handled when:
+
+- Each issue has either a merged implementation PR, a merged design decision
+  that intentionally splits the implementation, or a clear maintainer-approved
+  close/no-action comment.
+- Every implementation PR passed `bun run lint`, `bun run typecheck`, and
+  `bun test`.
+- Every PR completed a clean Sage review loop.
+- `main` is clean and fast-forwarded after the final merge.

--- a/Plans/2026-06-22-HANDOVER-soma-algorithm.md
+++ b/Plans/2026-06-22-HANDOVER-soma-algorithm.md
@@ -1,0 +1,142 @@
+# HANDOVER — Soma Algorithm / Vocabulary work (2026-06-22)
+
+Resume doc for a clean session. Read this first, then `CONTEXT.md` and
+`docs/adr/0001-de-miessler-vocabulary.md`.
+
+---
+
+## TL;DR — what happened, what's next
+
+Two bodies of work this session, both **merged to `main`**:
+1. **De-Miesslered the vocabulary** (#334, commit `1d38545`) — the seven Soma
+   compartments are now **Identity · Purpose · Verification · Skills · Memory ·
+   Policy · Learning**, with new glossary terms `checkpoint`, `intent`, `Purpose`,
+   `Verification`, `VSA`. Glossary in `CONTEXT.md`; rationale in `docs/adr/0001`.
+2. **Verification integrity fix** (#330 → PR #335, commit `5e10109`) — the LEARN
+   gate now rejects hollow "the design says X ∴ passed" verification. #330 closed.
+
+**Next priority (in order):** #331 → #333 → #329. Details below.
+
+---
+
+## Strategic direction (the why)
+
+Derived from a four-lens dissection of the PAI→LifeOS critique + Kyle's Letta/
+Soma/PAI usage signal. Canonical doc:
+`Plans/2026-06-22-soma-direction-verification-primitive.md`.
+
+- Portability is **already solved** (5 shipping adapters). Don't re-sell it.
+- The evolution = an **inference/agency layer on the deterministic spine**:
+  agentic memory + goal-aligned consolidation, *inside* deterministic gates.
+- Dividing line: **deterministic about movement/trust/gates/contracts; the model
+  is free to propose, but every proposal is typed, audited, reversible.**
+- `checkpoint` = the extracted primitive {criterion, evidence, typed verdict,
+  gate}, two axes: done-ness + `intent`. Telos and ISA both collapsed into it.
+- Naming is LOCKED (CONTEXT.md + ADR 0001). `heading` was rejected (collides with
+  markdown titles); `intent` chosen.
+
+---
+
+## What's merged (don't redo)
+
+| Item | Commit | Notes |
+| --- | --- | --- |
+| De-Miessler glossary + ADR + strategy/findings docs | `1d38545` (#334) | CONTEXT.md, docs/adr/0001, Plans/* |
+| Verification evidence-kind + deferred-probe + LEARN gate | `5e10109` (#335) | closes #330; Sage-clean over 6 rounds |
+
+**#330 detail:** `IdealStateCriterion` gained `evidenceKind` (`EvidenceKind` =
+specified|probed|tested) and a `deferred-probe` status (`CriterionStatus`), both
+round-tripping through ISA markdown (`~` mark, `Evidence (kind): …`). LEARN gate =
+`learnGateViolations` in `src/algorithm.ts` (shared by the gate and
+`algorithm-isa-sync.ts` `reachableTargetPhase` so they can't drift). CLI `verify`
+has `--evidence-kind` + accepts `--status deferred-probe`.
+
+**HONEST SCOPE (important — Sage's HonestOracle lens hammered this):** the evidence
+kind is **caller-asserted on every surface** (CLI, ISA markdown, library). The gate
+makes a hollow pass **explicit and auditable**, it does NOT verify the probe
+happened. Necessary, not sufficient. Real probe enforcement (evidence↔artifact
+linkage) is **future work**. Don't claim the hole is "closed" — say it's hardened.
+
+**Deliberate back-compat boundary:** a `passed` with **undefined** evidenceKind is
+**grandfathered** (legacy data can't be retro-probed); only an **explicit**
+`specified` blocks. Synthetic frontmatter-progress passes ARE forced to `specified`
+(they cap at VERIFY). Full enforcement (reject bare `passed`) waits on #331's
+prompt emitting `Evidence (probed/tested):`.
+
+---
+
+## Open issues + priority
+
+Source of truth: `Plans/2026-06-22-algorithm-runner-prompt-findings.md` (the
+188-run analysis behind all of these).
+
+1. **#331 — P2 OBSERVE current-state floor** (NEXT). 63% of 188 runs stall at
+   OBSERVE; the most-repeated reflection was "verify current-state assumptions
+   before proceeding." Add a gate: OBSERVE→THINK requires ≥1 recorded current-state
+   probe. **Wide-impact** — adding a new gate means every full-cycle test must
+   record a probe first (same churn pattern as #330's gate; budget for it). Was
+   claimed + a worktree was set up then removed; start fresh from `main`.
+2. **#333 — R7b port the meta-reflection layer** (the GENERATOR behind P2). PAI had
+   a per-run "a smarter algorithm would have…" self-assessment (`reflection_q1/q2/q3`)
+   that was never ported to Soma. Porting it makes P2-class fixes surface
+   themselves. **New subsystem — wants JC's design steer before building.** It's the
+   dream-cycle applied reflexively to the algorithm.
+3. **#329 — Telos→Purpose / ISA→VSA code+path rename.** The glossary's code side:
+   `interface Telos`→`Purpose`, `telos/` path, `TELOS.md` projection, `soma isa`→
+   `soma vsa`, `Isa*` identifiers, `src/skills/ISA/`, ~22 docs. Large but mechanical
+   find-replace with back-compat (CLI alias, home-path migration). Measured
+   footprint in the issue body.
+4. **#332 — backlog** (R2-R8, P3-P5): capability invoke-or-remove enforcement,
+   worktree isolation for build, schema versioning, substrate auto-capture,
+   read-only-vs-build phase branch, learning-writer dedup, classifier decision.
+
+---
+
+## SOP + tooling notes (learned the hard way this session)
+
+- **Worktree SOP:** claim issue (`gh issue comment` + assign) → `git worktree add
+  .worktrees/issue-<N>-<slug> -b issue-<N>-<slug> origin/main` → `bun install` →
+  TDD → `bun run lint && bun run typecheck && bun test` → PR → Sage → merge →
+  `git worktree remove`.
+- **Sage review WITHOUT the bus (use this):**
+  `sage review the-metafactory/soma#<PR> --post --emit-verdict-block --substrate claude`
+  — runs offline, posts to the PR, prints a JSON verdict block. Loop until verdict
+  is `commented`/`approved` with 0 blockers/0 majors. (HonestOracle lens always
+  keeps ~1 philosophical nit; don't chase it forever.)
+- **`pilot request-review`** works ONLY with `PILOT_PRINCIPAL=jc` env (principal id
+  `jc`, stack `jc/default`, from `~/.config/cortex/default/stacks/default.yaml`).
+  **`pilot wait-for-verdict`/`fetch` are BROKEN** — they need
+  `~/.config/cortex/cortex.yaml`, retired in the 2026-06-18 config split. Use
+  `sage review` offline instead until the cortex config path is restored.
+- **Merge gate:** branch protection requires an *approving* review; Sage posts
+  `commented`, not `approved`. So a clean Sage review still leaves the PR
+  `MERGEABLE / BLOCKED`. Merge needs JC's approval or `gh pr merge --squash --admin`
+  (JC authorized admin-merge this session) or `pilot approve --merge`.
+- **Pre-existing lint baseline failure:** `bun run lint` fails on clean `main`
+  (~23 problems in grok/doctor/bun-probe, #244-class). Unrelated to new work — lint
+  only your changed files (`bunx eslint <files>`) to confirm you're clean.
+- **Flaky tests under load:** grok-hook/install/init integration tests time out at
+  exactly 5000ms when many sessions run concurrently. Re-run in isolation to
+  confirm green before treating as a real failure.
+
+---
+
+## Gotchas
+
+- Two ISA run schemas coexist in `~/.soma/memory/WORK/algorithm-runs/` (106
+  unversioned flat-ISA, mostly PAI imports + 82 v2). Readers must handle both.
+- "Reflections stopped May 7" was a MISREAD — the REFLECTIONS jsonl is a PAI-era
+  artifact; Soma never wrote it. Soma's `LEARNING/ALGORITHM/*` capture is alive.
+  R7b is a PORT, not a revive.
+- When stacking PRs that touch `algorithm.ts` gates, branch off the prior branch,
+  not `main`, or expect a rebase at merge.
+
+---
+
+## State pointers
+
+- Project memory: `~/.claude/projects/-Users-fischer-work-mf-soma/memory/` —
+  `project_soma_dividing_line.md` (direction + locked vocab) and
+  `project_algorithm_runner_findings.md` (188-run findings + run status).
+- This repo's session memory protocol: `.claude/memory/decisions.md` +
+  `session-log.md` (per the work CLAUDE.md).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ context around the model:
 - telos: goals, principles, commitments, and desired state
 - memory: what has been learned across sessions
 - skills: reusable procedures and capability folders
-- working method: Algorithm, ISA, verification, and learning loops
+- working method: Algorithm, VSA, verification, and learning loops
 - policy: privacy, permission, and evidence rules
 
 Soma keeps that core in one filesystem-native home and projects it into each
@@ -72,7 +72,7 @@ import source; Soma is independent, MIT-licensed tooling, not a PAI fork.
              |   Soma home    |
              | identity       |
              | telos          |
-             | ISA            |
+             | VSA            |
              | skills         |
              | memory         |
              | policy         |
@@ -165,10 +165,10 @@ advances, criterion verification, capability invocation, and learning
 promotion all append substrate provenance when the caller supplies
 `--substrate`.
 
-The Algorithm and ISA are implemented by Soma itself — `soma algorithm` and
-`soma isa` work on any substrate, with run state in
-`~/.soma/memory/WORK/algorithm-runs/` and ISAs in `~/.soma/isa/`. See
-[The Algorithm](#the-algorithm) and [ISA](#isa) below, and
+The Algorithm and VSA are implemented by Soma itself — `soma algorithm` and
+`soma vsa` work on any substrate, with run state in
+`~/.soma/memory/WORK/algorithm-runs/` and VSAs in `~/.soma/isa/`. See
+[The Algorithm](#the-algorithm) and [VSA](#isa) below, and
 [docs/soma-home-layout.md](docs/soma-home-layout.md) for the full on-disk
 layout `soma init` creates.
 
@@ -275,14 +275,14 @@ Each adapter writes the same assistant context into the host's native shape:
 The shared experience comes from a single source of truth:
 
 - session startup reads the same identity, telos, active work, and learning
-- Algorithm runs and ISA state stay portable
+- Algorithm runs and VSA state stay portable
 - feedback and lifecycle events write back through Soma's memory and policy gates
 - uninstall removes only generated Soma projection files
 
 The home projection is the default assistant context for a substrate: identity,
 telos, memory layout, policy, active work, and shared skills. A workspace
 projection is an extra project-local layer. Use it when a repository needs its
-own ISA, local rules, local skills, or project-specific memory pointers. The
+own VSA, local rules, local skills, or project-specific memory pointers. The
 workspace layer adds that context for sessions started in that repository
 without forking the assistant or replacing the shared Soma home.
 
@@ -328,24 +328,24 @@ soma algorithm capabilities --id <run-id> --capability sequential-analysis --rea
 soma algorithm invoke --id <run-id> --capability sequential-analysis --evidence "Plan sequenced and recorded"
 ```
 
-### ISA
+### VSA
 
 An Ideal State Artifact is the definition of done for a project, task, or work
 session. It carries criteria and verification evidence across substrates.
 
 ```bash
-soma isa scaffold --slug launch-plan --effort E2 --goal "Ship the launch plan with evidence"
-soma isa use <yyyy-mm-dd-launch-plan>
-soma isa active
-soma isa check <yyyy-mm-dd-launch-plan>
+soma vsa scaffold --slug launch-plan --effort E2 --goal "Ship the launch plan with evidence"
+soma vsa use <yyyy-mm-dd-launch-plan>
+soma vsa active
+soma vsa check <yyyy-mm-dd-launch-plan>
 ```
 
-`soma isa scaffold` date-prefixes newly scaffolded slugs unless the slug is
+`soma vsa scaffold` date-prefixes newly scaffolded slugs unless the slug is
 already date-prefixed. Use the slug printed by the scaffold command for
 `use`, `active`, and `check`.
 
-For parallel feature work, Soma can reconcile feature ISAs back into a master
-ISA by stable criterion IDs. See [docs/isa-reconcile.md](docs/isa-reconcile.md).
+For parallel feature work, Soma can reconcile feature VSAs back into a master
+VSA by stable criterion IDs. See [docs/vsa-reconcile.md](docs/vsa-reconcile.md).
 
 ### Skills
 
@@ -457,7 +457,7 @@ public files and destructive root-level paths. See
 Soma is a typed CLI and library with shipping home projections for Codex,
 Claude Code, Pi.dev, and Cursor. The current center of gravity is the portable
 filesystem contract: profile, telos, memory, policy, skills, Algorithm runs,
-and ISAs stay in the Soma home while adapters project that core into each
+and VSAs stay in the Soma home while adapters project that core into each
 substrate's native shape.
 
 Daemon mode and deeper Cortex/Myelin integration come after the file format,
@@ -468,7 +468,7 @@ snapshot-backed exchange of eligible `~/.soma/` state between machines. It does
 not change projection or writeback semantics. See
 [docs/home-replication.md](docs/home-replication.md).
 
-Team-shared skills, knowledge, work artifacts, and ISAs are designed as
+Team-shared skills, knowledge, work artifacts, and VSAs are designed as
 read-only team overlays. A team overlay supplements one principal's Soma home;
 it does not make the home multi-principal or share private Identity, Purpose, or
 Relationship state. See [docs/team-overlays.md](docs/team-overlays.md).
@@ -482,8 +482,8 @@ writeback boundaries as substrate sessions. See
 
 ## Documentation
 
-- [CONTEXT.md](CONTEXT.md), the shared Soma vocabulary used by docs, CLI, and ISA
-- [docs/soma-home-layout.md](docs/soma-home-layout.md), what `soma init` creates and where Algorithm/ISA state lives
+- [CONTEXT.md](CONTEXT.md), the shared Soma vocabulary used by docs, CLI, and VSA
+- [docs/soma-home-layout.md](docs/soma-home-layout.md), what `soma init` creates and where Algorithm/VSA state lives
 - [docs/architecture.md](docs/architecture.md), the core/adapters/runtime model
 - [docs/boundaries.md](docs/boundaries.md), exactly what Soma owns and does not own
 - [docs/substrate-adapters.md](docs/substrate-adapters.md), adapter behavior by host

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ soma algorithm invoke --id <run-id> --capability sequential-analysis --evidence 
 
 ### VSA
 
-An Ideal State Artifact is the definition of done for a project, task, or work
+An Verification State Artifact is the definition of done for a project, task, or work
 session. It carries criteria and verification evidence across substrates.
 
 ```bash
@@ -345,7 +345,7 @@ already date-prefixed. Use the slug printed by the scaffold command for
 `use`, `active`, and `check`.
 
 For parallel feature work, Soma can reconcile feature VSAs back into a master
-VSA by stable criterion IDs. See [docs/vsa-reconcile.md](docs/vsa-reconcile.md).
+VSA by stable criterion IDs. See [docs/isa-reconcile.md](docs/isa-reconcile.md).
 
 ### Skills
 

--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -11,7 +11,7 @@
 
 Each decision is numbered, dated, and linked to the discussion or research that informed it. Decisions are grouped by domain. Status values: **decided**, **superseded**, **open**.
 
-`ISA.md` is the live source of truth for current scope and verification. DDs are the durable rule-record — the *why* behind decisions that future readers would otherwise have to reconstruct.
+`VSA.md` is the live source of truth for current scope and verification. DDs are the durable rule-record — the *why* behind decisions that future readers would otherwise have to reconstruct.
 
 ---
 
@@ -21,7 +21,7 @@ Each decision is numbered, dated, and linked to the discussion or research that 
 
 **Status:** Decided (2026-05-17)
 
-**Context:** Soma's mission is "substrate-portable Personal AI Assistant core" (per `ISA.md`, `CONTEXT.md`). A live migration path from PAI to Soma forced a foundational question: where does personal state *live*?
+**Context:** Soma's mission is "substrate-portable Personal AI Assistant core" (per `VSA.md`, `CONTEXT.md`). A live migration path from PAI to Soma forced a foundational question: where does personal state *live*?
 
 Three candidates surfaced:
 - **(a) Soma is the new canonical home.** PAI's `~/.claude/` becomes a *projection* that Soma writes (via `soma install claude-code`). PAI conventions are translated to Soma's shape during import.
@@ -119,7 +119,7 @@ Three candidates:
 **Status:** Decided (2026-05-22)
 
 **Context:** Soma's install path had substrate-specific facts spread across the
-installer, home projection, active ISA projection paths, private projection
+installer, home projection, active VSA projection paths, private projection
 roots, and adapter modules. Adding or changing a substrate required editing
 multiple unrelated modules, which weakened locality and made install,
 reproject, upgrade, and uninstall behavior harder to compare.
@@ -138,7 +138,7 @@ orchestration.
 Adapters own substrate-native facts: default home, projected file paths,
 substrate-specific skill destinations, lifecycle projection paths, validators,
 cleanup hooks, private projection roots, and uninstall targets. The installer
-owns orchestration: bootstrapping Soma home, loading active ISA, running
+owns orchestration: bootstrapping Soma home, loading active VSA, running
 lifecycle updates, writing projections, and applying the install, reproject,
 upgrade, and uninstall verbs.
 
@@ -219,7 +219,7 @@ separate work, tracked by the observability feature area.
 
 **Context:** PAI v5 uses two live continuation surfaces. Hooks
 deterministically maintain `MEMORY/STATE/work.json` and
-`MEMORY/STATE/session-names.json` at prompt and ISA-sync boundaries, while the
+`MEMORY/STATE/session-names.json` at prompt and VSA-sync boundaries, while the
 Algorithm assistant is responsible for creating
 `MEMORY/STATE/current-work-{sessionId}.json` during execution. Soma inherited
 the file shape in DD-5, but the PAI ownership split is too Claude-specific for
@@ -260,7 +260,7 @@ explicit writeback gates with deterministic merge rules.
   before any Algorithm-specific artifact exists.
 - Adapters should refresh the pointer at bounded semantic boundaries:
   `session_start`, prompt submission or before-agent-start classification,
-  Algorithm/ISA updates, result/feedback/rating capture, pre-compaction, and
+  Algorithm/VSA updates, result/feedback/rating capture, pre-compaction, and
   session end. Routine tool calls should not refresh the pointer unless they
   create or update a known artifact or emit a bounded observability event.
 - The pointer routes learning by naming learning sources such as events,
@@ -518,7 +518,7 @@ runtime policy decisions.
 
 **Status:** Decided (2026-05-31)
 
-**Context:** Issue #153 asks whether Soma should expose memory, skills, ISA,
+**Context:** Issue #153 asks whether Soma should expose memory, skills, VSA,
 Algorithm, and identity through an MCP server. MCP-capable substrates can call
 tools directly, but MCP tool schemas carry always-on token cost and mutating
 tools can bypass the deliberate writeback gates if the boundary is unclear.
@@ -535,7 +535,7 @@ Three candidates surfaced:
 **Decision:** **(b)** — MCP is an optional read-mostly access surface over Soma
 core. It is not a substrate adapter replacement. Adapters may configure
 substrate-native MCP clients, but the MCP server owns one portable tool
-inventory and calls Soma core APIs for memory, skills, ISA, Algorithm, identity,
+inventory and calls Soma core APIs for memory, skills, VSA, Algorithm, identity,
 policy, and writeback.
 
 The first implementation slice should expose read-only tools only:
@@ -557,7 +557,7 @@ calls must not return full skill or memory bodies, and large responses must
 require selector or pagination arguments.
 
 Read tools must validate the requesting principal, MCP client session,
-substrate, and allowed memory/identity/ISA/skill/Algorithm scope before
+substrate, and allowed memory/identity/VSA/skill/Algorithm scope before
 returning data. Unauthorized, out-of-scope, or malformed reads fail closed
 without returning private excerpts.
 
@@ -583,7 +583,7 @@ without returning private excerpts.
 **Status:** Decided (2026-05-31)
 
 **Context:** Issue #146 asks for cross-machine access to memory, identity,
-Purpose, skills, ISA state, and conflict resolution when a principal works from
+Purpose, skills, VSA state, and conflict resolution when a principal works from
 multiple machines. The obvious word is "sync", but Soma already reserves
 precise vocabulary for projection and writeback and rejects fuzzy bidirectional
 sync semantics in `CONTEXT.md`. The implementation needs a transport model
@@ -606,7 +606,7 @@ overlay. The first backend should be Git-backed because Soma homes and
 snapshots are already filesystem-native, but backend transport does not own
 merge or privacy semantics.
 
-Replication is scope-based. Identity, Purpose, skills, policy, ISA, append-only
+Replication is scope-based. Identity, Purpose, skills, policy, VSA, append-only
 state events, and session-keyed work state are eligible by default, subject to
 path policy and secret guards. Learning and knowledge are opt-in until
 promotion/citation merge rules exist. Relationship is private by default, and
@@ -615,7 +615,7 @@ raw and security scopes are off by default.
 Only stores with deterministic merge rules are auto-merged:
 `memory/STATE/events.jsonl` merges by event id, and DD-5/DD-6 work state may
 merge by session id, run id, or pointer filename. Durable profile, Purpose,
-skill, policy, ISA body, knowledge, learning, relationship, and work artifacts
+skill, policy, VSA body, knowledge, learning, relationship, and work artifacts
 surface conflicts instead of using last-writer-wins. Every pull or exchange
 operation snapshots before applying remote state.
 
@@ -643,7 +643,7 @@ operation snapshots before applying remote state.
 **Status:** Decided (2026-05-31)
 
 **Context:** Issue #152 asks for shared skill registries, team memory overlays,
-team ISAs, and a permission model for organizations. Soma is intentionally a
+team VSAs, and a permission model for organizations. Soma is intentionally a
 personal assistant core: Identity, Purpose, Relationship, Policy, and Memory are
 rooted in one principal. A direct multi-principal home would weaken the trust
 model and make it unclear which principal owns profile facts, private memory,
@@ -655,7 +655,7 @@ Three candidates surfaced:
   home and let permissions decide which parts each principal can see.
 - **(b) Use read-only team overlays.** Keep each personal Soma home
   single-principal, then mount shared team skills, team knowledge/work, team
-  ISAs, and team policy restrictions as explicit overlays with provenance.
+  VSAs, and team policy restrictions as explicit overlays with provenance.
 - **(c) Defer team support to Cortex/Myelin.** Keep Soma purely personal and
   let collaboration surfaces handle all team state.
 
@@ -666,7 +666,7 @@ Purpose, Relationship, raw transcripts, and security traces are never mounted
 from a team overlay.
 
 Team overlays start read-only. They may expose team skills, team
-`memory/KNOWLEDGE`, team `memory/WORK`, team ISAs, and team policy restrictions.
+`memory/KNOWLEDGE`, team `memory/WORK`, team VSAs, and team policy restrictions.
 Team policy can add restrictions or metadata requirements, but it must not relax
 personal policy. Search and projection must cite team/source/version
 provenance, and personal and team memory result groups remain separate.
@@ -681,14 +681,14 @@ organizational process.
   accidental sharing of personal Identity, Purpose, Relationship, raw
   transcripts, and security traces.
 - (c) is clean but too narrow: teams can safely share read-only skills,
-  knowledge, work artifacts, and ISAs before a daemon or bus is required.
+  knowledge, work artifacts, and VSAs before a daemon or bus is required.
 
 **Implications:**
 - The canonical design is documented in `docs/team-overlays.md`.
 - Future CLI work should use `soma team ...` for overlay management.
 - The first implementation slice should add read-only overlay install/list,
   team-provenanced memory search, team skill registry entries, and explicit
-  team ISA selection.
+  team VSA selection.
 - Collaborative team writes are deferred until team-specific merge rules,
   approval, provenance, and conflict reports exist.
 
@@ -718,7 +718,7 @@ Three candidates surfaced:
 
 **Decision:** **(b)** — daemon mode consumes Myelin contracts without owning
 the bus. Soma may run as a standalone Cortex agent and route work using Soma
-identity, memory, ISA, policy, and skill registry state. It must import or be
+identity, memory, VSA, policy, and skill registry state. It must import or be
 configured with Myelin-owned subject/envelope contracts before subscribing to
 live bus traffic.
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -4,7 +4,7 @@ How the engineering skills should consume soma's domain documentation when explo
 
 ## Hierarchy of authority
 
-1. **`ISA.md`** at repo root — current source of truth for scope, criteria, decisions in flight, and verification (per AGENTS.md).
+1. **`VSA.md`** at repo root — current source of truth for scope, criteria, decisions in flight, and verification (per AGENTS.md).
 2. **`design/design-decisions.md`** — the **metafactory Design Decisions** record. Numbered DD-N. If anything contradicts a DD, the DD wins.
 3. **`CONTEXT.md`** at repo root — domain glossary (does not yet exist; `/grill-with-docs` creates it lazily as terms get resolved).
 4. **`research/*.md`** — evidence base. DDs cite specific research findings.
@@ -41,7 +41,7 @@ DD numbering is **per-repo sequential**. Pick the next free number when adding o
 ```
 ~/work/mf/soma/
 ├── AGENTS.md
-├── ISA.md
+├── VSA.md
 ├── CONTEXT.md                    ← lazily created by /grill-with-docs
 ├── design/
 │   └── design-decisions.md       ← metafactory DD format, numbered DD-N

--- a/docs/algorithm-execution-modes.md
+++ b/docs/algorithm-execution-modes.md
@@ -1,7 +1,7 @@
 # Algorithm Execution Modes
 
 Issue #133 is a gap-fill, not a full Algorithm port. Soma already owns the
-core Algorithm run schema, phase gates, criteria state, audit logs, and ISA
+core Algorithm run schema, phase gates, criteria state, audit logs, and VSA
 bridge. The missing PAI capabilities are modeled here as substrate-neutral
 contracts so Codex, Pi.dev, Claude Code, Cortex, or a daemon can execute them
 without moving process spawning into Soma core.
@@ -34,9 +34,9 @@ isolation, and result consolidation remain substrate or orchestration concerns.
 
 New Algorithm runs created without an explicit `--id` use date-prefixed ids.
 This keeps repeated same-day tasks sortable and avoids collisions when several
-substrates start similar work. Existing explicit run ids are preserved. ISA
+substrates start similar work. Existing explicit run ids are preserved. VSA
 files written back from substrate OBSERVE hooks are normalized through the
-same date-prefixing helper so bare ISA slugs do not bypass run identity rules.
+same date-prefixing helper so bare VSA slugs do not bypass run identity rules.
 
 Algorithm mutations can also record per-hop substrate provenance. CLI paths
 such as phase advance, criterion verification, capability invocation, and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ The core is filesystem-native and substrate-neutral.
 SomaCore
   Identity
   Purpose
-  ISA
+  VSA
   Skills
   Memory
   Policy
@@ -29,15 +29,15 @@ the substrate.
 Purpose stores goals, principles, commitments, strategies, and desired state. It
 is the steering source for assistant recommendations and prioritization.
 
-### ISA
+### VSA
 
-Ideal State Artifacts define work. An ISA is both the articulation of done and
-the verification contract. Project ISAs live with projects. Task ISAs live under
+Ideal State Artifacts define work. An VSA is both the articulation of done and
+the verification contract. Project VSAs live with projects. Task VSAs live under
 Soma memory.
 
 ### Algorithm Harness
 
-The Algorithm harness is the deterministic execution layer around ISA. PAI used
+The Algorithm harness is the deterministic execution layer around VSA. PAI used
 TheAlgorithm mostly as doctrine projected into Claude; Soma keeps that doctrine
 as a portable skill, but also exposes typed run state and phase gates that a
 substrate or daemon can call directly.
@@ -91,7 +91,7 @@ task route selects them.
 
 MCP-capable substrates may use the optional
 [MCP server](./mcp-server.md) as the on-demand loading surface for skills,
-memory, ISA, Algorithm, and identity context. The server remains a core/library
+memory, VSA, Algorithm, and identity context. The server remains a core/library
 access surface; adapters only configure substrate-native MCP clients.
 
 Team-shared skills use **team overlays** rather than multi-principal Soma
@@ -120,7 +120,7 @@ substrate writeback. The design is Git-backed first, policy-gated per scope,
 and only auto-merges stores with deterministic merge semantics. See
 [docs/home-replication.md](./home-replication.md).
 
-Team `KNOWLEDGE`, `WORK`, and ISA material can be read through a team overlay,
+Team `KNOWLEDGE`, `WORK`, and VSA material can be read through a team overlay,
 but it stays namespaced and cited separately from personal memory. Team
 overlays are read-only in the first slice and must not expose personal Identity,
 Purpose, Relationship, raw transcript, or security-trace compartments.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,7 @@ is the steering source for assistant recommendations and prioritization.
 
 ### VSA
 
-Ideal State Artifacts define work. An VSA is both the articulation of done and
+Verification State Artifacts define work. A VSA is both the articulation of done and
 the verification contract. Project VSAs live with projects. Task VSAs live under
 Soma memory.
 

--- a/docs/boundaries.md
+++ b/docs/boundaries.md
@@ -11,8 +11,8 @@ Factory systems without absorbing their responsibilities. Glossary lives in
 | Personal assistant identity | Soma | Owns portable identity schema and projection. |
 | Principal profile | Soma | Owns personal profile shape and its projection (scrubbed so private data does not leak between substrates). |
 | Purpose | Soma | Owns personal goals, principles, commitments, and prioritization. |
-| Project ISA | Project repository | Reads and summarizes local `ISA.md`; does not centralize every project task. |
-| Personal/task ISA | Soma memory | Owns personal assistant tasks that do not belong to one project repo. |
+| Project VSA | Project repository | Reads and summarizes local `VSA.md`; does not centralize every project task. |
+| Personal/task VSA | Soma memory | Owns personal assistant tasks that do not belong to one project repo. |
 | Skills as portable capability folders | Soma | Owns portable skill metadata and discovery contract. |
 | Team skill distribution | Arc | Soma can mount Arc-installed skill packs as team overlays; Arc owns package lifecycle and version resolution. |
 | Team SOPs and governance | Compass | Soma can reference Compass ids in team overlays; Compass remains the governance authority. |

--- a/docs/codex-friendly-skills.md
+++ b/docs/codex-friendly-skills.md
@@ -49,11 +49,11 @@ The first #172 audit found two checked-in Soma skill entrypoints:
 | Entrypoint | Pre-refactor size | Role | Action |
 | --- | ---: | --- | --- |
 | `skill/SKILL.md` | 22 lines | Soma kernel skill | Already compact. |
-| `src/skills/ISA/SKILL.md` | 241 lines | Bundled ISA skill projected into substrates | Refactored into a compact entrypoint plus references. |
+| `src/skills/VSA/SKILL.md` | 241 lines | Bundled VSA skill projected into substrates | Refactored into a compact entrypoint plus references. |
 
-The ISA skill was the highest-impact representative target because it is bundled
+The VSA skill was the highest-impact representative target because it is bundled
 with Soma, projected into installed homes, and likely to be invoked inside Codex
-when working through Algorithm/ISA flows.
+when working through Algorithm/VSA flows.
 
 ## Authoring Rule
 

--- a/docs/daemon-mode.md
+++ b/docs/daemon-mode.md
@@ -11,7 +11,7 @@ owns transport and envelope semantics, and Spawn owns isolated execution.
 
 ## Goals
 
-- Keep Soma identity, memory, ISA, policy, and skill routing available without
+- Keep Soma identity, memory, VSA, policy, and skill routing available without
   requiring Codex, Claude Code, Pi.dev, Cursor, or another substrate session to
   already be active.
 - Let Cortex/Myelin address a standalone Soma Cortex agent through approved
@@ -35,7 +35,7 @@ owns transport and envelope semantics, and Spawn owns isolated execution.
 
 | Area | Owner | Soma daemon role |
 | --- | --- | --- |
-| Assistant identity, Purpose, ISA, memory, policy, and skill registry | Soma | Read and update through the normal Soma home contracts. |
+| Assistant identity, Purpose, VSA, memory, policy, and skill registry | Soma | Read and update through the normal Soma home contracts. |
 | Myelin subject names, envelope schemas, ack/retry semantics, credentials | Myelin | Consume imported contracts; never invent incompatible wire semantics. |
 | Collaboration routing, work queues, task assignment | Cortex | Let Cortex address or discover the Soma Cortex agent. |
 | Isolated execution lifecycle | Spawn | Request execution when a task needs an isolated runtime. |
@@ -60,14 +60,14 @@ configuration or packages.
 | Result or refusal | publish | Report routed result metadata, refusal reason, or handoff target. |
 
 Every inbound envelope is policy-checked before it can affect memory, skills,
-ISA state, Algorithm runs, or substrate spawning. Unauthorized or malformed
+VSA state, Algorithm runs, or substrate spawning. Unauthorized or malformed
 envelopes fail closed and produce a refusal event instead of partial work.
 
 ## Routing Flow
 
 1. Start `soma daemon` with a principal-selected Soma home and Cortex/Myelin
    configuration.
-2. Load the Soma kernel: identity summary, active work/ISA, policy, skill
+2. Load the Soma kernel: identity summary, active work/VSA, policy, skill
    registry, and team overlays that are enabled for daemon use.
 3. Publish readiness and health.
 4. Receive a Myelin envelope.
@@ -108,6 +108,6 @@ owning packages.
 - The daemon must not expose Identity, Purpose, Relationship, raw transcripts, or
   security traces through team or bus-facing surfaces.
 - The daemon records provenance for every accepted envelope and every selected
-  skill or ISA.
+  skill or VSA.
 - A bus envelope cannot become an unreviewed writeback operation.
 - Live subscription must be opt-in and visible in health output.

--- a/docs/default-availability.md
+++ b/docs/default-availability.md
@@ -16,7 +16,7 @@ Soma supports two projection placements relevant to default availability:
 1. **home** mode: the projection is installed into the substrate's user-level
    configuration directory. This makes the assistant available by default.
 2. **workspace** mode: the projection is installed into a project directory.
-   This adds project-specific ISA, skills, and policy overlays.
+   This adds project-specific VSA, skills, and policy overlays.
 
 The home projection is the primary install target. The workspace projection is
 a secondary overlay that takes precedence inside that workspace.
@@ -116,7 +116,7 @@ Current Soma projection target:
 <claude-home>/
   settings.json
   rules/soma/
-  skills/ISA/
+  skills/VSA/
   hooks/soma/soma-claude-code-hook.mjs
   hooks/soma/soma-claude-code-hook.config.json
 ```

--- a/docs/design-skill-packaging.md
+++ b/docs/design-skill-packaging.md
@@ -621,7 +621,7 @@ These are domain-specific behaviours that consume the core primitives. They migr
 |  | failure capture | `soma-skill-failure-capture` | Post-mortem capture, lessons routing into memory. |
 |  | session harvesting | `soma-skill-session-harvest` | Extract durable knowledge from session transcripts. |
 |  | metrics | `soma-skill-metrics` | Operational metrics on assistant performance + learning signals. |
-|  | progress | `soma-skill-progress` | Progress reporting / status synthesis across active ISAs. |
+|  | progress | `soma-skill-progress` | Progress reporting / status synthesis across active VSAs. |
 | [soma#131](https://github.com/the-metafactory/soma/issues/131) — Phase 3 (Wisdom Frames, 3 tools) | domain classifier, frame updater, cross-frame synthesizer | `soma-skill-wisdom-frames` | Single skill repo — the three tools genuinely co-evolve (shared frame schema). The architecture decision soma#131 calls out (knowledge taxonomy ownership) becomes a DD inside soma core: "where do frame schemas live, who can extend them." |
 | [soma#132](https://github.com/the-metafactory/soma/issues/132) — Phase 4 | `RelationshipReflect.ts` (opinion updates, milestone detection, notification) | `soma-skill-relationship-reflect` | Single skill. Notification dispatch goes through soma core's notification primitive (or a separate `soma-skill-notify` if more skills need notification). |
 

--- a/docs/home-replication.md
+++ b/docs/home-replication.md
@@ -15,7 +15,7 @@ when two machines edit the same durable artifact.
 - Let a principal carry one Soma home across laptop, VM, and future
   daemon-backed use.
 - Preserve the existing filesystem-native home contract: profile, Purpose,
-  memory, skills, policy, Algorithm runs, and ISAs remain plain files.
+  memory, skills, policy, Algorithm runs, and VSAs remain plain files.
 - Reuse Git history and the snapshot/rollback safety net before applying remote
   changes.
 - Merge append-only state deterministically where Soma already has merge
@@ -34,7 +34,7 @@ when two machines edit the same durable artifact.
 - The first backend does not need S3, Turso, or another hosted service.
 - The first implementation does not automatically reconcile arbitrary Markdown
   conflicts in `KNOWLEDGE`, `RELATIONSHIP`, `LEARNING`, `WORK`, profile, Purpose,
-  skills, policy, or ISA files.
+  skills, policy, or VSA files.
 - Home replication does not copy raw prompts, transcripts, full tool inputs, or
   command output unless a future policy explicitly allows that path.
 
@@ -152,7 +152,7 @@ Conflicting values for the same key must be reported, not silently overwritten.
 
 ### Durable Memory And Profile Files
 
-Files in profile, Purpose, skills, policy, ISA bodies, `KNOWLEDGE`, `LEARNING`,
+Files in profile, Purpose, skills, policy, VSA bodies, `KNOWLEDGE`, `LEARNING`,
 `RELATIONSHIP`, and `WORK` are normal durable artifacts. Until a store has a
 specific merge rule, concurrent edits are conflicts. The first implementation
 should keep both sides reachable through Git history and write a bounded

--- a/docs/integration-with-pai.md
+++ b/docs/integration-with-pai.md
@@ -175,11 +175,11 @@ This writes:
 
 - `~/.claude/rules/soma/README.md` + `CONTEXT.md` + `PROFILE.md` +
   `PURPOSE.md` + `MEMORY_LAYOUT.md` + `SKILLS.md` + `POLICY.md` +
-  `ACTIVE_ISA.md` — the canonical home projection. Claude Code
+  `ACTIVE_VSA.md` — the canonical home projection. Claude Code
   auto-discovers `.claude/rules/` at session start and loads Soma
   context from these files (per architectural pivot in soma#64; the
   pre-pivot `~/.claude/CLAUDE.md` `@`-import path was unreliable).
-- `~/.claude/skills/ISA/` — bundled ISA skill (Soma's verification
+- `~/.claude/skills/VSA/` — bundled VSA skill (Soma's verification
   harness).
 
 Hooks are deliberately not in the home install. They are an optional
@@ -216,7 +216,7 @@ This writes:
 - `~/.codex/AGENTS.md` — imports the Soma startup context and the
   Algorithm skill.
 - `~/.codex/rules/soma.rules` — Codex-native rule files projecting
-  Soma identity, purpose, active ISA, policy.
+  Soma identity, purpose, active VSA, policy.
 - `~/.codex/hooks/` — soma-lifecycle, policy, feedback-capture hooks.
 - `~/.codex/skills/{soma,the-algorithm}/SKILL.md` — local skill
   projection.
@@ -281,7 +281,7 @@ to the Soma home. You can also create one manually with
 ### Substrate check
 
 Start a session in each installed substrate. The principal identity,
-active ISA, and recent learning should appear unchanged across all
+active VSA, and recent learning should appear unchanged across all
 three.
 
 - **Claude Code** — `~/.claude/rules/soma/CONTEXT.md` and
@@ -318,10 +318,10 @@ ls ~/.soma/memory/WORK/algorithm-runs/  # the run is here, not under ~/.claude/
   to run. If you write into `~/.claude/PAI/MEMORY/` after migration,
   the next `migrate pai --apply` translates the new content forward;
   the inverse does not happen.
-- **The Algorithm and ISA are now Soma's.** Phase markers, ISC
-  verification, and learning routing land in `~/.soma/`. Project ISAs
-  created with `soma isa scaffold` live in the same place. Newly scaffolded
-  ISA slugs are date-prefixed unless the requested slug already starts with a
+- **The Algorithm and VSA are now Soma's.** Phase markers, ISC
+  verification, and learning routing land in `~/.soma/`. Project VSAs
+  created with `soma vsa scaffold` live in the same place. Newly scaffolded
+  VSA slugs are date-prefixed unless the requested slug already starts with a
   date; use the slug printed by the scaffold command.
 
 ## Failure modes

--- a/docs/isa-reconcile.md
+++ b/docs/isa-reconcile.md
@@ -1,26 +1,26 @@
-# VSA Reconcile
+# ISA Reconcile
 
-`reconcileVsa` merges a derived or ephemeral feature VSA back into the master
-VSA for the same work. The merge is deterministic and keyed by stable ISC IDs.
+`reconcileIsa` merges a derived or ephemeral feature ISA back into the master
+ISA for the same work. The merge is deterministic and keyed by stable ISC IDs.
 It is not a three-way merge and it does not try to infer author intent from
 free-form prose.
 
-The source of truth remains the master VSA under
-`<soma-home>/isa/<slug>.md`. Feature VSAs are derived views. They may
+The source of truth remains the master ISA under
+`<soma-home>/isa/<slug>.md`. Feature ISAs are derived views. They may
 contribute criterion status, criterion evidence, Decisions, Changelog,
 Verification entries, and new non-conflicting sections. They do not replace the
 master document wholesale.
 
 ## Interface
 
-The file-backed function lives in `src/vsa-reconcile.ts`:
+The file-backed function lives in `src/isa-reconcile.ts`:
 
 ```ts
-reconcileVsa(slug, feature, options)
+reconcileIsa(slug, feature, options)
 ```
 
-- `slug` identifies the master VSA in `<soma-home>/isa/<slug>.md`.
-- `feature` is either a parsed `IdealStateArtifact` or a path to a feature VSA.
+- `slug` identifies the master ISA in `<soma-home>/isa/<slug>.md`.
+- `feature` is either a parsed `IdealStateArtifact` or a path to a feature ISA.
 - `options.onConflict` can force a policy for tests or explicit callers.
 - without an override, the default policy is read from
   `<soma-home>/isa/config.json`:
@@ -40,7 +40,7 @@ Every file-backed reconcile appends an `isa.reconcile` event to
 
 ### Sections
 
-Known VSA sections are matched by canonical section name. Header whitespace is
+Known ISA sections are matched by canonical section name. Header whitespace is
 normalized by the parser, so `## Goal`, `##  Goal`, and `## Goal ` all identify
 the same section.
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -10,7 +10,7 @@ writeback channel.
 
 ## Goals
 
-- Let MCP-capable substrates discover Soma memory, skills, ISA, Algorithm, and
+- Let MCP-capable substrates discover Soma memory, skills, VSA, Algorithm, and
   identity context on demand.
 - Keep eager startup context small by making large registries and skill bodies
   indexed with on-demand bodies.
@@ -43,9 +43,9 @@ pagination or selector arguments for large outputs.
 | Skills | `soma_skill_registry` | read | List available skills with names, summaries, token estimates, and entrypoints. |
 | Skills | `soma_skill_route` | read | Route a task description to likely skills without loading every skill body. |
 | Skills | `soma_skill_load` | read | Load one selected skill entrypoint or referenced file. |
-| ISA | `soma_isa_active` | read | Return the active ISA summary and criterion IDs. |
-| ISA | `soma_isa_check` | read | Check proposed evidence against active ISA criteria without mutating state. |
-| ISA | `soma_isa_scaffold` | deferred write | Create a new ISA draft after explicit confirmation. |
+| VSA | `soma_isa_active` | read | Return the active VSA summary and criterion IDs. |
+| VSA | `soma_isa_check` | read | Check proposed evidence against active VSA criteria without mutating state. |
+| VSA | `soma_isa_scaffold` | deferred write | Create a new VSA draft after explicit confirmation. |
 | Algorithm | `soma_algorithm_classify` | read | Classify a prompt as MINIMAL, NATIVE, or ALGORITHM and map Algorithm depth. |
 | Algorithm | `soma_algorithm_new` | deferred write | Create a new Algorithm run. |
 | Algorithm | `soma_algorithm_advance` | deferred write | Advance an existing Algorithm run through phase gates. |
@@ -75,7 +75,7 @@ small registry, route, then load only the selected body.
 
 Every read tool must validate the requesting principal, MCP client session,
 substrate, and allowed scope before returning data. Scope includes the requested
-memory path or ID, identity context, active ISA, skill entrypoint, Algorithm
+memory path or ID, identity context, active VSA, skill entrypoint, Algorithm
 classification input, and any substrate-specific visibility limit.
 
 Path-based reads must resolve through Soma core path validation and must not
@@ -108,7 +108,7 @@ by default.
 ## Adapter Boundary
 
 The MCP server is a library/daemon surface. It owns the protocol transport and
-tool schemas, but it calls Soma core for identity, memory, skill routing, ISA,
+tool schemas, but it calls Soma core for identity, memory, skill routing, VSA,
 Algorithm, policy, and writeback.
 
 Adapters own substrate-native install facts:
@@ -130,5 +130,5 @@ from the Tool Inventory table, matching the default manifest in the Schema
 Budget section.
 
 It should include fixture-backed tests for schema shape, bounded responses,
-path validation, missing active ISA, missing skill, no raw prompt persistence,
+path validation, missing active VSA, missing skill, no raw prompt persistence,
 and no writes from read-only tools.

--- a/docs/memory-policy-v0.md
+++ b/docs/memory-policy-v0.md
@@ -134,6 +134,6 @@ sandboxes, or daemon controls exist.
 
 ## Verification V0
 
-Every task-facing ISA should include verification criteria. Adapters can add
-substrate-native verification commands, but they must not replace the ISA as
+Every task-facing VSA should include verification criteria. Adapters can add
+substrate-native verification commands, but they must not replace the VSA as
 the source of truth for done.

--- a/docs/portability-proof.md
+++ b/docs/portability-proof.md
@@ -19,7 +19,7 @@ The first workflow is a ledger update:
 
 ## Pass Conditions
 
-- The same profile, purpose, skill list, memory layout, and ISA are used unchanged.
+- The same profile, purpose, skill list, memory layout, and VSA are used unchanged.
 - Substrate adapters may change only projection shape, file names, and
   host-specific invocation.
 - The workflow has a shared verification criterion that does not depend on chat
@@ -49,7 +49,7 @@ The CI suite verifies:
   same semantic Soma content from one `ProjectionInput`.
 - Portable skills pass the existing static smoke verifier for the CI-supported
   smoke targets, Codex and Pi.dev.
-- Active ISA state survives a project -> writeback -> reproject round trip
+- Active VSA state survives a project -> writeback -> reproject round trip
   across all shipping home projections.
 
 This is intentionally not a live behavioral equivalence test. Running the same

--- a/docs/private-source-guard-v0.md
+++ b/docs/private-source-guard-v0.md
@@ -74,7 +74,7 @@ The default protected paths declare these allowed modify subpaths:
 
 | Root         | Allowed modify subpaths                | Rationale                                            |
 | ------------ | -------------------------------------- | ---------------------------------------------------- |
-| `~/.soma`    | `isa/`, `memory/`                      | ISA edits and memory writes are the assistant's job  |
+| `~/.soma`    | `isa/`, `memory/`                      | VSA edits and memory writes are the assistant's job  |
 | `~/.claude`  | `memory/`, `memories/`, `PAI/MEMORY/`  | Claude Code and PAI write working memory under these |
 | `~/.pi`      | `agent/memory/`                        | Pi.dev agent memory                                  |
 
@@ -82,7 +82,7 @@ Writes to a protected root that fall outside its `allowedSubpaths` remain
 denied. `~/.soma/profile/identity.md` and `~/.soma/secret.md` are blocked for
 modify even though `~/.soma/isa/draft.md` is allowed. This keeps private roots
 (profile, identity, purpose) safe while letting the assistant manage its own
-memory and ISA artifacts. See issue #79 (Pi.dev) and #48 (Codex) for the
+memory and VSA artifacts. See issue #79 (Pi.dev) and #48 (Codex) for the
 matching substrate-hook refinements.
 
 ## Pi.dev Projection

--- a/docs/progressive-skill-loading.md
+++ b/docs/progressive-skill-loading.md
@@ -68,7 +68,7 @@ The kernel is the maximum context that should be loaded by default:
 
 - assistant and principal identity
 - purpose summary
-- active Algorithm run or active ISA summary
+- active Algorithm run or active VSA summary
 - memory search instructions
 - policy and verification rules
 - skill registry location and loading protocol
@@ -126,7 +126,7 @@ narrow skills should be `never` until a router selects them.
 The router chooses candidate skills before their full bodies are loaded. Inputs:
 
 - current user prompt
-- active Algorithm run or active ISA
+- active Algorithm run or active VSA
 - current workspace overlay
 - substrate id and known context budget
 - available tool surface

--- a/docs/soma-home-layout.md
+++ b/docs/soma-home-layout.md
@@ -3,7 +3,7 @@
 `soma init --apply` creates `~/.soma/` (override with `--soma-home`). This
 directory is the portable source of truth for your assistant. Substrate homes
 (`~/.codex`, `~/.claude`, …) are generated projections of it. Everything in
-`~/.soma` is plain, readable files; profile, skills, memory, ISAs, and policy
+`~/.soma` is plain, readable files; profile, skills, memory, VSAs, and policy
 are yours to edit directly, while `projections/` holds generated caches that
 re-projection rewrites.
 
@@ -21,9 +21,9 @@ re-projection rewrites.
 │   ├── WORK/
 │   │   └── algorithm-runs/ # Algorithm run state, one <run-id>.json per run
 │   └── STATE/
-│       └── active.json     # active ISA pointer
+│       └── active.json     # active VSA pointer
 ├── isa/                    # Ideal State Artifacts, one <slug>.md per project/task
-│   └── .templates/         # ISA scaffolding templates
+│   └── .templates/         # VSA scaffolding templates
 ├── policy/                 # substrate policy declarations
 ├── imports/                # migration manifests and portability reports
 └── projections/            # cached generated projections (codex, claude-code, …)
@@ -34,19 +34,19 @@ On a fresh machine the profile files start as a **starter profile**
 content, or import an existing installation (see below). `soma doctor` warns
 while the starter profile is still in place.
 
-## Where the Algorithm and ISA live
+## Where the Algorithm and VSA live
 
 Soma ships its own, substrate-neutral implementation of the Algorithm work
 harness and Ideal State Artifacts — they do not depend on PAI or any
 substrate being installed:
 
-- **Implementation:** the `soma algorithm ...` and `soma isa ...` CLI commands
+- **Implementation:** the `soma algorithm ...` and `soma vsa ...` CLI commands
   (see [README — The Algorithm](../README.md#the-algorithm) and
-  [README — ISA](../README.md#isa)).
+  [README — VSA](../README.md#isa)).
 - **State on disk:** Algorithm runs persist as JSON under
-  `memory/WORK/algorithm-runs/`; ISAs are markdown files under `isa/`, with
-  the active ISA recorded in `memory/STATE/active.json`.
-- **Projection:** substrate adapters surface the active ISA and Algorithm
+  `memory/WORK/algorithm-runs/`; VSAs are markdown files under `isa/`, with
+  the active VSA recorded in `memory/STATE/active.json`.
+- **Projection:** substrate adapters surface the active VSA and Algorithm
   state into each substrate (for Claude Code: `~/.claude/rules/soma/`).
 
 ## How the home gets populated

--- a/docs/soma-home-layout.md
+++ b/docs/soma-home-layout.md
@@ -22,7 +22,7 @@ re-projection rewrites.
 │   │   └── algorithm-runs/ # Algorithm run state, one <run-id>.json per run
 │   └── STATE/
 │       └── active.json     # active VSA pointer
-├── isa/                    # Ideal State Artifacts, one <slug>.md per project/task
+├── isa/                    # Verification State Artifacts, one <slug>.md per project/task
 │   └── .templates/         # VSA scaffolding templates
 ├── policy/                 # substrate policy declarations
 ├── imports/                # migration manifests and portability reports
@@ -37,7 +37,7 @@ while the starter profile is still in place.
 ## Where the Algorithm and VSA live
 
 Soma ships its own, substrate-neutral implementation of the Algorithm work
-harness and Ideal State Artifacts — they do not depend on PAI or any
+harness and Verification State Artifacts — they do not depend on PAI or any
 substrate being installed:
 
 - **Implementation:** the `soma algorithm ...` and `soma vsa ...` CLI commands

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -10,7 +10,7 @@ Codex is a coding-agent substrate. The Codex projection should carry:
 
 - system/developer instruction fragments
 - Soma identity and purpose
-- active ISA summary
+- active VSA summary
 - relevant skills as local instructions
 - memory readback
 - verification policy
@@ -48,7 +48,7 @@ Pi.dev is model-agnostic and supports extensions and skills. The adapter should
 follow the reduced PAI-on-Pi pattern:
 
 - one core extension
-- registered tools for ISA, memory, learning, and notifications
+- registered tools for VSA, memory, learning, and notifications
 - skill directories with `SKILL.md`
 - settings and model provider config
 
@@ -120,8 +120,8 @@ into that shape without making Claude Code the source of truth.
 Current home install behavior:
 
 - `soma install claude-code --apply` writes context under
-  `<claude-home>/rules/soma/` and the ISA skill under
-  `<claude-home>/skills/ISA/`.
+  `<claude-home>/rules/soma/` and the VSA skill under
+  `<claude-home>/skills/VSA/`.
 - It installs a Soma-owned hook runner at
   `<claude-home>/hooks/soma/soma-claude-code-hook.mjs` with colocated runtime
   config.
@@ -138,7 +138,7 @@ Current home install behavior:
   Tool and subagent hooks emit metadata-only events through the Soma writeback
   gate; they do not mirror full raw transcripts or prompt text.
 - `soma uninstall claude-code` removes only the generated `rules/soma/`
-  projection, `skills/ISA/`, the Soma-owned hook runner/config, and matching
+  projection, `skills/VSA/`, the Soma-owned hook runner/config, and matching
   Soma hook entries in `settings.json`.
 
 Context projection, PAI Native Mode memory, and Soma shared memory remain
@@ -153,8 +153,8 @@ tools. The first Cursor adapter is intentionally filesystem-first:
 
 - `.cursorrules` points Cursor at the generated Soma rule directory
 - `.cursor/rules/soma/` carries context, profile, purpose, memory layout, skills,
-  policy, MCP notes, and the active ISA when present
-- `.cursor/rules/soma/skills/ISA/` carries the portable ISA skill source
+  policy, MCP notes, and the active VSA when present
+- `.cursor/rules/soma/skills/VSA/` carries the portable VSA skill source
 
 Initial implementation: `projectCursor` and `projectCursorHome` generate the
 same portable Soma context in Cursor's native rules shape. `soma install cursor
@@ -184,8 +184,8 @@ and `~/.grok/skills/<name>/SKILL.md` auto-load, while home `~/.grok/rules/` and
 
 - `skills/soma/SKILL.md` — the auto-loaded entry skill carrying the portable
   assistant core, with `context.md`, `memory-layout.md`, `skills.md`,
-  `policy.md`, `startup-context.md`, and (when an ISA is active)
-  `active-isa.md` colocated beside it.
+  `policy.md`, `startup-context.md`, and (when an VSA is active)
+  `active-vsa.md` colocated beside it.
 - `skills/the-algorithm/SKILL.md` — the shared seven-phase Algorithm rendering
   contract plus a Grok-native verification-gates section (see below).
 - `AGENTS.md` — a marked pointer block (appended idempotently, foreign content
@@ -218,10 +218,10 @@ empirical tool-name matchers (`Shell`, `Read`, `Write`, `StrReplace`, `Grep`,
 
 Algorithm rendering is honestly scoped to what Grok offers: text banners plus
 the native todo list. There is no Pi-style widget API, so the Algorithm skill
-instructs the in-substrate agent to mirror plan steps and active-ISA criteria
+instructs the in-substrate agent to mirror plan steps and active-VSA criteria
 into `todo_write`, and to run verification-heavy work headless with
 `--todo-gate` (a turn cannot end with open todos) and `--check` (Grok's
-self-verification loop). The active ISA's open criteria seed the todo list.
+self-verification loop). The active VSA's open criteria seed the todo list.
 Grok also has no sandbox on Windows (`--sandbox` is Landlock/Seatbelt-only) and
 no statusline surface; isolation guidance uses git worktrees.
 
@@ -264,7 +264,7 @@ structured selections remain unresolved.
 
 ## Adapter Contract
 
-Adapters should be thin. They do not own identity, memory, ISA, skill schemas, or
+Adapters should be thin. They do not own identity, memory, VSA, skill schemas, or
 policy semantics. They only project those contracts into a substrate's native
 mechanisms, and write back substrate-side events through the writeback gate.
 
@@ -294,7 +294,7 @@ Adapters own their substrate-native install facts: default home, projected file
 paths, substrate-specific skill destinations, lifecycle projection paths,
 validators, cleanup hooks, private projection roots, MCP client configuration,
 and uninstall targets. The installer owns orchestration: bootstrapping Soma
-home, loading active ISA, running lifecycle updates, writing projections, and
+home, loading active VSA, running lifecycle updates, writing projections, and
 applying the install, reproject, upgrade, and uninstall verbs.
 
 The optional MCP server is a shared library/daemon surface, not an adapter.

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -184,7 +184,7 @@ and `~/.grok/skills/<name>/SKILL.md` auto-load, while home `~/.grok/rules/` and
 
 - `skills/soma/SKILL.md` — the auto-loaded entry skill carrying the portable
   assistant core, with `context.md`, `memory-layout.md`, `skills.md`,
-  `policy.md`, `startup-context.md`, and (when an VSA is active)
+  `policy.md`, `startup-context.md`, and (when a VSA is active)
   `active-vsa.md` colocated beside it.
 - `skills/the-algorithm/SKILL.md` — the shared seven-phase Algorithm rendering
   contract plus a Grok-native verification-gates section (see below).

--- a/docs/team-overlays.md
+++ b/docs/team-overlays.md
@@ -1,6 +1,6 @@
 # Team Overlays
 
-Issue #152 asks for shared skills, team memory, team ISAs, and a permission
+Issue #152 asks for shared skills, team memory, team VSAs, and a permission
 model without leaking personal Identity, Purpose, or Relationship state. The
 implementation term is **team overlay**: a policy-scoped shared Soma layer that
 supplements one principal's local Soma home.
@@ -15,7 +15,7 @@ provenance when it is used.
 - Let several principals use a team-curated set of Soma skills.
 - Let personal Soma memory read shared team `KNOWLEDGE` and `WORK` without
   copying private personal stores into the team layer.
-- Let project or team ISAs be visible beside personal/task ISAs.
+- Let project or team VSAs be visible beside personal/task VSAs.
 - Keep shared state explicitly namespaced by team, source, and permission.
 - Preserve Arc as the package/distribution system and Compass as the SOP and
   governance authority.
@@ -71,7 +71,7 @@ personal files.
 | Skills | allowed | Team skills are shared capability folders distributed by Arc or an approved source. |
 | `memory/KNOWLEDGE` | read-only | Shared facts require provenance and stay team-cited. |
 | `memory/WORK` | read-only | Shared project/work artifacts are visible but not silently promoted into personal work. |
-| ISA | read-only | Team ISAs supplement personal/task ISAs and keep team provenance. |
+| VSA | read-only | Team VSAs supplement personal/task VSAs and keep team provenance. |
 | Policy | read-only | Team policy may add stricter rules; it must not relax personal policy. |
 | Identity | denied | Personal principal and assistant identity are never sourced from a team overlay. |
 | Purpose | denied | Personal goals and commitments are never shared by default. |
@@ -89,8 +89,8 @@ Team overlays supplement personal Soma; they do not override it.
    one side.
 4. Personal memory search results and team memory search results are separate
    cited result groups.
-5. A team ISA is selected explicitly by team and slug. It does not replace the
-   active personal ISA unless the principal chooses that team ISA for the
+5. A team VSA is selected explicitly by team and slug. It does not replace the
+   active personal VSA unless the principal chooses that team VSA for the
    current workspace or task.
 
 This avoids hidden last-writer-wins behavior and makes team provenance visible
@@ -148,7 +148,7 @@ The first code slice should implement read-only team overlays:
   provenance, but keeps personal and team result groups separate.
 - Skill registry can include team skills with team prefixes or aliases, but
   refuses unaliased name collisions.
-- Active ISA commands can show or select a team ISA explicitly by team and slug.
+- Active VSA commands can show or select a team VSA explicitly by team and slug.
 - Projection code includes only enabled read-only team artifacts and never
   projects personal-private compartments from a team overlay.
 

--- a/docs/vsa-reconcile.md
+++ b/docs/vsa-reconcile.md
@@ -1,26 +1,26 @@
-# ISA Reconcile
+# VSA Reconcile
 
-`reconcileIsa` merges a derived or ephemeral feature ISA back into the master
-ISA for the same work. The merge is deterministic and keyed by stable ISC IDs.
+`reconcileVsa` merges a derived or ephemeral feature VSA back into the master
+VSA for the same work. The merge is deterministic and keyed by stable ISC IDs.
 It is not a three-way merge and it does not try to infer author intent from
 free-form prose.
 
-The source of truth remains the master ISA under
-`<soma-home>/isa/<slug>.md`. Feature ISAs are derived views. They may
+The source of truth remains the master VSA under
+`<soma-home>/isa/<slug>.md`. Feature VSAs are derived views. They may
 contribute criterion status, criterion evidence, Decisions, Changelog,
 Verification entries, and new non-conflicting sections. They do not replace the
 master document wholesale.
 
 ## Interface
 
-The file-backed function lives in `src/isa-reconcile.ts`:
+The file-backed function lives in `src/vsa-reconcile.ts`:
 
 ```ts
-reconcileIsa(slug, feature, options)
+reconcileVsa(slug, feature, options)
 ```
 
-- `slug` identifies the master ISA in `<soma-home>/isa/<slug>.md`.
-- `feature` is either a parsed `IdealStateArtifact` or a path to a feature ISA.
+- `slug` identifies the master VSA in `<soma-home>/isa/<slug>.md`.
+- `feature` is either a parsed `IdealStateArtifact` or a path to a feature VSA.
 - `options.onConflict` can force a policy for tests or explicit callers.
 - without an override, the default policy is read from
   `<soma-home>/isa/config.json`:
@@ -40,7 +40,7 @@ Every file-backed reconcile appends an `isa.reconcile` event to
 
 ### Sections
 
-Known ISA sections are matched by canonical section name. Header whitespace is
+Known VSA sections are matched by canonical section name. Header whitespace is
 normalized by the parser, so `## Goal`, `##  Goal`, and `## Goal ` all identify
 the same section.
 

--- a/docs/writeback-and-policy.md
+++ b/docs/writeback-and-policy.md
@@ -132,7 +132,7 @@ semantics are deterministic:
 
 - `memory-event` writes append one event to `memory/STATE/events.jsonl`.
 - `isa-log` appends Decisions, Changelog, and Verification entries to the
-  active ISA, or to an explicit slug only when that slug matches the active ISA.
+  active VSA, or to an explicit slug only when that slug matches the active VSA.
 
 Every supported operation first runs Soma policy against the target path. Direct
 durable writes to stores such as `KNOWLEDGE`, `LEARNING`, `RELATIONSHIP`,
@@ -154,7 +154,7 @@ Until store-specific merge rules exist:
 
 Home replication must preserve these conflict rules across machines. It may
 merge append-only `memory/STATE/events.jsonl` entries and session-keyed work
-state, but durable memory, profile, Purpose, skill, policy, and ISA body
+state, but durable memory, profile, Purpose, skill, policy, and VSA body
 conflicts remain explicit conflicts until store-specific merge rules exist. See
 [home-replication.md](./home-replication.md).
 
@@ -168,9 +168,9 @@ Each memory store needs its own merge semantics before direct writes are allowed
 | Store | Likely merge strategy |
 | --- | --- |
 | `STATE` | Easy: append-only events, latest cache can be regenerated |
-| `ISA` | Supported for log sections only: append Decisions, Changelog, Verification through `applySomaWriteback` |
+| `VSA` | Supported for log sections only: append Decisions, Changelog, Verification through `applySomaWriteback` |
 | `LEARNING` | Medium: append candidate, consolidate into lessons explicitly |
-| `WORK` | Hard: task/ISA scoped updates with criteria-level history |
+| `WORK` | Hard: task/VSA scoped updates with criteria-level history |
 | `RELATIONSHIP` | Hard: conservative append plus review due privacy/sensitivity |
 | `KNOWLEDGE` | Hardest: citation/provenance required before durable promotion |
 


### PR DESCRIPTION
**Docs-only** carve-out of the ISA→VSA rename (#329), split out so it's small enough for automated review (the combined 139-file code+docs diff overran Sage's lens extractor).

## What changed
- ISA → VSA / Verification terminology across `docs/`, `README.md`, and `design/design-decisions.md` (concepts and vocabulary only — no forward references to renamed code symbols).
- Updated the four **doc-coupled design tests** (daemon / home-replication / mcp-server / team-overlays) whose assertions read the changed prose. (These are test-file edits, not `src/` changes.)

## Deliberately NOT here
- `docs/isa-reconcile.md` — it documents `src/isa-reconcile.ts` directly, so it moves with the **companion code-rename PR**, not this one (avoids asserting code symbols that don't exist yet).
- `CONTEXT.md` glossary ("formerly ISA", VSA/Verification entries) and **ADR 0001** — historical record.
- pai-migration reserved-name mentions.

## Verification
- `bun test` → **1443 pass / 0 fail** (the four updated design tests pass against the new prose).

Companion PR (the atomic code rename, incl. `isa-reconcile.md`→`vsa-reconcile.md`) follows. Refs ADR `docs/adr/0001-de-miessler-vocabulary.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)