### PR TITLE
refactor(skills): adapter-owned loader dir + batch projection (#356, #358)

### DIFF
--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -1,4 +1,4 @@
-import { vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
+import { skillsLoaderUnder, vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
 import { vsaSiblingPrunePrepare } from "../../legacy-skill-prune";
 import { CLAUDE_CODE_RULES_FILES } from "../claude-code";
 import {
@@ -26,6 +26,7 @@ export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
   optionalHomeFiles: (options) => isClaudeCodeInstallOptions(options) && options.modeClassifier === true
     ? [SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH, SOMA_CLAUDE_MODE_CLASSIFIER_CONFIG_RELATIVE_PATH]
     : [],
+  skillsLoaderDir: skillsLoaderUnder(),
   vsaSkillProjection: {
     destinationDir: vsaSkillUnder(),
     // soma#329: before reprojecting VSA, prune a sibling renamed-away "ISA" skill

--- a/src/adapters/codex/install.ts
+++ b/src/adapters/codex/install.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { configureCodexInstall } from "./config";
-import { vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
+import { skillsLoaderUnder, vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
 import { vsaSiblingPrunePrepare } from "../../legacy-skill-prune";
 import type { SubstrateId } from "../../types";
 
@@ -67,6 +67,7 @@ export const codexInstallSpec: SubstrateInstallSpec<"codex"> = {
   homeFiles: CODEX_HOME_FILES,
   // Owned (Soma-exclusive) dir — see ownedSubtrees JSDoc. (hooks/ + skills/ are shared.)
   ownedSubtrees: ["memories/soma"],
+  skillsLoaderDir: skillsLoaderUnder(),
   vsaSkillProjection: {
     destinationDir: vsaSkillUnder(),
     // soma#329: before reprojecting VSA, prune a sibling renamed-away "ISA" skill

--- a/src/adapters/cursor/install.ts
+++ b/src/adapters/cursor/install.ts
@@ -1,7 +1,7 @@
 import { readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { isEnoent } from "../../fs-errors";
-import { vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
+import { skillsLoaderUnder, vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
 import { CURSOR_HOME_FILE_PATHS, CURSOR_RULES_BLOCK_BEGIN, CURSOR_RULES_BLOCK_END, CURSOR_RULES_PATH } from "../cursor";
 
 async function shouldRemoveSomaRulesDir(target: string): Promise<boolean> {
@@ -52,6 +52,7 @@ export const cursorInstallSpec: SubstrateInstallSpec<"cursor"> = {
   // Owned (Soma-exclusive) dir — see ownedSubtrees JSDoc. Subsumes the former
   // obsoleteHomeFiles for TELOS.md/ACTIVE_ISA.md under .cursor/rules/soma.
   ownedSubtrees: [".cursor/rules/soma"],
+  skillsLoaderDir: skillsLoaderUnder(".cursor/rules/soma"),
   vsaSkillProjection: {
     destinationDir: vsaSkillUnder(".cursor/rules/soma"),
   },

--- a/src/adapters/grok/install.ts
+++ b/src/adapters/grok/install.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { isEnoent } from "../../fs-errors";
-import { vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
+import { skillsLoaderUnder, vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
 import type { SubstrateId } from "../../types";
 import {
   GROK_AGENT_MARKER,
@@ -185,6 +185,7 @@ export const grokInstallSpec: SubstrateInstallSpec<"grok"> = {
   // `~/.grok/version.json`; a missing manifest is an unversioned dev
   // runtime and does not block.
   validator: validateGrokInstallRuntime,
+  skillsLoaderDir: skillsLoaderUnder(),
   vsaSkillProjection: {
     // Lands the versioned VSA skill at `~/.grok/skills/VSA` (same shape
     // as Codex's `vsaSkillUnder()` → `~/.codex/skills/VSA`).

--- a/src/adapters/pi-dev/install.ts
+++ b/src/adapters/pi-dev/install.ts
@@ -1,6 +1,6 @@
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import type { SubstrateInstallSpec } from "../../install-spec";
+import { skillsLoaderUnder, type SubstrateInstallSpec } from "../../install-spec";
 import type { SubstrateId } from "../../types";
 import {
   PI_DEV_VSA_SKILL_ID,
@@ -42,6 +42,7 @@ export const piDevInstallSpec: SubstrateInstallSpec<"pi-dev"> = {
   homeFiles: PI_DEV_HOME_FILES,
   // Owned (Soma-exclusive) dir — see ownedSubtrees JSDoc. (agent/extensions + agent/skills shared.)
   ownedSubtrees: ["agent/soma"],
+  skillsLoaderDir: skillsLoaderUnder("agent"),
   vsaSkillProjection: {
     destinationDir: piDevVsaSkillDestinationDir,
     skillNameOverride: PI_DEV_VSA_SKILL_ID,

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -29,7 +29,7 @@ import {
 import type { ClaudeCodeInstallOptions } from "../adapters/claude-code/install-options";
 import { projectVsaSkillBundleFiles } from "../vsa-skill-installer";
 import { defaultSubstrateHome, installSpecFor } from "../install-spec-registry";
-import { projectSkill } from "../skill-projection";
+import { projectSkills } from "../skill-projection";
 import type {
   ProjectionInput,
   SomaInstallOptions,
@@ -414,20 +414,21 @@ async function projectInstallSkills(
   options: SomaInstallOptions,
 ): Promise<string> {
   const somaHome = options.somaHome ?? defaultSomaHomePath(options.homeDir);
-  const lines = ["Projected skills:"];
-  for (const name of skills) {
-    const skillDir = resolveJoin(somaHome, "skills", name);
-    const result = await projectSkill({
-      skillDir,
-      substrates: [substrate],
-      homeDir: options.homeDir,
-      somaHome: options.somaHome,
-      substrateHome: options.substrateHome,
-    });
-    const loader = result.links.find((link) => link.scope === "substrate");
-    lines.push(`- ${result.skill}: ${loader?.status ?? "linked"} ${loader?.path ?? skillDir}`);
-  }
-  return lines.join("\n");
+  // soma#358: link every selected skill, then refresh the catalog ONCE.
+  const { skills: projected } = await projectSkills({
+    skillDirs: skills.map((name) => resolveJoin(somaHome, "skills", name)),
+    substrates: [substrate],
+    homeDir: options.homeDir,
+    somaHome: options.somaHome,
+    substrateHome: options.substrateHome,
+  });
+  return [
+    "Projected skills:",
+    ...projected.map((result) => {
+      const loader = result.links.find((link) => link.scope === "substrate");
+      return `- ${result.skill}: ${loader?.status ?? "linked"} ${loader?.path ?? result.skillDir}`;
+    }),
+  ].join("\n");
 }
 
 function planInstall(substrate: InstallSubstrate, options: SomaInstallOptions): SomaInstallPlan {

--- a/src/home-projection.ts
+++ b/src/home-projection.ts
@@ -105,6 +105,30 @@ export function buildGrokHomeProjection(input: ProjectionInput, options: SomaHom
   );
 }
 
+/**
+ * Central substrate → home-projection dispatcher. soma#356: a single owner of
+ * the substrate-to-builder mapping so callers (e.g. `project-skill`'s catalog
+ * refresh) do not each maintain a parallel hard-coded map.
+ */
+export function buildSubstrateHomeProjection(
+  substrate: Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor" | "grok">,
+  input: ProjectionInput,
+  options: SomaHomeProjectionOptions = {},
+): SomaHomeProjection {
+  switch (substrate) {
+    case "codex":
+      return buildCodexHomeProjection(input, options);
+    case "pi-dev":
+      return buildPiDevHomeProjection(input, options);
+    case "claude-code":
+      return buildClaudeCodeHomeProjection(input, options);
+    case "cursor":
+      return buildCursorHomeProjection(input, options);
+    case "grok":
+      return buildGrokHomeProjection(input, options);
+  }
+}
+
 export async function installGrokHomeProjection(
   input: ProjectionInput,
   options: SomaHomeProjectionOptions = {},

--- a/src/install-spec.ts
+++ b/src/install-spec.ts
@@ -31,6 +31,17 @@ export function vsaSkillUnder(...pathSegments: string[]): (substrateHome: string
   return (substrateHome) => resolve(substrateHome, ...pathSegments, "skills/VSA");
 }
 
+/**
+ * Builds a substrate's invocable skill-loader root resolver — the directory a
+ * substrate scans for skill dirs (parent of where any one skill is projected).
+ * soma#356: `project-skill` asks the adapter spec for this rather than deriving
+ * it from the VSA skill destination, keeping the loader-path contract owned by
+ * the adapter.
+ */
+export function skillsLoaderUnder(...pathSegments: string[]): (substrateHome: string) => string {
+  return (substrateHome) => resolve(substrateHome, ...pathSegments, "skills");
+}
+
 export type InstallValidator = (substrateRoot: string) => Promise<void>;
 
 export interface UninstallContext {
@@ -82,6 +93,12 @@ export interface SubstrateInstallSpec<S extends InstallSubstrate = InstallSubstr
   ownedSubtrees?: readonly string[];
   optionalHomeFiles?(options: unknown): readonly string[];
   vsaSkillProjection: VsaSkillProjectionSpec;
+  /**
+   * The substrate's invocable skill-loader root (parent of where individual
+   * skills are projected). Owned by the adapter so `project-skill` (soma#356)
+   * does not derive loader paths from the VSA skill destination.
+   */
+  skillsLoaderDir(substrateHome: string): string;
   validator?: InstallValidator;
   lifecycleProjection?: LifecycleProjectionSpec;
   postProjection?: readonly InstallPostProjectionStep[];

--- a/src/skill-projection.ts
+++ b/src/skill-projection.ts
@@ -249,9 +249,11 @@ export async function projectSkills(options: {
       skills.push(await linkSkill(resolve(dir), somaHome, options.substrates, force, options));
     }
   } finally {
-    // Refresh once, in a finally: a mid-batch linkSkill failure still leaves the
-    // catalog consistent with whatever was linked (the registry-scan reflects the
-    // symlinks that succeeded), so a partial batch never strands a stale catalog.
+    // Refresh once, in a finally. linkSkill is all-or-nothing (it rolls back its
+    // own partial links on failure), so on a mid-batch failure the registry holds
+    // exactly the fully-linked skills — the refresh therefore catalogs only
+    // invocable skills, never a registry-only entry, and never strands a stale
+    // catalog from the skills that did link.
     catalogFiles = await refreshSkillCatalogs(somaHome, options.substrates, options);
   }
   return { skills, catalogFiles };
@@ -272,19 +274,33 @@ async function linkSkill(
   const name = await readSkillName(skillDir);
   const slots = skillSlots(name, somaHome, substrates, options);
   const links: SkillLink[] = [];
+  // Paths this call created or replaced — rolled back if a later link fails, so a
+  // skill is never left in the registry without all its loader links (which would
+  // catalog a non-invocable skill). Skips "unchanged" links we did not alter.
+  const created: string[] = [];
 
-  // 1. Registry symlink in the soma home — the scan source the catalog reads.
-  //    Skipped when the source already lives under the registry (authored in place).
-  const sourceAlreadyInRegistry = dirname(skillDir) === resolve(registrySkillsDir(somaHome));
-  if (!sourceAlreadyInRegistry) {
-    const status = await ensureSymlink(slots.registry, skillDir, force);
-    links.push({ scope: "registry", path: slots.registry, target: skillDir, status });
-  }
+  try {
+    // 1. Registry symlink in the soma home — the scan source the catalog reads.
+    //    Skipped when the source already lives under the registry (authored in place).
+    const sourceAlreadyInRegistry = dirname(skillDir) === resolve(registrySkillsDir(somaHome));
+    if (!sourceAlreadyInRegistry) {
+      const status = await ensureSymlink(slots.registry, skillDir, force);
+      if (status !== "unchanged") created.push(slots.registry);
+      links.push({ scope: "registry", path: slots.registry, target: skillDir, status });
+    }
 
-  // 2. Loader symlink in each substrate.
-  for (const { substrate, path } of slots.substrates) {
-    const status = await ensureSymlink(path, skillDir, force);
-    links.push({ scope: "substrate", substrate, path, target: skillDir, status });
+    // 2. Loader symlink in each substrate.
+    for (const { substrate, path } of slots.substrates) {
+      const status = await ensureSymlink(path, skillDir, force);
+      if (status !== "unchanged") created.push(path);
+      links.push({ scope: "substrate", substrate, path, target: skillDir, status });
+    }
+  } catch (error) {
+    // Best-effort rollback of this skill's partial links, then rethrow.
+    for (const path of created.reverse()) {
+      await rm(path, { recursive: true, force: true }).catch(() => undefined);
+    }
+    throw error;
   }
 
   return { skill: name, skillDir, links };

--- a/src/skill-projection.ts
+++ b/src/skill-projection.ts
@@ -2,18 +2,12 @@ import { lstat, mkdir, readFile, readlink, rm, stat, symlink } from "node:fs/pro
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { renderSkills } from "./adapters/shared";
-import {
-  buildClaudeCodeHomeProjection,
-  buildCodexHomeProjection,
-  buildCursorHomeProjection,
-  buildGrokHomeProjection,
-  buildPiDevHomeProjection,
-} from "./home-projection";
+import { buildSubstrateHomeProjection } from "./home-projection";
 import type { InstallSubstrate } from "./install-spec";
 import { installSpecFor } from "./install-spec-registry";
 import { writeProjection } from "./projection";
 import { loadSomaHome } from "./soma-home";
-import type { ProjectionInput, SomaHomeProjection, SomaHomeProjectionOptions } from "./types";
+import type { ProjectionInput, SomaHomeProjectionOptions } from "./types";
 
 /**
  * soma#354 slice 1 — the projection primitive.
@@ -34,17 +28,6 @@ import type { ProjectionInput, SomaHomeProjection, SomaHomeProjectionOptions } f
  * unless `force` is set. So a same-named user *symlink* is replaced; only a
  * same-named real *directory* is protected without `force`.
  */
-
-const projectionBuilders: Record<
-  InstallSubstrate,
-  (input: ProjectionInput, options: SomaHomeProjectionOptions) => SomaHomeProjection
-> = {
-  codex: buildCodexHomeProjection,
-  "pi-dev": buildPiDevHomeProjection,
-  "claude-code": buildClaudeCodeHomeProjection,
-  cursor: buildCursorHomeProjection,
-  grok: buildGrokHomeProjection,
-};
 
 export interface ProjectSkillOptions {
   /** Path to the source skill directory (must contain a SKILL.md). */
@@ -112,9 +95,9 @@ function registrySkillsDir(somaHome: string): string {
   return join(somaHome, "skills");
 }
 
-/** Per-substrate invocable skill loader root (parent of the VSA skill dir). */
+/** Per-substrate invocable skill loader root — owned by the adapter spec (soma#356). */
 function substrateSkillsRoot(substrate: InstallSubstrate, substrateHome: string): string {
-  return dirname(installSpecFor(substrate).vsaSkillProjection.destinationDir(substrateHome));
+  return installSpecFor(substrate).skillsLoaderDir(substrateHome);
 }
 
 /**
@@ -222,18 +205,62 @@ function findCatalogFile(
   options: SomaHomeProjectionOptions,
 ): { path: string; content: string } | undefined {
   const expected = renderSkills(input);
-  const bundle = projectionBuilders[substrate](input, options).bundle;
+  const bundle = buildSubstrateHomeProjection(substrate, input, options).bundle;
   return bundle.files.find((file) => file.content === expected);
 }
 
 export async function projectSkill(options: ProjectSkillOptions): Promise<SkillProjectionResult> {
   assertSingleSubstrateForHome(options);
-  const skillDir = resolve(options.skillDir);
-  const name = await readSkillName(skillDir);
   const somaHome = resolveSomaHome(options);
+  const linked = await linkSkill(resolve(options.skillDir), somaHome, options.substrates, options.force ?? false, options);
 
+  // Refresh the catalog once — reload so the registry scan reflects the new skill,
+  // then rewrite only the SKILLS.md file.
+  const catalogFiles = await refreshSkillCatalogs(somaHome, options.substrates, options);
+
+  return { ...linked, catalogFiles };
+}
+
+/**
+ * Project multiple skills into the same substrate(s) and refresh the catalog
+ * ONCE (soma#358). Used by `install --skills` so an N-skill install pays the
+ * catalog-rebuild cost a single time instead of per skill.
+ */
+export async function projectSkills(options: {
+  skillDirs: string[];
+  substrates: InstallSubstrate[];
+  homeDir?: string;
+  somaHome?: string;
+  substrateHome?: string;
+  force?: boolean;
+}): Promise<{ skills: { skill: string; skillDir: string; links: SkillLink[] }[]; catalogFiles: { substrate: InstallSubstrate; path: string }[] }> {
+  assertSingleSubstrateForHome(options);
+  const somaHome = resolveSomaHome(options);
   const force = options.force ?? false;
-  const slots = skillSlots(name, somaHome, options.substrates, options);
+
+  const skills: { skill: string; skillDir: string; links: SkillLink[] }[] = [];
+  for (const dir of options.skillDirs) {
+    skills.push(await linkSkill(resolve(dir), somaHome, options.substrates, force, options));
+  }
+
+  const catalogFiles = await refreshSkillCatalogs(somaHome, options.substrates, options);
+  return { skills, catalogFiles };
+}
+
+/**
+ * Create the registry + per-substrate loader symlinks for one skill, WITHOUT
+ * refreshing the catalog. Callers refresh the catalog once after linking one or
+ * many skills (single-skill: projectSkill; batch: projectSkills).
+ */
+async function linkSkill(
+  skillDir: string,
+  somaHome: string,
+  substrates: InstallSubstrate[],
+  force: boolean,
+  options: { homeDir?: string; substrateHome?: string },
+): Promise<{ skill: string; skillDir: string; links: SkillLink[] }> {
+  const name = await readSkillName(skillDir);
+  const slots = skillSlots(name, somaHome, substrates, options);
   const links: SkillLink[] = [];
 
   // 1. Registry symlink in the soma home — the scan source the catalog reads.
@@ -250,11 +277,7 @@ export async function projectSkill(options: ProjectSkillOptions): Promise<SkillP
     links.push({ scope: "substrate", substrate, path, target: skillDir, status });
   }
 
-  // 3. Refresh the catalog per substrate — reload so the registry scan reflects
-  //    the new skill, then rewrite only the SKILLS.md file.
-  const catalogFiles = await refreshSkillCatalogs(somaHome, options.substrates, options);
-
-  return { skill: name, skillDir, links, catalogFiles };
+  return { skill: name, skillDir, links };
 }
 
 /**

--- a/src/skill-projection.ts
+++ b/src/skill-projection.ts
@@ -68,10 +68,14 @@ export interface SkillLink {
   status: SkillLinkStatus;
 }
 
-export interface SkillProjectionResult {
+/** The registry + per-substrate loader symlinks created for one skill (no catalog). */
+export interface LinkedSkillResult {
   skill: string;
   skillDir: string;
   links: SkillLink[];
+}
+
+export interface SkillProjectionResult extends LinkedSkillResult {
   catalogFiles: { substrate: InstallSubstrate; path: string }[];
   /** Set by unprojectSkill: whether a Soma-created registry symlink was removed. */
   registryRemoved?: boolean;
@@ -233,17 +237,23 @@ export async function projectSkills(options: {
   somaHome?: string;
   substrateHome?: string;
   force?: boolean;
-}): Promise<{ skills: { skill: string; skillDir: string; links: SkillLink[] }[]; catalogFiles: { substrate: InstallSubstrate; path: string }[] }> {
+}): Promise<{ skills: LinkedSkillResult[]; catalogFiles: { substrate: InstallSubstrate; path: string }[] }> {
   assertSingleSubstrateForHome(options);
   const somaHome = resolveSomaHome(options);
   const force = options.force ?? false;
 
-  const skills: { skill: string; skillDir: string; links: SkillLink[] }[] = [];
-  for (const dir of options.skillDirs) {
-    skills.push(await linkSkill(resolve(dir), somaHome, options.substrates, force, options));
+  const skills: LinkedSkillResult[] = [];
+  let catalogFiles: { substrate: InstallSubstrate; path: string }[];
+  try {
+    for (const dir of options.skillDirs) {
+      skills.push(await linkSkill(resolve(dir), somaHome, options.substrates, force, options));
+    }
+  } finally {
+    // Refresh once, in a finally: a mid-batch linkSkill failure still leaves the
+    // catalog consistent with whatever was linked (the registry-scan reflects the
+    // symlinks that succeeded), so a partial batch never strands a stale catalog.
+    catalogFiles = await refreshSkillCatalogs(somaHome, options.substrates, options);
   }
-
-  const catalogFiles = await refreshSkillCatalogs(somaHome, options.substrates, options);
   return { skills, catalogFiles };
 }
 
@@ -258,7 +268,7 @@ async function linkSkill(
   substrates: InstallSubstrate[],
   force: boolean,
   options: { homeDir?: string; substrateHome?: string },
-): Promise<{ skill: string; skillDir: string; links: SkillLink[] }> {
+): Promise<LinkedSkillResult> {
   const name = await readSkillName(skillDir);
   const slots = skillSlots(name, somaHome, substrates, options);
   const links: SkillLink[] = [];

--- a/test/skill-projection.test.ts
+++ b/test/skill-projection.test.ts
@@ -252,6 +252,24 @@ describe("projectSkills (batch)", () => {
       expect(catalog).toContain("## Beta");
     });
   });
+
+  test("a mid-batch failure still leaves the catalog consistent with what was linked", async () => {
+    await withTempHome(async (homeDir) => {
+      const okDir = join(homeDir, ".soma", "skills", "Ok");
+      await mkdir(okDir, { recursive: true });
+      await writeFile(join(okDir, "SKILL.md"), `---\nname: Ok\n---\n`, "utf8");
+      const missingDir = join(homeDir, ".soma", "skills", "Missing"); // no SKILL.md
+
+      await expect(
+        projectSkills({ skillDirs: [okDir, missingDir], substrates: ["claude-code"], homeDir }),
+      ).rejects.toThrow();
+
+      // Ok was linked before the failure; the finally-refresh catalogued it.
+      expect((await lstat(join(homeDir, ".claude", "skills", "Ok"))).isSymbolicLink()).toBe(true);
+      const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
+      expect(catalog).toContain("## Ok");
+    });
+  });
 });
 
 describe("soma install --skills", () => {

--- a/test/skill-projection.test.ts
+++ b/test/skill-projection.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { lstat, mkdir, mkdtemp, readFile, readlink, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { planProjectSkill, planUnprojectSkill, projectSkill, unprojectSkill } from "../src/skill-projection";
+import { planProjectSkill, planUnprojectSkill, projectSkill, projectSkills, unprojectSkill } from "../src/skill-projection";
 import { bootstrapSomaHome } from "../src/index";
 import { runSomaCli } from "../src/cli";
 
@@ -224,6 +224,32 @@ describe("unprojectSkill", () => {
       const result = await unprojectSkill({ skill: "Authored", substrates: ["claude-code"], homeDir, force: true });
       expect(result.registryRemoved).toBe(true);
       await expect(lstat(registryDir)).rejects.toThrow();
+    });
+  });
+});
+
+describe("projectSkills (batch)", () => {
+  test("links all skills into the substrate + catalog with a single refresh", async () => {
+    await withTempHome(async (homeDir) => {
+      for (const name of ["Alpha", "Beta"]) {
+        const dir = join(homeDir, ".soma", "skills", name);
+        await mkdir(dir, { recursive: true });
+        await writeFile(join(dir, "SKILL.md"), `---\nname: ${name}\n---\n`, "utf8");
+      }
+
+      const result = await projectSkills({
+        skillDirs: [join(homeDir, ".soma", "skills", "Alpha"), join(homeDir, ".soma", "skills", "Beta")],
+        substrates: ["claude-code"],
+        homeDir,
+      });
+
+      expect(result.skills.map((s) => s.skill).sort()).toEqual(["Alpha", "Beta"]);
+      expect((await lstat(join(homeDir, ".claude", "skills", "Alpha"))).isSymbolicLink()).toBe(true);
+      expect((await lstat(join(homeDir, ".claude", "skills", "Beta"))).isSymbolicLink()).toBe(true);
+
+      const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
+      expect(catalog).toContain("## Alpha");
+      expect(catalog).toContain("## Beta");
     });
   });
 });

--- a/test/skill-projection.test.ts
+++ b/test/skill-projection.test.ts
@@ -270,6 +270,31 @@ describe("projectSkills (batch)", () => {
       expect(catalog).toContain("## Ok");
     });
   });
+
+  test("rolls back the registry link when a loader link fails, so the catalog never lists a non-invocable skill", async () => {
+    await withTempHome(async (homeDir) => {
+      // Source outside the registry, so a registry symlink IS created first.
+      const srcDir = join(homeDir, "src", "Solo");
+      await mkdir(srcDir, { recursive: true });
+      await writeFile(join(srcDir, "SKILL.md"), `---\nname: Solo\n---\n`, "utf8");
+      // A real dir already occupies the loader slot → loader ensureSymlink throws
+      // (no --force), AFTER the registry link succeeded.
+      const loaderSlot = join(homeDir, ".claude", "skills", "Solo");
+      await mkdir(loaderSlot, { recursive: true });
+      await writeFile(join(loaderSlot, "SKILL.md"), "user\n", "utf8");
+
+      await expect(
+        projectSkills({ skillDirs: [srcDir], substrates: ["claude-code"], homeDir }),
+      ).rejects.toThrow(/non-symlink/);
+
+      // Registry link rolled back → Solo is neither registered nor cataloged.
+      await expect(lstat(join(homeDir, ".soma", "skills", "Solo"))).rejects.toThrow();
+      const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
+      expect(catalog).not.toContain("## Solo");
+      // The user's real loader dir is untouched.
+      expect((await lstat(loaderSlot)).isDirectory()).toBe(true);
+    });
+  });
 });
 
 describe("soma install --skills", () => {


### PR DESCRIPTION
Closes #356 and #358 (both refine the soma#354 projection primitive's internals).

## #356 — adapter owns the loader-path contract
- `SubstrateInstallSpec.skillsLoaderDir(substrateHome)` — each adapter declares its invocable skill-loader root (`skillsLoaderUnder()`; cursor `".cursor/rules/soma"`, pi-dev `"agent"`). `substrateSkillsRoot` calls the spec instead of `dirname(vsaSkillProjection.destinationDir(...))`. Paths identical — a pure boundary move.
- `home-projection.buildSubstrateHomeProjection(substrate, input, options)` — one substrate→builder dispatcher; `skill-projection`'s parallel hard-coded `projectionBuilders` map is gone.

## #358 — batch projection, one catalog refresh
- Extracted `linkSkill()` (registry + loader symlinks, no catalog). `projectSkill` = `linkSkill` + one refresh; new `projectSkills()` links N skills then refreshes the catalog ONCE.
- `linkSkill` is **all-or-nothing**: it rolls back its own registry/loader symlinks on failure, and `projectSkills` refreshes in a `finally` — so a mid-batch failure leaves the registry holding only fully-linked skills and the catalog lists only invocable ones (never a registry-only entry, never a stale catalog).
- `install --skills` calls `projectSkills`, so an N-skill install rebuilds the catalog once instead of per skill.

## Verification (local, commit 26627e2)
```
$ bun run typecheck      # (no output, exit 0)
$ bun test
 0 fail
 5597 expect() calls
Ran 1499 tests across 98 files. [87.31s]
```
`bun run lint` clean on the changed files. 18 skill-projection tests including: batch multi-skill (single refresh), mid-batch failure stays catalog-consistent, and loader-collision rolls back the registry link. Not CI-verified — these are local runs at 26627e2.

## Remaining #354
Evict the ~100 migrated third-party skills from `~/.soma/skills/`; trivial RunAlgorithm prefix dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)