### PR TITLE
feat(vsa): rename IdealStateCriterion type → Checkpoint with deprecated alias (#329 slice 3, Piece B)

### DIFF
--- a/src/adapters/pi-dev/extensions/vsa-checklist.ts
+++ b/src/adapters/pi-dev/extensions/vsa-checklist.ts
@@ -12,7 +12,7 @@
  *   dropped  → [-]   (deliberately removed)
  *   pending  → [ ]   (everything else: unverified, in-progress, etc.)
  *
- * Status strings mirror `IdealStateCriterion.status` in `src/types.ts`.
+ * Status strings mirror `Checkpoint.status` in `src/types.ts`.
  * This module deliberately accepts any string status and falls through
  * to "pending" for unrecognized values rather than crashing the widget.
  *

--- a/src/algorithm-execution-modes.ts
+++ b/src/algorithm-execution-modes.ts
@@ -5,7 +5,7 @@ import type {
   AlgorithmNotificationEvent,
   AlgorithmPhase,
   AlgorithmRun,
-  IdealStateCriterion,
+  Checkpoint,
   IdeateParameters,
   IdeatePresetName,
   OptimizeParameters,
@@ -185,11 +185,11 @@ function domainFromCriterionId(id: string): string {
 }
 
 export function partitionCriteriaByDomain(
-  criteria: readonly IdealStateCriterion[],
+  criteria: readonly Checkpoint[],
   maxPartitions?: number,
 ): AlgorithmCriteriaPartition[] {
   if (maxPartitions !== undefined) assertPositiveInteger(maxPartitions, "maxPartitions");
-  const grouped = new Map<string, IdealStateCriterion[]>();
+  const grouped = new Map<string, Checkpoint[]>();
   for (const criterion of criteria) {
     const domain = domainFromCriterionId(criterion.id);
     const group = grouped.get(domain);

--- a/src/algorithm-store.ts
+++ b/src/algorithm-store.ts
@@ -9,7 +9,7 @@ import type {
   AlgorithmRun,
   AlgorithmRunSummary,
   VerificationStateArtifact,
-  IdealStateCriterion,
+  Checkpoint,
 } from "./types";
 import { buildVsaArtifact, getCriteria, getGoal } from "./vsa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
@@ -76,7 +76,7 @@ interface LegacyVsa {
   slug: string;
   phase: AlgorithmPhase;
   goal: string;
-  criteria: IdealStateCriterion[];
+  criteria: Checkpoint[];
 }
 
 // LegacyAlgorithmRun = pre-#41 on-disk shape. Derived from AlgorithmRun so

--- a/src/algorithm-vsa-sync.ts
+++ b/src/algorithm-vsa-sync.ts
@@ -46,7 +46,7 @@ import type {
   AlgorithmPhase,
   AlgorithmRun,
   VerificationStateArtifact,
-  IdealStateCriterion,
+  Checkpoint,
   SubstrateId,
 } from "./types";
 
@@ -187,7 +187,7 @@ function phaseIndex(phase: AlgorithmPhase): number {
  * is passed/dropped, so we never try to advance past VERIFY when criteria are
  * still open — even if the VSA claims `learn`/`complete`.
  */
-function reachableTargetPhase(target: AlgorithmPhase, criteria: readonly IdealStateCriterion[]): AlgorithmPhase {
+function reachableTargetPhase(target: AlgorithmPhase, criteria: readonly Checkpoint[]): AlgorithmPhase {
   // Mirror the LEARN integrity gate via the shared rule so the two cannot drift:
   // a `passed` criterion verified by specification only (e.g. a pass fabricated
   // from a frontmatter progress counter) cannot clear LEARN, so sync caps such a
@@ -290,7 +290,7 @@ function progressCompletedCount(progress: string, total: number): number | null 
   return completed;
 }
 
-function frontmatterCompletionCount(isa: VerificationStateArtifact, vsaCriteria: readonly IdealStateCriterion[]): number {
+function frontmatterCompletionCount(isa: VerificationStateArtifact, vsaCriteria: readonly Checkpoint[]): number {
   const checked = vsaCriteria.filter(isClosedCriterion).length;
   const progress = progressCompletedCount(isa.frontmatter.progress, vsaCriteria.length) ?? 0;
   const phaseCompleted = phaseIndex(isa.frontmatter.phase) >= phaseIndex("learn") ? vsaCriteria.length : 0;
@@ -301,7 +301,7 @@ function frontmatterCompletionCount(isa: VerificationStateArtifact, vsaCriteria:
 function reconcileCriteria(
   run: AlgorithmRun,
   isa: VerificationStateArtifact,
-  vsaCriteria: readonly IdealStateCriterion[],
+  vsaCriteria: readonly Checkpoint[],
   timestamp: string,
   substrate: SubstrateId,
 ): AlgorithmRun {

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -10,7 +10,7 @@ import type {
   AlgorithmRunInput,
   EvidenceKind,
   VerificationStateArtifact,
-  IdealStateCriterion,
+  Checkpoint,
 } from "./types";
 import {
   assertAlgorithmCapabilitiesSatisfied,
@@ -38,9 +38,9 @@ import {
  * is added. Composes the pure vsa-accessor predicates; gate policy lives here in
  * the Algorithm module, not in the structural accessor layer.
  */
-export function learnGateViolations(criteria: readonly IdealStateCriterion[]): {
-  unresolved: IdealStateCriterion[];
-  hollow: IdealStateCriterion[];
+export function learnGateViolations(criteria: readonly Checkpoint[]): {
+  unresolved: Checkpoint[];
+  hollow: Checkpoint[];
 } {
   return {
     unresolved: criteria.filter((criterion) => !isClosedCriterion(criterion)),
@@ -92,7 +92,7 @@ function uniqueIds(criteria: { id: string }[], field: string): void {
   }
 }
 
-function criterionFromInput(input: { id: string; text: string; verification?: string }): IdealStateCriterion {
+function criterionFromInput(input: { id: string; text: string; verification?: string }): Checkpoint {
   assertNonEmpty(input.text, `criterion ${input.id} text`);
 
   return {
@@ -379,7 +379,7 @@ export function verifyAlgorithmCriterion(
   evidence: string,
   timestamp?: string,
   provenance?: Pick<AlgorithmProvenanceInput, "substrate">,
-  evidenceKind?: IdealStateCriterion["evidenceKind"],
+  evidenceKind?: Checkpoint["evidenceKind"],
 ): AlgorithmRun {
   assertNonEmpty(evidence, "verification evidence");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export type {
   DerivedFrontmatter,
   VerificationStateArtifact,
   Checkpoint,
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- intentional back-compat re-export of the deprecated alias (soma#329)
   IdealStateCriterion,
   IdeateParameters,
   IdeatePresetName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export type {
   AuthoredFrontmatter,
   DerivedFrontmatter,
   VerificationStateArtifact,
+  Checkpoint,
   IdealStateCriterion,
   IdeateParameters,
   IdeatePresetName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,12 @@ export type EvidenceKind = "specified" | "probed" | "tested";
 
 export type CriterionStatus = "open" | "passed" | "failed" | "dropped" | "deferred-probe";
 
-export interface IdealStateCriterion {
+/**
+ * The unit of evidence-gated verification: { criterion, required evidence, typed
+ * verdict, completion gate }. See CONTEXT.md and ADR 0001 — this code shape *is*
+ * the extracted `checkpoint` primitive (#329).
+ */
+export interface Checkpoint {
   id: string;
   text: string;
   status: CriterionStatus;
@@ -46,6 +51,12 @@ export interface IdealStateCriterion {
   /** See {@link EvidenceKind}. Undefined on legacy/pre-feature criteria (grandfathered by the LEARN gate). */
   evidenceKind?: EvidenceKind;
 }
+
+/**
+ * @deprecated soma#329: renamed to {@link Checkpoint}. Retained as a back-compat
+ * alias for the PAI-era name; prefer `Checkpoint` in new code.
+ */
+export type IdealStateCriterion = Checkpoint;
 
 export type AlgorithmPhase = "observe" | "think" | "plan" | "build" | "execute" | "verify" | "learn" | "complete" | "abandoned";
 
@@ -75,7 +86,7 @@ export interface AlgorithmLoopState {
 export interface AlgorithmCriteriaPartition {
   id: string;
   domain: string;
-  criteria: IdealStateCriterion[];
+  criteria: Checkpoint[];
 }
 
 export interface IdeateParameters {
@@ -355,7 +366,7 @@ export interface AlgorithmRun {
   currentState: string;
   isa: VerificationStateArtifact;
   loop: AlgorithmLoopState;
-  antiCriteria: IdealStateCriterion[];
+  antiCriteria: Checkpoint[];
   capabilities: string[];
   capabilityDefinitions?: AlgorithmCapabilityDefinition[];
   capabilitySelections?: AlgorithmCapabilitySelection[];

--- a/src/vsa-accessors.ts
+++ b/src/vsa-accessors.ts
@@ -6,7 +6,7 @@ import type {
   CriterionStatus,
   EvidenceKind,
   VerificationStateArtifact,
-  IdealStateCriterion,
+  Checkpoint,
   VsaSection,
 } from "./types";
 
@@ -46,7 +46,7 @@ export function getGoal(isa: VerificationStateArtifact): string | null {
   return trimmed.length === 0 ? null : trimmed;
 }
 
-export function getCriteria(isa: VerificationStateArtifact): IdealStateCriterion[] {
+export function getCriteria(isa: VerificationStateArtifact): Checkpoint[] {
   const section = getSection(isa, SECTION_NAME_MAP.criteria);
   if (section === null) return [];
   return parseCriteriaMarkdown(section.content);
@@ -80,21 +80,21 @@ export function setSection(isa: VerificationStateArtifact, name: string, content
   return { ...isa, sections };
 }
 
-export function setCriteria(isa: VerificationStateArtifact, criteria: readonly IdealStateCriterion[]): VerificationStateArtifact {
+export function setCriteria(isa: VerificationStateArtifact, criteria: readonly Checkpoint[]): VerificationStateArtifact {
   return setSection(isa, SECTION_NAME_MAP.criteria, renderCriteriaMarkdown(criteria));
 }
 
 export interface UpdateCriterionResult {
   isa: VerificationStateArtifact;
-  criteria: IdealStateCriterion[];
+  criteria: Checkpoint[];
 }
 
 export function updateCriterionWithResult(
   isa: VerificationStateArtifact,
   criterionId: string,
-  status: IdealStateCriterion["status"],
+  status: Checkpoint["status"],
   verification?: string,
-  evidenceKind?: IdealStateCriterion["evidenceKind"],
+  evidenceKind?: Checkpoint["evidenceKind"],
 ): UpdateCriterionResult {
   const criteria = getCriteria(isa);
   if (!criteria.some((criterion) => criterion.id === criterionId)) {
@@ -115,8 +115,8 @@ export function updateCriterionWithResult(
 
 /** A criterion that no longer needs work: verified, dropped, or honestly deferred. */
 export function isClosedCriterion(
-  criterion: IdealStateCriterion,
-): criterion is IdealStateCriterion & { status: "passed" | "dropped" | "deferred-probe" } {
+  criterion: Checkpoint,
+): criterion is Checkpoint & { status: "passed" | "dropped" | "deferred-probe" } {
   return (
     criterion.status === "passed" || criterion.status === "dropped" || criterion.status === "deferred-probe"
   );
@@ -126,7 +126,7 @@ export function isClosedCriterion(
  * A `passed` criterion whose evidence is a specification/design claim only.
  * It is self-attested, not a real probe, so it must not clear the LEARN gate.
  */
-export function isHollowPass(criterion: IdealStateCriterion): boolean {
+export function isHollowPass(criterion: Checkpoint): boolean {
   return criterion.status === "passed" && criterion.evidenceKind === "specified";
 }
 
@@ -150,13 +150,13 @@ export function defaultEvidenceKind(
 export function updateCriterion(
   isa: VerificationStateArtifact,
   criterionId: string,
-  status: IdealStateCriterion["status"],
+  status: Checkpoint["status"],
   verification?: string,
 ): VerificationStateArtifact {
   return updateCriterionWithResult(isa, criterionId, status, verification).isa;
 }
 
-export function appendCriterion(isa: VerificationStateArtifact, criterion: IdealStateCriterion): VerificationStateArtifact {
+export function appendCriterion(isa: VerificationStateArtifact, criterion: Checkpoint): VerificationStateArtifact {
   const criteria = getCriteria(isa);
   if (criteria.some((existing) => existing.id === criterion.id)) {
     throw new Error(`Algorithm criterion already exists: ${criterion.id}`);
@@ -199,8 +199,8 @@ function canonicalInsertIndex(sections: readonly VsaSection[], name: string): nu
 const CRITERION_LINE = /^- \[([ x\-_!~])\]\s+([^:]+):\s*(.+)$/;
 const EVIDENCE_LINE = /^\s{2,}Evidence(?:\s*\((specified|probed|tested)\))?:\s*(.+)$/;
 
-export function parseCriteriaMarkdown(content: string): IdealStateCriterion[] {
-  const out: IdealStateCriterion[] = [];
+export function parseCriteriaMarkdown(content: string): Checkpoint[] {
+  const out: Checkpoint[] = [];
   for (const rawLine of content.split("\n")) {
     const line = rawLine.replace(/\s+$/, "");
     const evidenceMatch = EVIDENCE_LINE.exec(rawLine);
@@ -219,7 +219,7 @@ export function parseCriteriaMarkdown(content: string): IdealStateCriterion[] {
   return out;
 }
 
-function parseCriterionLine(line: string): IdealStateCriterion | null {
+function parseCriterionLine(line: string): Checkpoint | null {
   const match = CRITERION_LINE.exec(line);
   if (match === null) return null;
   const [, mark, idRaw, textRaw] = match;
@@ -230,7 +230,7 @@ function parseCriterionLine(line: string): IdealStateCriterion | null {
   };
 }
 
-function criterionStatusFromMark(mark: string): IdealStateCriterion["status"] {
+function criterionStatusFromMark(mark: string): Checkpoint["status"] {
   switch (mark) {
     case "x":
       return "passed";
@@ -245,7 +245,7 @@ function criterionStatusFromMark(mark: string): IdealStateCriterion["status"] {
   }
 }
 
-function criterionStatusMark(status: IdealStateCriterion["status"]): string {
+function criterionStatusMark(status: Checkpoint["status"]): string {
   switch (status) {
     case "passed":
       return "x";
@@ -266,7 +266,7 @@ function assertSingleLine(field: string, criterionId: string, value: string): vo
   }
 }
 
-export function renderCriteriaMarkdown(criteria: readonly IdealStateCriterion[]): string {
+export function renderCriteriaMarkdown(criteria: readonly Checkpoint[]): string {
   if (criteria.length === 0) return "";
   return criteria
     .map((criterion) => {
@@ -322,7 +322,7 @@ export interface BuildVsaInput {
   slug: string;
   task: string;
   goal: string;
-  criteria: IdealStateCriterion[];
+  criteria: Checkpoint[];
   effort: AlgorithmEffortTier;
   mode?: AlgorithmMode;
   phase?: AlgorithmPhase;
@@ -372,13 +372,13 @@ export function recomputeVerified(isa: VerificationStateArtifact): boolean {
   return verifiedFromCriteria(getCriteria(isa));
 }
 
-export function progressFromCriteria(criteria: readonly IdealStateCriterion[]): string {
+export function progressFromCriteria(criteria: readonly Checkpoint[]): string {
   if (criteria.length === 0) return "0/0";
   const completed = criteria.filter((c) => c.status === "passed" || c.status === "dropped").length;
   return `${completed}/${criteria.length}`;
 }
 
-export function verifiedFromCriteria(criteria: readonly IdealStateCriterion[]): boolean {
+export function verifiedFromCriteria(criteria: readonly Checkpoint[]): boolean {
   if (criteria.length === 0) return false;
   return criteria.every((c) => c.status === "passed" || c.status === "dropped");
 }

--- a/src/vsa-reconcile.ts
+++ b/src/vsa-reconcile.ts
@@ -13,7 +13,7 @@ import {
 import { readVsa, resolveSomaHome, writeVsa, type VsaLibraryOptions } from "./vsa";
 import { appendSomaMemoryEvent } from "./memory";
 import { parseVsa } from "./vsa-parse";
-import type { AlgorithmLogEntry, VerificationStateArtifact, IdealStateCriterion, VsaSection, SubstrateId } from "./types";
+import type { AlgorithmLogEntry, VerificationStateArtifact, Checkpoint, VsaSection, SubstrateId } from "./types";
 
 export type VsaConflictPolicy = "error" | "prefer-master" | "prefer-feature";
 
@@ -172,7 +172,7 @@ function assertUniqueCriterionLines(isa: VerificationStateArtifact, policy: VsaC
   }
 }
 
-function parseCriterionLines(section: VsaSection): IdealStateCriterion[] {
+function parseCriterionLines(section: VsaSection): Checkpoint[] {
   const synthetic: VerificationStateArtifact = {
     slug: "section",
     frontmatter: {
@@ -214,15 +214,15 @@ function mergeCriteria(
     if (JSON.stringify(merged) !== JSON.stringify(current)) report.mergedCriteria.push(featureCriterion.id);
   }
 
-  return setSection(master, SECTION_NAME_MAP.criteria, renderCriteriaMarkdown(order.map((id) => byId.get(id)).filter((criterion): criterion is IdealStateCriterion => !!criterion)));
+  return setSection(master, SECTION_NAME_MAP.criteria, renderCriteriaMarkdown(order.map((id) => byId.get(id)).filter((criterion): criterion is Checkpoint => !!criterion)));
 }
 
 function mergeCriterion(
-  master: IdealStateCriterion,
-  feature: IdealStateCriterion,
+  master: Checkpoint,
+  feature: Checkpoint,
   policy: VsaConflictPolicy,
   report: VsaReconcileReport,
-): IdealStateCriterion {
+): Checkpoint {
   if (master.status === "dropped" && feature.status !== "dropped") {
     addConflict(report, policy, {
       kind: "criterion-tombstone",
@@ -259,11 +259,11 @@ function mergeCriterion(
 }
 
 function mergeStatus(
-  master: IdealStateCriterion,
-  feature: IdealStateCriterion,
+  master: Checkpoint,
+  feature: Checkpoint,
   policy: VsaConflictPolicy,
   report: VsaReconcileReport,
-): IdealStateCriterion["status"] {
+): Checkpoint["status"] {
   if (master.status === feature.status) return master.status;
   if (master.status === "dropped") return "dropped";
   if (feature.status === "dropped") {
@@ -287,7 +287,7 @@ function mergeStatus(
   return feature.status;
 }
 
-function statusRank(status: IdealStateCriterion["status"]): number {
+function statusRank(status: Checkpoint["status"]): number {
   switch (status) {
     case "open":
       return 0;

--- a/src/vsa.ts
+++ b/src/vsa.ts
@@ -20,7 +20,7 @@ import type {
   AlgorithmEffortTier,
   AlgorithmPhase,
   VerificationStateArtifact,
-  IdealStateCriterion,
+  Checkpoint,
   SomaActiveVsaState,
   SubstrateId,
 } from "./types";
@@ -52,7 +52,7 @@ export interface ScaffoldVsaInput extends VsaLibraryOptions {
   effort: EffortTier;
   task?: string;
   timestamp?: string;
-  initialCriteria?: IdealStateCriterion[];
+  initialCriteria?: Checkpoint[];
 }
 
 export interface WriteVsaResult {
@@ -217,7 +217,7 @@ export async function scaffoldVsa(input: ScaffoldVsaInput): Promise<{ path: stri
 function buildScaffoldSections(
   effort: EffortTier,
   goal: string,
-  initialCriteria: readonly IdealStateCriterion[],
+  initialCriteria: readonly Checkpoint[],
 ): { name: string; content: string }[] {
   // Required sections per tier are pre-filled with `TODO_PLACEHOLDER` so
   // a freshly-scaffolded VSA passes `checkCompleteness` at its own tier

--- a/test/algorithm-execution-modes.test.ts
+++ b/test/algorithm-execution-modes.test.ts
@@ -15,13 +15,13 @@ import {
   validateIdeateParameters,
   validateOptimizeParameters,
 } from "../src";
-import type { AlgorithmRun, IdealStateCriterion } from "../src";
+import type { AlgorithmRun, Checkpoint } from "../src";
 import { loadAlgorithmRun } from "../src/algorithm-store";
 
 const algorithmExecutionModesDocs = readFileSync("docs/algorithm-execution-modes.md", "utf8");
 const normalizedAlgorithmExecutionModesDocs = algorithmExecutionModesDocs.replace(/\s+/g, " ");
 
-function criterion(id: string): IdealStateCriterion {
+function criterion(id: string): Checkpoint {
   return { id, text: `${id} criterion`, status: "open" };
 }
 

--- a/test/vsa-accessors.test.ts
+++ b/test/vsa-accessors.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import type { VerificationStateArtifact, IdealStateCriterion } from "../src/index";
+import type { VerificationStateArtifact, Checkpoint } from "../src/index";
 import {
   SECTION_NAME_MAP,
   appendCriterion,
@@ -145,7 +145,7 @@ test("renderCriteriaMarkdown rejects newlines in id, text, and verification", ()
 test("criterion text containing pipe-and-evidence-like content survives round-trip", () => {
   // Regression: previous inline `| Evidence: ...` delimiter could swallow
   // ordinary criterion text containing those characters as verification.
-  const original: IdealStateCriterion[] = [
+  const original: Checkpoint[] = [
     { id: "C1", text: "mention | Evidence: literally", status: "open" },
     { id: "C2", text: "regular criterion", status: "passed", verification: "actual evidence" },
   ];

--- a/test/vsa-reconcile.test.ts
+++ b/test/vsa-reconcile.test.ts
@@ -14,7 +14,7 @@ import {
   writeVsa,
 } from "../src/index";
 import { SECTION_NAME_MAP, getDecisions, getGoal, renderCriteriaMarkdown, renderLogEntries, setSection } from "../src/vsa-accessors";
-import type { AlgorithmLogEntry, VerificationStateArtifact, IdealStateCriterion } from "../src/types";
+import type { AlgorithmLogEntry, VerificationStateArtifact, Checkpoint } from "../src/types";
 
 async function withSomaHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-vsa-reconcile-"));
@@ -26,7 +26,7 @@ async function withSomaHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
   }
 }
 
-function buildVsa(slug: string, criteria: IdealStateCriterion[], sections: Record<string, string> = {}): VerificationStateArtifact {
+function buildVsa(slug: string, criteria: Checkpoint[], sections: Record<string, string> = {}): VerificationStateArtifact {
   const timestamp = "2026-05-17T00:00:00.000Z";
   const isa = parseVsa(
     [
@@ -54,7 +54,7 @@ function decisions(...entries: AlgorithmLogEntry[]): string {
   return renderLogEntries(entries);
 }
 
-function criterion(id: string, status: IdealStateCriterion["status"], text = `${id} works`, verification?: string): IdealStateCriterion {
+function criterion(id: string, status: Checkpoint["status"], text = `${id} works`, verification?: string): Checkpoint {
   return { id, text, status, verification };
 }
 


### PR DESCRIPTION
The ISC→`checkpoint` primitive rename for #329 slice 3. **TS-type-only scope** (per JC steer): rename the type, keep a deprecated alias, no markdown/CLI/on-disk change.

## What changed
- `interface IdealStateCriterion` → `interface Checkpoint` — the extracted evidence-gated verification primitive (`{ criterion, required evidence, typed verdict, completion gate }`) per CONTEXT.md + ADR 0001. The existing code shape already *was* a checkpoint.
- `export type IdealStateCriterion = Checkpoint` retained as an `@deprecated` back-compat alias (mirrors slice-1 `Telos`→`Purpose`). Both re-exported from `index.ts` (the deprecated re-export carries a scoped eslint-disable).
- All in-repo consumers migrated to `Checkpoint` (src + test).

## Deliberately unchanged (per chosen scope)
- VSA markdown stays `## Criteria`; criterion ids stay `ISC-N`.
- No CLI vocabulary change.
- **No on-disk migration** — pure type rename, zero runtime behavior change.
- ADR 0001 keeps `ISC` as an optional Algorithm-pack surface; this PR doesn't touch that.

## Verification
- `bun run typecheck` clean
- `bun test` = **1444 pass / 0 fail**
- lint clean on changed files (deprecated-alias re-export suppressed intentionally)

## Relationship to #343
Independent of #343 (Piece A, storage/wire isa→vsa). Both branch off `main`; the only shared file is `src/types.ts` (different regions). Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)