### PR TITLE
feat(install): prune renamed-away 'ISA' skill orphan (case-clean — part 2)

### DIFF
--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -29,7 +29,8 @@ export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
   vsaSkillProjection: {
     destinationDir: vsaSkillUnder(),
     // soma#329: before reprojecting VSA, prune a sibling renamed-away "ISA" skill
-    // from <home>/skills (provenance-gated — never a user skill).
+    // from <home>/skills (provenance-gated to Soma's published ISA identity — a
+    // user skill lacking that identity is preserved; see pruneLegacyVsaSkill doc).
     prepare: vsaSiblingPrunePrepare(),
   },
   postProjection: [

--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -1,4 +1,6 @@
+import { resolve } from "node:path";
 import { vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
+import { pruneLegacyVsaSkill } from "../../legacy-skill-prune";
 import { CLAUDE_CODE_RULES_FILES } from "../claude-code";
 import {
   SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH,
@@ -27,6 +29,10 @@ export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
     : [],
   vsaSkillProjection: {
     destinationDir: vsaSkillUnder(),
+    // soma#329: before reprojecting VSA, prune a sibling "ISA" skill left over
+    // from the rename. `vsaSkillUnder()` puts VSA at <home>/skills/VSA, so the
+    // shared skills dir is <home>/skills. Provenance-gated — never a user skill.
+    prepare: (substrateHome) => pruneLegacyVsaSkill(resolve(substrateHome, "skills")).then(() => undefined),
   },
   postProjection: [
     {

--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -1,6 +1,5 @@
-import { resolve } from "node:path";
 import { vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
-import { pruneLegacyVsaSkill } from "../../legacy-skill-prune";
+import { vsaSiblingPrunePrepare } from "../../legacy-skill-prune";
 import { CLAUDE_CODE_RULES_FILES } from "../claude-code";
 import {
   SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH,
@@ -29,10 +28,9 @@ export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
     : [],
   vsaSkillProjection: {
     destinationDir: vsaSkillUnder(),
-    // soma#329: before reprojecting VSA, prune a sibling "ISA" skill left over
-    // from the rename. `vsaSkillUnder()` puts VSA at <home>/skills/VSA, so the
-    // shared skills dir is <home>/skills. Provenance-gated — never a user skill.
-    prepare: (substrateHome) => pruneLegacyVsaSkill(resolve(substrateHome, "skills")).then(() => undefined),
+    // soma#329: before reprojecting VSA, prune a sibling renamed-away "ISA" skill
+    // from <home>/skills (provenance-gated — never a user skill).
+    prepare: vsaSiblingPrunePrepare(),
   },
   postProjection: [
     {

--- a/src/adapters/codex/install.ts
+++ b/src/adapters/codex/install.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { configureCodexInstall } from "./config";
 import { vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
+import { pruneLegacyVsaSkill } from "../../legacy-skill-prune";
 import type { SubstrateId } from "../../types";
 
 const CODEX_DEFAULT_HOME = ".codex";
@@ -68,6 +69,10 @@ export const codexInstallSpec: SubstrateInstallSpec<"codex"> = {
   ownedSubtrees: ["memories/soma"],
   vsaSkillProjection: {
     destinationDir: vsaSkillUnder(),
+    // soma#329: before reprojecting VSA, prune a sibling "ISA" skill left over
+    // from the rename. `vsaSkillUnder()` puts VSA at <home>/skills/VSA, so the
+    // shared skills dir is <home>/skills. Provenance-gated — never a user skill.
+    prepare: (substrateHome) => pruneLegacyVsaSkill(resolve(substrateHome, "skills")).then(() => undefined),
   },
   lifecycleProjection: {
     startupContextPath: "memories/soma/startup-context.md",

--- a/src/adapters/codex/install.ts
+++ b/src/adapters/codex/install.ts
@@ -70,7 +70,8 @@ export const codexInstallSpec: SubstrateInstallSpec<"codex"> = {
   vsaSkillProjection: {
     destinationDir: vsaSkillUnder(),
     // soma#329: before reprojecting VSA, prune a sibling renamed-away "ISA" skill
-    // from <home>/skills (provenance-gated — never a user skill).
+    // from <home>/skills (provenance-gated to Soma's published ISA identity — a
+    // user skill lacking that identity is preserved; see pruneLegacyVsaSkill doc).
     prepare: vsaSiblingPrunePrepare(),
   },
   lifecycleProjection: {

--- a/src/adapters/codex/install.ts
+++ b/src/adapters/codex/install.ts
@@ -3,7 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { configureCodexInstall } from "./config";
 import { vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
-import { pruneLegacyVsaSkill } from "../../legacy-skill-prune";
+import { vsaSiblingPrunePrepare } from "../../legacy-skill-prune";
 import type { SubstrateId } from "../../types";
 
 const CODEX_DEFAULT_HOME = ".codex";
@@ -69,10 +69,9 @@ export const codexInstallSpec: SubstrateInstallSpec<"codex"> = {
   ownedSubtrees: ["memories/soma"],
   vsaSkillProjection: {
     destinationDir: vsaSkillUnder(),
-    // soma#329: before reprojecting VSA, prune a sibling "ISA" skill left over
-    // from the rename. `vsaSkillUnder()` puts VSA at <home>/skills/VSA, so the
-    // shared skills dir is <home>/skills. Provenance-gated — never a user skill.
-    prepare: (substrateHome) => pruneLegacyVsaSkill(resolve(substrateHome, "skills")).then(() => undefined),
+    // soma#329: before reprojecting VSA, prune a sibling renamed-away "ISA" skill
+    // from <home>/skills (provenance-gated — never a user skill).
+    prepare: vsaSiblingPrunePrepare(),
   },
   lifecycleProjection: {
     startupContextPath: "memories/soma/startup-context.md",

--- a/src/install.ts
+++ b/src/install.ts
@@ -127,10 +127,12 @@ async function installSomaForSubstrate(
   // doesn't prove anything about the hook's later spawn environment.
   requireBunInPath();
   const somaHome = await bootstrapSomaHome(options);
-  // soma#329: prune the renamed-away "ISA" skill from the SOURCE home BEFORE the
-  // VSA baseline is (re)written and BEFORE loadSomaHome enumerates skills below.
-  // `loadSomaSkills` projects EVERY dir under <somaHome>/skills, so a stale ISA
-  // here would re-propagate to every substrate on each install. Provenance-gated
+  // soma#329 MIGRATION SHIM (removable once all homes are reprojected past the
+  // ISA→VSA rename): prune the renamed-away "ISA" skill from the SOURCE home
+  // BEFORE the VSA baseline is (re)written and BEFORE loadSomaHome enumerates
+  // skills below. `loadSomaSkills` projects EVERY dir under <somaHome>/skills, so a
+  // stale ISA here would re-propagate to every substrate on each install. Cheap +
+  // idempotent (a no-op readdir+gate once ISA is gone). Provenance-gated
   // (frontmatter name: ISA + identity marker) — a user "ISA" skill is preserved.
   await pruneLegacyVsaSkill(createPaths(somaHome.somaHome).skills());
   const somaRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();

--- a/src/install.ts
+++ b/src/install.ts
@@ -13,6 +13,8 @@ import { buildSomaStartupContext, runSomaLifecycleAlgorithmUpdated } from "./lif
 import { SOMA_MEMORY_CATEGORIES } from "./memory-readmes";
 import { defaultSomaRepoPath } from "./repo-path";
 import { bootstrapSomaHome, loadSomaHome } from "./soma-home";
+import { createPaths } from "./paths";
+import { pruneLegacyVsaSkill } from "./legacy-skill-prune";
 import { installVsaSkillProjection } from "./vsa-skill-installer";
 import { loadActiveVsaForBundle } from "./adapter-active-vsa";
 import { isUnderOrEqual, reconcileOwnedDir } from "./projection-reconcile";
@@ -125,6 +127,12 @@ async function installSomaForSubstrate(
   // doesn't prove anything about the hook's later spawn environment.
   requireBunInPath();
   const somaHome = await bootstrapSomaHome(options);
+  // soma#329: prune the renamed-away "ISA" skill from the SOURCE home BEFORE the
+  // VSA baseline is (re)written and BEFORE loadSomaHome enumerates skills below.
+  // `loadSomaSkills` projects EVERY dir under <somaHome>/skills, so a stale ISA
+  // here would re-propagate to every substrate on each install. Provenance-gated
+  // (frontmatter name: ISA + identity marker) — a user "ISA" skill is preserved.
+  await pruneLegacyVsaSkill(createPaths(somaHome.somaHome).skills());
   const somaRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();
   // Install VSA skill into Soma home (canonical baseline) so other
   // tooling reading <somaHome>/skills/VSA continues to work.

--- a/src/legacy-skill-prune.ts
+++ b/src/legacy-skill-prune.ts
@@ -11,7 +11,7 @@ const LEGACY_VSA_SKILL_DIR = "ISA" as const;
 // The renamed-away Soma skill is identified by a two-signal provenance gate so a
 // USER skill that merely happens to be named "ISA" is never deleted:
 //   1. SKILL.md frontmatter `name: ISA`
-//   2. SKILL.md description begins (anywhere) with this identity sentence —
+//   2. SKILL.md description contains this identity sentence (anywhere) —
 //      shared verbatim by the old ISA and the canonical VSA skill.
 const SOMA_VSA_SKILL_NAME = "ISA" as const;
 const SOMA_VSA_SKILL_IDENTITY_MARKER = "Owns the Ideal State Artifact" as const;
@@ -56,6 +56,10 @@ function isSomaRenamedVsaSkill(skillMd: string): boolean {
  * it IS the renamed-away Soma skill (its successor is VSA). The gate proves "a dir
  * lacking the identity is safe", not "this is provably not user-authored".
  * isEnoent-safe: a missing ISA dir, SKILL.md, or skills dir is a no-op.
+ *
+ * DESTRUCTIVE: removal is `rm -rf` with no backup. If the gate ever mis-fires
+ * (e.g. the indistinguishable verbatim-fork case above), the dir's contents are
+ * destroyed irrecoverably — recover only from a `soma snapshot`.
  *
  * @param skillsDir absolute path to the shared `skills/` directory.
  * @returns true when the soma ISA dir was removed, false otherwise.

--- a/src/legacy-skill-prune.ts
+++ b/src/legacy-skill-prune.ts
@@ -1,0 +1,77 @@
+import { readdir, readFile, rm } from "node:fs/promises";
+import { resolve } from "node:path";
+import { isEnoent } from "./fs-errors";
+
+// The on-disk name the Soma VSA skill was projected/stored under before the
+// #329 rename to "VSA". Matched EXACTLY against the real readdir entry name —
+// the exact-name match is load-bearing on case-insensitive filesystems, where a
+// blind rm of "ISA" could resolve to the SAME inode as a user dir cased "isa".
+const LEGACY_VSA_SKILL_DIR = "ISA" as const;
+
+// The renamed-away Soma skill is identified by a two-signal provenance gate so a
+// USER skill that merely happens to be named "ISA" is never deleted:
+//   1. SKILL.md frontmatter `name: ISA`
+//   2. SKILL.md description begins (anywhere) with this identity sentence —
+//      shared verbatim by the old ISA and the canonical VSA skill.
+const SOMA_VSA_SKILL_NAME = "ISA" as const;
+const SOMA_VSA_SKILL_IDENTITY_MARKER = "Owns the Ideal State Artifact" as const;
+
+const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---(?=\r?\n|$)/;
+
+function frontmatterField(content: string, key: string): string | undefined {
+  const frontmatter = FRONTMATTER.exec(content);
+  if (!frontmatter) return undefined;
+  const match = new RegExp(`^${key}:\\s*(.+?)\\s*$`, "m").exec(frontmatter[1]);
+  return match?.[1]?.trim().replace(/^["']|["']$/g, "");
+}
+
+// True only when BOTH provenance signals match the Soma renamed-away VSA
+// predecessor. Conservative by construction: any missing/differing signal → false.
+function isSomaRenamedVsaSkill(skillMd: string): boolean {
+  const name = frontmatterField(skillMd, "name");
+  if (name !== SOMA_VSA_SKILL_NAME) return false;
+  const description = frontmatterField(skillMd, "description");
+  return description?.includes(SOMA_VSA_SKILL_IDENTITY_MARKER) ?? false;
+}
+
+/**
+ * Remove the Soma renamed-away "ISA" skill dir from a shared `skills/` directory
+ * IFF the two-signal provenance gate passes (frontmatter `name: ISA` AND its
+ * description contains "Owns the Ideal State Artifact").
+ *
+ * Safe by design — `skills/` also holds the principal's own skills (dozens of
+ * them). A user dir named "ISA" whose SKILL.md lacks the marker (or has a
+ * different `name`) is preserved untouched. isEnoent-safe: a missing ISA dir, a
+ * missing SKILL.md, or a missing skills dir is a no-op.
+ *
+ * @param skillsDir absolute path to the shared `skills/` directory.
+ * @returns true when the soma ISA dir was removed, false otherwise.
+ */
+export async function pruneLegacyVsaSkill(skillsDir: string): Promise<boolean> {
+  let entries;
+  try {
+    entries = await readdir(skillsDir, { withFileTypes: true });
+  } catch (error) {
+    if (isEnoent(error)) return false;
+    throw error;
+  }
+
+  // Exact on-disk-name match (see LEGACY_VSA_SKILL_DIR). On a case-insensitive FS
+  // a user dir stored as "isa" yields readdir name "isa" ≠ "ISA" → never matched.
+  const legacyDir = entries.find((entry) => entry.isDirectory() && entry.name === LEGACY_VSA_SKILL_DIR);
+  if (!legacyDir) return false;
+
+  const skillMdPath = resolve(skillsDir, legacyDir.name, "SKILL.md");
+  let skillMd: string;
+  try {
+    skillMd = await readFile(skillMdPath, "utf8");
+  } catch (error) {
+    if (isEnoent(error)) return false;
+    throw error;
+  }
+
+  if (!isSomaRenamedVsaSkill(skillMd)) return false;
+
+  await rm(resolve(skillsDir, legacyDir.name), { recursive: true, force: true });
+  return true;
+}

--- a/src/legacy-skill-prune.ts
+++ b/src/legacy-skill-prune.ts
@@ -26,8 +26,12 @@ function frontmatterField(content: string, key: string): string | undefined {
   const frontmatter = FRONTMATTER.exec(content);
   if (!frontmatter) return undefined;
   const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = new RegExp(`^${escapedKey}:\\s*(.+?)\\s*$`, "m").exec(frontmatter[1]);
-  return match?.[1]?.trim().replace(/^["']|["']$/g, "");
+  const raw = new RegExp(`^${escapedKey}:\\s*(.+?)\\s*$`, "m").exec(frontmatter[1])?.[1]?.trim();
+  if (raw === undefined) return undefined;
+  // Strip a BALANCED surrounding quote pair only (not one leading + one trailing
+  // independently, which would normalize a malformed `'ISA"` to `ISA`).
+  const quoted = /^"(.*)"$/.exec(raw) ?? /^'(.*)'$/.exec(raw);
+  return quoted ? quoted[1] : raw;
 }
 
 // True only when BOTH provenance signals match the Soma renamed-away VSA
@@ -44,10 +48,14 @@ function isSomaRenamedVsaSkill(skillMd: string): boolean {
  * IFF the two-signal provenance gate passes (frontmatter `name: ISA` AND its
  * description contains "Owns the Ideal State Artifact").
  *
- * Safe by design — `skills/` also holds the principal's own skills (dozens of
- * them). A user dir named "ISA" whose SKILL.md lacks the marker (or has a
- * different `name`) is preserved untouched. isEnoent-safe: a missing ISA dir, a
- * missing SKILL.md, or a missing skills dir is a no-op.
+ * Conservative — `skills/` also holds the principal's own skills (dozens of them).
+ * A user dir named "ISA" whose SKILL.md lacks the marker (or has a different
+ * `name`) is preserved untouched. NOTE: the gate keys on Soma's OWN published ISA
+ * identity, so a verbatim user FORK of the old ISA skill (frontmatter kept) is
+ * indistinguishable from the orphan and would also be removed — acceptable, since
+ * it IS the renamed-away Soma skill (its successor is VSA). The gate proves "a dir
+ * lacking the identity is safe", not "this is provably not user-authored".
+ * isEnoent-safe: a missing ISA dir, SKILL.md, or skills dir is a no-op.
  *
  * @param skillsDir absolute path to the shared `skills/` directory.
  * @returns true when the soma ISA dir was removed, false otherwise.

--- a/src/legacy-skill-prune.ts
+++ b/src/legacy-skill-prune.ts
@@ -18,10 +18,15 @@ const SOMA_VSA_SKILL_IDENTITY_MARKER = "Owns the Ideal State Artifact" as const;
 
 const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---(?=\r?\n|$)/;
 
+// NOTE: matches a single-line scalar value only. Soma's ISA/VSA `name` and
+// `description` are always single-line; a folded/multi-line YAML value would not
+// be captured here — which fails SAFE (the provenance gate would not match, so the
+// dir is preserved rather than wrongly deleted).
 function frontmatterField(content: string, key: string): string | undefined {
   const frontmatter = FRONTMATTER.exec(content);
   if (!frontmatter) return undefined;
-  const match = new RegExp(`^${key}:\\s*(.+?)\\s*$`, "m").exec(frontmatter[1]);
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(`^${escapedKey}:\\s*(.+?)\\s*$`, "m").exec(frontmatter[1]);
   return match?.[1]?.trim().replace(/^["']|["']$/g, "");
 }
 
@@ -74,4 +79,15 @@ export async function pruneLegacyVsaSkill(skillsDir: string): Promise<boolean> {
 
   await rm(resolve(skillsDir, legacyDir.name), { recursive: true, force: true });
   return true;
+}
+
+/**
+ * A `vsaSkillProjection.prepare` hook that prunes a sibling renamed-away ISA skill
+ * from a substrate's shared skills dir before the canonical VSA skill installs.
+ * Shared by every substrate whose VSA skill lives at `<substrateHome>/<skillsSubpath>/VSA`.
+ */
+export function vsaSiblingPrunePrepare(skillsSubpath = "skills"): (substrateHome: string) => Promise<void> {
+  return async (substrateHome: string) => {
+    await pruneLegacyVsaSkill(resolve(substrateHome, skillsSubpath));
+  };
 }

--- a/test/legacy-skill-prune.test.ts
+++ b/test/legacy-skill-prune.test.ts
@@ -1,0 +1,169 @@
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { expect, test } from "bun:test";
+import { pruneLegacyVsaSkill } from "../src/legacy-skill-prune";
+import { installSomaForClaudeCode, installSomaForCodex } from "../src/index";
+import { createPaths } from "../src/paths";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-prune-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+// A SKILL.md identical in shape to the renamed-away Soma ISA skill: frontmatter
+// `name: ISA` AND a description beginning with the shared identity sentence.
+const SOMA_ISA_SKILL_MD = [
+  "---",
+  "name: ISA",
+  'description: "Owns the Ideal State Artifact: the commitment-time scaffold for articulating done."',
+  "effort: medium",
+  "---",
+  "",
+  "# ISA",
+  "",
+  "Body.",
+  "",
+].join("\n");
+
+async function plantSkill(skillsDir: string, name: string, skillMd: string): Promise<string> {
+  const dir = join(skillsDir, name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "SKILL.md"), skillMd, "utf8");
+  return dir;
+}
+
+test("pruneLegacyVsaSkill removes a soma ISA dir (name + identity marker) and returns true", async () => {
+  await withTempHome(async (homeDir) => {
+    const skills = join(homeDir, "skills");
+    const isaDir = await plantSkill(skills, "ISA", SOMA_ISA_SKILL_MD);
+
+    const removed = await pruneLegacyVsaSkill(skills);
+
+    expect(removed).toBe(true);
+    await expect(stat(isaDir)).rejects.toThrow();
+  });
+});
+
+test("pruneLegacyVsaSkill PRESERVES a user ISA dir whose SKILL.md lacks the identity marker", async () => {
+  await withTempHome(async (homeDir) => {
+    const skills = join(homeDir, "skills");
+    const userMd = ["---", "name: ISA", 'description: "International Standard Atmosphere reference tables."', "---", "", "# ISA", ""].join("\n");
+    const isaDir = await plantSkill(skills, "ISA", userMd);
+
+    const removed = await pruneLegacyVsaSkill(skills);
+
+    expect(removed).toBe(false);
+    expect(await readFile(join(isaDir, "SKILL.md"), "utf8")).toBe(userMd); // intact
+  });
+});
+
+test("pruneLegacyVsaSkill PRESERVES an ISA dir whose frontmatter name differs even with the marker", async () => {
+  await withTempHome(async (homeDir) => {
+    const skills = join(homeDir, "skills");
+    // Identity marker present, but `name` is not ISA — both signals required.
+    const md = ["---", "name: MyArtifacts", 'description: "Owns the Ideal State Artifact: do not delete me."', "---", "", "# X", ""].join("\n");
+    const isaDir = await plantSkill(skills, "ISA", md);
+
+    const removed = await pruneLegacyVsaSkill(skills);
+
+    expect(removed).toBe(false);
+    expect(await readFile(join(isaDir, "SKILL.md"), "utf8")).toBe(md);
+  });
+});
+
+test("pruneLegacyVsaSkill is a no-op when the ISA dir is absent", async () => {
+  await withTempHome(async (homeDir) => {
+    const skills = join(homeDir, "skills");
+    await plantSkill(skills, "VSA", SOMA_ISA_SKILL_MD.replace("name: ISA", "name: VSA"));
+
+    const removed = await pruneLegacyVsaSkill(skills);
+
+    expect(removed).toBe(false);
+    expect(await stat(join(skills, "VSA"))).toBeTruthy(); // sibling untouched
+  });
+});
+
+test("pruneLegacyVsaSkill is a no-op when the skills dir is absent", async () => {
+  await withTempHome(async (homeDir) => {
+    const removed = await pruneLegacyVsaSkill(join(homeDir, "does-not-exist"));
+    expect(removed).toBe(false);
+  });
+});
+
+test("pruneLegacyVsaSkill is a no-op when ISA dir has no SKILL.md", async () => {
+  await withTempHome(async (homeDir) => {
+    const skills = join(homeDir, "skills");
+    const isaDir = join(skills, "ISA");
+    await mkdir(isaDir, { recursive: true });
+
+    const removed = await pruneLegacyVsaSkill(skills);
+
+    expect(removed).toBe(false);
+    expect(await stat(isaDir)).toBeTruthy();
+  });
+});
+
+test("codex install prunes a sibling ISA skill but preserves projected VSA and user skills", async () => {
+  await withTempHome(async (homeDir) => {
+    const codexSkills = join(homeDir, ".codex", "skills");
+    // Plant a soma-style ISA skill + a genuine user skill in the shared dir.
+    await plantSkill(codexSkills, "ISA", SOMA_ISA_SKILL_MD);
+    const userSkillMd = ["---", "name: my-skill", 'description: "A user skill."', "---", "", "# my-skill", ""].join("\n");
+    await plantSkill(codexSkills, "my-skill", userSkillMd);
+    // A user dir literally named ISA-like but non-soma must also survive.
+    const userIsaMd = ["---", "name: ISA", 'description: "Not a soma skill at all."', "---", "", "# ISA", ""].join("\n");
+
+    await installSomaForCodex({ homeDir });
+
+    await expect(stat(join(codexSkills, "ISA"))).rejects.toThrow(); // soma ISA pruned
+    expect(await readFile(join(codexSkills, "VSA", "SKILL.md"), "utf8")).toContain("name: VSA"); // VSA projected
+    expect(await readFile(join(codexSkills, "my-skill", "SKILL.md"), "utf8")).toBe(userSkillMd); // user skill survives
+
+    // Now reproject with a non-soma ISA dir present: it must be preserved.
+    const userIsaDir = await plantSkill(codexSkills, "ISA", userIsaMd);
+    await installSomaForCodex({ homeDir });
+    expect(await readFile(join(userIsaDir, "SKILL.md"), "utf8")).toBe(userIsaMd);
+  });
+});
+
+test("claude-code install prunes a sibling ISA skill but preserves projected VSA and user skills", async () => {
+  await withTempHome(async (homeDir) => {
+    const claudeSkills = join(homeDir, ".claude", "skills");
+    await plantSkill(claudeSkills, "ISA", SOMA_ISA_SKILL_MD);
+    const userSkillMd = ["---", "name: my-skill", 'description: "A user skill."', "---", "", "# my-skill", ""].join("\n");
+    await plantSkill(claudeSkills, "my-skill", userSkillMd);
+
+    await installSomaForClaudeCode({ homeDir });
+
+    await expect(stat(join(claudeSkills, "ISA"))).rejects.toThrow(); // soma ISA pruned
+    expect(await readFile(join(claudeSkills, "VSA", "SKILL.md"), "utf8")).toContain("name: VSA"); // VSA projected
+    expect(await readFile(join(claudeSkills, "my-skill", "SKILL.md"), "utf8")).toBe(userSkillMd); // user skill survives
+  });
+});
+
+test("install prunes the SOURCE-home ISA so it stops propagating, preserving user skill + canonical VSA", async () => {
+  await withTempHome(async (homeDir) => {
+    // Bootstrap the soma home first (via a real install), then plant a stale ISA
+    // alongside the canonical VSA + a genuine user skill in the SOURCE home.
+    await installSomaForCodex({ homeDir });
+    const somaSkills = createPaths({ homeDir }).skills();
+    await plantSkill(somaSkills, "ISA", SOMA_ISA_SKILL_MD);
+    const userSkillMd = ["---", "name: user-source-skill", 'description: "A user source skill."', "---", "", "# x", ""].join("\n");
+    await plantSkill(somaSkills, "user-source-skill", userSkillMd);
+
+    // Re-install: source-home prune must remove ISA before loadSomaSkills runs.
+    await installSomaForCodex({ homeDir });
+
+    await expect(stat(join(somaSkills, "ISA"))).rejects.toThrow(); // source ISA pruned
+    expect(await readFile(join(somaSkills, "VSA", "SKILL.md"), "utf8")).toContain("name: VSA"); // canonical VSA survives
+    expect(await readFile(join(somaSkills, "user-source-skill", "SKILL.md"), "utf8")).toBe(userSkillMd); // user skill survives
+
+    // And the stale ISA must NOT have re-propagated to the codex substrate.
+    await expect(stat(join(homeDir, ".codex", "skills", "ISA"))).rejects.toThrow();
+  });
+});

--- a/test/legacy-skill-prune.test.ts
+++ b/test/legacy-skill-prune.test.ts
@@ -15,20 +15,16 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
   }
 }
 
+function makeSkillMd({ name, description }: { name: string; description: string }): string {
+  return ["---", `name: ${name}`, `description: "${description}"`, "effort: medium", "---", "", `# ${name}`, "", "Body.", ""].join("\n");
+}
+
 // A SKILL.md identical in shape to the renamed-away Soma ISA skill: frontmatter
 // `name: ISA` AND a description beginning with the shared identity sentence.
-const SOMA_ISA_SKILL_MD = [
-  "---",
-  "name: ISA",
-  'description: "Owns the Ideal State Artifact: the commitment-time scaffold for articulating done."',
-  "effort: medium",
-  "---",
-  "",
-  "# ISA",
-  "",
-  "Body.",
-  "",
-].join("\n");
+const SOMA_ISA_SKILL_MD = makeSkillMd({
+  name: "ISA",
+  description: "Owns the Ideal State Artifact: the commitment-time scaffold for articulating done.",
+});
 
 async function plantSkill(skillsDir: string, name: string, skillMd: string): Promise<string> {
   const dir = join(skillsDir, name);
@@ -52,7 +48,7 @@ test("pruneLegacyVsaSkill removes a soma ISA dir (name + identity marker) and re
 test("pruneLegacyVsaSkill PRESERVES a user ISA dir whose SKILL.md lacks the identity marker", async () => {
   await withTempHome(async (homeDir) => {
     const skills = join(homeDir, "skills");
-    const userMd = ["---", "name: ISA", 'description: "International Standard Atmosphere reference tables."', "---", "", "# ISA", ""].join("\n");
+    const userMd = makeSkillMd({ name: "ISA", description: "International Standard Atmosphere reference tables." });
     const isaDir = await plantSkill(skills, "ISA", userMd);
 
     const removed = await pruneLegacyVsaSkill(skills);
@@ -66,7 +62,7 @@ test("pruneLegacyVsaSkill PRESERVES an ISA dir whose frontmatter name differs ev
   await withTempHome(async (homeDir) => {
     const skills = join(homeDir, "skills");
     // Identity marker present, but `name` is not ISA — both signals required.
-    const md = ["---", "name: MyArtifacts", 'description: "Owns the Ideal State Artifact: do not delete me."', "---", "", "# X", ""].join("\n");
+    const md = makeSkillMd({ name: "MyArtifacts", description: "Owns the Ideal State Artifact: do not delete me." });
     const isaDir = await plantSkill(skills, "ISA", md);
 
     const removed = await pruneLegacyVsaSkill(skills);
@@ -81,6 +77,9 @@ test("pruneLegacyVsaSkill PRESERVES a lowercase 'isa' dir — the load-bearing c
   // "ISA" would resolve to the same inode as a user dir stored as "isa". The exact
   // on-disk-name match (entry.name === "ISA") prevents that: a dir whose stored
   // name is "isa" is never matched, EVEN with soma's exact provenance content.
+  // NOTE: the dangerous collision only EXISTS on a case-insensitive host (where
+  // this test bites); on case-sensitive CI "isa" and "ISA" are distinct dirs so
+  // the same assertion holds trivially — preservation is correct on both regardless.
   await withTempHome(async (homeDir) => {
     const skills = join(homeDir, "skills");
     const isaDir = await plantSkill(skills, "isa", SOMA_ISA_SKILL_MD);

--- a/test/legacy-skill-prune.test.ts
+++ b/test/legacy-skill-prune.test.ts
@@ -76,6 +76,22 @@ test("pruneLegacyVsaSkill PRESERVES an ISA dir whose frontmatter name differs ev
   });
 });
 
+test("pruneLegacyVsaSkill PRESERVES a lowercase 'isa' dir — the load-bearing case-insensitive guard", async () => {
+  // On a case-insensitive FS (macOS/APFS, the author's host) a blind rm of path
+  // "ISA" would resolve to the same inode as a user dir stored as "isa". The exact
+  // on-disk-name match (entry.name === "ISA") prevents that: a dir whose stored
+  // name is "isa" is never matched, EVEN with soma's exact provenance content.
+  await withTempHome(async (homeDir) => {
+    const skills = join(homeDir, "skills");
+    const isaDir = await plantSkill(skills, "isa", SOMA_ISA_SKILL_MD);
+
+    const removed = await pruneLegacyVsaSkill(skills);
+
+    expect(removed).toBe(false);
+    expect(await readFile(join(isaDir, "SKILL.md"), "utf8")).toBe(SOMA_ISA_SKILL_MD); // intact
+  });
+});
+
 test("pruneLegacyVsaSkill is a no-op when the ISA dir is absent", async () => {
   await withTempHome(async (homeDir) => {
     const skills = join(homeDir, "skills");


### PR DESCRIPTION
**Part 2** of the case-clean work (part 1 = #351, merged). Removes the orphaned `ISA` skill dirs that soma#329's ISA→VSA rename left behind — the leftover #351 explicitly deferred.

## Orphans this PR removes (verified here)
- **Source root** `~/.soma/skills/ISA` — `loadSomaSkills` enumerates every dir under the soma home skills dir and projects it, so this stale ISA re-propagated to every substrate each install. The propagation root. (pruned before `loadSomaHome`.)
- **Projected copies** in the shared `skills/` roots of **codex** and **claude-code** (via `vsaSkillProjection.prepare`).

Handled by prior work, NOT re-verified in this PR: cursor's `ISA` (under the owned `.cursor/rules/soma` → removed by part-1 reconcile, #351) and pi-dev (`removeLegacyPiDevVsaSkillProjection`, #351). After this lands a full reproject is expected to clean every home, but only codex/claude/source are wired+tested here.

## Safety — the hard part
`~/.soma/skills` and the substrate `skills/` roots also hold the principal's own skills (dozens). `pruneLegacyVsaSkill(skillsDir)` removes the ISA dir ONLY behind a two-signal provenance gate:
1. exact on-disk dir name `ISA` (load-bearing on case-insensitive FS — a user dir cased `isa` is never matched; now has a dedicated test), AND
2. `SKILL.md` frontmatter `name: ISA` **AND** description contains the VSA-skill identity sentence `"Owns the Ideal State Artifact"`.

A user skill named `ISA` lacking the marker (or with a different `name`) is preserved. `isEnoent`-safe; any other fs error re-throws.

## Tests (10)
helper unit: removes soma ISA; preserves a user ISA lacking the marker; preserves an ISA with a different name; **preserves a lowercase `isa`** (case-insensitive guard); no-ops (absent ISA / absent skills dir / no SKILL.md). Integration: codex & claude install prune sibling ISA while projected VSA **and** a planted user skill survive a reproject; source-home prune (ISA pruned, user skill + canonical VSA survive). typecheck + eslint clean; full suite **1481 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)