### PR TITLE
chore(release): 0.10.0 — skill projection primitive + official skill collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   three-tier model (Core / official Soma skills / third-party via arc) and the
   soma-owned projection primitive. Corrected mid-epic: the VSA skill is *not*
   code-gen (it ships plain `.md` with a drift-protected installer, retained); and
-  the migrated ~100 PAI skills are *not* evicted — they are the principal's
-  actively-used skills and `~/.soma/skills/` is their home (official vs. imported
-  is distinguished by `pack-id` presence, not directory partition).
+  the migrated ~100 PAI skills are *not* evicted (a recorded stakeholder decision —
+  see ADR 0002) — they stay in `~/.soma/skills/` rather than being relocated, with
+  official vs. imported distinguished by `pack-id` presence, not directory partition.
 
 ## [0.9.1] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Names only, not paths; dry-run names them, apply projects + reports status.
 - **`projectSkills` batch projection (#358 / #360)** — `install --skills` links
   all selected skills then refreshes the catalog ONCE. `linkSkill` is
-  all-or-nothing: it rolls back its own partial symlinks on failure, so the
-  catalog never lists a skill that isn't fully invocable.
+  all-or-nothing: it rolls back its own partial symlinks on failure, so a mid-batch
+  failure leaves the registry holding only fully-linked skills and the one
+  post-batch catalog refresh reflects only those (no partially-linked, non-invocable
+  entry).
 
 ### Changed
 - **Adapter owns the skill-loader path (#356)** — `SubstrateInstallSpec` gains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,13 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Soma-native, not PAI imports.
 
 ### Docs
-- **ADR 0002 — official skill collection + projection primitive.** Records the
-  three-tier model (Core / official Soma skills / third-party via arc) and the
-  soma-owned projection primitive. Corrected mid-epic: the VSA skill is *not*
-  code-gen (it ships plain `.md` with a drift-protected installer, retained); and
-  the migrated ~100 PAI skills are *not* evicted (a recorded stakeholder decision —
-  see ADR 0002) — they stay in `~/.soma/skills/` rather than being relocated, with
-  official vs. imported distinguished by `pack-id` presence, not directory partition.
+- The design and decisions behind this release — the official skill collection,
+  the projection primitive, and the mid-epic course corrections (the VSA skill is
+  not code-gen and stays; the migrated PAI skills are not evicted) — are recorded
+  in `docs/adr/0002-official-skill-collection-and-projection-primitive.md`. See
+  that ADR for the rationale; it is the source of truth, not duplicated here.
 
 ## [0.9.1] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-26
+
+### Added
+- **Skill projection primitive (#354 / #355)** — `soma project-skill <dir>` and
+  `soma unproject-skill <dir|name>`: symlink a skill into the soma registry
+  (`~/.soma/skills/`) and each substrate's invocable loader, then refresh only the
+  `SKILLS.md` catalog. Idempotent, multi-substrate, dry-run by default with
+  `--apply`; `--force` replaces a real (non-symlink) directory occupying a slot
+  (otherwise refused, guarding user skills from clobber). One owned projection
+  truth that `install --skills` and (future) arc delegate to. Fixes the latent
+  `loadSomaSkills` bug that silently skipped symlinked skills.
+- **`soma install <substrate> --skills <name[,name…]>` (#357)** — projects the
+  named official skills (under `~/.soma/skills/`) into the substrate on install.
+  Names only, not paths; dry-run names them, apply projects + reports status.
+- **`projectSkills` batch projection (#358 / #360)** — `install --skills` links
+  all selected skills then refreshes the catalog ONCE. `linkSkill` is
+  all-or-nothing: it rolls back its own partial symlinks on failure, so the
+  catalog never lists a skill that isn't fully invocable.
+
+### Changed
+- **Adapter owns the skill-loader path (#356)** — `SubstrateInstallSpec` gains
+  `skillsLoaderDir(substrateHome)`; `home-projection` exposes a single
+  `buildSubstrateHomeProjection` dispatcher. `project-skill` no longer derives
+  loader paths from the VSA skill destination or keeps a parallel builder map.
+- **the-algorithm ships as plain `.md` (#359)** — retired the
+  `renderSkill()` / `renderRunWorkflow()` string-literal code-gen in
+  `algorithm-importer.ts`; the content lives in `src/skills/the-algorithm/` and is
+  read from the bundled repo source on import (same model as the VSA skill).
+- **Official skill `pack-id` `pai-*` → `soma-*` (#362)** — `VSA`
+  (`soma-vsa-v1.0.0`) and `Purpose` (`soma-purpose-v1.0.0`), since these are
+  Soma-native, not PAI imports.
+
+### Docs
+- **ADR 0002 — official skill collection + projection primitive.** Records the
+  three-tier model (Core / official Soma skills / third-party via arc) and the
+  soma-owned projection primitive. Corrected mid-epic: the VSA skill is *not*
+  code-gen (it ships plain `.md` with a drift-protected installer, retained); and
+  the migrated ~100 PAI skills are *not* evicted — they are the principal's
+  actively-used skills and `~/.soma/skills/` is their home (official vs. imported
+  is distinguished by `pack-id` presence, not directory partition).
+
 ## [0.9.1] - 2026-06-25
 
 ### Fixed

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,6 +1,6 @@
 schema: arc/v1
 name: soma
-version: 0.9.1
+version: 0.10.0
 type: tool
 tier: community
 description: Substrate-portable Personal AI Assistant core for identity, memory, VSA, skills, learning, and adapters.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soma",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "Substrate-portable Personal AI Assistant core.",


### PR DESCRIPTION
Minor release for the #354 epic (8 PRs merged this cycle).

## Version
Dual bump 0.9.1 → 0.10.0: `package.json` + `arc-manifest.yaml`. CHANGELOG `[0.10.0]` added.

## What 0.10.0 ships (#354)
- `soma project-skill` / `unproject-skill` primitive (#355)
- `soma install --skills <name,…>` (#357)
- adapter-owned `skillsLoaderDir` + `buildSubstrateHomeProjection` (#356); `projectSkills` batch + all-or-nothing rollback (#358/#360)
- the-algorithm code-gen → plain `.md` (#359)
- official `pack-id` `pai-*` → `soma-*`; skill eviction dropped (#362)
- ADR 0002 (corrected: VSA-not-codegen; skills-not-evicted)

## Gates (local)
```
$ bun scripts/check-skill-version.ts      # ok (VSA untouched)
$ bun scripts/check-release-privacy.ts    # ok — no private markers
$ bun run typecheck                       # PASS
```
Versions consistent: package.json / arc-manifest.yaml / CHANGELOG all 0.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)