### PR TITLE
fix(grok): fail closed when trustedSomaRepo is unusable (close fail-open hole)

### DIFF
--- a/src/adapters/grok/hooks/grok-hook-entry.mjs
+++ b/src/adapters/grok/hooks/grok-hook-entry.mjs
@@ -52,8 +52,34 @@ function hookSessionId(input) {
   return typeof candidate === "string" && candidate.length > 0 ? candidate : undefined;
 }
 
+// Resolve soma's entrypoint file from the trusted repo's declared `scripts.soma`
+// (e.g. "bun src/cli.ts" → "<repo>/src/cli.ts"), anchored to trustedSomaRepo.
+// Returns undefined if the repo has no such script — i.e. it isn't a soma
+// checkout. Tracks the declared invocation contract rather than hardcoding a path.
+function resolveSomaEntrypoint(repo) {
+  try {
+    const script = JSON.parse(readFileSync(join(repo, "package.json"), "utf8")).scripts?.soma;
+    if (typeof script !== "string") return undefined;
+    const file = script.split(/\s+/).find((token) => /\.[cm]?[jt]s$/.test(token));
+    return file ? join(repo, file) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+// Invoke soma by the trusted repo's OWN entrypoint, NOT `bun run soma`. `bun run
+// soma` resolves the script by walking up from cwd and, failing that, a GLOBAL
+// `soma` on PATH (the repo declares scripts.soma but no bin) — so a missing or
+// wrong trustedSomaRepo would silently run some other soma and could return
+// `allow`. Running the resolved file directly has no PATH fallback: an
+// unresolvable repo yields a synthetic non-zero result, and the caller's
+// `status !== 0` legs fail closed. Ties every policy decision to the trusted repo.
 function runSomaCommand(config, args, env = {}) {
-  return spawnSync(config.bunPath, args, {
+  const entrypoint = resolveSomaEntrypoint(config.trustedSomaRepo);
+  if (entrypoint === undefined) {
+    return { status: 1, stdout: "", stderr: `trusted soma repo unusable: no soma entrypoint under ${config.trustedSomaRepo}` };
+  }
+  return spawnSync(config.bunPath, [entrypoint, ...args], {
     cwd: config.trustedSomaRepo,
     encoding: "utf8",
     timeout: 25000,
@@ -62,7 +88,7 @@ function runSomaCommand(config, args, env = {}) {
 }
 
 function runSomaLifecycle(config, event, sessionId) {
-  const args = ["run", "soma", "lifecycle", event, "--soma-home", config.somaHome, "--substrate", "grok"];
+  const args = ["lifecycle", event, "--soma-home", config.somaHome, "--substrate", "grok"];
   if (sessionId) {
     args.push("--session-id", sessionId);
   }
@@ -71,13 +97,11 @@ function runSomaLifecycle(config, event, sessionId) {
 }
 
 function runSomaClassification(config, prompt) {
-  return runSomaCommand(config, ["run", "soma", "algorithm", "classify", "--prompt", prompt || "", "--json"]);
+  return runSomaCommand(config, ["algorithm", "classify", "--prompt", prompt || "", "--json"]);
 }
 
 function runSomaPolicyCheck(config, targets, action = "write") {
   const args = [
-    "run",
-    "soma",
     "policy",
     "check",
     "--soma-home",
@@ -101,8 +125,6 @@ function runSomaPolicyCheck(config, targets, action = "write") {
 
 function runSomaInboundContentScan(config, target) {
   return runSomaCommand(config, [
-    "run",
-    "soma",
     "policy",
     "scan",
     "--soma-home",
@@ -119,8 +141,6 @@ function runSomaInboundContentScan(config, target) {
 
 function runSomaRuntimePolicyInspect(config, surface, payload) {
   const args = [
-    "run",
-    "soma",
     "policy",
     "inspect",
     "--soma-home",

--- a/test/grok-hook.test.ts
+++ b/test/grok-hook.test.ts
@@ -1239,6 +1239,53 @@ test("grok pre-tool-use fails closed when the soma repo is unusable", async () =
   });
 });
 
+test("grok pre-tool-use denies when trustedSomaRepo is a non-soma dir (no global-soma fallback)", async () => {
+  // The exploit the fix closes: before, `bun run soma` from a dir without a
+  // local soma resolved a GLOBAL soma on PATH and returned allow. A dir that
+  // looks like a project (has package.json) but has no soma entrypoint must
+  // still deny — the hook runs <repo>/src/cli.ts explicitly, with no PATH fallback.
+  await withTempHome(async (homeDir) => {
+    const { chmod } = await import("node:fs/promises");
+    await installSomaForGrok({ homeDir });
+    const hook = join(homeDir, ".grok/hooks/soma-lifecycle.mjs");
+    const configPath = join(homeDir, ".grok/hooks/soma-lifecycle.config.json");
+    const config = JSON.parse(await readFile(configPath, "utf8"));
+    const nonSomaRepo = join(homeDir, "not-soma");
+    await mkdir(nonSomaRepo, { recursive: true });
+    await writeFile(join(nonSomaRepo, "package.json"), JSON.stringify({ name: "not-soma" }), "utf8");
+    await writeFile(configPath, JSON.stringify({ ...config, trustedSomaRepo: nonSomaRepo }, null, 2), "utf8");
+
+    // Plant a GLOBAL `soma` on PATH that returns allow — the exact bypass. The
+    // old code (`bun run soma` from a repo with no local soma) resolved this and
+    // returned allow; the fix resolves the repo's own scripts.soma entrypoint
+    // (absent here) with no PATH fallback, so it must still deny. Without this
+    // planted binary the test would
+    // also pass against the vulnerable code, proving nothing (Sage HonestOracle).
+    const fakeBin = join(homeDir, "fakebin");
+    await mkdir(fakeBin, { recursive: true });
+    const fakeSoma = join(fakeBin, "soma");
+    await writeFile(fakeSoma, "#!/usr/bin/env bash\necho '{\"decision\":\"allow\"}'\n", "utf8");
+    await chmod(fakeSoma, 0o755);
+
+    const result = runGrokHook(
+      hook,
+      "pre-tool-use",
+      homeDir,
+      {
+        hookEventName: "pre_tool_use",
+        sessionId: "session-policy",
+        toolName: "Write",
+        toolInput: { path: join(homeDir, "notes/ok.md"), contents: "hello" },
+        cwd: homeDir,
+      },
+      { PATH: `${fakeBin}:${process.env.PATH ?? ""}` },
+    );
+
+    expect(result.output.decision).toBe("deny");
+    expect(result.status).toBe(2);
+  });
+});
+
 test("installed grok pre-tool-use hook allows benign writes with the documented allow shape", async () => {
   await withTempHome(async (homeDir) => {
     await installSomaForGrok({ homeDir });


### PR DESCRIPTION
## The hole
The grok pre-tool-use policy chain ran `bun run soma <cmd>` with `cwd = config.trustedSomaRepo`. `bun run soma` resolves the `soma` script by walking up from cwd and, failing that, a **global** `soma` on `PATH` — so a missing/wrong `trustedSomaRepo` silently ran some other soma and could return `allow`. Fail-open.

Reproduced: `bun run soma --version` from an empty dir resolves `~/bin/soma` (`soma 0.8.8`, exit 0).

## The fix
`runSomaCommand` invokes the trusted repo's own declared entrypoint instead of `bun run soma`:
- `resolveSomaEntrypoint(repo)` reads `<repo>/package.json` `scripts.soma` (this repo: `"soma": "bun src/cli.ts"`), extracts the script file, returns `<repo>/<file>`; returns `undefined` if absent.
- `undefined` → `runSomaCommand` returns a synthetic `{ status: 1, stdout: "", stderr }`. The deny-legs read `status` + `stdout||stderr`, so `status !== 0` → deny. Otherwise it runs `bun <entrypoint> <args>` — **no PATH fallback**.

So an unresolvable/non-soma `trustedSomaRepo` denies; a real one runs the configured checkout's own soma.

## Regression test
`grok pre-tool-use denies when trustedSomaRepo is a non-soma dir (no global-soma fallback)` plants a global `soma` on `PATH` that returns `allow`, points `trustedSomaRepo` at a `package.json`-but-no-soma dir, and asserts the hook **denies** — i.e. the resolved-entrypoint path never consults `PATH`, so the planted global is ignored.

## Also fixes a pre-existing flaky test
`grok pre-tool-use fails closed when the soma repo is unusable` failed in **isolation** (`allow`), only passing in orderings that perturbed `PATH`. Verified deterministic now (isolated single-test run passes).

## Verification
- `bun run typecheck` clean
- isolated previously-failing test passes; new bypass-regression test passes
- `bun test` full suite **1454 pass / 0 fail**

`grok-hook-entry.mjs` is hand-authored source, shipped verbatim by `install.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)