### PR TITLE
fix(skills): bump VSA version 1.0.4 → 1.0.5 to propagate the soma-vsa pack-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **VSA skill version bump `1.0.4` → `1.0.5`** — the 0.10.0 `pack-id`
+  `pai-vsa` → `soma-vsa` rename (#362) changed `src/skills/VSA/SKILL.md` without
+  bumping its `version:`. The drift-protected installer treats same-version as
+  "no upgrade" (restores missing files only, never overwrites), so the rename
+  never propagated to `~/.soma/skills/VSA` or the substrate projections (they
+  stayed `pai-vsa`). Bumping the version lets the installer re-copy on the next
+  release + reproject. (Cosmetic — `pack-id` is presence-gated, not value-gated.)
+
 ## [0.10.0] - 2026-06-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **VSA skill version bump `1.0.4` → `1.0.5`** — the 0.10.0 `pack-id`
-  `pai-vsa` → `soma-vsa` rename (#362) changed `src/skills/VSA/SKILL.md` without
-  bumping its `version:`. The drift-protected installer treats same-version as
-  "no upgrade" (restores missing files only, never overwrites), so the rename
-  never propagated to `~/.soma/skills/VSA` or the substrate projections (they
-  stayed `pai-vsa`). Bumping the version lets the installer re-copy on the next
-  release + reproject.
+  `pai-vsa-v1.0.0` → `soma-vsa-v1.0.0` rename (#362) changed
+  `src/skills/VSA/SKILL.md` without bumping its `version:`. The drift-protected
+  installer treats same-version as "no upgrade" (restores missing files only,
+  never overwrites), so the rename never propagated to `~/.soma/skills/VSA` or the
+  substrate projections (they stayed `pai-vsa-v1.0.0`). Bumping the version lets
+  the installer re-copy on the next release + reproject.
 
 ## [0.10.0] - 2026-06-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "no upgrade" (restores missing files only, never overwrites), so the rename
   never propagated to `~/.soma/skills/VSA` or the substrate projections (they
   stayed `pai-vsa`). Bumping the version lets the installer re-copy on the next
-  release + reproject. (Cosmetic — `pack-id` is presence-gated, not value-gated.)
+  release + reproject.
 
 ## [0.10.0] - 2026-06-26
 

--- a/src/skills/VSA/SKILL.md
+++ b/src/skills/VSA/SKILL.md
@@ -2,7 +2,7 @@
 name: VSA
 description: "Owns the Ideal State Artifact: the commitment-time scaffold for articulating done, deriving ISC criteria, planning features, recording decisions, and verifying work. Use for ideal state, VSA/ISC criteria, project specs, scaffolding, completeness checks, reconciliation, or seeding an VSA from a repo."
 effort: medium
-version: 1.0.4
+version: 1.0.5
 pack-id: soma-vsa-v1.0.0
 ---
 


### PR DESCRIPTION
## Problem
After publishing 0.10.0 and reprojecting all 5 substrates, the VSA skill's `pack-id` still showed `pai-vsa` in `~/.soma/skills/VSA` and every substrate projection — the #362 `soma-vsa` rename didn't land.

## Root cause
#362 changed `src/skills/VSA/SKILL.md` (the pack-id) but did **not** bump its `version:` (1.0.4). The drift-protected `vsa-skill-installer` treats same-version as "no upgrade" — it restores missing files only and never overwrites existing content — so the rename never propagated. This is exactly what `scripts/check-skill-version.ts` guards against; #362 slipped through (admin-merged).

## Fix
Bump VSA `version:` `1.0.4` → `1.0.5`. The installer now re-copies the skill on the next release + reproject, landing `soma-vsa`.

**No release cut** (per request) — this rides the next feature release. Until then the live projections keep the stale `pai-vsa`, which is cosmetic: `pack-id` is *presence*-gated (the installer requires it exists, never compares the value), so the skill is fully functional and the official/imported tier boundary holds.

## Verification
```
$ bun scripts/check-skill-version.ts   # ok — content changed and version bumped 1.0.4 → 1.0.5
$ bun test test/vsa-skill-installer.test.ts   # pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)