### PR TITLE
fix(manifest): drop cortex from runtime.substrates (#304)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -17,6 +17,7 @@ runtime:
     - pi-dev
     - claude-code
     - cursor
+    - grok
 
 provides:
   cli:

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -17,7 +17,6 @@ runtime:
     - pi-dev
     - claude-code
     - cursor
-    - cortex
 
 provides:
   cli:
@@ -33,7 +32,7 @@ provides:
       trigger: substrate-neutral assistant core
     - name: Soma
       path: skill/
-      trigger: portable assistant core across Codex Pi Claude Cortex
+      trigger: portable assistant core across Codex Pi Claude Cursor
 
 capabilities:
   filesystem:

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -33,7 +33,7 @@ provides:
       trigger: substrate-neutral assistant core
     - name: Soma
       path: skill/
-      trigger: portable assistant core across Codex Pi Claude Cursor
+      trigger: portable assistant core across Codex Pi Claude Cursor Grok
 
 capabilities:
   filesystem:

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Soma
-description: Portable Personal AI Assistant core. USE WHEN designing substrate-neutral assistant identity, memory, ISA, skills, learning, or adapters for Codex, Pi.dev, Claude Code, or Cortex.
+description: Portable Personal AI Assistant core. USE WHEN designing substrate-neutral assistant identity, memory, ISA, skills, learning, or adapters for Codex, Pi.dev, Claude Code, Cursor, or Grok.
 ---
 
 # Soma
@@ -13,7 +13,6 @@ Use this skill when work concerns:
 - personal memory layout
 - Ideal State Artifacts
 - substrate adapters
-- Cortex/Myelin assistant integration
 - translating PAI concepts into a substrate-neutral form
 
 ## Workflows


### PR DESCRIPTION
## Problem

`arc-manifest.yaml` mis-declared Soma's substrate coverage two ways:

1. **Over-listed:** `runtime.substrates` and a skill `trigger:` string listed
   `cortex`, but Cortex/Myelin is **planned** per the README (README:273
   `| Cortex/Myelin | planned agent/daemon integration |`). `arc info` and the
   skill therefore implied Cortex was an available adapter.
2. **Under-listed:** `grok` — the fifth shipped substrate (`INSTALL_SUBSTRATES`
   in `src/cli/substrate-lifecycle.ts:96`, `src/adapters/grok/`, CHANGELOG "the
   fifth Soma substrate", 14 test files) — was **absent** from
   `runtime.substrates`.

Additionally, the skill frontmatter #304 explicitly cited —
`skill/SKILL.md` description "…adapters for Codex, Pi.dev, Claude Code, or
Cortex" — still listed Cortex verbatim (this is the trigger Claude Code actually
loads; the manifest `trigger:` is redundant).

## Fix

- `runtime.substrates`: drop `cortex`, add `grok` → now matches
  `INSTALL_SUBSTRATES` exactly (codex, pi-dev, claude-code, cursor, grok).
- `skill/SKILL.md`: description Cortex → "Cursor, or Grok"; drop the
  "Cortex/Myelin assistant integration" use-when bullet.
- Manifest `trigger:` string aligned to the same five substrates.

README already frames Cortex/Myelin honestly as planned, so no README change.
Revisit substrate coverage once Cortex/Myelin integration lands.

## Verification

- `bun test test/types.test.ts test/install.test.ts` → 80 pass, 0 fail.
- Sage re-review confirmed the full suite green (1515 pass).
- No test pinned the substrate list; the two `cortex` test refs
  (`adapter-active-vsa.test.ts:46`, `home-projection.test.ts:57`) assert `cortex`
  **throws** as unsupported, which this reinforces.

Closes #304.

🤖 Generated with [Claude Code](https://claude.com/claude-code)