### PR TITLE
feat(install): soma install --skills selector (#354 slice 2)

### DIFF
--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -293,7 +293,9 @@ function parseSkillNames(csv: string): string[] {
   const names = csv.split(",").map((part) => part.trim()).filter((part) => part.length > 0);
   if (names.length === 0) throw new Error("--skills requires at least one skill name.");
   for (const name of names) {
-    if (name.includes("/") || name.includes("\\") || name === "." || name === "..") {
+    // Reject any separator or dot-segment anywhere — the slot is derived as
+    // `~/.soma/skills/<name>`, so a name is a single path segment, never a path.
+    if (name.includes("/") || name.includes("\\") || name.includes("..") || name === ".") {
       throw new Error(`--skills takes skill names, not paths (got "${name}").`);
     }
   }

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -29,6 +29,7 @@ import {
 import type { ClaudeCodeInstallOptions } from "../adapters/claude-code/install-options";
 import { projectVsaSkillBundleFiles } from "../vsa-skill-installer";
 import { defaultSubstrateHome, installSpecFor } from "../install-spec-registry";
+import { projectSkill } from "../skill-projection";
 import type {
   ProjectionInput,
   SomaInstallOptions,
@@ -47,6 +48,8 @@ export interface ParsedInstallArgs {
   substrate: InstallSubstrate;
   apply: boolean;
   workspace: boolean;
+  /** Official skill names (under `~/.soma/skills/`) to project on install. */
+  skills: string[];
   options: InstallCliOptions;
 }
 
@@ -93,7 +96,7 @@ export type ParsedSubstrateLifecycleArgs =
 export const INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code", "cursor", "grok"] as const satisfies readonly InstallSubstrate[];
 
 const substrateList = INSTALL_SUBSTRATES.join("|");
-const installOptions = "[--dry-run] [--apply] [--workspace] [--mode-classifier] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
+const installOptions = "[--dry-run] [--apply] [--workspace] [--mode-classifier] [--skills <name[,name…]>] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 // Shared by uninstall, reproject, and upgrade — all workspace-capable verbs.
 const workspaceVerbOptions = "[--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 const uninstallOptions = workspaceVerbOptions;
@@ -242,11 +245,16 @@ function parseSubstrateLifecycleOptions<TOptions extends SomaInstallOptions = So
 }
 
 export function parseInstallArgs(args: string[]): ParsedInstallArgs {
-  const [command, substrate, ...rest] = args;
+  const [command, substrate, ...rawRest] = args;
 
   if (command !== "install" || !isInstallSubstrate(substrate)) {
     throw new Error(commandUsage("install"));
   }
+
+  // `--skills` carries a value, which the shared lifecycle parser (boolean
+  // extras only) can't consume — pull it out first, then parse the remainder.
+  const { value: skillsCsv, rest } = extractValueFlag(rawRest, "--skills");
+  const skills = skillsCsv === undefined ? [] : parseSkillNames(skillsCsv);
 
   let apply = false;
   const { workspace, options } = parseSubstrateLifecycleOptions<InstallCliOptions>(substrate, rest, (arg, _index, parsedOptions) => {
@@ -267,7 +275,29 @@ export function parseInstallArgs(args: string[]): ParsedInstallArgs {
     throw new Error("--mode-classifier is only supported for claude-code installs.");
   }
 
-  return { command, substrate, apply, workspace, options };
+  return { command, substrate, apply, workspace, skills, options };
+}
+
+/** Pull a `--flag <value>` pair out of an arg list, returning the value and the remaining args. */
+function extractValueFlag(args: string[], flag: string): { value?: string; rest: string[] } {
+  const index = args.indexOf(flag);
+  if (index === -1) return { rest: args };
+  const value = args[index + 1] as string | undefined;
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${flag} requires a value.`);
+  }
+  return { value, rest: [...args.slice(0, index), ...args.slice(index + 2)] };
+}
+
+function parseSkillNames(csv: string): string[] {
+  const names = csv.split(",").map((part) => part.trim()).filter((part) => part.length > 0);
+  if (names.length === 0) throw new Error("--skills requires at least one skill name.");
+  for (const name of names) {
+    if (name.includes("/") || name.includes("\\") || name === "." || name === "..") {
+      throw new Error(`--skills takes skill names, not paths (got "${name}").`);
+    }
+  }
+  return names;
 }
 
 function parseLifecycleVerbArgs(
@@ -362,10 +392,40 @@ export async function runSubstrateLifecycleCli(parsed: ParsedSubstrateLifecycleA
   }
 
   if (!parsed.apply) {
-    return formatPlan(planInstall(parsed.substrate, parsed.options));
+    const plan = formatPlan(planInstall(parsed.substrate, parsed.options));
+    return parsed.skills.length === 0
+      ? plan
+      : `${plan}\n\nSkills to project (on --apply): ${parsed.skills.join(", ")}`;
   }
 
-  return formatInstallResult(await runInstall(parsed.substrate, parsed.options));
+  const result = formatInstallResult(await runInstall(parsed.substrate, parsed.options));
+  if (parsed.skills.length === 0) return result;
+  // Project the selected official skills now that the substrate home + catalog
+  // exist; reuses the soma#354 slice-1 primitive.
+  const projected = await projectInstallSkills(parsed.substrate, parsed.skills, parsed.options);
+  return `${result}\n\n${projected}`;
+}
+
+async function projectInstallSkills(
+  substrate: InstallSubstrate,
+  skills: string[],
+  options: SomaInstallOptions,
+): Promise<string> {
+  const somaHome = options.somaHome ?? defaultSomaHomePath(options.homeDir);
+  const lines = ["Projected skills:"];
+  for (const name of skills) {
+    const skillDir = resolveJoin(somaHome, "skills", name);
+    const result = await projectSkill({
+      skillDir,
+      substrates: [substrate],
+      homeDir: options.homeDir,
+      somaHome: options.somaHome,
+      substrateHome: options.substrateHome,
+    });
+    const loader = result.links.find((link) => link.scope === "substrate");
+    lines.push(`- ${result.skill}: ${loader?.status ?? "linked"} ${loader?.path ?? skillDir}`);
+  }
+  return lines.join("\n");
 }
 
 function planInstall(substrate: InstallSubstrate, options: SomaInstallOptions): SomaInstallPlan {

--- a/test/skill-projection.test.ts
+++ b/test/skill-projection.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { planProjectSkill, planUnprojectSkill, projectSkill, unprojectSkill } from "../src/skill-projection";
 import { bootstrapSomaHome } from "../src/index";
+import { runSomaCli } from "../src/cli";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-skill-projection-"));
@@ -223,6 +224,45 @@ describe("unprojectSkill", () => {
       const result = await unprojectSkill({ skill: "Authored", substrates: ["claude-code"], homeDir, force: true });
       expect(result.registryRemoved).toBe(true);
       await expect(lstat(registryDir)).rejects.toThrow();
+    });
+  });
+});
+
+describe("soma install --skills", () => {
+  async function authorRegistrySkill(homeDir: string, name: string): Promise<void> {
+    const dir = join(homeDir, ".soma", "skills", name);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "SKILL.md"), `---\nname: ${name}\ndescription: "x"\n---\n# ${name}\n`, "utf8");
+  }
+
+  test("projects selected skills into the substrate loader + catalog on apply", async () => {
+    await withTempHome(async (homeDir) => {
+      await authorRegistrySkill(homeDir, "Widget");
+
+      const out = await runSomaCli(["install", "claude-code", "--apply", "--home-dir", homeDir, "--skills", "Widget"]);
+      expect(out).toContain("Projected skills:");
+
+      expect((await lstat(join(homeDir, ".claude", "skills", "Widget"))).isSymbolicLink()).toBe(true);
+      const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
+      expect(catalog).toContain("## Widget");
+    });
+  });
+
+  test("dry-run names the skills but writes nothing", async () => {
+    await withTempHome(async (homeDir) => {
+      await authorRegistrySkill(homeDir, "Widget");
+
+      const out = await runSomaCli(["install", "claude-code", "--home-dir", homeDir, "--skills", "Widget"]);
+      expect(out).toContain("Skills to project (on --apply): Widget");
+      await expect(lstat(join(homeDir, ".claude", "skills", "Widget"))).rejects.toThrow();
+    });
+  });
+
+  test("rejects a path-shaped --skills value", async () => {
+    await withTempHome(async (homeDir) => {
+      await expect(
+        runSomaCli(["install", "claude-code", "--apply", "--home-dir", homeDir, "--skills", "../evil"]),
+      ).rejects.toThrow(/skill names, not paths/);
     });
   });
 });


### PR DESCRIPTION
Slice 2 of #354. Wires the slice-1 projection primitive into `soma install`.

## What lands
`soma install <substrate> --skills <name[,name…]>` — after the substrate home + catalog are written, each named skill (resolved under `~/.soma/skills/<name>`) is projected into that substrate via `projectSkill` (loader symlink + catalog refresh). Default install (no `--skills`) is unchanged.

- `--skills` is value-bearing; the shared lifecycle parser only handles boolean extras, so `parseInstallArgs` pre-extracts it (`extractValueFlag`).
- Names only, not paths — `parseSkillNames` rejects any `/`, `\`, or `..` substring (and `.`), so a value is always a single path segment (slot is `~/.soma/skills/<name>`).
- Dry-run names the skills it would project; apply projects + reports per-skill status.

## Reproduce verification
```
bun run typecheck            # -> PASS
bun run lint                 # changed files: clean
bun test test/skill-projection.test.ts   # 15 pass / 0 fail (3 new --skills tests)
bun test                     # full suite: 1496 pass / 0 fail
```
e2e (temp home): `install claude-code --skills Widget` dry-run prints "Skills to project (on --apply): Widget"; `--apply` creates `~/.claude/skills/Widget` symlink and `## Widget` in `SKILLS.md`; `--skills ../evil` is rejected.

## Review history
sage cycle 1 (changes-requested): [important] `..`-rejection claim overstated → fixed in 33cef53 (rejects any `..` substring); [suggestion] verification lacked evidence → reproduce commands added above.

## Not in this slice
Retire the code-gen skill installers → plain `.md` skills in repo `skills/` so `--skills` can target *official* skills; evict the migrated third-party skills from `~/.soma/skills/`. Boundary cleanup tracked in #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)