### PR TITLE
feat(vsa): VSA section heading Criteria → Checkpoints (dual-read, no migration) (#329 slice 4)

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -8,7 +8,7 @@ import { appendAlgorithmProvenance } from "./algorithm-provenance";
 import { appendSomaMemoryEvent } from "./memory";
 import { loadSomaProfile } from "./soma-home";
 import { normalizeSomaWorkRegistryArtifacts, upsertSomaCurrentWorkPointer } from "./work-registry";
-import { getCriteria, getGoal } from "./vsa-accessors";
+import { SECTION_NAME_MAP, getCriteria, getGoal } from "./vsa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
 import {
   applyVsaUpdate,
@@ -252,7 +252,7 @@ function completedLearningContent(run: AlgorithmRun, timestamp: string): string 
     `Goal: ${getGoal(run.vsa) ?? ""}`,
     `Effort: ${run.effort}`,
     "",
-    "## Checkpoints",
+    `## ${SECTION_NAME_MAP.criteria}`,
     ...getCriteria(run.vsa).map((criterion) => `- [${criterion.status === "passed" ? "x" : " "}] ${criterion.id}: ${criterion.text}`),
     "",
     "## Verification",

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -252,7 +252,7 @@ function completedLearningContent(run: AlgorithmRun, timestamp: string): string 
     `Goal: ${getGoal(run.vsa) ?? ""}`,
     `Effort: ${run.effort}`,
     "",
-    "## Criteria",
+    "## Checkpoints",
     ...getCriteria(run.vsa).map((criterion) => `- [${criterion.status === "passed" ? "x" : " "}] ${criterion.id}: ${criterion.text}`),
     "",
     "## Verification",

--- a/src/vsa-accessors.ts
+++ b/src/vsa-accessors.ts
@@ -100,15 +100,28 @@ export function getVerification(isa: VerificationStateArtifact): AlgorithmLogEnt
 }
 
 export function setSection(isa: VerificationStateArtifact, name: string, content: string): VerificationStateArtifact {
-  // Locate via dual-read so a legacy-aliased section (e.g. `Criteria`) is found
-  // and replaced in place — renamed to the canonical `name` — rather than
-  // leaving a stale legacy section alongside a new canonical one.
-  const existingIndex = findSectionIndex(isa.sections, name);
+  // Dual-read so a legacy-aliased section (e.g. `Criteria`) is found, replaced in
+  // place, and renamed to the canonical `name`. If the VSA somehow carries BOTH
+  // the canonical and a legacy-aliased section (hand-edited / partial state),
+  // collapse them: replace the first match, drop the rest — never leave a stale
+  // duplicate behind.
+  const aliases = SECTION_LEGACY_ALIASES[name] ?? [];
+  const matchesTarget = (sectionName: string): boolean => sectionName === name || aliases.includes(sectionName);
   const next: VsaSection = { name, content };
 
-  if (existingIndex >= 0) {
-    const sections = isa.sections.slice();
-    sections[existingIndex] = next;
+  if (isa.sections.some((section) => matchesTarget(section.name))) {
+    let replaced = false;
+    const sections: VsaSection[] = [];
+    for (const section of isa.sections) {
+      if (matchesTarget(section.name)) {
+        if (!replaced) {
+          sections.push(next);
+          replaced = true;
+        }
+        continue; // drop any further canonical/legacy duplicate
+      }
+      sections.push(section);
+    }
     return { ...isa, sections };
   }
 

--- a/src/vsa-accessors.ts
+++ b/src/vsa-accessors.ts
@@ -25,7 +25,7 @@ export const SECTION_NAME_MAP = {
   principles: "Principles",
   constraints: "Constraints",
   goal: "Goal",
-  criteria: "Criteria",
+  criteria: "Checkpoints",
   testStrategy: "Test Strategy",
   features: "Features",
   decisions: "Decisions",
@@ -35,8 +35,43 @@ export const SECTION_NAME_MAP = {
 
 export const TWELVE_SECTIONS = Object.values(SECTION_NAME_MAP);
 
+/**
+ * soma#329 slice 4: legacy section headings a VSA may carry on disk, mapped to
+ * their current canonical name. Reads accept either; writes emit the canonical
+ * name. No migration — an untouched legacy VSA keeps its old heading; a mutated
+ * one is upgraded in place by {@link setSection}.
+ */
+const SECTION_LEGACY_ALIASES: Record<string, readonly string[]> = {
+  [SECTION_NAME_MAP.criteria]: ["Criteria"],
+};
+
+/** Inverse of {@link SECTION_LEGACY_ALIASES}: legacy heading → its canonical name. */
+const SECTION_CANONICAL_BY_ALIAS: Record<string, string> = Object.fromEntries(
+  Object.entries(SECTION_LEGACY_ALIASES).flatMap(([canonical, aliases]) => aliases.map((alias) => [alias, canonical])),
+);
+
+/**
+ * Map a (possibly legacy) section heading to its canonical name, so callers that
+ * compare section names treat `Criteria` and `Checkpoints` as the same section.
+ */
+export function canonicalSectionName(name: string): string {
+  return SECTION_CANONICAL_BY_ALIAS[name] ?? name;
+}
+
+/** Index of the section matching `name` exactly, else a declared legacy alias of `name`. */
+function findSectionIndex(sections: readonly VsaSection[], name: string): number {
+  const exact = sections.findIndex((section) => section.name === name);
+  if (exact >= 0) return exact;
+  for (const alias of SECTION_LEGACY_ALIASES[name] ?? []) {
+    const aliasIndex = sections.findIndex((section) => section.name === alias);
+    if (aliasIndex >= 0) return aliasIndex;
+  }
+  return -1;
+}
+
 export function getSection(isa: VerificationStateArtifact, name: string): VsaSection | null {
-  return isa.sections.find((section) => section.name === name) ?? null;
+  const index = findSectionIndex(isa.sections, name);
+  return index >= 0 ? isa.sections[index] : null;
 }
 
 export function getGoal(isa: VerificationStateArtifact): string | null {
@@ -65,7 +100,10 @@ export function getVerification(isa: VerificationStateArtifact): AlgorithmLogEnt
 }
 
 export function setSection(isa: VerificationStateArtifact, name: string, content: string): VerificationStateArtifact {
-  const existingIndex = isa.sections.findIndex((section) => section.name === name);
+  // Locate via dual-read so a legacy-aliased section (e.g. `Criteria`) is found
+  // and replaced in place — renamed to the canonical `name` — rather than
+  // leaving a stale legacy section alongside a new canonical one.
+  const existingIndex = findSectionIndex(isa.sections, name);
   const next: VsaSection = { name, content };
 
   if (existingIndex >= 0) {

--- a/src/vsa-reconcile.ts
+++ b/src/vsa-reconcile.ts
@@ -2,9 +2,11 @@ import { readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import {
   SECTION_NAME_MAP,
+  canonicalSectionName,
   getChangelog,
   getCriteria,
   getDecisions,
+  getSection,
   getVerification,
   renderCriteriaMarkdown,
   renderLogEntries,
@@ -214,7 +216,14 @@ function mergeCriteria(
     if (JSON.stringify(merged) !== JSON.stringify(current)) report.mergedCriteria.push(featureCriterion.id);
   }
 
-  return setSection(master, SECTION_NAME_MAP.criteria, renderCriteriaMarkdown(order.map((id) => byId.get(id)).filter((criterion): criterion is Checkpoint => !!criterion)));
+  const rendered = renderCriteriaMarkdown(order.map((id) => byId.get(id)).filter((criterion): criterion is Checkpoint => !!criterion));
+  // soma#329 slice 4: skip the write when nothing changed, so a no-op reconcile
+  // of a legacy-headed VSA stays byte-identical (and keeps its `## Criteria`
+  // heading) rather than being rewritten to `## Checkpoints`. A real change
+  // writes via setSection, which upgrades the heading in place.
+  const existing = getSection(master, SECTION_NAME_MAP.criteria);
+  if (existing !== null && existing.content === rendered) return master;
+  return setSection(master, SECTION_NAME_MAP.criteria, rendered);
 }
 
 function mergeCriterion(
@@ -369,7 +378,10 @@ function mergeOtherSections(
   let next = master;
   const masterNames = new Set(master.sections.map((section) => section.name));
   for (const featureSection of feature.sections) {
-    if (featureSection.name === SECTION_NAME_MAP.criteria || LOG_SECTIONS.has(featureSection.name)) continue;
+    // Criteria are merged separately (mergeCriteria); skip the section here under
+    // either its canonical (`Checkpoints`) or legacy (`Criteria`) heading so a
+    // legacy-headed feature VSA isn't misread as an unrelated "other" section.
+    if (canonicalSectionName(featureSection.name) === SECTION_NAME_MAP.criteria || LOG_SECTIONS.has(featureSection.name)) continue;
     const masterSection = next.sections.find((section) => section.name === featureSection.name);
     if (!masterSection) {
       const renamed = findLikelyRenamedSection(next.sections, featureSection);

--- a/test/vsa-accessors.test.ts
+++ b/test/vsa-accessors.test.ts
@@ -206,3 +206,18 @@ test("slice4: appendCriterion on a fresh VSA emits the canonical `Checkpoints` h
   expect(withCriterion.sections.some((s) => s.name === "Checkpoints")).toBe(true);
   expect(withCriterion.sections.some((s) => s.name === "Criteria")).toBe(false);
 });
+
+test("slice4: setSection collapses a VSA carrying both Checkpoints and legacy Criteria", () => {
+  const isa: VerificationStateArtifact = {
+    ...buildVsa(),
+    sections: [
+      { name: SECTION_NAME_MAP.goal, content: "g" },
+      { name: "Checkpoints", content: renderCriteriaMarkdown([{ id: "C1", text: "canon", status: "open" }]) },
+      { name: "Criteria", content: renderCriteriaMarkdown([{ id: "OLD", text: "legacy", status: "open" }]) },
+    ],
+  };
+  const updated = setSection(isa, SECTION_NAME_MAP.criteria, renderCriteriaMarkdown([{ id: "C1", text: "canon", status: "passed" }]));
+  const names = updated.sections.map((s) => s.name);
+  expect(names.filter((n) => n === "Checkpoints")).toHaveLength(1);
+  expect(names).not.toContain("Criteria"); // stale legacy duplicate dropped, not orphaned
+});

--- a/test/vsa-accessors.test.ts
+++ b/test/vsa-accessors.test.ts
@@ -164,3 +164,45 @@ test("derived accessors are pure functions (no memoization side effects)", () =>
   expect(first).toEqual(second);
   expect(first).not.toBe(second); // each call returns a fresh array
 });
+
+// soma#329 slice 4: `## Criteria` → `## Checkpoints` (dual-read legacy, emit new).
+function legacyCriteriaVsa(): VerificationStateArtifact {
+  return {
+    slug: "legacy",
+    frontmatter: {
+      task: "legacy task",
+      effort: "E2",
+      mode: "algorithm",
+      phase: "observe",
+      progress: "0/1",
+      verified: false,
+      updated: "2026-05-16T10:00:00.000Z",
+    },
+    // pre-rename heading authored on disk
+    sections: [{ name: "Criteria", content: renderCriteriaMarkdown([{ id: "ISC-1", text: "Legacy", status: "open" }]) }],
+  };
+}
+
+test("slice4: getCriteria dual-reads a legacy `Criteria` section", () => {
+  const criteria = getCriteria(legacyCriteriaVsa());
+  expect(criteria.map((c) => c.id)).toEqual(["ISC-1"]);
+});
+
+test("slice4: getSection(Checkpoints) resolves a legacy `Criteria` section", () => {
+  expect(getSection(legacyCriteriaVsa(), SECTION_NAME_MAP.criteria)?.name).toBe("Criteria");
+});
+
+test("slice4: setCriteria-style write upgrades a legacy `Criteria` section in place (no duplicate)", () => {
+  const upgraded = setSection(legacyCriteriaVsa(), SECTION_NAME_MAP.criteria, renderCriteriaMarkdown([{ id: "ISC-1", text: "Legacy", status: "passed" }]));
+  const names = upgraded.sections.map((s) => s.name);
+  expect(names).toContain("Checkpoints");
+  expect(names).not.toContain("Criteria"); // renamed in place, not duplicated
+  expect(names.filter((n) => n === "Checkpoints")).toHaveLength(1);
+});
+
+test("slice4: appendCriterion on a fresh VSA emits the canonical `Checkpoints` heading", () => {
+  const isa: VerificationStateArtifact = { ...buildVsa(), sections: [{ name: SECTION_NAME_MAP.goal, content: "g" }] };
+  const withCriterion = appendCriterion(isa, { id: "C1", text: "New", status: "open" });
+  expect(withCriterion.sections.some((s) => s.name === "Checkpoints")).toBe(true);
+  expect(withCriterion.sections.some((s) => s.name === "Criteria")).toBe(false);
+});


### PR DESCRIPTION
#329 slice 4 — the VSA section-heading half of the ISC→checkpoint vocab move. **TS-emit-only scope** (per JC steer): dual-read legacy, emit the new heading, **no migration**. Section ids (`ISC-N`) and CLI are deliberately unchanged.

## What changed
- `SECTION_NAME_MAP.criteria = "Checkpoints"` — the canonical heading, emitted by `setCriteria`/`appendCriterion`/`buildVsaArtifact` and the lifecycle render.
- `SECTION_LEGACY_ALIASES` + `findSectionIndex`: `getSection`/`setSection` dual-read a legacy `## Criteria` section. `setSection` finds it via the alias and replaces it **in place** (renamed to `## Checkpoints`) — no duplicate section.
- `canonicalSectionName()` export. `vsa-reconcile` uses it so a legacy-headed feature VSA isn't misread as an unrelated "other" section; `mergeCriteria` skips the write when criteria are unchanged, so a no-op reconcile stays **byte-identical** (keeps the legacy heading until a real change upgrades it).

## No migration
Untouched on-disk VSAs keep `## Criteria` and load via dual-read; only a mutated or freshly-scaffolded VSA emits `## Checkpoints`. Honors the format's never-rewrite intent. `ISC-N` ids unchanged; no CLI vocab change.

## Tests
- `getCriteria`/`getSection` dual-read a legacy `## Criteria` section
- `setSection` upgrades a legacy section in place (no duplicate)
- `appendCriterion` on a fresh VSA emits `## Checkpoints`
- existing reconcile/parse suites still green (legacy headings authored throughout)

## Verification
- `bun run typecheck` clean
- `bun test` targeted suites green; changed-file lint clean

Builds on #345 (grok fail-open fix), which is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)