### PR TITLE
docs(algorithm): dedup substrate command-prefixes in RunAlgorithm.md (#354)

### DIFF
--- a/src/skills/the-algorithm/Workflows/RunAlgorithm.md
+++ b/src/skills/the-algorithm/Workflows/RunAlgorithm.md
@@ -5,7 +5,7 @@ Use this workflow to execute the portable PAI Algorithm inside any substrate.
 ## Portable Contract
 
 1. Restate the user's intent in one sentence before planning.
-2. Create a harness run with the installed Soma lifecycle tool or repo CLI. For Codex use `cd $(cat ~/.codex/memories/soma/soma-repo.txt) && bun run soma algorithm new ...`; for Pi.dev use `cd $(cat ~/.pi/agent/soma/soma-repo.txt) && bun run soma algorithm new ...`. Do not assume a global `soma` binary exists.
+2. Create a harness run with the installed Soma lifecycle tool or the repo-local CLI, using your substrate's prefix from the Harness CLI section below — e.g. `<prefix> algorithm new ...`. Do not assume a global `soma` binary exists.
 3. Choose the smallest sufficient effort tier: E1, E2, E3, E4, or E5.
 4. Treat the work as a transition from current state to ideal state.
 5. Create or update the VSA that belongs to the thing being articulated.


### PR DESCRIPTION
Trivial follow-up from sage's #359 review (slice 3).

The Codex/Pi.dev repo-CLI prefixes (`cd $(cat …) && bun run soma`) appeared twice in `src/skills/the-algorithm/Workflows/RunAlgorithm.md`: inline in Portable Contract step 2, and again in the Harness CLI section. A prefix change meant editing two places for both substrates.

Step 2 now references the Harness CLI prefixes (`<prefix> algorithm new ...`); the literal forms live only in Harness CLI (one source).

Doc-only, no behavioral change. `test/algorithm-importer.test.ts` 5/5 (skill still loads/parses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)