### PR TITLE
docs(adr)+refactor(skills): drop eviction; official pack-id pai-* → soma-* (#354)

### DIFF
--- a/docs/adr/0002-official-skill-collection-and-projection-primitive.md
+++ b/docs/adr/0002-official-skill-collection-and-projection-primitive.md
@@ -39,10 +39,12 @@ Two further problems compound it:
 
 2. **Tier legibility.** `~/.soma/skills/` holds 104 entries — 103 skill
    directories (a handful of primitive-operating skills alongside ~100 PAI skills:
-   art, research, scraping…) plus a `README`. The principal migrated those PAI
-   skills in and actively uses them. They are not noise: Soma's mission is to be the
-   portable home for the principal's assistant context, and those skills *are* that
-   context — they belong in `~/.soma/skills/`. **Correction (see below):** the tier
+   art, research, scraping…) plus a `README`. **Decision (recorded here):** on
+   reviewing the eviction task (soma#354), the principal declined it — stating those
+   are skills they migrated in and actively use — and Soma's mission is to be the
+   portable home for the principal's assistant context, so those skills belong in
+   `~/.soma/skills/`. This ADR records that stakeholder call; the eviction was never
+   executed. **Correction (see below):** the tier
    boundary turned out to already be legible without moving anything. The clean,
    complete signal is the `pack-id` — verified against the live home at decision
    time, `grep -l '^pack-id:' ~/.soma/skills/*/SKILL.md | wc -l` returns 2 — a

--- a/docs/adr/0002-official-skill-collection-and-projection-primitive.md
+++ b/docs/adr/0002-official-skill-collection-and-projection-primitive.md
@@ -37,19 +37,22 @@ Two further problems compound it:
    are hand-made copies there; the newly-added `Purpose` skill had to be symlinked by
    hand to become invocable. (Recorded as the skill-projection gap.)
 
-2. **Tier legibility.** `~/.soma/skills/` holds 104 entries — a handful of
-   primitive-operating skills alongside ~100 PAI skills (art, research, scraping…)
-   the principal migrated in and actively uses. These are not noise: Soma's mission
-   is to be the portable home for the principal's assistant context, and those
-   skills *are* that context — they belong in `~/.soma/skills/`. **Correction (see
-   below):** the tier boundary turned out to already be legible without moving
-   anything. Verified against the live home at decision time:
-   `grep -c '^pack-id:' ~/.soma/skills/*/SKILL.md` finds a pack-id on exactly 2 of
-   103 skills — `VSA` and `Purpose`, both official — and the remaining 101 migrated
-   skills carry none, with their origin recorded in `imports/claude-skills/.manifest.json`
-   (+ `imports/pai-*`). So there is a distinction to draw (official vs. imported),
-   but it is metadata that already exists, not a reason to relocate the principal's
-   skills.
+2. **Tier legibility.** `~/.soma/skills/` holds 104 entries — 103 skill
+   directories (a handful of primitive-operating skills alongside ~100 PAI skills:
+   art, research, scraping…) plus a `README`. The principal migrated those PAI
+   skills in and actively uses them. They are not noise: Soma's mission is to be the
+   portable home for the principal's assistant context, and those skills *are* that
+   context — they belong in `~/.soma/skills/`. **Correction (see below):** the tier
+   boundary turned out to already be legible without moving anything. The clean,
+   complete signal is the `pack-id` — verified against the live home at decision
+   time, `grep -c '^pack-id:' ~/.soma/skills/*/SKILL.md` finds one on exactly 2 of
+   the 103 skill directories (`VSA` and `Purpose`, both official); the other 101
+   carry none. (Import provenance is *additionally* tracked under `~/.soma/imports/`
+   — the `claude-skills/.manifest.json` alone records 74, the rest came via
+   `imports/pai-packs` / `imports/pai-migration` — but that is a partial,
+   multi-source record, whereas pack-id presence is the single complete check.) So
+   the official/imported distinction is metadata that already exists, not a reason
+   to relocate the principal's skills.
 
 JC's stance: a *collection* of official Soma skills that extends core without
 bloating it — install what you need — with arc able to install further skills and
@@ -136,9 +139,9 @@ all installed); the contract above is substrate-list-parameterised either way.
   the principal's actively-used skills and `~/.soma/skills/` is their rightful home.
   The original "evict squatters" framing was wrong (the principal pushed back).
   Official skills are distinguished by a `soma-*` `pack-id`; migrated ones lack one
-  and are tracked in `imports/claude-skills/.manifest.json`. Tier is a label, not a
-  directory partition. Official skill pack-ids use the `soma-*` prefix (renamed from
-  the migration-era `pai-*`), since these are now Soma-native, not PAI imports.
+  (the complete signal — see Context). Tier is a label, not a directory partition.
+  Official skill pack-ids use the `soma-*` prefix (renamed from the migration-era
+  `pai-*`), since these are now Soma-native, not PAI imports.
 - Backward compatibility: existing hand-materialised `~/.claude/skills/{VSA,
   Interview}` copies are superseded by projected symlinks; the projector must be
   idempotent and reconcile a prior copy without clobbering unrelated user skills.

--- a/docs/adr/0002-official-skill-collection-and-projection-primitive.md
+++ b/docs/adr/0002-official-skill-collection-and-projection-primitive.md
@@ -43,10 +43,13 @@ Two further problems compound it:
    is to be the portable home for the principal's assistant context, and those
    skills *are* that context — they belong in `~/.soma/skills/`. **Correction (see
    below):** the tier boundary turned out to already be legible without moving
-   anything — official skills carry a `pack-id` (`soma-*`), migrated ones do not and
-   are recorded in `imports/claude-skills/.manifest.json` (+ `imports/pai-*`). So
-   there is a distinction to draw (official vs. imported), but it is metadata, not a
-   reason to relocate the principal's skills.
+   anything. Verified against the live home at decision time:
+   `grep -c '^pack-id:' ~/.soma/skills/*/SKILL.md` finds a pack-id on exactly 2 of
+   103 skills — `VSA` and `Purpose`, both official — and the remaining 101 migrated
+   skills carry none, with their origin recorded in `imports/claude-skills/.manifest.json`
+   (+ `imports/pai-*`). So there is a distinction to draw (official vs. imported),
+   but it is metadata that already exists, not a reason to relocate the principal's
+   skills.
 
 JC's stance: a *collection* of official Soma skills that extends core without
 bloating it — install what you need — with arc able to install further skills and

--- a/docs/adr/0002-official-skill-collection-and-projection-primitive.md
+++ b/docs/adr/0002-official-skill-collection-and-projection-primitive.md
@@ -37,12 +37,16 @@ Two further problems compound it:
    are hand-made copies there; the newly-added `Purpose` skill had to be symlinked by
    hand to become invocable. (Recorded as the skill-projection gap.)
 
-2. **Tier confusion.** `~/.soma/skills/` holds 104 entries — a handful of
-   primitive-operating skills mixed with ~100 migrated general PAI skills (art,
-   research, scraping…) that have nothing to do with Soma's core. Meanwhile six
-   genuinely third-party skills already install cleanly as external packs via arc
-   (`~/.config/arc/pkg/repos/*`, symlinked into `~/.claude/skills/`). The boundary
-   between "Soma's own skills" and "arbitrary skills" is unmarked.
+2. **Tier legibility.** `~/.soma/skills/` holds 104 entries — a handful of
+   primitive-operating skills alongside ~100 PAI skills (art, research, scraping…)
+   the principal migrated in and actively uses. These are not noise: Soma's mission
+   is to be the portable home for the principal's assistant context, and those
+   skills *are* that context — they belong in `~/.soma/skills/`. **Correction (see
+   below):** the tier boundary turned out to already be legible without moving
+   anything — official skills carry a `pack-id` (`soma-*`), migrated ones do not and
+   are recorded in `imports/claude-skills/.manifest.json` (+ `imports/pai-*`). So
+   there is a distinction to draw (official vs. imported), but it is metadata, not a
+   reason to relocate the principal's skills.
 
 JC's stance: a *collection* of official Soma skills that extends core without
 bloating it — install what you need — with arc able to install further skills and
@@ -125,8 +129,13 @@ all installed); the contract above is substrate-list-parameterised either way.
   opt-in. Default install stays minimal.
 - arc gains a post-install / post-uninstall hook that calls the soma primitive;
   tracked as a separate arc issue (cross-repo contract).
-- The ~100 migrated third-party skills squatting in `~/.soma/skills/` are evicted
-  from core's skill dir (separate cleanup) so the tier boundary is legible.
+- The ~100 migrated PAI skills in `~/.soma/skills/` are **not** evicted — they are
+  the principal's actively-used skills and `~/.soma/skills/` is their rightful home.
+  The original "evict squatters" framing was wrong (the principal pushed back).
+  Official skills are distinguished by a `soma-*` `pack-id`; migrated ones lack one
+  and are tracked in `imports/claude-skills/.manifest.json`. Tier is a label, not a
+  directory partition. Official skill pack-ids use the `soma-*` prefix (renamed from
+  the migration-era `pai-*`), since these are now Soma-native, not PAI imports.
 - Backward compatibility: existing hand-materialised `~/.claude/skills/{VSA,
   Interview}` copies are superseded by projected symlinks; the projector must be
   idempotent and reconcile a prior copy without clobbering unrelated user skills.

--- a/docs/adr/0002-official-skill-collection-and-projection-primitive.md
+++ b/docs/adr/0002-official-skill-collection-and-projection-primitive.md
@@ -45,9 +45,9 @@ Two further problems compound it:
    context — they belong in `~/.soma/skills/`. **Correction (see below):** the tier
    boundary turned out to already be legible without moving anything. The clean,
    complete signal is the `pack-id` — verified against the live home at decision
-   time, `grep -c '^pack-id:' ~/.soma/skills/*/SKILL.md` finds one on exactly 2 of
-   the 103 skill directories (`VSA` and `Purpose`, both official); the other 101
-   carry none. (Import provenance is *additionally* tracked under `~/.soma/imports/`
+   time, `grep -l '^pack-id:' ~/.soma/skills/*/SKILL.md | wc -l` returns 2 — a
+   pack-id on exactly 2 of the 103 skill directories (`VSA` and `Purpose`, both
+   official); the other 101 carry none. (Import provenance is *additionally* tracked under `~/.soma/imports/`
    — the `claude-skills/.manifest.json` alone records 74, the rest came via
    `imports/pai-packs` / `imports/pai-migration` — but that is a partial,
    multi-source record, whereas pack-id presence is the single complete check.) So

--- a/src/skills/VSA/SKILL.md
+++ b/src/skills/VSA/SKILL.md
@@ -3,7 +3,7 @@ name: VSA
 description: "Owns the Ideal State Artifact: the commitment-time scaffold for articulating done, deriving ISC criteria, planning features, recording decisions, and verifying work. Use for ideal state, VSA/ISC criteria, project specs, scaffolding, completeness checks, reconciliation, or seeding an VSA from a repo."
 effort: medium
 version: 1.0.4
-pack-id: pai-vsa-v1.0.0
+pack-id: soma-vsa-v1.0.0
 ---
 
 # VSA

--- a/test/vsa-skill-installer.test.ts
+++ b/test/vsa-skill-installer.test.ts
@@ -306,7 +306,7 @@ test("ship config: real src/skills/VSA carries version + pack-id frontmatter", a
   const fm = parseSkillFrontmatter(content);
   expect(fm).not.toBeNull();
   expect(fm?.version).toMatch(/^\d+\.\d+\.\d+/);
-  expect(fm?.packId).toMatch(/^pai-vsa/);
+  expect(fm?.packId).toMatch(/^soma-vsa/);
 });
 
 test("ship config: real src/skills/VSA description fits portable metadata limit", async () => {


### PR DESCRIPTION
Final #354 item, reframed after principal feedback.

## Drop the skill eviction
The remaining #354 task was "evict the ~100 migrated PAI skills in `~/.soma/skills/`." The principal pushed back: those are his **actively-used** skills, and `~/.soma/skills/` is their rightful home. Eviction would de-list them from the catalog for no real gain.

The tier boundary already exists as metadata. Verified against the live home (aggregating count):
```
$ grep -l '^pack-id:' ~/.soma/skills/*/SKILL.md | wc -l   # 2 (of 103 skill dirs)
#   VSA (official), Purpose (official); the other 101 migrated skills carry none.
```
ADR Context + Consequences corrected.

## Official pack-id pai-* → soma-*
Soma-native now, not PAI imports, so `pack-id` prefix `pai-* → soma-*`:
- `src/skills/VSA` → `soma-vsa-v1.0.0` (+ real-file test assertion `/^soma-vsa/`) — **in this PR**
- `Purpose` → `soma-purpose-v1.0.0` — in the `~/.soma` home repo (filesystem-native, not the soma source repo), committed at `502717b` ("chore(skills): Purpose pack-id pai-purpose -> soma-purpose"). Not visible in this PR's diff because it is a different repository; flagged here so #354 closure is traceable.
- `the-algorithm` carries no pack-id

## Safety of the value change (audit)
Only `src/skills/VSA/SKILL.md` changes pack-id in this repo. The change is the *value*, not the key.
```
$ grep -rn 'pai-vsa\|pai-purpose' src/ | grep -v src/skills/   # no matches — nothing gates the literal value
```
The sole consumer, `vsa-skill-installer.ts`, extracts pack-id by presence (`PACK_ID_KEY = /^pack-id:\s*(.+?)\s*$/m`, no value compare); the legacy-prune gate matches `name: ISA`, not the pack-id; drift baselines key on skill name. The one real-file assertion (`test/vsa-skill-installer.test.ts:309`) is updated to `/^soma-vsa/`.

## Verification (local)
```
$ bun test test/vsa-skill-installer.test.ts   # 21 pass / 0 fail
$ bun test                                     # 1499 pass / 0 fail
```

Closes #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)