### PR TITLE
refactor(algorithm): retire renderSkill code-gen → plain .md (#354 slice 3)

### DIFF
--- a/docs/adr/0002-official-skill-collection-and-projection-primitive.md
+++ b/docs/adr/0002-official-skill-collection-and-projection-primitive.md
@@ -6,13 +6,21 @@ status: proposed
 
 ## Context
 
-Soma's primitive-operating skills — the ones that author and run Soma's own
-compartments (Purpose, VSA, the Algorithm, and a future Memory skill) — are today
-each a bespoke TypeScript *importer* that emits the skill's markdown as string
-literals: `the-algorithm` via `renderSkill()` in `src/algorithm-importer.ts:37`
-(`files.set("skills/the-algorithm/SKILL.md", renderSkill())` at line 246), and VSA
-via a dedicated `src/vsa-skill-installer.ts` (20.5 KB). Every new official skill
-costs another 15–20 KB code-gen renderer. That is the bloat path.
+Soma's primitive-operating skills (Purpose, VSA, the Algorithm, and a future
+Memory skill) reach their substrates through inconsistent paths. **the-algorithm**
+emitted its SKILL.md + workflow as TypeScript string literals — `renderSkill()` /
+`renderRunWorkflow()` in `src/algorithm-importer.ts` — genuine code-gen bloat that
+grew per skill.
+
+**Correction (soma#354 slice 3):** VSA was initially assumed to be the same
+pattern, but it is not. The VSA skill already ships as plain `.md` under
+`src/skills/VSA/`; `src/vsa-skill-installer.ts` (20.5 KB) is not a renderer but a
+*drift-protected projector* — it reads those files and adds baseline hashing,
+edit-preserving upgrade markers, per-substrate name override (pi-dev `vsa`), and
+content rewrites. That machinery is load-bearing, not bloat, and the slice-1
+symlink primitive cannot replace it. So this ADR's original "retire
+`vsa-skill-installer.ts`" framing was wrong: only the-algorithm's string-literal
+renderers are retired; the VSA installer stays.
 
 Two further problems compound it:
 
@@ -47,8 +55,11 @@ Three tiers, named, with one projection truth shared across them.
   never drift from the format in another release train. They are **opt-in**:
   `soma install <substrate> --skills purpose,memory` projects only the chosen
   skills. The Purpose skill (plain `.md`, symlink-projected) is the prototype of
-  this pattern; the `vsa-skill-installer.ts` / `algorithm-importer.ts` code-gen
-  renderers are the legacy pattern to retire.
+  this pattern; the legacy pattern to retire is **string-literal code-gen** —
+  `algorithm-importer.ts`'s `renderSkill()` / `renderRunWorkflow()` (done in
+  slice 3, content moved to `src/skills/the-algorithm/`). The VSA installer is
+  *not* in scope to retire — it is a drift-protected projector over already-plain
+  `.md`, not a renderer (see Context correction).
 - **Third-party** — general/optional skills, distributed as external packs (arc).
   Soma does not own them; it projects and catalogs them on request.
 
@@ -85,11 +96,13 @@ all installed); the contract above is substrate-list-parameterised either way.
   duplicates `src/adapters/*` and forks the projection truth the moment soma's
   adapters change. **Soma-owned with arc delegating** chosen: one implementation,
   many callers.
-- **Skill authoring: code-gen renderers vs. plain `.md`.** The current
-  `renderSkill()`/`vsa-skill-installer.ts` string-literal renderers were rejected
-  as the go-forward pattern: 15–20 KB of TS per skill, awkward to edit, no reason
-  for skills (static prose) to be computed. **Plain `.md` in `skills/`** chosen;
-  the legacy renderers are migrated to files and retired.
+- **Skill authoring: code-gen renderers vs. plain `.md`.** the-algorithm's
+  `renderSkill()` / `renderRunWorkflow()` string-literal renderers were rejected
+  as the go-forward pattern: TS string literals for static prose, awkward to edit,
+  no reason to compute. **Plain `.md` in `skills/`** chosen; the renderers were
+  migrated to `src/skills/the-algorithm/` and removed (slice 3). (VSA was *not* a
+  renderer — it already ships plain `.md`; its installer is drift machinery and
+  stays — see Context.)
 - **Catalog-only projection (status quo) vs. invocable-dir projection.**
   Catalog-only was rejected: a listed-but-not-loadable skill is not usable
   (exactly the Purpose failure). Projection must materialise an invocable
@@ -99,9 +112,10 @@ all installed); the contract above is substrate-list-parameterised either way.
 
 - A new `soma project-skill` / `unproject-skill` primitive (CLI + lib), reused by
   `install`, by `--skills` selective install, and by arc.
-- `vsa-skill-installer.ts` and `algorithm-importer.ts`'s `renderSkill()` path are
-  replaced by plain `.md` skills under `skills/` + the generic projector. Net code
-  removed, not added.
+- `algorithm-importer.ts`'s `renderSkill()` / `renderRunWorkflow()` are removed;
+  the content lives in `src/skills/the-algorithm/{SKILL.md,Workflows/RunAlgorithm.md}`
+  and the importer reads it from disk (slice 3). `vsa-skill-installer.ts` is
+  retained — it is drift-protected projection, not a renderer.
 - `soma install` gains a `--skills <list>` selector; official skills become
   opt-in. Default install stays minimal.
 - arc gains a post-install / post-uninstall hook that calls the soma primitive;

--- a/docs/adr/0002-official-skill-collection-and-projection-primitive.md
+++ b/docs/adr/0002-official-skill-collection-and-projection-primitive.md
@@ -14,13 +14,18 @@ grew per skill.
 
 **Correction (soma#354 slice 3):** VSA was initially assumed to be the same
 pattern, but it is not. The VSA skill already ships as plain `.md` under
-`src/skills/VSA/`; `src/vsa-skill-installer.ts` (20.5 KB) is not a renderer but a
-*drift-protected projector* — it reads those files and adds baseline hashing,
-edit-preserving upgrade markers, per-substrate name override (pi-dev `vsa`), and
-content rewrites. That machinery is load-bearing, not bloat, and the slice-1
-symlink primitive cannot replace it. So this ADR's original "retire
-`vsa-skill-installer.ts`" framing was wrong: only the-algorithm's string-literal
-renderers are retired; the VSA installer stays.
+`src/skills/VSA/` (`SOURCE_SUBPATH = src/skills/VSA`, `vsa-skill-installer.ts:27`),
+read by `computeSourceFileEntries()` (`:227`). The 20.5 KB is not a renderer but a
+*drift-protected projector*: per-file SHA baseline hashing keyed per destination
+(`baselineKey` `:37`), fail-closed drift detection against user edits
+(`detectDrift` `:251`), edit-preserving `.upgrade-available` markers
+(`writeUpgradeMarker` `:522`), per-substrate name override (pi-dev `vsa`, via
+`SubstrateInstallSpec.vsaSkillProjection.skillNameOverride`), and substrate content
+rewrites (`rewriteSubstrateProjectionContent`, imported `:7`). The slice-1 symlink
+primitive does none of that — it cannot replace this installer without losing
+user-edit protection. So this ADR's original "retire `vsa-skill-installer.ts`"
+framing was wrong: only the-algorithm's string-literal renderers are retired; the
+VSA installer stays.
 
 Two further problems compound it:
 

--- a/src/algorithm-importer.ts
+++ b/src/algorithm-importer.ts
@@ -2,9 +2,19 @@ import { existsSync, readFileSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
+import { defaultSomaRepoPath } from "./repo-path";
 import type { AlgorithmImportOptions, AlgorithmImportPlan, AlgorithmImportResult, ImportSourceCheck } from "./types";
 
 const FALLBACK_ALGORITHM_SOURCE = "v6.3.0.md";
+
+// soma#354: the-algorithm SKILL.md + RunAlgorithm.md ship as plain `.md` in the
+// repo (no longer code-generated). Read them from the bundled source on import,
+// the same way the VSA skill is sourced from `src/skills/VSA`.
+const BUNDLED_SKILL_SUBPATH = "src/skills/the-algorithm";
+
+function readBundledSkillFile(rel: string): Promise<string> {
+  return readFile(join(defaultSomaRepoPath(), BUNDLED_SKILL_SUBPATH, rel), "utf8");
+}
 
 const OPTIONAL_SOURCE_FILES = [
   { path: "capabilities.md", target: "references/capabilities.md", required: false },
@@ -32,43 +42,6 @@ function resolveHomes(options: AlgorithmImportOptions = {}): { paiAlgorithmDir: 
     paiAlgorithmDir: resolve(options.paiAlgorithmDir ?? join(home, ".claude/PAI/Algorithm")),
     somaHome: resolve(options.somaHome ?? join(home, ".soma")),
   };
-}
-
-function renderSkill(): string {
-  return [
-    "---",
-    "name: the-algorithm",
-    'description: "Use when work should run through the PAI Algorithm: current-state to ideal-state, VSA/ISC creation or refinement, effort tiers, seven-phase execution, verification-first planning, euphoric-surprise goals, substantial build/design/refactor/migration work, or explicit Algorithm requests."',
-    "metadata:",
-    "  short-description: PAI Algorithm execution doctrine",
-    "---",
-    "",
-    "# The Algorithm",
-    "",
-    "The Algorithm is Soma's portable version of PAI's core execution doctrine. It turns work into a transition from current state to ideal state, captured as an VSA whose criteria are granular, binary, and verifiable.",
-    "",
-    "Prefer the Soma Algorithm harness over freeform execution when it is available. The harness is the deterministic layer; these files are the doctrine and substrate-facing instructions.",
-    "",
-    "## Use",
-    "",
-    "- Start with `Workflows/RunAlgorithm.md`.",
-    "- Read `references/algorithm.md` when doctrine detail matters.",
-    "- Read `references/capabilities.md` before selecting thinking or delegation capabilities.",
-    "- Read `references/mode-detection.md` when effort tier, fast-path, ideate, optimize, or research mode is ambiguous.",
-    "- Read `references/parameter-schema.md` for ideate and optimize parameter handling.",
-    "- Treat Claude-specific hooks, voice curls, and agents as source history, not portable requirements.",
-    "",
-    "## Triggers",
-    "",
-    "- algorithm",
-    "- ideal state",
-    "- VSA",
-    "- ISC",
-    "- verification criteria",
-    "- current state to ideal state",
-    "- euphoric surprise",
-    "- substantial build/design/refactor/migration work",
-  ].join("\n");
 }
 
 function normalizeLatestAlgorithmPointer(pointer: string): string {
@@ -110,91 +83,6 @@ function inspectAlgorithmSources(paiAlgorithmDir: string): AlgorithmImportSource
     sources,
     sourceChecks: sources.map((source) => sourceCheck(paiAlgorithmDir, source)),
   };
-}
-
-function renderRunWorkflow(): string {
-  return [
-    "# Run The Algorithm",
-    "",
-    "Use this workflow to execute the portable PAI Algorithm inside any substrate.",
-    "",
-    "## Portable Contract",
-    "",
-    "1. Restate the user's intent in one sentence before planning.",
-    "2. Create a harness run with the installed Soma lifecycle tool or repo CLI. For Codex use `cd $(cat ~/.codex/memories/soma/soma-repo.txt) && bun run soma algorithm new ...`; for Pi.dev use `cd $(cat ~/.pi/agent/soma/soma-repo.txt) && bun run soma algorithm new ...`. Do not assume a global `soma` binary exists.",
-    "3. Choose the smallest sufficient effort tier: E1, E2, E3, E4, or E5.",
-    "4. Treat the work as a transition from current state to ideal state.",
-    "5. Create or update the VSA that belongs to the thing being articulated.",
-    "6. Write criteria as atomic yes/no claims with nameable probes.",
-    "7. Preserve anti-criteria with `Anti:` criteria when something must not happen.",
-    "8. Execute through the seven phases unless an E1 fast path clearly applies.",
-    "9. Verify every criterion with evidence before declaring completion.",
-    "10. Record decisions, changelog, and verification in the VSA rather than parallel artifacts.",
-    "",
-    "## Seven Phases",
-    "",
-    "1. OBSERVE: restate intent, identify current state, choose VSA home, draft problem/goal/criteria.",
-    "2. THINK: refine assumptions, split vague criteria, select thinking capabilities from the closed list.",
-    "3. PLAN: map criteria to implementation steps, capabilities, dependencies, and verification probes.",
-    "4. BUILD: create or modify artifacts while updating criteria when reality sharpens the ideal state.",
-    "5. EXECUTE: run the concrete steps and keep criteria state current.",
-    "6. VERIFY: prove each criterion and anti-criterion with evidence.",
-    "7. LEARN: capture decisions, refutations, lessons, and next iteration.",
-    "",
-    "## Harness CLI",
-    "",
-    "The harness is mutable run state, not just a document. Use the repo-local CLI for the active substrate:",
-    "",
-    "- Codex prefix: `cd $(cat ~/.codex/memories/soma/soma-repo.txt) && bun run soma`",
-    "- Pi.dev prefix: `cd $(cat ~/.pi/agent/soma/soma-repo.txt) && bun run soma`",
-    "",
-    "Common commands:",
-    "",
-    "- `algorithm classify --prompt \"...\"`",
-    "- `algorithm new --id <run-id> --prompt \"...\" --intent \"...\" --current-state \"...\" --goal \"...\" --criterion \"C1:...\" --effort E2`",
-    "- `algorithm list`",
-    "- `algorithm show --id <run-id>`",
-    "- `algorithm capabilities --id <run-id> --capability <CapabilityName> --reason <why>`",
-    "- `algorithm invoke --id <run-id> --capability <CapabilityName> --evidence <what happened>`",
-    "- `algorithm remove-capability --id <run-id> --capability <CapabilityName> --reason <why no longer needed>`",
-    "- `algorithm plan --id <run-id> --step \"P1:C1[,C2]:Do the concrete work.\"`",
-    "- `algorithm decision --id <run-id> --text \"Decision made and why.\"`",
-    "- `algorithm change --id <run-id> --text \"Artifact changed.\"`",
-    "- `algorithm step --id <run-id> --step-id P1 --status done --evidence \"Probe output or file path.\"`",
-    "- `algorithm verify --id <run-id> --criterion-id C1 --status passed --evidence \"Verification evidence.\"`",
-    "- `algorithm learn --id <run-id> --text \"Reusable lesson.\"`",
-    "- `algorithm batch --id <run-id> --op \"decision:Decision made.\" --op \"change:Artifact changed.\" --op \"step:P1:done:Evidence.\"`",
-    "- `algorithm advance --id <run-id>`",
-    "",
-    "Prefer `algorithm batch` when recording routine decision/change/step/verify/learn evidence from a substrate. It avoids long shell `&&` chains and reduces repeated approval prompts.",
-    "",
-    "`algorithm classify` decides MINIMAL, NATIVE, or ALGORITHM and maps Algorithm prompts to E1-E5. `algorithm new` uses the same classifier when `--effort` is omitted; explicit `/eN`, `EN`, or `--effort EN` overrides classification.",
-    "",
-    "`algorithm advance` is the deterministic gate. If required capabilities, capability invocation evidence, plan steps, build changes, verification, or learning are missing, Soma rejects the transition and the substrate must fill the missing state before trying again.",
-    "",
-    "## Effort Tiers",
-    "",
-    "- E1 Standard: quick work; minimal VSA with Goal and Criteria is enough.",
-    "- E2 Extended: structured work; include Problem, Goal, Criteria, Test Strategy.",
-    "- E3 Advanced: substantial multi-file or multi-step work; include project-grade sections.",
-    "- E4 Deep: architecture/doctrine/cross-cutting work; all twelve VSA sections.",
-    "- E5 Comprehensive: long-running comprehensive work; all twelve sections plus interview/refinement before build.",
-    "",
-    "## Closed Thinking Capability Names",
-    "",
-    "When naming thinking capabilities, use names verbatim from `references/capabilities.md`. Do not invent synonyms.",
-    "",
-    "## Substrate Adaptation",
-    "",
-    "- Codex: use repository edits, tests, and final verification reports as the execution surface.",
-    "- Pi.dev: use the Soma system-prompt context and `soma_context` tool for identity/PAI detail; use Pi tools for work.",
-    "- Claude Code: defer live home integration until no active agents depend on `~/.claude`.",
-    "- Cortex/Myelin: later, the VSA becomes bus-visible work state.",
-    "",
-    "## Completion Gate",
-    "",
-    "Before final response, re-read the user's latest request and check every explicit ask against shipped artifacts. Do not claim done if any explicit ask is missing.",
-  ].join("\n");
 }
 
 export function planAlgorithmImport(options: AlgorithmImportOptions = {}): AlgorithmImportPlan {
@@ -243,8 +131,8 @@ export async function importAlgorithm(options: AlgorithmImportOptions = {}): Pro
   }
   const files = new Map<string, string>();
 
-  files.set("skills/the-algorithm/SKILL.md", renderSkill());
-  files.set("skills/the-algorithm/Workflows/RunAlgorithm.md", renderRunWorkflow());
+  files.set("skills/the-algorithm/SKILL.md", await readBundledSkillFile("SKILL.md"));
+  files.set("skills/the-algorithm/Workflows/RunAlgorithm.md", await readBundledSkillFile("Workflows/RunAlgorithm.md"));
 
   for (const [path, content] of sources) {
     files.set(`skills/the-algorithm/${path}`, content);

--- a/src/skills/the-algorithm/SKILL.md
+++ b/src/skills/the-algorithm/SKILL.md
@@ -18,7 +18,7 @@ Prefer the Soma Algorithm harness over freeform execution when it is available. 
 - Read `references/capabilities.md` before selecting thinking or delegation capabilities.
 - Read `references/mode-detection.md` when effort tier, fast-path, ideate, optimize, or research mode is ambiguous.
 - Read `references/parameter-schema.md` for ideate and optimize parameter handling.
-- Treat Claude-specific hooks, voice curls, and agents as source history, not portable requirements.
+- Treat Claude-specific hooks, voice curls, and Claude Code sub-agents as source history, not portable requirements.
 
 ## Triggers
 

--- a/src/skills/the-algorithm/SKILL.md
+++ b/src/skills/the-algorithm/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: the-algorithm
+description: "Use when work should run through the PAI Algorithm: current-state to ideal-state, VSA/ISC creation or refinement, effort tiers, seven-phase execution, verification-first planning, euphoric-surprise goals, substantial build/design/refactor/migration work, or explicit Algorithm requests."
+metadata:
+  short-description: PAI Algorithm execution doctrine
+---
+
+# The Algorithm
+
+The Algorithm is Soma's portable version of PAI's core execution doctrine. It turns work into a transition from current state to ideal state, captured as an VSA whose criteria are granular, binary, and verifiable.
+
+Prefer the Soma Algorithm harness over freeform execution when it is available. The harness is the deterministic layer; these files are the doctrine and substrate-facing instructions.
+
+## Use
+
+- Start with `Workflows/RunAlgorithm.md`.
+- Read `references/algorithm.md` when doctrine detail matters.
+- Read `references/capabilities.md` before selecting thinking or delegation capabilities.
+- Read `references/mode-detection.md` when effort tier, fast-path, ideate, optimize, or research mode is ambiguous.
+- Read `references/parameter-schema.md` for ideate and optimize parameter handling.
+- Treat Claude-specific hooks, voice curls, and agents as source history, not portable requirements.
+
+## Triggers
+
+- algorithm
+- ideal state
+- VSA
+- ISC
+- verification criteria
+- current state to ideal state
+- euphoric surprise
+- substantial build/design/refactor/migration work

--- a/src/skills/the-algorithm/Workflows/RunAlgorithm.md
+++ b/src/skills/the-algorithm/Workflows/RunAlgorithm.md
@@ -72,7 +72,7 @@ When naming thinking capabilities, use names verbatim from `references/capabilit
 
 - Codex: use repository edits, tests, and final verification reports as the execution surface.
 - Pi.dev: use the Soma system-prompt context and `soma_context` tool for identity/PAI detail; use Pi tools for work.
-- Claude Code: defer live home integration until no active agents depend on `~/.claude`.
+- Claude Code: defer live home integration until no active Claude Code agents depend on `~/.claude`.
 - Cortex/Myelin: later, the VSA becomes bus-visible work state.
 
 ## Completion Gate

--- a/src/skills/the-algorithm/Workflows/RunAlgorithm.md
+++ b/src/skills/the-algorithm/Workflows/RunAlgorithm.md
@@ -1,0 +1,80 @@
+# Run The Algorithm
+
+Use this workflow to execute the portable PAI Algorithm inside any substrate.
+
+## Portable Contract
+
+1. Restate the user's intent in one sentence before planning.
+2. Create a harness run with the installed Soma lifecycle tool or repo CLI. For Codex use `cd $(cat ~/.codex/memories/soma/soma-repo.txt) && bun run soma algorithm new ...`; for Pi.dev use `cd $(cat ~/.pi/agent/soma/soma-repo.txt) && bun run soma algorithm new ...`. Do not assume a global `soma` binary exists.
+3. Choose the smallest sufficient effort tier: E1, E2, E3, E4, or E5.
+4. Treat the work as a transition from current state to ideal state.
+5. Create or update the VSA that belongs to the thing being articulated.
+6. Write criteria as atomic yes/no claims with nameable probes.
+7. Preserve anti-criteria with `Anti:` criteria when something must not happen.
+8. Execute through the seven phases unless an E1 fast path clearly applies.
+9. Verify every criterion with evidence before declaring completion.
+10. Record decisions, changelog, and verification in the VSA rather than parallel artifacts.
+
+## Seven Phases
+
+1. OBSERVE: restate intent, identify current state, choose VSA home, draft problem/goal/criteria.
+2. THINK: refine assumptions, split vague criteria, select thinking capabilities from the closed list.
+3. PLAN: map criteria to implementation steps, capabilities, dependencies, and verification probes.
+4. BUILD: create or modify artifacts while updating criteria when reality sharpens the ideal state.
+5. EXECUTE: run the concrete steps and keep criteria state current.
+6. VERIFY: prove each criterion and anti-criterion with evidence.
+7. LEARN: capture decisions, refutations, lessons, and next iteration.
+
+## Harness CLI
+
+The harness is mutable run state, not just a document. Use the repo-local CLI for the active substrate:
+
+- Codex prefix: `cd $(cat ~/.codex/memories/soma/soma-repo.txt) && bun run soma`
+- Pi.dev prefix: `cd $(cat ~/.pi/agent/soma/soma-repo.txt) && bun run soma`
+
+Common commands:
+
+- `algorithm classify --prompt "..."`
+- `algorithm new --id <run-id> --prompt "..." --intent "..." --current-state "..." --goal "..." --criterion "C1:..." --effort E2`
+- `algorithm list`
+- `algorithm show --id <run-id>`
+- `algorithm capabilities --id <run-id> --capability <CapabilityName> --reason <why>`
+- `algorithm invoke --id <run-id> --capability <CapabilityName> --evidence <what happened>`
+- `algorithm remove-capability --id <run-id> --capability <CapabilityName> --reason <why no longer needed>`
+- `algorithm plan --id <run-id> --step "P1:C1[,C2]:Do the concrete work."`
+- `algorithm decision --id <run-id> --text "Decision made and why."`
+- `algorithm change --id <run-id> --text "Artifact changed."`
+- `algorithm step --id <run-id> --step-id P1 --status done --evidence "Probe output or file path."`
+- `algorithm verify --id <run-id> --criterion-id C1 --status passed --evidence "Verification evidence."`
+- `algorithm learn --id <run-id> --text "Reusable lesson."`
+- `algorithm batch --id <run-id> --op "decision:Decision made." --op "change:Artifact changed." --op "step:P1:done:Evidence."`
+- `algorithm advance --id <run-id>`
+
+Prefer `algorithm batch` when recording routine decision/change/step/verify/learn evidence from a substrate. It avoids long shell `&&` chains and reduces repeated approval prompts.
+
+`algorithm classify` decides MINIMAL, NATIVE, or ALGORITHM and maps Algorithm prompts to E1-E5. `algorithm new` uses the same classifier when `--effort` is omitted; explicit `/eN`, `EN`, or `--effort EN` overrides classification.
+
+`algorithm advance` is the deterministic gate. If required capabilities, capability invocation evidence, plan steps, build changes, verification, or learning are missing, Soma rejects the transition and the substrate must fill the missing state before trying again.
+
+## Effort Tiers
+
+- E1 Standard: quick work; minimal VSA with Goal and Criteria is enough.
+- E2 Extended: structured work; include Problem, Goal, Criteria, Test Strategy.
+- E3 Advanced: substantial multi-file or multi-step work; include project-grade sections.
+- E4 Deep: architecture/doctrine/cross-cutting work; all twelve VSA sections.
+- E5 Comprehensive: long-running comprehensive work; all twelve sections plus interview/refinement before build.
+
+## Closed Thinking Capability Names
+
+When naming thinking capabilities, use names verbatim from `references/capabilities.md`. Do not invent synonyms.
+
+## Substrate Adaptation
+
+- Codex: use repository edits, tests, and final verification reports as the execution surface.
+- Pi.dev: use the Soma system-prompt context and `soma_context` tool for identity/PAI detail; use Pi tools for work.
+- Claude Code: defer live home integration until no active agents depend on `~/.claude`.
+- Cortex/Myelin: later, the VSA becomes bus-visible work state.
+
+## Completion Gate
+
+Before final response, re-read the user's latest request and check every explicit ask against shipped artifacts. Do not claim done if any explicit ask is missing.

--- a/src/skills/the-algorithm/Workflows/RunAlgorithm.md
+++ b/src/skills/the-algorithm/Workflows/RunAlgorithm.md
@@ -72,7 +72,7 @@ When naming thinking capabilities, use names verbatim from `references/capabilit
 
 - Codex: use repository edits, tests, and final verification reports as the execution surface.
 - Pi.dev: use the Soma system-prompt context and `soma_context` tool for identity/PAI detail; use Pi tools for work.
-- Claude Code: defer live home integration until no active Claude Code agents depend on `~/.claude`.
+- Claude Code: defer live home integration until no active Claude Code sub-agents depend on `~/.claude`.
 - Cortex/Myelin: later, the VSA becomes bus-visible work state.
 
 ## Completion Gate


### PR DESCRIPTION
Slice 3 of #354. Retires the genuine code-gen in the-algorithm importer.

## Scope correction (ADR 0002 updated in this PR)
The map showed the ADR's premise was wrong: **VSA is not code-gen.** It already ships plain `.md` under `src/skills/VSA/`, and `vsa-skill-installer.ts` (20.5 KB) is a *drift-protected projector* — baseline hashing, edit-preserving upgrade markers, per-substrate name override (pi-dev `vsa`), content rewrites (cited by file:line in the ADR). The slice-1 symlink primitive can't replace that. So **only the-algorithm's string-literal renderers are retired; the VSA installer stays.**

## What lands
- `renderSkill()` + `renderRunWorkflow()` deleted from `src/algorithm-importer.ts`.
- Content moved to `src/skills/the-algorithm/SKILL.md` + `Workflows/RunAlgorithm.md`.
- Importer reads them from the bundled repo source (`defaultSomaRepoPath()` + `src/skills/the-algorithm/`), same model as VSA.

## Content parity
The `.md` is the render-array content **with two intentional fixes**: bare `agents` → `Claude Code sub-agents` in two places (CONTEXT.md:550 bans bare `agent`; the violation rode in verbatim from the retired code-gen). Otherwise identical; the writer still does `content.trimEnd() + "\n"`. **Not** a pure byte-for-byte relocation — the two vocab fixes are deliberate.

## Reproduce verification
```
bun run typecheck                          # PASS
bun run lint                               # changed files clean
bun test test/algorithm-importer.test.ts   # 5 pass / 0 fail
bun test                                   # full suite: 1496 pass / 0 fail
```

## Remaining #354
Evict the ~100 migrated third-party skills from `~/.soma/skills/`; #356 adapter boundary; #358 batch projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)