### PR TITLE
feat(skills): soma project-skill / unproject-skill projection primitive (#354 slice 1)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,16 @@ import {
   type ParsedUpgradeArgs,
 } from "./cli/substrate-lifecycle";
 import {
+  PROJECT_SKILL_COMMAND_HELP,
+  UNPROJECT_SKILL_COMMAND_HELP,
+  parseProjectSkillArgs,
+  parseUnprojectSkillArgs,
+  runProjectSkillCli,
+  runUnprojectSkillCli,
+  type ParsedProjectSkillArgs,
+  type ParsedUnprojectSkillArgs,
+} from "./cli/skill-projection-cli";
+import {
   MIGRATE_COMMAND_HELP,
   parseMigrateArgs,
   runMigrateCli,
@@ -131,6 +141,8 @@ type ParsedArgs =
   | ParsedUpgradeArgs
   | ParsedExportArgs
   | ParsedDaemonArgs
+  | ParsedProjectSkillArgs
+  | ParsedUnprojectSkillArgs
   | ParsedOnboardingArgs
   | ParsedImportArgs
   | ParsedMigrateArgs
@@ -167,8 +179,10 @@ const TOP_LEVEL_COMMANDS = [
   "migrate",
   "opinion",
   "policy",
+  "project-skill",
   "relationship",
   "reproject",
+  "unproject-skill",
   "result",
   "rollback",
   "session",
@@ -195,6 +209,8 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
   install: SUBSTRATE_LIFECYCLE_COMMAND_HELP.install,
   uninstall: SUBSTRATE_LIFECYCLE_COMMAND_HELP.uninstall,
   reproject: SUBSTRATE_LIFECYCLE_COMMAND_HELP.reproject,
+  "project-skill": PROJECT_SKILL_COMMAND_HELP,
+  "unproject-skill": UNPROJECT_SKILL_COMMAND_HELP,
   upgrade: SUBSTRATE_LIFECYCLE_COMMAND_HELP.upgrade,
   export: SUBSTRATE_LIFECYCLE_COMMAND_HELP.export,
   daemon: SUBSTRATE_LIFECYCLE_COMMAND_HELP.daemon,
@@ -291,6 +307,14 @@ function parseArgs(args: string[]): ParsedArgs {
 
   if (args[0] === "reproject") {
     return parseReprojectArgs(args);
+  }
+
+  if (args[0] === "project-skill") {
+    return parseProjectSkillArgs(args);
+  }
+
+  if (args[0] === "unproject-skill") {
+    return parseUnprojectSkillArgs(args);
   }
 
   if (args[0] === "upgrade") {
@@ -514,6 +538,14 @@ export async function runSomaCli(args: string[]): Promise<string> {
 
   if (parsed.command === "snapshot" || parsed.command === "history" || parsed.command === "rollback") {
     return runSnapshotCli(parsed);
+  }
+
+  if (parsed.command === "project-skill") {
+    return runProjectSkillCli(parsed);
+  }
+
+  if (parsed.command === "unproject-skill") {
+    return runUnprojectSkillCli(parsed);
   }
 
   if (isSubstrateLifecycleArgs(parsed)) {

--- a/src/cli/skill-projection-cli.ts
+++ b/src/cli/skill-projection-cli.ts
@@ -14,18 +14,18 @@ export interface ParsedProjectSkillArgs {
   skillDir: string;
   substrates: InstallSubstrate[];
   apply: boolean;
-  options: { homeDir?: string; somaHome?: string; substrateHome?: string };
+  options: { homeDir?: string; somaHome?: string; substrateHome?: string; force?: boolean };
 }
 
 export interface ParsedUnprojectSkillArgs {
   command: "unproject-skill";
   skill: string;
   substrates: InstallSubstrate[];
-  options: { homeDir?: string; somaHome?: string; substrateHome?: string };
+  options: { homeDir?: string; somaHome?: string; substrateHome?: string; force?: boolean };
 }
 
 const SUBSTRATE_LIST = INSTALL_SUBSTRATES.join("|");
-const SKILL_OPTIONS = "[--substrate <id[,id…]>] [--dry-run] [--apply] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
+const SKILL_OPTIONS = "[--substrate <id[,id…]>] [--dry-run] [--apply] [--force] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 
 export const PROJECT_SKILL_COMMAND_HELP = {
   usage: `Usage: soma project-skill <skill-dir> ${SKILL_OPTIONS}  (--substrate defaults to claude-code; ${SUBSTRATE_LIST})`,
@@ -50,7 +50,7 @@ interface SkillCommonParse {
   positional: string;
   substrates: InstallSubstrate[];
   apply: boolean;
-  options: { homeDir?: string; somaHome?: string; substrateHome?: string };
+  options: { homeDir?: string; somaHome?: string; substrateHome?: string; force?: boolean };
 }
 
 function parseSkillArgs(verb: string, usage: string, args: string[]): SkillCommonParse {
@@ -59,7 +59,7 @@ function parseSkillArgs(verb: string, usage: string, args: string[]): SkillCommo
     throw new Error(usage);
   }
 
-  const options: { homeDir?: string; somaHome?: string; substrateHome?: string } = {};
+  const options: { homeDir?: string; somaHome?: string; substrateHome?: string; force?: boolean } = {};
   let substrates: InstallSubstrate[] = ["claude-code"];
   let apply = false;
 
@@ -81,6 +81,9 @@ function parseSkillArgs(verb: string, usage: string, args: string[]): SkillCommo
       case "--substrate-home":
         options.substrateHome = readOption(rest, index, arg);
         index += 1;
+        continue;
+      case "--force":
+        options.force = true;
         continue;
       case "--apply":
         apply = true;

--- a/src/cli/skill-projection-cli.ts
+++ b/src/cli/skill-projection-cli.ts
@@ -1,0 +1,167 @@
+import {
+  planProjectSkill,
+  projectSkill,
+  unprojectSkill,
+  type ProjectSkillOptions,
+  type SkillProjectionResult,
+  type UnprojectSkillOptions,
+} from "../skill-projection";
+import { INSTALL_SUBSTRATES, isInstallSubstrate, type InstallSubstrate } from "./substrate-lifecycle";
+import { readOption } from "./parse-utils";
+
+export interface ParsedProjectSkillArgs {
+  command: "project-skill";
+  skillDir: string;
+  substrates: InstallSubstrate[];
+  apply: boolean;
+  options: { homeDir?: string; somaHome?: string; substrateHome?: string };
+}
+
+export interface ParsedUnprojectSkillArgs {
+  command: "unproject-skill";
+  skill: string;
+  substrates: InstallSubstrate[];
+  options: { homeDir?: string; somaHome?: string; substrateHome?: string };
+}
+
+const SUBSTRATE_LIST = INSTALL_SUBSTRATES.join("|");
+const SKILL_OPTIONS = "[--substrate <id[,id…]>] [--dry-run] [--apply] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
+
+export const PROJECT_SKILL_COMMAND_HELP = {
+  usage: `Usage: soma project-skill <skill-dir> ${SKILL_OPTIONS}  (--substrate defaults to claude-code; ${SUBSTRATE_LIST})`,
+};
+
+export const UNPROJECT_SKILL_COMMAND_HELP = {
+  usage: `Usage: soma unproject-skill <skill-dir|name> ${SKILL_OPTIONS}  (--substrate defaults to claude-code; ${SUBSTRATE_LIST})`,
+};
+
+function parseSubstrateCsv(value: string): InstallSubstrate[] {
+  const ids = value.split(",").map((part) => part.trim()).filter((part) => part.length > 0);
+  if (ids.length === 0) throw new Error("--substrate requires at least one substrate id.");
+  for (const id of ids) {
+    if (!isInstallSubstrate(id)) {
+      throw new Error(`--substrate must be one of ${INSTALL_SUBSTRATES.join(", ")} (got "${id}").`);
+    }
+  }
+  return ids as InstallSubstrate[];
+}
+
+interface SkillCommonParse {
+  positional: string;
+  substrates: InstallSubstrate[];
+  apply: boolean;
+  options: { homeDir?: string; somaHome?: string; substrateHome?: string };
+}
+
+function parseSkillArgs(verb: string, usage: string, args: string[]): SkillCommonParse {
+  const [command, positional, ...rest] = args;
+  if (command !== verb || !positional || positional.startsWith("--")) {
+    throw new Error(usage);
+  }
+
+  const options: { homeDir?: string; somaHome?: string; substrateHome?: string } = {};
+  let substrates: InstallSubstrate[] = ["claude-code"];
+  let apply = false;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    switch (arg) {
+      case "--substrate":
+        substrates = parseSubstrateCsv(readOption(rest, index, arg));
+        index += 1;
+        continue;
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        continue;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        continue;
+      case "--substrate-home":
+        options.substrateHome = readOption(rest, index, arg);
+        index += 1;
+        continue;
+      case "--apply":
+        apply = true;
+        continue;
+      case "--dry-run":
+        apply = false;
+        continue;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return { positional, substrates, apply, options };
+}
+
+export function parseProjectSkillArgs(args: string[]): ParsedProjectSkillArgs {
+  const { positional, substrates, apply, options } = parseSkillArgs(
+    "project-skill",
+    PROJECT_SKILL_COMMAND_HELP.usage,
+    args,
+  );
+  return { command: "project-skill", skillDir: positional, substrates, apply, options };
+}
+
+export function parseUnprojectSkillArgs(args: string[]): ParsedUnprojectSkillArgs {
+  const { positional, substrates, options } = parseSkillArgs(
+    "unproject-skill",
+    UNPROJECT_SKILL_COMMAND_HELP.usage,
+    args,
+  );
+  return { command: "unproject-skill", skill: positional, substrates, options };
+}
+
+export async function runProjectSkillCli(parsed: ParsedProjectSkillArgs): Promise<string> {
+  const options: ProjectSkillOptions = {
+    skillDir: parsed.skillDir,
+    substrates: parsed.substrates,
+    ...parsed.options,
+  };
+
+  if (!parsed.apply) {
+    const plan = await planProjectSkill(options);
+    return [
+      "Soma project-skill PLAN (no changes written) - pass --apply to apply",
+      `skill: ${plan.skill}`,
+      `source: ${plan.skillDir}`,
+      "",
+      "Links:",
+      ...plan.links.map((link) =>
+        `- ${link.scope === "registry" ? "registry" : link.substrate} → ${link.path}`,
+      ),
+      "",
+      `Catalog refresh: ${plan.catalogRefresh.join(", ")}`,
+      "",
+      "No changes were written. Re-run with --apply to apply this plan.",
+    ].join("\n");
+  }
+
+  return formatProjectionResult("Soma project-skill applied", await projectSkill(options));
+}
+
+export async function runUnprojectSkillCli(parsed: ParsedUnprojectSkillArgs): Promise<string> {
+  const options: UnprojectSkillOptions = {
+    skill: parsed.skill,
+    substrates: parsed.substrates,
+    ...parsed.options,
+  };
+  return formatProjectionResult("Soma unproject-skill applied", await unprojectSkill(options));
+}
+
+function formatProjectionResult(title: string, result: SkillProjectionResult): string {
+  return [
+    title,
+    `skill: ${result.skill}`,
+    "",
+    "Links:",
+    ...result.links.map((link) =>
+      `- ${link.scope === "registry" ? "registry" : link.substrate}: ${link.status} ${link.path}`,
+    ),
+    "",
+    "Catalog:",
+    ...result.catalogFiles.map((catalog) => `- ${catalog.substrate}: ${catalog.path}`),
+  ].join("\n");
+}

--- a/src/cli/skill-projection-cli.ts
+++ b/src/cli/skill-projection-cli.ts
@@ -1,8 +1,10 @@
 import {
   planProjectSkill,
+  planUnprojectSkill,
   projectSkill,
   unprojectSkill,
   type ProjectSkillOptions,
+  type SkillProjectionPlan,
   type SkillProjectionResult,
   type UnprojectSkillOptions,
 } from "../skill-projection";
@@ -21,6 +23,7 @@ export interface ParsedUnprojectSkillArgs {
   command: "unproject-skill";
   skill: string;
   substrates: InstallSubstrate[];
+  apply: boolean;
   options: { homeDir?: string; somaHome?: string; substrateHome?: string; force?: boolean };
 }
 
@@ -109,12 +112,12 @@ export function parseProjectSkillArgs(args: string[]): ParsedProjectSkillArgs {
 }
 
 export function parseUnprojectSkillArgs(args: string[]): ParsedUnprojectSkillArgs {
-  const { positional, substrates, options } = parseSkillArgs(
+  const { positional, substrates, apply, options } = parseSkillArgs(
     "unproject-skill",
     UNPROJECT_SKILL_COMMAND_HELP.usage,
     args,
   );
-  return { command: "unproject-skill", skill: positional, substrates, options };
+  return { command: "unproject-skill", skill: positional, substrates, apply, options };
 }
 
 export async function runProjectSkillCli(parsed: ParsedProjectSkillArgs): Promise<string> {
@@ -125,23 +128,8 @@ export async function runProjectSkillCli(parsed: ParsedProjectSkillArgs): Promis
   };
 
   if (!parsed.apply) {
-    const plan = await planProjectSkill(options);
-    return [
-      "Soma project-skill PLAN (no changes written) - pass --apply to apply",
-      `skill: ${plan.skill}`,
-      `source: ${plan.skillDir}`,
-      "",
-      "Links:",
-      ...plan.links.map((link) =>
-        `- ${link.scope === "registry" ? "registry" : link.substrate} → ${link.path}`,
-      ),
-      "",
-      `Catalog refresh: ${plan.catalogRefresh.join(", ")}`,
-      "",
-      "No changes were written. Re-run with --apply to apply this plan.",
-    ].join("\n");
+    return formatPlan("project-skill", await planProjectSkill(options), "→");
   }
-
   return formatProjectionResult("Soma project-skill applied", await projectSkill(options));
 }
 
@@ -151,7 +139,25 @@ export async function runUnprojectSkillCli(parsed: ParsedUnprojectSkillArgs): Pr
     substrates: parsed.substrates,
     ...parsed.options,
   };
+
+  if (!parsed.apply) {
+    return formatPlan("unproject-skill", await planUnprojectSkill(options), "✗");
+  }
   return formatProjectionResult("Soma unproject-skill applied", await unprojectSkill(options));
+}
+
+function formatPlan(verb: string, plan: SkillProjectionPlan, marker: string): string {
+  return [
+    `Soma ${verb} PLAN (no changes written) - pass --apply to apply`,
+    `skill: ${plan.skill}`,
+    "",
+    "Links:",
+    ...plan.links.map((link) => `- ${link.scope === "registry" ? "registry" : link.substrate} ${marker} ${link.path}`),
+    "",
+    `Catalog refresh: ${plan.catalogRefresh.join(", ")}`,
+    "",
+    "No changes were written. Re-run with --apply to apply this plan.",
+  ].join("\n");
 }
 
 function formatProjectionResult(title: string, result: SkillProjectionResult): string {

--- a/src/skill-projection.ts
+++ b/src/skill-projection.ts
@@ -1,0 +1,315 @@
+import { lstat, mkdir, readFile, readlink, rm, symlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { renderSkills } from "./adapters/shared";
+import {
+  buildClaudeCodeHomeProjection,
+  buildCodexHomeProjection,
+  buildCursorHomeProjection,
+  buildGrokHomeProjection,
+  buildPiDevHomeProjection,
+} from "./home-projection";
+import type { InstallSubstrate } from "./install-spec";
+import { installSpecFor } from "./install-spec-registry";
+import { writeProjection } from "./projection";
+import { loadSomaHome } from "./soma-home";
+import type { ProjectionInput, SomaHomeProjection, SomaHomeProjectionOptions } from "./types";
+
+/**
+ * soma#354 slice 1 — the projection primitive.
+ *
+ * Materialises an invocable skill directory into one or more substrate skill
+ * loaders (e.g. `~/.claude/skills/<Name>`) and refreshes the Soma skill catalog
+ * (`rules/soma/SKILLS.md`) so the skill is both loadable AND listed. The unit
+ * `soma install --skills`, and arc, both delegate to this — soma stays the
+ * single projection truth (ADR 0002).
+ *
+ * Skills are linked, not copied: `~/.soma/skills/<Name>` (the registry the
+ * catalog scans) and each substrate loader point at the source dir, so edits to
+ * the source propagate with no re-sync. Reconciliation is scoped to the skill's
+ * own name — a pre-existing copy at that name (e.g. the hand-made VSA/Interview
+ * dirs) is replaced; unrelated user skills are never touched.
+ */
+
+const projectionBuilders: Record<
+  InstallSubstrate,
+  (input: ProjectionInput, options: SomaHomeProjectionOptions) => SomaHomeProjection
+> = {
+  codex: buildCodexHomeProjection,
+  "pi-dev": buildPiDevHomeProjection,
+  "claude-code": buildClaudeCodeHomeProjection,
+  cursor: buildCursorHomeProjection,
+  grok: buildGrokHomeProjection,
+};
+
+export interface ProjectSkillOptions {
+  /** Path to the source skill directory (must contain a SKILL.md). */
+  skillDir: string;
+  /** Substrates to project into. */
+  substrates: InstallSubstrate[];
+  homeDir?: string;
+  somaHome?: string;
+  /** Only valid with a single substrate. */
+  substrateHome?: string;
+}
+
+export interface UnprojectSkillOptions {
+  /** Source skill dir, or a bare skill name. */
+  skill: string;
+  substrates: InstallSubstrate[];
+  homeDir?: string;
+  somaHome?: string;
+  substrateHome?: string;
+}
+
+export type SkillLinkStatus = "linked" | "unchanged" | "replaced" | "removed" | "absent";
+
+export interface SkillLink {
+  scope: "registry" | "substrate";
+  substrate?: InstallSubstrate;
+  path: string;
+  target?: string;
+  status: SkillLinkStatus;
+}
+
+export interface SkillProjectionResult {
+  skill: string;
+  skillDir: string;
+  links: SkillLink[];
+  catalogFiles: { substrate: InstallSubstrate; path: string }[];
+  /** Set by unprojectSkill: whether a Soma-created registry symlink was removed. */
+  registryRemoved?: boolean;
+}
+
+export interface SkillProjectionPlan {
+  skill: string;
+  skillDir: string;
+  links: { scope: "registry" | "substrate"; substrate?: InstallSubstrate; path: string; target: string }[];
+  catalogRefresh: InstallSubstrate[];
+}
+
+class SkillProjectionError extends Error {}
+
+function resolveSomaHome(options: { homeDir?: string; somaHome?: string }): string {
+  if (options.somaHome) return resolve(options.somaHome);
+  return resolve(options.homeDir ?? homedir(), ".soma");
+}
+
+function registrySkillsDir(somaHome: string): string {
+  return join(somaHome, "skills");
+}
+
+/** Per-substrate invocable skill loader root (parent of the VSA skill dir). */
+function substrateSkillsRoot(substrate: InstallSubstrate, substrateHome: string): string {
+  return dirname(installSpecFor(substrate).vsaSkillProjection.destinationDir(substrateHome));
+}
+
+function resolveSubstrateHome(
+  substrate: InstallSubstrate,
+  options: { homeDir?: string; substrateHome?: string },
+): string {
+  if (options.substrateHome) return resolve(options.substrateHome);
+  const homeDir = resolve(options.homeDir ?? homedir());
+  return resolve(homeDir, installSpecFor(substrate).defaultHome);
+}
+
+function assertSafeSkillName(name: string): void {
+  if (name.length === 0 || name.includes("/") || name.includes("\\") || name === "." || name === "..") {
+    throw new SkillProjectionError(`Unsafe skill name derived from frontmatter/dir: "${name}".`);
+  }
+}
+
+/** Skill identity = frontmatter `name`, falling back to the dir basename. */
+async function readSkillName(skillDir: string): Promise<string> {
+  const skillMdPath = join(skillDir, "SKILL.md");
+  let content: string;
+  try {
+    content = await readFile(skillMdPath, "utf8");
+  } catch {
+    throw new SkillProjectionError(`No SKILL.md found in skill dir: ${skillDir}`);
+  }
+  const match = /^name:\s*["']?(.+?)["']?\s*$/m.exec(content);
+  const name = (match?.[1] ?? basename(skillDir)).trim();
+  assertSafeSkillName(name);
+  return name;
+}
+
+function assertSingleSubstrateForHome(options: { substrates: InstallSubstrate[]; substrateHome?: string }): void {
+  if (options.substrateHome && options.substrates.length > 1) {
+    throw new SkillProjectionError("--substrate-home is only valid with a single substrate.");
+  }
+}
+
+async function ensureSymlink(linkPath: string, targetPath: string): Promise<"linked" | "unchanged" | "replaced"> {
+  const target = resolve(targetPath);
+  await mkdir(dirname(linkPath), { recursive: true });
+
+  let existed = false;
+  try {
+    const stat = await lstat(linkPath);
+    existed = true;
+    if (stat.isSymbolicLink()) {
+      const current = await readlink(linkPath);
+      if (resolve(dirname(linkPath), current) === target) return "unchanged";
+    }
+    // Our skill name, our slot: a stale symlink or a hand-made copy is replaced.
+    // Reconciliation is scoped to this single path — unrelated skills untouched.
+    await rm(linkPath, { recursive: true, force: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  await symlink(target, linkPath);
+  return existed ? "replaced" : "linked";
+}
+
+/**
+ * Find the catalog file (SKILLS.md) within a substrate bundle without hard-coding
+ * its per-substrate path: it is the file whose content equals `renderSkills(input)`.
+ */
+function findCatalogFile(
+  substrate: InstallSubstrate,
+  input: ProjectionInput,
+  options: SomaHomeProjectionOptions,
+): { path: string; content: string } | undefined {
+  const expected = renderSkills(input);
+  const bundle = projectionBuilders[substrate](input, options).bundle;
+  return bundle.files.find((file) => file.content === expected);
+}
+
+export async function projectSkill(options: ProjectSkillOptions): Promise<SkillProjectionResult> {
+  assertSingleSubstrateForHome(options);
+  const skillDir = resolve(options.skillDir);
+  const name = await readSkillName(skillDir);
+  const somaHome = resolveSomaHome(options);
+
+  const links: SkillLink[] = [];
+
+  // 1. Registry symlink in the soma home — the scan source the catalog reads.
+  //    Skipped when the source already lives under the registry (authored in place).
+  const registryDir = registrySkillsDir(somaHome);
+  const registryDest = join(registryDir, name);
+  const sourceAlreadyInRegistry = dirname(skillDir) === resolve(registryDir);
+  if (!sourceAlreadyInRegistry) {
+    const status = await ensureSymlink(registryDest, skillDir);
+    links.push({ scope: "registry", path: registryDest, target: skillDir, status });
+  }
+
+  // 2. Loader symlink in each substrate.
+  for (const substrate of options.substrates) {
+    const substrateHome = resolveSubstrateHome(substrate, options);
+    const dest = join(substrateSkillsRoot(substrate, substrateHome), name);
+    const status = await ensureSymlink(dest, skillDir);
+    links.push({ scope: "substrate", substrate, path: dest, target: skillDir, status });
+  }
+
+  // 3. Refresh the catalog per substrate — reload so the registry scan now
+  //    includes the new skill, then rewrite only the SKILLS.md file.
+  const input = await loadSomaHome(somaHome);
+  const catalogFiles: { substrate: InstallSubstrate; path: string }[] = [];
+  for (const substrate of options.substrates) {
+    const substrateHome = resolveSubstrateHome(substrate, options);
+    const projectionOptions: SomaHomeProjectionOptions = { homeDir: options.homeDir, somaHome, substrateHome };
+    const catalog = findCatalogFile(substrate, input, projectionOptions);
+    if (!catalog) continue;
+    const written = await writeProjection({ substrate, instructions: "", files: [catalog] }, substrateHome);
+    catalogFiles.push({ substrate, path: written.files[0] ?? join(substrateHome, catalog.path) });
+  }
+
+  return { skill: name, skillDir, links, catalogFiles };
+}
+
+export async function planProjectSkill(options: ProjectSkillOptions): Promise<SkillProjectionPlan> {
+  assertSingleSubstrateForHome(options);
+  const skillDir = resolve(options.skillDir);
+  const name = await readSkillName(skillDir);
+  const somaHome = resolveSomaHome(options);
+
+  const links: SkillProjectionPlan["links"] = [];
+  const registryDir = registrySkillsDir(somaHome);
+  if (dirname(skillDir) !== resolve(registryDir)) {
+    links.push({ scope: "registry", path: join(registryDir, name), target: skillDir });
+  }
+  for (const substrate of options.substrates) {
+    const substrateHome = resolveSubstrateHome(substrate, options);
+    links.push({
+      scope: "substrate",
+      substrate,
+      path: join(substrateSkillsRoot(substrate, substrateHome), name),
+      target: skillDir,
+    });
+  }
+
+  return { skill: name, skillDir, links, catalogRefresh: [...options.substrates] };
+}
+
+export async function unprojectSkill(options: UnprojectSkillOptions): Promise<SkillProjectionResult> {
+  assertSingleSubstrateForHome(options);
+  const somaHome = resolveSomaHome(options);
+
+  // Resolve the skill name: from a source dir if the arg is one, else verbatim.
+  let name = options.skill;
+  let skillDir = "";
+  const candidate = resolve(options.skill);
+  try {
+    const stat = await lstat(candidate);
+    if (stat.isDirectory()) {
+      name = await readSkillName(candidate);
+      skillDir = candidate;
+    }
+  } catch {
+    // Not a path — treat as a bare skill name.
+  }
+  assertSafeSkillName(name);
+
+  const links: SkillLink[] = [];
+
+  // 1. Remove each substrate loader link.
+  for (const substrate of options.substrates) {
+    const substrateHome = resolveSubstrateHome(substrate, options);
+    const dest = join(substrateSkillsRoot(substrate, substrateHome), name);
+    const status = await removeLink(dest);
+    links.push({ scope: "substrate", substrate, path: dest, status });
+  }
+
+  // 2. Remove the registry symlink — only if it IS a symlink Soma created.
+  //    An authored real dir (source of truth) is left intact.
+  const registryDest = join(registrySkillsDir(somaHome), name);
+  let registryRemoved = false;
+  try {
+    const stat = await lstat(registryDest);
+    if (stat.isSymbolicLink()) {
+      await rm(registryDest, { force: true });
+      registryRemoved = true;
+      links.push({ scope: "registry", path: registryDest, status: "removed" });
+    } else {
+      links.push({ scope: "registry", path: registryDest, status: "absent" });
+    }
+  } catch {
+    links.push({ scope: "registry", path: registryDest, status: "absent" });
+  }
+
+  // 3. Refresh the catalog — drops the skill only if the registry no longer has it.
+  const input = await loadSomaHome(somaHome);
+  const catalogFiles: { substrate: InstallSubstrate; path: string }[] = [];
+  for (const substrate of options.substrates) {
+    const substrateHome = resolveSubstrateHome(substrate, options);
+    const projectionOptions: SomaHomeProjectionOptions = { homeDir: options.homeDir, somaHome, substrateHome };
+    const catalog = findCatalogFile(substrate, input, projectionOptions);
+    if (!catalog) continue;
+    const written = await writeProjection({ substrate, instructions: "", files: [catalog] }, substrateHome);
+    catalogFiles.push({ substrate, path: written.files[0] ?? join(substrateHome, catalog.path) });
+  }
+
+  return { skill: name, skillDir, links, catalogFiles, registryRemoved };
+}
+
+async function removeLink(linkPath: string): Promise<"removed" | "absent"> {
+  try {
+    await lstat(linkPath);
+  } catch {
+    return "absent";
+  }
+  await rm(linkPath, { recursive: true, force: true });
+  return "removed";
+}

--- a/src/skill-projection.ts
+++ b/src/skill-projection.ts
@@ -20,9 +20,10 @@ import type { ProjectionInput, SomaHomeProjection, SomaHomeProjectionOptions } f
  *
  * Materialises an invocable skill directory into one or more substrate skill
  * loaders (e.g. `~/.claude/skills/<Name>`) and refreshes the Soma skill catalog
- * (`rules/soma/SKILLS.md`) so the skill is both loadable AND listed. The unit
- * `soma install --skills`, and arc, both delegate to this — soma stays the
- * single projection truth (ADR 0002).
+ * (`rules/soma/SKILLS.md`) so the skill is both loadable AND listed. This is the
+ * primitive `soma install --skills` and arc will delegate to in later #354 /
+ * arc#251 slices, so soma can be the single projection truth (ADR 0002); this
+ * slice ships the primitive only and does not yet wire those callers.
  *
  * Skills are linked, not copied: `~/.soma/skills/<Name>` (the registry the
  * catalog scans) and each substrate loader point at the source dir, so edits to
@@ -71,7 +72,7 @@ export interface UnprojectSkillOptions {
   force?: boolean;
 }
 
-export type SkillLinkStatus = "linked" | "unchanged" | "replaced" | "removed" | "absent";
+export type SkillLinkStatus = "linked" | "unchanged" | "replaced" | "removed" | "absent" | "preserved";
 
 export interface SkillLink {
   scope: "registry" | "substrate";
@@ -111,6 +112,26 @@ function registrySkillsDir(somaHome: string): string {
 /** Per-substrate invocable skill loader root (parent of the VSA skill dir). */
 function substrateSkillsRoot(substrate: InstallSubstrate, substrateHome: string): string {
   return dirname(installSpecFor(substrate).vsaSkillProjection.destinationDir(substrateHome));
+}
+
+/**
+ * The filesystem slots a skill occupies: the soma registry entry and one loader
+ * entry per substrate. Single source of these paths so plan and apply can never
+ * drift on how a loader root or registry slot is computed.
+ */
+function skillSlots(
+  name: string,
+  somaHome: string,
+  substrates: InstallSubstrate[],
+  options: { homeDir?: string; substrateHome?: string },
+): { registry: string; substrates: { substrate: InstallSubstrate; path: string }[] } {
+  return {
+    registry: join(registrySkillsDir(somaHome), name),
+    substrates: substrates.map((substrate) => ({
+      substrate,
+      path: join(substrateSkillsRoot(substrate, resolveSubstrateHome(substrate, options)), name),
+    })),
+  };
 }
 
 function resolveSubstrateHome(
@@ -204,24 +225,22 @@ export async function projectSkill(options: ProjectSkillOptions): Promise<SkillP
   const name = await readSkillName(skillDir);
   const somaHome = resolveSomaHome(options);
 
+  const force = options.force ?? false;
+  const slots = skillSlots(name, somaHome, options.substrates, options);
   const links: SkillLink[] = [];
 
   // 1. Registry symlink in the soma home — the scan source the catalog reads.
   //    Skipped when the source already lives under the registry (authored in place).
-  const registryDir = registrySkillsDir(somaHome);
-  const registryDest = join(registryDir, name);
-  const sourceAlreadyInRegistry = dirname(skillDir) === resolve(registryDir);
+  const sourceAlreadyInRegistry = dirname(skillDir) === resolve(registrySkillsDir(somaHome));
   if (!sourceAlreadyInRegistry) {
-    const status = await ensureSymlink(registryDest, skillDir, options.force ?? false);
-    links.push({ scope: "registry", path: registryDest, target: skillDir, status });
+    const status = await ensureSymlink(slots.registry, skillDir, force);
+    links.push({ scope: "registry", path: slots.registry, target: skillDir, status });
   }
 
   // 2. Loader symlink in each substrate.
-  for (const substrate of options.substrates) {
-    const substrateHome = resolveSubstrateHome(substrate, options);
-    const dest = join(substrateSkillsRoot(substrate, substrateHome), name);
-    const status = await ensureSymlink(dest, skillDir, options.force ?? false);
-    links.push({ scope: "substrate", substrate, path: dest, target: skillDir, status });
+  for (const { substrate, path } of slots.substrates) {
+    const status = await ensureSymlink(path, skillDir, force);
+    links.push({ scope: "substrate", substrate, path, target: skillDir, status });
   }
 
   // 3. Refresh the catalog per substrate — reload so the registry scan reflects
@@ -266,19 +285,13 @@ export async function planProjectSkill(options: ProjectSkillOptions): Promise<Sk
   const name = await readSkillName(skillDir);
   const somaHome = resolveSomaHome(options);
 
+  const slots = skillSlots(name, somaHome, options.substrates, options);
   const links: SkillProjectionPlan["links"] = [];
-  const registryDir = registrySkillsDir(somaHome);
-  if (dirname(skillDir) !== resolve(registryDir)) {
-    links.push({ scope: "registry", path: join(registryDir, name), target: skillDir });
+  if (dirname(skillDir) !== resolve(registrySkillsDir(somaHome))) {
+    links.push({ scope: "registry", path: slots.registry, target: skillDir });
   }
-  for (const substrate of options.substrates) {
-    const substrateHome = resolveSubstrateHome(substrate, options);
-    links.push({
-      scope: "substrate",
-      substrate,
-      path: join(substrateSkillsRoot(substrate, substrateHome), name),
-      target: skillDir,
-    });
+  for (const { substrate, path } of slots.substrates) {
+    links.push({ scope: "substrate", substrate, path, target: skillDir });
   }
 
   return { skill: name, skillDir, links, catalogRefresh: [...options.substrates] };
@@ -315,15 +328,31 @@ export async function planUnprojectSkill(options: UnprojectSkillOptions): Promis
   assertSingleSubstrateForHome(options);
   const somaHome = resolveSomaHome(options);
   const { name, skillDir } = await resolveSkillArg(options.skill);
+  const force = options.force ?? false;
+  const slots = skillSlots(name, somaHome, options.substrates, options);
 
   const links: SkillProjectionPlan["links"] = [];
-  for (const substrate of options.substrates) {
-    const substrateHome = resolveSubstrateHome(substrate, options);
-    links.push({ scope: "substrate", substrate, path: join(substrateSkillsRoot(substrate, substrateHome), name), target: "" });
+  for (const { substrate, path } of slots.substrates) {
+    links.push({ scope: "substrate", substrate, path, target: "" });
   }
-  links.push({ scope: "registry", path: join(registrySkillsDir(somaHome), name), target: "" });
+  // List the registry only when it would actually be removed — a symlink Soma
+  // owns, or (with --force) a real dir. An authored real dir left intact must
+  // not appear as a removal.
+  if (await registryWouldBeRemoved(slots.registry, force)) {
+    links.push({ scope: "registry", path: slots.registry, target: "" });
+  }
 
   return { skill: name, skillDir, links, catalogRefresh: [...options.substrates] };
+}
+
+/** True when unproject would remove the registry entry: a symlink, or a real dir under --force. */
+async function registryWouldBeRemoved(registryDest: string, force: boolean): Promise<boolean> {
+  try {
+    const entry = await lstat(registryDest);
+    return entry.isSymbolicLink() || force;
+  } catch {
+    return false;
+  }
 }
 
 export async function unprojectSkill(options: UnprojectSkillOptions): Promise<SkillProjectionResult> {
@@ -332,31 +361,29 @@ export async function unprojectSkill(options: UnprojectSkillOptions): Promise<Sk
   const { name, skillDir } = await resolveSkillArg(options.skill);
 
   const force = options.force ?? false;
+  const slots = skillSlots(name, somaHome, options.substrates, options);
   const links: SkillLink[] = [];
 
   // 1. Remove each substrate loader link.
-  for (const substrate of options.substrates) {
-    const substrateHome = resolveSubstrateHome(substrate, options);
-    const dest = join(substrateSkillsRoot(substrate, substrateHome), name);
-    const status = await removeLink(dest, force);
-    links.push({ scope: "substrate", substrate, path: dest, status });
+  for (const { substrate, path } of slots.substrates) {
+    const status = await removeLink(path, force);
+    links.push({ scope: "substrate", substrate, path, status });
   }
 
-  // 2. Remove the registry symlink — only if it IS a symlink Soma created.
-  //    An authored real dir (source of truth) is left intact.
-  const registryDest = join(registrySkillsDir(somaHome), name);
+  // 2. Remove the registry entry — a symlink Soma created always; a real
+  //    authored dir (source of truth) only under --force, else preserved.
   let registryRemoved = false;
   try {
-    const entry = await lstat(registryDest);
-    if (entry.isSymbolicLink()) {
-      await rm(registryDest, { force: true });
+    const entry = await lstat(slots.registry);
+    if (entry.isSymbolicLink() || force) {
+      await rm(slots.registry, { recursive: true, force: true });
       registryRemoved = true;
-      links.push({ scope: "registry", path: registryDest, status: "removed" });
+      links.push({ scope: "registry", path: slots.registry, status: "removed" });
     } else {
-      links.push({ scope: "registry", path: registryDest, status: "absent" });
+      links.push({ scope: "registry", path: slots.registry, status: "preserved" });
     }
   } catch {
-    links.push({ scope: "registry", path: registryDest, status: "absent" });
+    links.push({ scope: "registry", path: slots.registry, status: "absent" });
   }
 
   // 3. Refresh the catalog — drops the skill only if the registry no longer has it.

--- a/src/skill-projection.ts
+++ b/src/skill-projection.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, readFile, readlink, rm, symlink } from "node:fs/promises";
+import { lstat, mkdir, readFile, readlink, rm, stat, symlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { renderSkills } from "./adapters/shared";
@@ -224,11 +224,26 @@ export async function projectSkill(options: ProjectSkillOptions): Promise<SkillP
     links.push({ scope: "substrate", substrate, path: dest, target: skillDir, status });
   }
 
-  // 3. Refresh the catalog per substrate — reload so the registry scan now
-  //    includes the new skill, then rewrite only the SKILLS.md file.
+  // 3. Refresh the catalog per substrate — reload so the registry scan reflects
+  //    the new skill, then rewrite only the SKILLS.md file.
+  const catalogFiles = await refreshSkillCatalogs(somaHome, options.substrates, options);
+
+  return { skill: name, skillDir, links, catalogFiles };
+}
+
+/**
+ * Reload the soma home (so the registry scan reflects the current skill set) and
+ * rewrite each substrate's SKILLS.md catalog in place. Shared by project and
+ * unproject — a catalog-format change has a single site to track.
+ */
+async function refreshSkillCatalogs(
+  somaHome: string,
+  substrates: InstallSubstrate[],
+  options: { homeDir?: string; substrateHome?: string },
+): Promise<{ substrate: InstallSubstrate; path: string }[]> {
   const input = await loadSomaHome(somaHome);
   const catalogFiles: { substrate: InstallSubstrate; path: string }[] = [];
-  for (const substrate of options.substrates) {
+  for (const substrate of substrates) {
     const substrateHome = resolveSubstrateHome(substrate, options);
     const projectionOptions: SomaHomeProjectionOptions = { homeDir: options.homeDir, somaHome, substrateHome };
     const catalog = findCatalogFile(substrate, input, projectionOptions);
@@ -242,8 +257,7 @@ export async function projectSkill(options: ProjectSkillOptions): Promise<SkillP
     const written = await writeProjection({ substrate, instructions: "", files: [catalog] }, substrateHome);
     catalogFiles.push({ substrate, path: written.files[0] ?? join(substrateHome, catalog.path) });
   }
-
-  return { skill: name, skillDir, links, catalogFiles };
+  return catalogFiles;
 }
 
 export async function planProjectSkill(options: ProjectSkillOptions): Promise<SkillProjectionPlan> {
@@ -270,22 +284,22 @@ export async function planProjectSkill(options: ProjectSkillOptions): Promise<Sk
   return { skill: name, skillDir, links, catalogRefresh: [...options.substrates] };
 }
 
-export async function unprojectSkill(options: UnprojectSkillOptions): Promise<SkillProjectionResult> {
-  assertSingleSubstrateForHome(options);
-  const somaHome = resolveSomaHome(options);
-
-  // Resolve the skill name. Only probe the filesystem when the arg looks
-  // path-like — otherwise a bare name like "MyTool" run from a dir that happens
-  // to contain a "MyTool/" subdir would be misread as that local dir.
-  let name = options.skill;
+/**
+ * Resolve an unproject arg to a skill name. Only probe the filesystem when the
+ * arg looks path-like — otherwise a bare name like "MyTool" run from a dir that
+ * happens to contain a "MyTool/" subdir would be misread as that local dir. Uses
+ * `stat` (not `lstat`) so a registry symlink-to-dir resolves to a skill name
+ * rather than falling through to a slash-bearing path.
+ */
+async function resolveSkillArg(arg: string): Promise<{ name: string; skillDir: string }> {
+  let name = arg;
   let skillDir = "";
-  const looksLikePath =
-    options.skill.includes("/") || options.skill.includes("\\") || options.skill.startsWith(".") || isAbsolute(options.skill);
+  const looksLikePath = arg.includes("/") || arg.includes("\\") || arg.startsWith(".") || isAbsolute(arg);
   if (looksLikePath) {
-    const candidate = resolve(options.skill);
+    const candidate = resolve(arg);
     try {
-      const stat = await lstat(candidate);
-      if (stat.isDirectory()) {
+      const st = await stat(candidate);
+      if (st.isDirectory()) {
         name = await readSkillName(candidate);
         skillDir = candidate;
       }
@@ -294,6 +308,28 @@ export async function unprojectSkill(options: UnprojectSkillOptions): Promise<Sk
     }
   }
   assertSafeSkillName(name);
+  return { name, skillDir };
+}
+
+export async function planUnprojectSkill(options: UnprojectSkillOptions): Promise<SkillProjectionPlan> {
+  assertSingleSubstrateForHome(options);
+  const somaHome = resolveSomaHome(options);
+  const { name, skillDir } = await resolveSkillArg(options.skill);
+
+  const links: SkillProjectionPlan["links"] = [];
+  for (const substrate of options.substrates) {
+    const substrateHome = resolveSubstrateHome(substrate, options);
+    links.push({ scope: "substrate", substrate, path: join(substrateSkillsRoot(substrate, substrateHome), name), target: "" });
+  }
+  links.push({ scope: "registry", path: join(registrySkillsDir(somaHome), name), target: "" });
+
+  return { skill: name, skillDir, links, catalogRefresh: [...options.substrates] };
+}
+
+export async function unprojectSkill(options: UnprojectSkillOptions): Promise<SkillProjectionResult> {
+  assertSingleSubstrateForHome(options);
+  const somaHome = resolveSomaHome(options);
+  const { name, skillDir } = await resolveSkillArg(options.skill);
 
   const force = options.force ?? false;
   const links: SkillLink[] = [];
@@ -311,8 +347,8 @@ export async function unprojectSkill(options: UnprojectSkillOptions): Promise<Sk
   const registryDest = join(registrySkillsDir(somaHome), name);
   let registryRemoved = false;
   try {
-    const stat = await lstat(registryDest);
-    if (stat.isSymbolicLink()) {
+    const entry = await lstat(registryDest);
+    if (entry.isSymbolicLink()) {
       await rm(registryDest, { force: true });
       registryRemoved = true;
       links.push({ scope: "registry", path: registryDest, status: "removed" });
@@ -324,22 +360,7 @@ export async function unprojectSkill(options: UnprojectSkillOptions): Promise<Sk
   }
 
   // 3. Refresh the catalog — drops the skill only if the registry no longer has it.
-  const input = await loadSomaHome(somaHome);
-  const catalogFiles: { substrate: InstallSubstrate; path: string }[] = [];
-  for (const substrate of options.substrates) {
-    const substrateHome = resolveSubstrateHome(substrate, options);
-    const projectionOptions: SomaHomeProjectionOptions = { homeDir: options.homeDir, somaHome, substrateHome };
-    const catalog = findCatalogFile(substrate, input, projectionOptions);
-    if (!catalog) {
-      // Every adapter emits a file byte-equal to renderSkills(input), so a miss
-      // means the projection format drifted — surface it rather than silently
-      // skipping the catalog refresh.
-      process.stderr.write(`Warning: no SKILLS catalog file found for substrate ${substrate}; catalog not refreshed.\n`);
-      continue;
-    }
-    const written = await writeProjection({ substrate, instructions: "", files: [catalog] }, substrateHome);
-    catalogFiles.push({ substrate, path: written.files[0] ?? join(substrateHome, catalog.path) });
-  }
+  const catalogFiles = await refreshSkillCatalogs(somaHome, options.substrates, options);
 
   return { skill: name, skillDir, links, catalogFiles, registryRemoved };
 }

--- a/src/skill-projection.ts
+++ b/src/skill-projection.ts
@@ -27,9 +27,12 @@ import type { ProjectionInput, SomaHomeProjection, SomaHomeProjectionOptions } f
  *
  * Skills are linked, not copied: `~/.soma/skills/<Name>` (the registry the
  * catalog scans) and each substrate loader point at the source dir, so edits to
- * the source propagate with no re-sync. Reconciliation is scoped to the skill's
- * own name — a pre-existing copy at that name (e.g. the hand-made VSA/Interview
- * dirs) is replaced; unrelated user skills are never touched.
+ * the source propagate with no re-sync. Reconciliation is scoped to the single
+ * `<name>` slot: a differently-named skill is never touched. At that exact name,
+ * an existing symlink is replaced unconditionally (a link loses no data), while a
+ * real directory — a hand-made copy or a same-named user skill — is preserved
+ * unless `force` is set. So a same-named user *symlink* is replaced; only a
+ * same-named real *directory* is protected without `force`.
  */
 
 const projectionBuilders: Record<

--- a/src/skill-projection.ts
+++ b/src/skill-projection.ts
@@ -185,7 +185,11 @@ async function ensureSymlink(
     if (stat.isSymbolicLink()) {
       const current = await readlink(linkPath);
       if (resolve(dirname(linkPath), current) === target) return "unchanged";
-      // A symlink in the slot is Soma-owned (or a prior link) — replace freely.
+      // Any symlink in the slot is replaced without a provenance check — including
+      // a user-created one pointing elsewhere. This is intentional: project-skill
+      // owns the `<skillsRoot>/<name>` slot, and replacing a link loses no data
+      // (its target dir is untouched). Real directories ARE the data-loss risk and
+      // are guarded below by `force`.
     } else if (!force) {
       // A real dir/file we did not create: a hand-authored skill, or a same-named
       // user skill. Refuse to delete it silently — that is the data-loss path.

--- a/src/skill-projection.ts
+++ b/src/skill-projection.ts
@@ -1,6 +1,6 @@
 import { lstat, mkdir, readFile, readlink, rm, symlink } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { renderSkills } from "./adapters/shared";
 import {
   buildClaudeCodeHomeProjection,
@@ -51,6 +51,13 @@ export interface ProjectSkillOptions {
   somaHome?: string;
   /** Only valid with a single substrate. */
   substrateHome?: string;
+  /**
+   * Replace a real (non-symlink) directory occupying the skill's slot. Off by
+   * default: a symlink Soma owns is always replaced, but a real dir we did not
+   * create (a hand-authored skill, or a same-named user skill) is left intact
+   * unless this is set — guarding against silent data loss on name collision.
+   */
+  force?: boolean;
 }
 
 export interface UnprojectSkillOptions {
@@ -60,6 +67,8 @@ export interface UnprojectSkillOptions {
   homeDir?: string;
   somaHome?: string;
   substrateHome?: string;
+  /** Remove a real (non-symlink) directory at the slot; off by default. */
+  force?: boolean;
 }
 
 export type SkillLinkStatus = "linked" | "unchanged" | "replaced" | "removed" | "absent";
@@ -140,7 +149,11 @@ function assertSingleSubstrateForHome(options: { substrates: InstallSubstrate[];
   }
 }
 
-async function ensureSymlink(linkPath: string, targetPath: string): Promise<"linked" | "unchanged" | "replaced"> {
+async function ensureSymlink(
+  linkPath: string,
+  targetPath: string,
+  force: boolean,
+): Promise<"linked" | "unchanged" | "replaced"> {
   const target = resolve(targetPath);
   await mkdir(dirname(linkPath), { recursive: true });
 
@@ -151,11 +164,19 @@ async function ensureSymlink(linkPath: string, targetPath: string): Promise<"lin
     if (stat.isSymbolicLink()) {
       const current = await readlink(linkPath);
       if (resolve(dirname(linkPath), current) === target) return "unchanged";
+      // A symlink in the slot is Soma-owned (or a prior link) — replace freely.
+    } else if (!force) {
+      // A real dir/file we did not create: a hand-authored skill, or a same-named
+      // user skill. Refuse to delete it silently — that is the data-loss path.
+      throw new SkillProjectionError(
+        `Refusing to replace non-symlink path at ${linkPath} (not a Soma-created symlink). ` +
+          `Pass force to overwrite it.`,
+      );
     }
-    // Our skill name, our slot: a stale symlink or a hand-made copy is replaced.
-    // Reconciliation is scoped to this single path — unrelated skills untouched.
+    // Scoped to this single named path — unrelated skills are never touched.
     await rm(linkPath, { recursive: true, force: true });
   } catch (error) {
+    if (error instanceof SkillProjectionError) throw error;
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
 
@@ -191,7 +212,7 @@ export async function projectSkill(options: ProjectSkillOptions): Promise<SkillP
   const registryDest = join(registryDir, name);
   const sourceAlreadyInRegistry = dirname(skillDir) === resolve(registryDir);
   if (!sourceAlreadyInRegistry) {
-    const status = await ensureSymlink(registryDest, skillDir);
+    const status = await ensureSymlink(registryDest, skillDir, options.force ?? false);
     links.push({ scope: "registry", path: registryDest, target: skillDir, status });
   }
 
@@ -199,7 +220,7 @@ export async function projectSkill(options: ProjectSkillOptions): Promise<SkillP
   for (const substrate of options.substrates) {
     const substrateHome = resolveSubstrateHome(substrate, options);
     const dest = join(substrateSkillsRoot(substrate, substrateHome), name);
-    const status = await ensureSymlink(dest, skillDir);
+    const status = await ensureSymlink(dest, skillDir, options.force ?? false);
     links.push({ scope: "substrate", substrate, path: dest, target: skillDir, status });
   }
 
@@ -211,7 +232,13 @@ export async function projectSkill(options: ProjectSkillOptions): Promise<SkillP
     const substrateHome = resolveSubstrateHome(substrate, options);
     const projectionOptions: SomaHomeProjectionOptions = { homeDir: options.homeDir, somaHome, substrateHome };
     const catalog = findCatalogFile(substrate, input, projectionOptions);
-    if (!catalog) continue;
+    if (!catalog) {
+      // Every adapter emits a file byte-equal to renderSkills(input), so a miss
+      // means the projection format drifted — surface it rather than silently
+      // skipping the catalog refresh.
+      process.stderr.write(`Warning: no SKILLS catalog file found for substrate ${substrate}; catalog not refreshed.\n`);
+      continue;
+    }
     const written = await writeProjection({ substrate, instructions: "", files: [catalog] }, substrateHome);
     catalogFiles.push({ substrate, path: written.files[0] ?? join(substrateHome, catalog.path) });
   }
@@ -247,28 +274,35 @@ export async function unprojectSkill(options: UnprojectSkillOptions): Promise<Sk
   assertSingleSubstrateForHome(options);
   const somaHome = resolveSomaHome(options);
 
-  // Resolve the skill name: from a source dir if the arg is one, else verbatim.
+  // Resolve the skill name. Only probe the filesystem when the arg looks
+  // path-like — otherwise a bare name like "MyTool" run from a dir that happens
+  // to contain a "MyTool/" subdir would be misread as that local dir.
   let name = options.skill;
   let skillDir = "";
-  const candidate = resolve(options.skill);
-  try {
-    const stat = await lstat(candidate);
-    if (stat.isDirectory()) {
-      name = await readSkillName(candidate);
-      skillDir = candidate;
+  const looksLikePath =
+    options.skill.includes("/") || options.skill.includes("\\") || options.skill.startsWith(".") || isAbsolute(options.skill);
+  if (looksLikePath) {
+    const candidate = resolve(options.skill);
+    try {
+      const stat = await lstat(candidate);
+      if (stat.isDirectory()) {
+        name = await readSkillName(candidate);
+        skillDir = candidate;
+      }
+    } catch {
+      // Path-like but absent — fall back to treating it as a bare name.
     }
-  } catch {
-    // Not a path — treat as a bare skill name.
   }
   assertSafeSkillName(name);
 
+  const force = options.force ?? false;
   const links: SkillLink[] = [];
 
   // 1. Remove each substrate loader link.
   for (const substrate of options.substrates) {
     const substrateHome = resolveSubstrateHome(substrate, options);
     const dest = join(substrateSkillsRoot(substrate, substrateHome), name);
-    const status = await removeLink(dest);
+    const status = await removeLink(dest, force);
     links.push({ scope: "substrate", substrate, path: dest, status });
   }
 
@@ -296,7 +330,13 @@ export async function unprojectSkill(options: UnprojectSkillOptions): Promise<Sk
     const substrateHome = resolveSubstrateHome(substrate, options);
     const projectionOptions: SomaHomeProjectionOptions = { homeDir: options.homeDir, somaHome, substrateHome };
     const catalog = findCatalogFile(substrate, input, projectionOptions);
-    if (!catalog) continue;
+    if (!catalog) {
+      // Every adapter emits a file byte-equal to renderSkills(input), so a miss
+      // means the projection format drifted — surface it rather than silently
+      // skipping the catalog refresh.
+      process.stderr.write(`Warning: no SKILLS catalog file found for substrate ${substrate}; catalog not refreshed.\n`);
+      continue;
+    }
     const written = await writeProjection({ substrate, instructions: "", files: [catalog] }, substrateHome);
     catalogFiles.push({ substrate, path: written.files[0] ?? join(substrateHome, catalog.path) });
   }
@@ -304,11 +344,18 @@ export async function unprojectSkill(options: UnprojectSkillOptions): Promise<Sk
   return { skill: name, skillDir, links, catalogFiles, registryRemoved };
 }
 
-async function removeLink(linkPath: string): Promise<"removed" | "absent"> {
+async function removeLink(linkPath: string, force: boolean): Promise<"removed" | "absent"> {
+  let stat;
   try {
-    await lstat(linkPath);
+    stat = await lstat(linkPath);
   } catch {
     return "absent";
+  }
+  if (!stat.isSymbolicLink() && !force) {
+    // A real dir we did not create (not our symlink) — don't recurse-delete it.
+    throw new SkillProjectionError(
+      `Refusing to remove non-symlink path at ${linkPath} (not a Soma-created symlink). Pass force to override.`,
+    );
   }
   await rm(linkPath, { recursive: true, force: true });
   return "removed";

--- a/src/soma-home.ts
+++ b/src/soma-home.ts
@@ -158,7 +158,12 @@ async function loadSomaSkills(somaHome: string): Promise<SomaSkill[]> {
   const skills: SomaSkill[] = [];
 
   for (const entry of entries) {
-    if (!entry.isDirectory()) {
+    // A skill may be a real dir OR a symlink to one (soma#354: `project-skill`
+    // registers skills by symlink). `readdir(withFileTypes)` reports a
+    // symlink-to-dir as isSymbolicLink, not isDirectory, so both are admitted;
+    // the SKILL.md read below is the real gate — a symlinked file fails it and
+    // is skipped.
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
       continue;
     }
 

--- a/test/skill-projection.test.ts
+++ b/test/skill-projection.test.ts
@@ -71,15 +71,29 @@ describe("projectSkill", () => {
     });
   });
 
-  test("replaces a pre-existing hand-made copy at the skill's name", async () => {
+  test("refuses to clobber a real (non-symlink) dir in the loader slot without force", async () => {
     await withTempHome(async (homeDir) => {
       const skillDir = await writeSourceSkill(homeDir, "MyTool");
-      // Simulate a hand-made copy (real dir) already sitting in the loader slot.
+      // A user's own real skill dir already sits in the loader slot.
+      const loaderSlot = join(homeDir, ".claude", "skills", "MyTool");
+      await mkdir(loaderSlot, { recursive: true });
+      await writeFile(join(loaderSlot, "SKILL.md"), "user skill\n", "utf8");
+
+      await expect(projectSkill({ skillDir, substrates: ["claude-code"], homeDir })).rejects.toThrow(/non-symlink/);
+      // The user's dir is untouched.
+      expect((await lstat(loaderSlot)).isDirectory()).toBe(true);
+      expect((await lstat(loaderSlot)).isSymbolicLink()).toBe(false);
+    });
+  });
+
+  test("replaces a real dir with force (migrating a hand-made copy)", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
       const loaderSlot = join(homeDir, ".claude", "skills", "MyTool");
       await mkdir(loaderSlot, { recursive: true });
       await writeFile(join(loaderSlot, "SKILL.md"), "stale\n", "utf8");
 
-      const result = await projectSkill({ skillDir, substrates: ["claude-code"], homeDir });
+      const result = await projectSkill({ skillDir, substrates: ["claude-code"], homeDir, force: true });
       const loaderLinkStatus = result.links.find((l) => l.scope === "substrate")?.status;
       expect(loaderLinkStatus).toBe("replaced");
       expect((await lstat(loaderSlot)).isSymbolicLink()).toBe(true);

--- a/test/skill-projection.test.ts
+++ b/test/skill-projection.test.ts
@@ -204,4 +204,25 @@ describe("unprojectSkill", () => {
       expect((await lstat(registryDir)).isDirectory()).toBe(true);
     });
   });
+
+  test("force removes an authored registry dir (and the plan reflects it)", async () => {
+    await withTempHome(async (homeDir) => {
+      const registryDir = join(homeDir, ".soma", "skills", "Authored");
+      await mkdir(registryDir, { recursive: true });
+      await writeFile(join(registryDir, "SKILL.md"), `---\nname: Authored\n---\n`, "utf8");
+      await projectSkill({ skillDir: registryDir, substrates: ["claude-code"], homeDir });
+
+      // Without force the plan must NOT list the registry as a removal.
+      const planNoForce = await planUnprojectSkill({ skill: "Authored", substrates: ["claude-code"], homeDir });
+      expect(planNoForce.links.some((l) => l.scope === "registry")).toBe(false);
+
+      // With force the plan lists it, and apply removes it.
+      const planForce = await planUnprojectSkill({ skill: "Authored", substrates: ["claude-code"], homeDir, force: true });
+      expect(planForce.links.some((l) => l.scope === "registry")).toBe(true);
+
+      const result = await unprojectSkill({ skill: "Authored", substrates: ["claude-code"], homeDir, force: true });
+      expect(result.registryRemoved).toBe(true);
+      await expect(lstat(registryDir)).rejects.toThrow();
+    });
+  });
 });

--- a/test/skill-projection.test.ts
+++ b/test/skill-projection.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+import { lstat, mkdir, mkdtemp, readFile, readlink, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { planProjectSkill, projectSkill, unprojectSkill } from "../src/skill-projection";
+import { bootstrapSomaHome } from "../src/index";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-skill-projection-"));
+  try {
+    // project-skill runs against a real soma home (the catalog refresh reads it).
+    await bootstrapSomaHome({ homeDir });
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+/** Source skill whose dir basename ≠ frontmatter name, to prove name resolution. */
+async function writeSourceSkill(homeDir: string, frontmatterName: string, dirName = "pack-dir"): Promise<string> {
+  const skillDir = join(homeDir, "source", dirName);
+  await mkdir(join(skillDir, "Workflows"), { recursive: true });
+  await writeFile(
+    join(skillDir, "SKILL.md"),
+    `---\nname: ${frontmatterName}\ndescription: "A test skill."\n---\n\n# ${frontmatterName}\n`,
+    "utf8",
+  );
+  await writeFile(join(skillDir, "Workflows", "Run.md"), "# Run\n", "utf8");
+  return skillDir;
+}
+
+async function readlinkAbs(linkPath: string): Promise<string> {
+  const target = await readlink(linkPath);
+  return resolve(linkPath, "..", target);
+}
+
+describe("projectSkill", () => {
+  test("symlinks into the claude-code loader and the soma registry, and lists it in the catalog", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+
+      const result = await projectSkill({ skillDir, substrates: ["claude-code"], homeDir });
+
+      expect(result.skill).toBe("MyTool");
+
+      // Loader symlink — invocable dir keyed by frontmatter name, not "pack-dir".
+      const loaderLink = join(homeDir, ".claude", "skills", "MyTool");
+      expect((await lstat(loaderLink)).isSymbolicLink()).toBe(true);
+      expect(await readlinkAbs(loaderLink)).toBe(resolve(skillDir));
+
+      // Registry symlink in the soma home (the scan source the catalog reads).
+      const registryLink = join(homeDir, ".soma", "skills", "MyTool");
+      expect((await lstat(registryLink)).isSymbolicLink()).toBe(true);
+      expect(await readlinkAbs(registryLink)).toBe(resolve(skillDir));
+
+      // Catalog lists it.
+      const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
+      expect(catalog).toContain("## MyTool");
+    });
+  });
+
+  test("is idempotent — a second projection reports unchanged links", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      await projectSkill({ skillDir, substrates: ["claude-code"], homeDir });
+
+      const second = await projectSkill({ skillDir, substrates: ["claude-code"], homeDir });
+      for (const link of second.links) {
+        expect(link.status).toBe("unchanged");
+      }
+    });
+  });
+
+  test("replaces a pre-existing hand-made copy at the skill's name", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      // Simulate a hand-made copy (real dir) already sitting in the loader slot.
+      const loaderSlot = join(homeDir, ".claude", "skills", "MyTool");
+      await mkdir(loaderSlot, { recursive: true });
+      await writeFile(join(loaderSlot, "SKILL.md"), "stale\n", "utf8");
+
+      const result = await projectSkill({ skillDir, substrates: ["claude-code"], homeDir });
+      const loaderLinkStatus = result.links.find((l) => l.scope === "substrate")?.status;
+      expect(loaderLinkStatus).toBe("replaced");
+      expect((await lstat(loaderSlot)).isSymbolicLink()).toBe(true);
+    });
+  });
+
+  test("projects into multiple substrates", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      await projectSkill({ skillDir, substrates: ["claude-code", "codex"], homeDir });
+
+      expect((await lstat(join(homeDir, ".claude", "skills", "MyTool"))).isSymbolicLink()).toBe(true);
+      expect((await lstat(join(homeDir, ".codex", "skills", "MyTool"))).isSymbolicLink()).toBe(true);
+    });
+  });
+
+  test("rejects --substrate-home with more than one substrate", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      await expect(
+        projectSkill({ skillDir, substrates: ["claude-code", "codex"], homeDir, substrateHome: join(homeDir, "x") }),
+      ).rejects.toThrow(/single substrate/);
+    });
+  });
+});
+
+describe("planProjectSkill", () => {
+  test("reports intended links without writing anything", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      const plan = await planProjectSkill({ skillDir, substrates: ["claude-code"], homeDir });
+
+      expect(plan.skill).toBe("MyTool");
+      expect(plan.links.some((l) => l.scope === "registry")).toBe(true);
+      expect(plan.links.some((l) => l.scope === "substrate")).toBe(true);
+
+      // Nothing was written.
+      await expect(lstat(join(homeDir, ".claude", "skills", "MyTool"))).rejects.toThrow();
+      await expect(lstat(join(homeDir, ".soma", "skills", "MyTool"))).rejects.toThrow();
+    });
+  });
+});
+
+describe("unprojectSkill", () => {
+  test("removes the loader + registry symlinks and drops the skill from the catalog", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      await projectSkill({ skillDir, substrates: ["claude-code"], homeDir });
+
+      const result = await unprojectSkill({ skill: "MyTool", substrates: ["claude-code"], homeDir });
+      expect(result.registryRemoved).toBe(true);
+
+      await expect(lstat(join(homeDir, ".claude", "skills", "MyTool"))).rejects.toThrow();
+      await expect(lstat(join(homeDir, ".soma", "skills", "MyTool"))).rejects.toThrow();
+
+      const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
+      expect(catalog).not.toContain("## MyTool");
+    });
+  });
+
+  test("leaves an authored registry dir intact (only removes the substrate projection)", async () => {
+    await withTempHome(async (homeDir) => {
+      // Author the skill directly in the registry (Purpose-style), not via a symlink.
+      const registryDir = join(homeDir, ".soma", "skills", "Authored");
+      await mkdir(registryDir, { recursive: true });
+      await writeFile(
+        join(registryDir, "SKILL.md"),
+        `---\nname: Authored\ndescription: "Authored in place."\n---\n`,
+        "utf8",
+      );
+      await projectSkill({ skillDir: registryDir, substrates: ["claude-code"], homeDir });
+      expect((await lstat(join(homeDir, ".claude", "skills", "Authored"))).isSymbolicLink()).toBe(true);
+
+      const result = await unprojectSkill({ skill: "Authored", substrates: ["claude-code"], homeDir });
+      expect(result.registryRemoved).toBe(false);
+
+      // Loader projection gone; authored registry dir preserved.
+      await expect(lstat(join(homeDir, ".claude", "skills", "Authored"))).rejects.toThrow();
+      expect((await lstat(registryDir)).isDirectory()).toBe(true);
+    });
+  });
+});

--- a/test/skill-projection.test.ts
+++ b/test/skill-projection.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { lstat, mkdir, mkdtemp, readFile, readlink, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { planProjectSkill, projectSkill, unprojectSkill } from "../src/skill-projection";
+import { planProjectSkill, planUnprojectSkill, projectSkill, unprojectSkill } from "../src/skill-projection";
 import { bootstrapSomaHome } from "../src/index";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
@@ -151,6 +151,35 @@ describe("unprojectSkill", () => {
 
       const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
       expect(catalog).not.toContain("## MyTool");
+    });
+  });
+
+  test("resolves a registry symlink path to its skill name (stat follows the link)", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      await projectSkill({ skillDir, substrates: ["claude-code"], homeDir });
+      const registryLink = join(homeDir, ".soma", "skills", "MyTool");
+
+      // Unproject by the registry SYMLINK path — must resolve to "MyTool",
+      // not fall through to a slash-bearing name.
+      const result = await unprojectSkill({ skill: registryLink, substrates: ["claude-code"], homeDir });
+      expect(result.skill).toBe("MyTool");
+      await expect(lstat(join(homeDir, ".claude", "skills", "MyTool"))).rejects.toThrow();
+    });
+  });
+
+  test("planUnprojectSkill lists removals without touching the filesystem", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      await projectSkill({ skillDir, substrates: ["claude-code"], homeDir });
+
+      const plan = await planUnprojectSkill({ skill: "MyTool", substrates: ["claude-code"], homeDir });
+      expect(plan.skill).toBe("MyTool");
+      expect(plan.links.some((l) => l.scope === "registry")).toBe(true);
+
+      // Still present — plan wrote nothing.
+      expect((await lstat(join(homeDir, ".claude", "skills", "MyTool"))).isSymbolicLink()).toBe(true);
+      expect((await lstat(join(homeDir, ".soma", "skills", "MyTool"))).isSymbolicLink()).toBe(true);
     });
   });
 


### PR DESCRIPTION
Slice 1 of #354 (per ADR 0002). Adds a standalone, idempotent, multi-substrate projection primitive (CLI + lib): `soma project-skill` / `unproject-skill`.

**Scope of THIS PR:** the primitive itself + its CLI wiring (`src/skill-projection.ts`, `src/cli/skill-projection-cli.ts`, `cli.ts`) and the `loadSomaSkills` symlink-scanner fix. It does **not** yet wire `soma install --skills` or arc — those are later #354 / arc#251 slices that will *call* this primitive. The ADR's "single projection truth" is the design intent the primitive enables, not a claim that existing install paths route through it today.

## What lands
- `projectSkill` / `unprojectSkill` / `planProjectSkill` / `planUnprojectSkill`. Links (not copies) source → `~/.soma/skills/<Name>` (registry the catalog scans) + each substrate loader, then refreshes only the `SKILLS.md` catalog file (content-match, no per-substrate path hardcoding). Identity = frontmatter `name`.
- Both verbs default to **dry-run**; `--apply` to execute. `--force` to replace a real (non-symlink) dir occupying a slot (otherwise refused — guards user skills from clobber).
- `src/soma-home.ts`: `loadSomaSkills` admits a symlink-to-dir (latent bug — symlinked skills were silently skipped).

## Review history
Self-review + sage review (changes-requested) addressed:
- **blocker** unproject ignored `--dry-run` → now gated on `--apply` (+ `planUnprojectSkill`).
- **major** symlink-dir arg rejected → `stat` (follows links) for name resolution.
- **major** provenance: refuse to clobber a non-symlink dir without `--force`.
- **major** PR-description delegation claim → corrected (this paragraph).
- **suggestions** dedup catalog-refresh loop; split parser apply state.
- **deferred** → #356: move loader projection behind an adapter/install-spec method (boundary cleanup).

## Verification
typecheck PASS · lint clean · 11 unit tests · full suite **1492/0** · e2e: dry-run/apply/force/unproject all confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)