### PR TITLE
docs(vsa): VSA skill section heading Criteria → Checkpoints (#329 slice 4 docs)

### DIFF
--- a/src/skills/VSA/Examples/canonical-vsa.md
+++ b/src/skills/VSA/Examples/canonical-vsa.md
@@ -56,7 +56,7 @@ A small focused marketplace at `beanline.example.com` where a verified roaster l
 
 Ship a Cloudflare-hosted marketplace at `beanline.example.com` where verified roasters can list 5–50kg green-coffee lots and verified buyers can purchase via Stripe escrow with QR-handoff confirmation; the platform takes ≤ 5.1% margin (≤ 8% all-in including Stripe), browse pages render in ≤ 1s p95 on cellular, and the in-house quality lead can approve a new listing in ≤ 10 minutes per lot.
 
-## Criteria
+## Checkpoints
 
 ### Build & Deploy
 

--- a/src/skills/VSA/Examples/e1-minimal.md
+++ b/src/skills/VSA/Examples/e1-minimal.md
@@ -16,7 +16,7 @@ updated: 2026-04-28T21:15:00Z
 
 Add a `--no-color` flag to the `dump.ts` CLI so output strips ANSI escape codes when the flag is present (or when `NO_COLOR` env is set, per the no-color.org convention).
 
-## Criteria
+## Checkpoints
 
 - [ ] ISC-1: `dump.ts --no-color | cat | head -1` produces output containing zero ANSI escape sequences (probe: `dump.ts --no-color | rg -c $'\x1b\['` returns 0).
 - [ ] ISC-2: `NO_COLOR=1 dump.ts | rg -c $'\x1b\['` returns 0 (env-var path also strips).
@@ -24,6 +24,6 @@ Add a `--no-color` flag to the `dump.ts` CLI so output strips ANSI escape codes 
 - [ ] ISC-4: Anti: `dump.ts --no-color` does not emit any new warning to stderr (probe: `dump.ts --no-color 2>&1 >/dev/null | wc -c` returns 0).
 
 <!--
-E1 minimal VSA. Required sections at this tier: Goal + Criteria.
+E1 minimal VSA. Required sections at this tier: Goal + Checkpoints.
 Problem / Vision / Out of Scope / Principles / Constraints / Test Strategy / Features / Decisions / Changelog / Verification all omitted — the task is small enough that the Goal sentence plus four binary probes carries the entire articulation. The Anti-criterion (ISC-4) is what keeps a sloppy implementation from passing — adding a "color disabled" log line would technically meet ISC-1 while breaking the silent-by-default expectation.
 -->

--- a/src/skills/VSA/Examples/e2-backup-verify.md
+++ b/src/skills/VSA/Examples/e2-backup-verify.md
@@ -20,7 +20,7 @@ The `rsync-verify` CLI copies a source directory to a backup destination and rep
 
 Add a `--verify` flag that, after the rsync copy step completes, walks both source and destination, computes SHA-256 per file, compares hashes, and either exits 0 with a pass summary or exits 2 with a per-file mismatch report. The verification step must not double the run-time of a clean backup more than 1.5×.
 
-## Criteria
+## Checkpoints
 
 ### Verification correctness
 
@@ -96,6 +96,6 @@ Add a `--verify` flag that, after the rsync copy step completes, walks both sour
 ```
 
 <!--
-E2 medium VSA. Required sections: Problem, Goal, Criteria, Test Strategy.
+E2 medium VSA. Required sections: Problem, Goal, Checkpoints, Test Strategy.
 Vision, Out of Scope, Principles, Constraints, Features, Decisions, Changelog, Verification omitted — the work surface is single-domain (one CLI, one feature) and the tier completeness gate doesn't require them. ISC count of 18 meets the E2 floor of 16. Four anti-criteria (ISC-15, 16, 17, 18) cover scope, regression, privacy, and a future-compat lock — typical E2 anti-criteria density.
 -->

--- a/src/skills/VSA/Examples/e2-rotate-credential.md
+++ b/src/skills/VSA/Examples/e2-rotate-credential.md
@@ -20,7 +20,7 @@ The production deploy credential (a long-lived API token stored in CI as `DEPLOY
 
 Rotate `DEPLOY_API_TOKEN` end-to-end: provision a new token with the same scope, update the CI secret, run a verification deploy on a non-production branch, then revoke the old token. The next production deploy after this rotation must succeed, and the old token must be inactive within four hours of the new one going live.
 
-## Criteria
+## Checkpoints
 
 ### Pre-rotation
 
@@ -97,6 +97,6 @@ Rotate `DEPLOY_API_TOKEN` end-to-end: provision a new token with the same scope,
 ```
 
 <!--
-E2 ops VSA. Required sections: Problem, Goal, Criteria, Test Strategy.
+E2 ops VSA. Required sections: Problem, Goal, Checkpoints, Test Strategy.
 Demonstrates the VSA primitive applied to an ops/runbook task — the same shape as a code task. ISC count of 16 hits the E2 floor exactly. Anti-criteria (ISC-14, 15, 16) cover privacy, scope, and rollback safety — typical ops-task regression-prevention concerns. Note ISC-16 explicitly preserves a safety window — a real-world lesson learned from prior bungled rotations.
 -->

--- a/src/skills/VSA/Examples/e3-essay.md
+++ b/src/skills/VSA/Examples/e3-essay.md
@@ -50,7 +50,7 @@ A 1500-word essay that a first-time founder reads in eight minutes, recognizes t
 
 Ship a 1400–1600-word essay in three sections that opens with a concrete first-time-founder situation the reader recognizes within 30 seconds, develops a single thesis ("most productivity advice was built for a different game"), and closes with a calibration tool the reader can apply within 24 hours — a one-question filter for which advice to keep and which to drop.
 
-## Criteria
+## Checkpoints
 
 ### Word count and structure
 
@@ -194,7 +194,7 @@ Ship a 1400–1600-word essay in three sections that opens with a concrete first
 - 2026-03-21 09:00: refined: ISC-12 added (≤ 5 first-person plural) after a draft read like a "we should all" sermon. The essay is observation, not exhortation.
 
 <!--
-E3 art VSA. Required sections: Problem, Vision, Out of Scope, Constraints, Goal, Criteria, Features, Test Strategy.
+E3 art VSA. Required sections: Problem, Vision, Out of Scope, Constraints, Goal, Checkpoints, Features, Test Strategy.
 Optional Principles included because the essay is experiential and the principles do real work in the writing pass.
 ISC count of 34 exceeds the E3 floor of 32. Three Antecedent ISCs (ISC-13, 14, 15) carry the experiential-goal contract: they name the preconditions that reliably produce the target reader experience. Without them, ISC-29 and ISC-30 (post-publish reception) would be unfalsifiable hopes rather than testable claims. Anti-criteria (ISC-18, 19, 20, 21) cover scope, regression, voice, and a future-essay-drift trap. The Decisions section shows two ❌ DEAD ENDs and three refinements — typical density for a first draft of an essay that knows its shape but is still finding its load-bearing moments.
 -->

--- a/src/skills/VSA/Examples/e3-help-redesign.md
+++ b/src/skills/VSA/Examples/e3-help-redesign.md
@@ -50,7 +50,7 @@ A `duck --help` that a first-time user can read top-to-bottom in 30 seconds and 
 
 Ship a redesigned `duck --help` template (≤ 100 lines, 80-col safe) that opens with a one-sentence project summary, shows the two most-common usages as concrete examples, lists the flag reference grouped by category (not declaration order), and ends with a "see also" footer pointing at man + docs URL — all reference content preserved, all flags still grep-able, first-time-user help-to-first-command time drops from 95s median to ≤ 30s median.
 
-## Criteria
+## Checkpoints
 
 ### Length and layout
 
@@ -217,7 +217,7 @@ Ship a redesigned `duck --help` template (≤ 100 lines, 80-col safe) that opens
 - 2026-04-15 16:00: refined: ISC-16 added a 30-day post-ship probe (ISC-30) — without it, the redesign passes its launch test but could regress in 90 days as new flags are added without category discipline.
 
 <!--
-E3 design VSA. Required sections: Problem, Vision, Out of Scope, Constraints, Goal, Criteria, Features, Test Strategy.
+E3 design VSA. Required sections: Problem, Vision, Out of Scope, Constraints, Goal, Checkpoints, Features, Test Strategy.
 Optional Principles included — the design has experiential goals (first 30 seconds, recognition, intuition) and principles do real work in the design pass.
 ISC count of 36 exceeds the E3 floor of 32. Three Antecedent ISCs (ISC-18, 19, 20) carry the experiential contract: hard-to-vary one-sentence summary, telemetry-grounded examples, and intuitive categories. Anti-criteria (ISC-24, 25, 26, 27) cover scope, regression, drift, and density. The Decisions section shows two ❌ DEAD ENDs and three refinements — typical for a redesign where every aesthetic temptation needs to be tested against actual users.
 -->

--- a/src/skills/VSA/Examples/e3-project.md
+++ b/src/skills/VSA/Examples/e3-project.md
@@ -36,7 +36,7 @@ A single bun TypeScript CLI: `bun arxiv.ts <id1> <id2> ... > papers.jsonl`. One 
 
 Ship a single-file `arxiv.ts` CLI that takes paper IDs as arguments, queries the arxiv Atom API, parses the response, and writes one JSONL row per paper to stdout with fields: `id`, `title`, `authors`, `abstract`, `categories`, `submitted`, `updated`.
 
-## Criteria
+## Checkpoints
 
 - [x] ISC-1: `arxiv.ts` is a single file at the project root.
 - [x] ISC-2: Zero entries in `package.json` `dependencies` (probe: `jq '.dependencies | length' package.json` returns 0).

--- a/src/skills/VSA/Examples/e4-api-migration.md
+++ b/src/skills/VSA/Examples/e4-api-migration.md
@@ -54,7 +54,7 @@ A partner integration team opens our docs, sees a single GraphQL playground next
 
 Ship the GraphQL endpoint at `api.apibridge.example.org/graphql` with full coverage of the 14 REST endpoints' read and write surface area, parity-tested under load, with a published 6-month deprecation runway for REST that emits RFC 8594 sunset headers, exposes per-partner deprecation telemetry on an internal dashboard, and lands the cutover without any external integration breaking before its partner-confirmed migration date.
 
-## Criteria
+## Checkpoints
 
 - [x] ISC-1: `schema/api.graphql` exists, validates against `graphql-schema-linter`, and covers all 14 REST endpoint shapes.
 - [x] ISC-2: GraphQL endpoint responds with `200` and a valid introspection result for `query { __schema { queryType { name } } }`.

--- a/src/skills/VSA/Examples/e4-brand-identity.md
+++ b/src/skills/VSA/Examples/e4-brand-identity.md
@@ -57,7 +57,7 @@ The founder's mom — who has never used the product and doesn't know what it do
 
 Deliver a complete Cardinal brand identity v1 — logo (3 lockups), type system (1 family, 2 weights, 6 sizes), color palette (2 hues + 5-step neutral), voice and tone guide (1 page with 6 worked rewrites), and the first 5 marketing surfaces (homepage hero, App Store screenshot set, welcome email, partner one-pager, launch tweet) — all designed against constraints that survive the smallest-size and 1-bit tests, packaged as a Figma file and a public GitHub repo, ready to ship together on the founder-confirmed launch date of April 26, 2026.
 
-## Criteria
+## Checkpoints
 
 - [x] ISC-1: Wordmark and standalone mark exist as separate Figma components with shared baseline.
 - [x] ISC-2: Three logo lockups in the kit: horizontal wordmark, stacked wordmark + mark, mark-only.

--- a/src/skills/VSA/Examples/e5-album.md
+++ b/src/skills/VSA/Examples/e5-album.md
@@ -54,7 +54,7 @@ A 12-track instrumental album titled `Mariner Frequencies` — roughly 48 minute
 
 Produce, mix, master, and release a 12-track instrumental album titled `Mariner Frequencies` between 2025-11-01 and 2026-05-15, totaling 42–54 minutes, mixed by the artist and mastered by a paid third-party engineer to streaming-spec LUFS, distributed via Bandcamp and DistroKid, with at least one track that the artist would still defend as a representative work five years later.
 
-## Criteria
+## Checkpoints
 
 ### Composition (Phase 1: Nov–Dec 2025)
 

--- a/src/skills/VSA/Examples/e5-desktop-app.md
+++ b/src/skills/VSA/Examples/e5-desktop-app.md
@@ -53,7 +53,7 @@ A native desktop application (macOS-first, Linux next, Windows last) that the ho
 
 Ship a Tauri-based desktop application — code-named WattWatch and distributed via signed installers from `wattwatch.example.org` — that aggregates Shelly, Emporia Vue, Sense, and Tesla Powerwall sensor data into a unified local SQLite store, presents a real-time whole-house energy view with per-device attribution and a six-month historical archive, and operates fully offline by default with optional end-to-end-encrypted cloud sync.
 
-## Criteria
+## Checkpoints
 
 ### Build & Distribution
 

--- a/src/skills/VSA/Examples/e5-enterprise.md
+++ b/src/skills/VSA/Examples/e5-enterprise.md
@@ -61,7 +61,7 @@ A unified patient portal at `portal.beaconhealth.example.org` serving all 50 hos
 
 Deliver a multi-region active-active patient portal at `portal.beaconhealth.example.org` that replaces the legacy 2014 forked codebase before the 2027-06-30 vendor end-of-life, unifies records across all 50 hospitals (Epic, MEDITECH, Cerner) into a single longitudinal view, supports patient/clinician/admin/auditor roles with HIPAA-conformant audit logging at 6-year retention, exposes appointment scheduling and secure messaging across all regions, provides authoritative read-only chart access plus e-prescription handoff to Surescripts, and stays inside the data-residency, BAA, encryption, and session-management constraints across both standard operations and regional failover.
 
-## Criteria
+## Checkpoints
 
 ### Identity and Authentication
 

--- a/src/skills/VSA/Workflows/Append.md
+++ b/src/skills/VSA/Workflows/Append.md
@@ -75,7 +75,7 @@ Read the VSA at `isa_path`. Find the target section (`## Decisions` | `## Change
 |------|-----------------|--------------|
 | Decision | text + timestamp | text is empty |
 | Changelog | conjectured + refuted_by + learned + criterion_now + date | any of the four C/R/L pieces is missing |
-| Verification | isc_id + probe_type + evidence | isc_id doesn't exist in `## Criteria`, or evidence is empty |
+| Verification | isc_id + probe_type + evidence | isc_id doesn't exist in `## Checkpoints`, or evidence is empty |
 
 **Refuse mode:** If validation fails, do not write. Surface the missing piece. The whole point of Append is to keep these sections clean — silently writing partial entries defeats it.
 
@@ -89,7 +89,7 @@ Edit the VSA: append the entry to the end of the target section, preserving prio
 
 ### Step 6 — Update progress (Verification only)
 
-When appending a Verification entry that corresponds to a previously-`[ ]` ISC, also flip that ISC to `[x]` in `## Criteria` and recompute `progress: M/N` in frontmatter.
+When appending a Verification entry that corresponds to a previously-`[ ]` ISC, also flip that ISC to `[x]` in `## Checkpoints` and recompute `progress: M/N` in frontmatter.
 
 ### Step 7 — Return the appended block
 
@@ -113,4 +113,4 @@ The Reconcile workflow (merging an ephemeral feature file back to master) calls 
 
 - **Concurrent edits:** Append reads the VSA, decides where to insert, then writes. If the file is edited mid-flight, the second write may insert at a stale offset. Treat Append as best-effort under contention; structural edits to VSAs should be serialized.
 - **Section header missing:** Append creates the section if absent, in canonical position. If the canonical position is ambiguous (file is malformed), abort and surface the structural problem.
-- **ISC ID mismatch on Verification:** the ISC must exist. Refuse to write Verification for an ID that isn't in `## Criteria` — this is the same ID-stability contract Reconcile relies on.
+- **ISC ID mismatch on Verification:** the ISC must exist. Refuse to write Verification for an ID that isn't in `## Checkpoints` — this is the same ID-stability contract Reconcile relies on.

--- a/src/skills/VSA/Workflows/Append.md
+++ b/src/skills/VSA/Workflows/Append.md
@@ -89,7 +89,7 @@ Edit the VSA: append the entry to the end of the target section, preserving prio
 
 ### Step 6 — Update progress (Verification only)
 
-When appending a Verification entry that corresponds to a previously-`[ ]` ISC, also flip that ISC to `[x]` in `## Checkpoints` and recompute `progress: M/N` in frontmatter.
+When appending a Verification entry that corresponds to a previously-`[ ]` ISC, also flip that ISC to `[x]` in `## Checkpoints` (a pre-rename VSA's section is `## Criteria` — edit whichever heading the file actually has) and recompute `progress: M/N` in frontmatter.
 
 ### Step 7 — Return the appended block
 

--- a/src/skills/VSA/Workflows/CheckCompleteness.md
+++ b/src/skills/VSA/Workflows/CheckCompleteness.md
@@ -29,7 +29,7 @@ required_sections:
   Principles: thin       # ≤ 1 sentence
   Constraints: present
   Goal: present
-  Criteria: present
+  Checkpoints: present
   Test Strategy: present
   Features: present
   Decisions: present
@@ -74,9 +74,9 @@ Load `isa_path`. Parse frontmatter and section headers.
 
 | Tier | Required Sections |
 |------|-------------------|
-| E1 | Goal, Criteria |
-| E2 | Problem, Goal, Criteria, Test Strategy |
-| E3 | Problem, Vision, Out of Scope, Constraints, Goal, Criteria, Features, Test Strategy |
+| E1 | Goal, Checkpoints |
+| E2 | Problem, Goal, Checkpoints, Test Strategy |
+| E3 | Problem, Vision, Out of Scope, Constraints, Goal, Checkpoints, Features, Test Strategy |
 | E4 | All twelve sections |
 | E5 | All twelve sections + Interview workflow ran before BUILD |
 
@@ -95,7 +95,7 @@ For each required section:
 
 ### Step 5 — Audit ISC quality
 
-Walk every ISC in `## Criteria`:
+Walk every ISC in `## Checkpoints`:
 
 - **Granularity** — every ISC names a single binary tool probe (or has one inferable from its phrasing). Compound "and/with" criteria fail.
 - **Tier floor** — at E2+, total ISC count meets the floor (E2 ≥16, E3 ≥32, E4 ≥128, E5 ≥256). Soft fail if under.
@@ -116,7 +116,7 @@ When invoked from VERIFY-phase doctrine, hard gaps block the `phase: complete` t
 | Gap | Severity at E1 | E2 | E3 | E4 | E5 |
 |-----|----------------|----|----|----|----|
 | Goal missing | hard | hard | hard | hard | hard |
-| Criteria missing | hard | hard | hard | hard | hard |
+| Checkpoints missing | hard | hard | hard | hard | hard |
 | Problem missing | — | hard | hard | hard | hard |
 | Test Strategy missing | — | hard | hard | hard | hard |
 | Vision missing | — | — | hard | hard | hard |

--- a/src/skills/VSA/Workflows/Interview.md
+++ b/src/skills/VSA/Workflows/Interview.md
@@ -44,7 +44,7 @@ Walk sections in priority order. For each section, ask zero or more questions on
 | **Principles** | "What truths must this work respect regardless of implementation choices?" / "What would you say to a future maintainer about how to think?" |
 | **Constraints** | "What are the architectural mandates that bound the solution space?" / "What do you not want anyone to ever try?" |
 | **Goal** | "In one or two sentences, what is the verifiable done state?" |
-| **Criteria** | "Walk me through the test that would prove ISC-N." / "Is this ISC actually one binary probe, or could it be split?" |
+| **Checkpoints** | "Walk me through the test that would prove ISC-N." / "Is this ISC actually one binary probe, or could it be split?" |
 | **Test Strategy** | "How would you actually verify ISC-N? What command, tool, or probe?" |
 | **Features** | "What feature units would you split this into?" / "What can run in parallel? What blocks the critical path?" |
 

--- a/src/skills/VSA/Workflows/Reconcile.md
+++ b/src/skills/VSA/Workflows/Reconcile.md
@@ -81,7 +81,7 @@ If `dry_run: true`, emit the YAML output and stop.
 
 If `dry_run: false`, apply all staged changes via Edit/Write tools. Order:
 1. Edit master VSA frontmatter.
-2. Edit master `## Checkpoints` ISC checkmarks.
+2. Edit master `## Checkpoints` (or legacy `## Criteria`, whichever the file has) ISC checkmarks.
 3. Edit master `## Verification` (append).
 4. Edit master `## Decisions` (append).
 5. Edit master `## Changelog` (append).

--- a/src/skills/VSA/Workflows/Reconcile.md
+++ b/src/skills/VSA/Workflows/Reconcile.md
@@ -81,7 +81,7 @@ If `dry_run: true`, emit the YAML output and stop.
 
 If `dry_run: false`, apply all staged changes via Edit/Write tools. Order:
 1. Edit master VSA frontmatter.
-2. Edit master `## Criteria` ISC checkmarks.
+2. Edit master `## Checkpoints` ISC checkmarks.
 3. Edit master `## Verification` (append).
 4. Edit master `## Decisions` (append).
 5. Edit master `## Changelog` (append).

--- a/src/skills/VSA/Workflows/Scaffold.md
+++ b/src/skills/VSA/Workflows/Scaffold.md
@@ -71,9 +71,9 @@ updated: <ISO-8601>
 
 | Tier | Required Sections |
 |------|-------------------|
-| E1 | Goal, Criteria |
-| E2 | Problem, Goal, Criteria, Test Strategy |
-| E3 | Problem, Vision, Out of Scope, Constraints, Goal, Criteria, Features, Test Strategy |
+| E1 | Goal, Checkpoints |
+| E2 | Problem, Goal, Checkpoints, Test Strategy |
+| E3 | Problem, Vision, Out of Scope, Constraints, Goal, Checkpoints, Features, Test Strategy |
 | E4 | All twelve sections |
 | E5 | All twelve sections + run Interview workflow before BUILD |
 
@@ -116,7 +116,7 @@ When `ephemeral_feature` is set:
 3. Extract:
    - `## Vision` and `## Goal` from master (read-only context)
    - `## Constraints` filtered to those relevant to this feature
-   - `## Criteria` ISCs whose IDs appear in the feature's `satisfies:` list, with stable IDs preserved
+   - `## Checkpoints` ISCs whose IDs appear in the feature's `satisfies:` list, with stable IDs preserved
    - `## Test Strategy` entries matching those ISCs
    - `## Decisions` filtered to entries mentioning this feature's ISC IDs (optional)
    - Empty `## Verification` section ready to populate

--- a/src/skills/VSA/Workflows/Seed.md
+++ b/src/skills/VSA/Workflows/Seed.md
@@ -30,7 +30,7 @@ sources_consulted:
   - tsconfig.json
   - last 30 git commits
   - existing PRD.md / SPEC.md / acceptance.yaml (if found)
-sections_drafted: [Problem, Vision, Out of Scope, Constraints, Goal, Criteria, Test Strategy, Features]
+sections_drafted: [Problem, Vision, Out of Scope, Constraints, Goal, Checkpoints, Test Strategy, Features]
 sections_skipped: [Principles, Decisions, Changelog, Verification]   # left for user to author
 isc_count: 18
 review_required: true
@@ -86,7 +86,7 @@ Inferred from package.json, tsconfig, deploy configs:
 
 If the project has a clear deliverable (a CLI, a website, an app), state it as 1–3 sentences. Otherwise, lift the README headline.
 
-### Step 9 — Draft Criteria from existing test files / acceptance criteria
+### Step 9 — Draft Checkpoints from existing test files / acceptance criteria
 
 If the repo has `*.test.ts` files, walk them; each test name is a candidate ISC source. Convert to atomic ISCs preserving the granularity rule. Apply Splitting Test.
 
@@ -106,7 +106,7 @@ For each top-level subdirectory of `src/` or main project directory, propose a F
 
 ### Step 12 — Skip Principles, Decisions, Changelog, Verification
 
-These are author-driven. Leave them out (Bitter Pill — empty sections never appear). Add a final TODO note in Decisions: "Seed-generated draft. Run `Skill('VSA', 'interview me on <path>')` to fill Principles, refine Vision and Goal, audit Criteria."
+These are author-driven. Leave them out (Bitter Pill — empty sections never appear). Add a final TODO note in Decisions: "Seed-generated draft. Run `Skill('VSA', 'interview me on <path>')` to fill Principles, refine Vision and Goal, audit Checkpoints."
 
 ### Step 13 — Write the file
 

--- a/src/skills/VSA/references/format.md
+++ b/src/skills/VSA/references/format.md
@@ -17,12 +17,16 @@ decides which are required. Sections never appear empty. Order is fixed.
 | 4 | `## Principles` | Substrate-independent truths the work must respect | OBSERVE |
 | 5 | `## Constraints` | Immovable mandates that bound the solution space | OBSERVE |
 | 6 | `## Goal` | Verifiable done in 1-3 sentences | OBSERVE |
-| 7 | `## Criteria` | Atomic ISCs, including derived `Anti:` ISCs | OBSERVE to EXECUTE |
+| 7 | `## Checkpoints` | Atomic ISCs, including derived `Anti:` ISCs | OBSERVE to EXECUTE |
 | 8 | `## Test Strategy` | Per-ISC verification approach | OBSERVE / PLAN |
 | 9 | `## Features` | Work breakdown tied to ISC IDs | PLAN |
 | 10 | `## Decisions` | Timestamped decisions and dead ends | any phase |
 | 11 | `## Changelog` | Conjecture / refuted-by / learned / criterion-now trail | LEARN |
 | 12 | `## Verification` | Evidence that each ISC passed | VERIFY |
+
+> Section 7 was renamed `## Criteria` → `## Checkpoints` (soma#329). Pre-rename VSAs
+> that still carry `## Criteria` are read transparently (dual-read); they are
+> rewritten to `## Checkpoints` only when that section is next mutated. No migration.
 
 ## Guardrail Taxonomy
 
@@ -31,7 +35,7 @@ decides which are required. Sections never appear empty. Order is fixed.
 | Principles | The thinking | Aspirational and generalizable | `## Principles` |
 | Constraints | The solution space | Immovable and non-negotiable | `## Constraints` |
 | Out of Scope | The vision | Explicit prose boundary | `## Out of Scope` |
-| Anti-criteria | The test surface | Granular yes/no probe | `## Criteria` with `Anti:` |
+| Anti-criteria | The test surface | Granular yes/no probe | `## Checkpoints` with `Anti:` |
 
 Principles, Constraints, and Out of Scope are author-stated. Anti-criteria are
 derived from those guardrails so they become probe-able.
@@ -40,9 +44,9 @@ derived from those guardrails so they become probe-able.
 
 | Tier | Required sections |
 | --- | --- |
-| E1 | Goal, Criteria |
-| E2 | Problem, Goal, Criteria, Test Strategy |
-| E3 | Problem, Vision, Out of Scope, Constraints, Goal, Criteria, Features, Test Strategy |
+| E1 | Goal, Checkpoints |
+| E2 | Problem, Goal, Checkpoints, Test Strategy |
+| E3 | Problem, Vision, Out of Scope, Constraints, Goal, Checkpoints, Features, Test Strategy |
 | E4 | All twelve sections |
 | E5 | All twelve sections plus an active Interview workflow run before BUILD |
 

--- a/src/skills/VSA/references/format.md
+++ b/src/skills/VSA/references/format.md
@@ -24,9 +24,11 @@ decides which are required. Sections never appear empty. Order is fixed.
 | 11 | `## Changelog` | Conjecture / refuted-by / learned / criterion-now trail | LEARN |
 | 12 | `## Verification` | Evidence that each ISC passed | VERIFY |
 
-> Section 7 was renamed `## Criteria` → `## Checkpoints` (soma#329). Pre-rename VSAs
-> that still carry `## Criteria` are read transparently (dual-read); they are
-> rewritten to `## Checkpoints` only when that section is next mutated. No migration.
+> Section 7 was renamed `## Criteria` → `## Checkpoints` (soma#329). The reader
+> dual-reads both headings (slice-4 code, #348), so pre-rename VSAs that still
+> carry `## Criteria` keep loading; that section is rewritten to `## Checkpoints`
+> only when it is next mutated. No migration. Where a workflow names
+> `## Checkpoints`, operate on `## Criteria` instead if that is what the file has.
 
 ## Guardrail Taxonomy
 


### PR DESCRIPTION
Docs half of #329 slice 4 — aligns the VSA skill markdown with the emitted heading (code: #348).

## What changed (19 files)
- `## Criteria` → `## Checkpoints` across `references/`, `Workflows/`, `Examples/`.
- Capitalized section-name references (section lists like `Goal, Criteria, Test Strategy`, `Required sections: … Criteria`, `Criteria missing`, `Draft Criteria`) → `Checkpoints`. Lowercase `criteria`/`criterion` (common nouns) left as-is.
- `ISC-N` ids **unchanged** (heading-only scope); CLI unchanged.
- `format.md` adds a note: the rename is dual-read (legacy `## Criteria` still loads, rewritten only on next mutation, **no migration**).

## Verification
- `bun test` **1459 pass / 0 fail** — no example `.md` is parsed with an exact-heading assertion (the code dual-reads either heading anyway).

Builds on #348 (slice-4 code) on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)