### PR TITLE
docs(plans): memory subsystem plan v2 (recall-informed) + adoption analysis

### DIFF
--- a/Plans/2026-07-01-memory-skill-design.md
+++ b/Plans/2026-07-01-memory-skill-design.md
@@ -1,0 +1,275 @@
+# Soma Memory Skill — Design
+
+**Date:** 2026-07-01
+**Status:** Design proposal (greenfield; migration explicitly deferred)
+**Inputs:** Audit of all 10 memory systems in the current PAI installation · Tana note `hS1HEbSQiZZU` ("Building own AI memory", YouTube HgAQOkG_v8c) · External research sweep (Sift corpus + web, 2025/26 literature)
+**Related:** `docs/memory-policy-v0.md`, `docs/writeback-and-policy.md`, DD-2, VSA skill (structural precedent)
+
+---
+
+## 1. The core finding
+
+The current installation runs ten memory systems. Audit result:
+
+**Every system designed write-first is dead or dying. Both systems that work were designed read-first.**
+
+Evidence:
+
+- Writers vs readers: 11 hooks write memory; 4 read it back, and of those, `LoadContext` is broken (reads `~/.claude/PAI/MEMORY/STATE|SIGNALS|WISDOM` — none exist; live data lands in `~/.claude/MEMORY/`), leaving only ACR and Claude Code native auto-memory functioning.
+- Volume without recall: 2,849 learning `.md` files, 5,570 rating lines, 6,363 soma `current-work-*.json`, a 3.3 MB `work.json` — none of it resurfaces. `learning-readback.ts:6` admits it: *"writes extensively (8,400+ files across 5 hooks) but previously had no readback mechanism."*
+- Silent failure: every reader `existsSync`-guards and returns null, so the session-start "learning context" has been injecting nothing, and nobody noticed — proof that the injection was not load-bearing.
+- Three generations of partial migration coexist (`~/.claude/MEMORY` → `~/.claude/PAI/MEMORY` → `~/.soma/memory`), each holding a fragment. 13 of soma's 19 memory categories contain only their README.
+- The two working systems: **Claude Code auto-memory** (tiny always-loaded `MEMORY.md` index, one-fact-per-file bodies, staleness banner, consolidation, size cap) and **ACR** (prompt-time semantic surfacing of prior session pointers). Both start from the read side.
+
+**Design law that follows:** *A memory may only be written if it names the future moment it will resurface. No resurfacing trigger → no write.* The unit of design is the resurfacing moment, not the store.
+
+Systems-thinking framing: the old landscape is the "Fixes That Fail" archetype — each fix for "agent forgets" added a write path, grew the landfill, made recall harder, triggered the next migration. This design closes the loop instead: **usage is the retention signal** (resurfaced-and-useful memories get re-verified; unused memories age out).
+
+## 2. What research and the video contribute
+
+External findings (confidence-tagged, full citations in §10):
+
+1. **Write is the hard part, not retrieval.** Microsoft Memora beat RAG/Mem0/Zep/LangMem on LoCoMo (86.3%) while storing *half* as many entries — merged under stable abstractions instead of fragmenting. [HIGH]
+2. **Tiny index + just-in-time bodies.** Anthropic's own pattern (memory tool, auto-memory, "smallest set of high-signal tokens"): a pointer layer that is always loaded, bodies fetched by tool call. Context rot makes the marketed window unusable as memory residence — even 1M-token models degrade sharply past ~150-400K. [HIGH]
+3. **Consolidation is background compute.** Letta sleep-time agents, Claude autoDream (orient → gather → consolidate → prune, ≤200 lines / 25KB), Generative Agents reflection: never do memory maintenance on the request path. [HIGH]
+4. **Memory is a hint; verify at read.** GitHub Copilot memories carry citations and are verified against the code before being applied; Claude Code treats memory "as a hint, not a fact." Read-time verification replaces expensive write-time curation. [HIGH]
+5. **Invalidate, don't delete.** Zep/Graphiti bi-temporal model: contradiction closes the old fact's validity window; history stays queryable. [HIGH]
+6. **Delta updates, never full rewrites.** ACE: iterative full regeneration causes context collapse and brevity bias; itemized delta edits preserve detail. [HIGH]
+7. **Procedural memory is the growth engine.** ACE-style playbooks and skill files updated after successes/failures deliver the measured capability gains; episodic recall is mostly UX. [HIGH]
+8. **Memory is an attack surface.** MINJA: >95% injection success into agent long-term memory; OWASP agentic ASI06. Provenance + human-reviewable stores (files!) are the defense. [HIGH]
+9. Taxonomy consensus: **episodic / semantic / procedural** (+ working state). Typed lifecycles — each type rots, updates, and resurfaces differently. [HIGH]
+
+From the video ("own the memory, rent the intelligence"):
+
+- Memory is the **portable, substrate-independent layer** — exactly Soma's thesis; the prize is "owning the context every future agent will need, so when an agent comes, you can just plug it right in."
+- Memory has shifted from "remember me" to **action platform**: store the *context that would change an answer*, plus what the agent may do with it.
+- **Action memory** is a distinct type: a visible, queryable record of what the agent did and why (the ticket/approval primitive) — "an agent that can prove that it did what it did on purpose." Not hidden in chat logs or chain-of-thought.
+- **Break-in loop**: memory quality comes from repeated correction on recurring situations, not bulk ingestion. Human stays the write-approval authority.
+- The video supplies principles but zero mechanics (no schema, scoring, forgetting) — those come from §3–§7 below.
+
+## 3. Design principles
+
+P1. **Read-path-first.** Every memory type declares its resurfacing trigger before its write path exists. (Corollary: anything currently written that nothing reads — ratings landfill, per-turn work JSONs — is telemetry, not memory, and moves out of the memory tree.)
+P2. **Files are the substrate; search is an access method.** Markdown + frontmatter, git-versioned, human-auditable, substrate-portable. Grep/BM25/embeddings may index it; nothing lives *only* in an index.
+P3. **Curated writes, few and merged.** Default disposition SKIP. Before create: search; then merge (delta), supersede (close validity), or create. One fact per file.
+P4. **Tiny always-loaded index; bodies just-in-time.** Hard budget. Pointers carry enough hook to let a Fable-class model decide to read the body.
+P5. **Consolidation off the request path.** A background "sleep" pass owns dedupe, promotion, pruning, index rebuild.
+P6. **Memory is a hint — verify at read.** Age + provenance rendered at every read; memories cite their source of truth so the agent can check before acting.
+P7. **Invalidate, never silently delete.** Bi-temporal frontmatter; superseded memories become tombstones; "what did I believe in March" stays answerable.
+P8. **Provenance on every write; untrusted content quarantined.** Web/scraped/tool content never writes memory directly (poisoning defense). Trust tiers align with `docs/writeback-and-policy.md`.
+P9. **Deterministic code first, prompts wrap code.** The `soma memory` CLI does the mechanics; the skill teaches the model when and how to call it. Hooks are substrate enhancements, never requirements.
+
+## 4. Taxonomy — four types, not nineteen
+
+The 19-category tree is an assumption disproven by its own emptiness (13/19 never written). Four types, each defined by its *lifecycle*:
+
+| Type | Contains | Written by | Resurfaces via | Decays by |
+|---|---|---|---|---|
+| **semantic/** | Facts that are currently true: identity, people, preferences, project truths, decisions | Explicit "remember", corrections, consolidation promotions | Index (always) + recall search (task-time) | Superseded → validity window closed |
+| **episodic/** | What happened: session digests, **action log** (what the agent did, with approval state) | Session-end digest (auto, one per session); action entries at consequential-action time | Recall search; consolidation reads it to mine patterns | Digested monthly, then archived; raw entries prune at ~90d |
+| **procedural/** | How to do things: playbooks, break-in corrections ("never em-dashes"), learned strategies per recurring situation | Feedback moments; consolidation promoting repeated episodic patterns | Matched by task context at prompt/task time — highest-value injection | Delta-edited in place (never rewritten); dropped only when contradicted repeatedly |
+| **state/** | Working memory: active work pointers, open loops | Harness/CLI during work | Session start (small, current only) | GC'd aggressively; never archived |
+
+Notes:
+- **Action log is first-class episodic memory** (the video's ticket primitive): `episodic/actions/` entries record intent → approval state → outcome for consequential actions. This is what lets the agent "prove it acted on purpose" and gives consolidation honest success/failure data for procedural promotion.
+- Knowledge-base material (Tana graph, Knowledge archive, research notes) is **reference, not agent memory** — different lifecycle (curated by human, unbounded, browsed not injected). The memory skill may *cite into* it; it does not own it.
+
+## 5. Storage layout
+
+```
+~/.soma/memory/
+  INDEX.md                     # THE resurfacing artifact. ≤200 lines / ≤25KB, always projected.
+  semantic/
+    <slug>.md                  # one fact per file
+  episodic/
+    sessions/2026-07/<date>-<slug>.md
+    actions/2026-07/<date>-<slug>.md
+    digests/2026-06.md         # monthly consolidation output
+  procedural/
+    <situation-slug>.md        # playbook per recurring situation
+  state/
+    active.json                # open work pointers (exists today)
+    events.jsonl               # append-only journal (exists today — keep as write journal)
+  archive/                     # tombstones: superseded memories, pruned episodics
+```
+
+Memory file format (frontmatter is the schema):
+
+```markdown
+---
+id: prefers-colon-over-emdash
+type: procedural            # semantic | episodic | procedural
+created: 2026-04-12
+last_verified: 2026-06-28   # bumped when resurfaced-and-confirmed
+valid_until: null           # set instead of deleting; bi-temporal close
+provenance: conversation    # conversation | consolidation | import | tool:<name>
+trust: principal            # principal | agent | quarantined
+source_of_truth: null       # optional pointer to verify against (file, URL, calendar)
+links: [ai-writing-tells, andreas-style-feedback]
+---
+One assertion, written for a future model that has no other context.
+**Why:** the reason it matters (procedural/feedback entries).
+**Applies when:** trigger conditions (procedural entries).
+```
+
+INDEX.md entry format — one line, ≤150 chars, pointer + hook:
+
+```markdown
+- [prefers-colon-over-emdash] Andreas reads em-dashes as AI tell; use colon/comma (procedural, verified 3d ago)
+```
+
+## 6. Resurfacing — the design center
+
+Four tiers, ordered by cost:
+
+**Tier 0 — Always loaded (projection).** `INDEX.md` is projected into every substrate (Claude Code: `~/.claude/rules/soma/MEMORY.md`, replacing today's static `MEMORY_LAYOUT.md` pointers). Hard budget ≤200 lines / 25KB (~5-6K tokens worst case; target ≤2K). This is the only permanently resident memory context. Fable-class models follow pointers reliably — the index entry's job is to make the model *want* to read the right body file, not to contain the content.
+
+**Tier 1 — Prompt-time surfacing (hook, optional enhancement).** A UserPromptSubmit hook does deterministic entity/keyword match of the prompt against index lines and injects at most 3 *pointers* (never bodies): `Possibly relevant memory: semantic/andreas-mellanon.md — read before answering about Andreas.` Cheap, non-blocking, degradable — a substrate without hooks simply loses this tier, nothing breaks (Soma policy: hooks are enhancements). This is ACR's good idea, minus the broken paths and with pointers instead of excerpts.
+
+**Tier 2 — Task-time recall (skill discipline).** The skill instructs: before non-trivial work, run `soma memory recall "<topic>"` (term-scored search over the tree — exists today as `soma memory search`; extend with type filters and link-following one hop). The model reads whole files it selects. No chunking, no vector infra required: retrieval-by-attention over 1-3 loaded files beats top-k fragments at this corpus size (personal memory is thousands of files, not millions).
+
+**Tier 3 — Read-time verification banner.** `soma memory recall`/`read` renders each memory with a generated header: `⚠ 84 days old, provenance: conversation, source_of_truth: paroli/CONTEXT.md — verify before relying.` Stolen from Claude Code auto-memory (the only current system with decay signaling) and generalized. If the memory names a `source_of_truth`, the skill directs a check against it before consequential use (Copilot citation pattern).
+
+**Usage closes the loop:** when a resurfaced memory proves correct, the agent bumps `last_verified` (one CLI call). Consolidation uses `last_verified` vs `created` as the retention/decay signal. Unused, unverified memories age toward the archive; used ones persist. This is the reinforcing loop the old systems never had.
+
+## 7. Write policy
+
+Triggers (exhaustive — anything else is SKIP):
+1. **Principal says remember** / corrects the agent ("no, always X") → procedural or semantic, trust `principal`.
+2. **Session end** → exactly one episodic digest (8-15 lines: what happened, what changed, open loops). Replaces today's 6,363-file `current-work-*.json` spray.
+3. **Consequential action** (sent, deployed, deleted, paid, published) → one action-log entry at approval time.
+4. **Consolidation** promotes/merges (see §8), trust `agent`.
+5. **Import** (migration, external docs) → trust `quarantined` until human-reviewed. Web/tool content NEVER writes directly (MINJA defense).
+
+Write procedure (skill-enforced, CLI-assisted):
+- `soma memory recall` for the topic first. Then: **merge** (delta-edit existing file, ACE-style — never regenerate), **supersede** (set old file's `valid_until`, create new), or **create**.
+- Every write through `soma memory write` (extends existing `promote` machinery): validates frontmatter, journals to `events.jsonl`, git-commits. Human can `git log` the whole memory history — the audit story.
+- Deferred-by-design: no automatic per-turn writes, no rating capture into the memory tree, no reflection essays. Telemetry ≠ memory.
+
+## 8. Consolidation — `soma memory consolidate` ("sleep")
+
+Background run (idle-time, cron, or manual), never on the request path. A Fable/Opus-class model *is* the consolidation engine — this is where its judgment is spent, off-interactive:
+
+1. **Dedupe/merge** semantic near-duplicates under one abstraction (Memora's lesson: fewer, merged entries outperform).
+2. **Promote**: recurring episodic patterns (≥3 similar corrections/outcomes in the action log) → draft procedural playbook entry, flagged for principal review (break-in loop, human as write authority).
+3. **Contradiction sweep**: newer fact vs older → close validity window, link supersession.
+4. **Prune**: episodic raw >90d → monthly digest → archive. Enforce INDEX budget by dropping lowest-value lines (stale `last_verified`, never resurfaced).
+5. **Rebuild INDEX.md** from frontmatter (deterministic code renders; model picks the hook phrases).
+6. Emit a **reviewable diff** (git branch or plain diff) — the principal approves memory evolution the way they approve PRs. All operations delta-based; full-file regeneration forbidden (context collapse).
+
+## 9. Skill surface + harness integration
+
+Mirror the VSA skill (proven Soma pattern: `SKILL.md` frontmatter + `Workflows/` + `references/`, progressive Fast Path):
+
+```
+src/skills/Memory/
+  SKILL.md            # contract: the four types, write triggers, recall discipline, budgets
+  Workflows/
+    Remember.md       # classify → recall-first → merge/supersede/create via CLI
+    Recall.md         # tiered retrieval discipline + verification banner handling
+    Consolidate.md    # the sleep pass (drives soma memory consolidate + review diff)
+    Audit.md          # health check: index budget, orphans, quarantine queue, dead links
+  references/
+    format.md         # frontmatter schema, index line format
+    gotchas.md        # incl. poisoning rules, "telemetry is not memory"
+```
+
+CLI additions to `src/cli/memory.ts` (deterministic layer): `soma memory recall` (typed, link-following), `write` (validated create/merge/supersede), `verify <id>` (bump last_verified), `consolidate`, `index` (rebuild). All journal to `events.jsonl` — the existing event contract is kept.
+
+Claude Code projection: INDEX.md → `rules/soma/MEMORY.md` (always loaded); skill symlink-projected like every Soma skill; optional Tier-1 recall hook into `hooks/soma/`; session-end digest hook wired into the existing `soma-claude-code-hook.mjs` lifecycle. **Portability:** a substrate with only file-read + shell gets tiers 0/2/3 fully (codex, cursor, pi-dev); hooks add tier 1; nothing depends on a memory *service* running.
+
+Fable/Opus-class exploitation (explicit): (1) retrieval-by-attention over whole just-in-time-loaded files replaces chunk-RAG and vector infra; (2) write-time judgment — merge-vs-supersede-vs-create decided inline by the model, no extraction pipeline; (3) instruction-following strong enough that the write policy is a prompt-level contract enforced by skill + CLI validation, not middleware; (4) background consolidation delegates the expensive judgment to sleep-time model runs; (5) long context tolerates a richer INDEX than 2024-era designs — spent on better *hooks*, not on resident bodies.
+
+## 10. Relationship to current systems
+
+| Current system | Disposition | Rationale |
+|---|---|---|
+| Claude Code auto-memory | **Keep pattern, generalize** — index + one-fact files + staleness banner become the Soma-wide design | Only fully healthy loop found |
+| ACR prompt surfacing | **Keep idea as Tier 1**, deterministic + pointer-only | Only working injection path; fix its hardcoded paths by owning the layout |
+| soma `events.jsonl` + `promote` + PROMOTED | **Keep as write journal / trust machinery** | Sound contract (`memory-policy-v0.md`); this design is its planned "later layers" |
+| 19-category soma tree | **Collapse to 4 types** | 13/19 empty; lifecycle, not topic, is the right partition |
+| `~/.claude/MEMORY` + `~/.claude/PAI/MEMORY` learning hooks | **Retire from memory; reclassify as telemetry** | Split-brain paths; 8,400+ files, zero readback |
+| Tana #ai-memory | **Demote to optional projection target** | No runtime evidence of use; graph is reference knowledge, not agent memory; desktop dependency breaks portability |
+| Knowledge skill / KNOWLEDGE | **Reference layer, not memory** | Different lifecycle; memory may cite into it |
+| `~/work/CLAUDE.md` decisions.md protocol | **Superseded by episodic digests + semantic decisions** | Unenforced convention, uneven adoption (10KB in 2 repos, empty seeds elsewhere) |
+| work.json / ContextSearch | **Replace with `state/active.json` + episodic recall** | Registry read path already broken |
+
+Migration: **deferred by prior agreement.** Single note: `src/pai-memory-migrator.ts` already exists as the natural home; quarantine-import (§7 trigger 5) is the intended path — nothing auto-migrates.
+
+## 11. Open questions for Jens-Christian
+
+1. **Consolidation cadence + engine** — nightly cron with which model? Local (privacy) vs frontier (quality) for the sleep pass?
+2. **Embedding tier** — add optional semantic index (ACR-style) once corpus outgrows grep, or is deterministic search + links enough for years at personal scale? (Recommendation: defer; revisit >5K memory files.)
+3. **Scoping** — one global memory tree, or per-project semantic namespaces (auto-memory's per-project scoping is part of why it works)? (Recommendation: global tree + `project:` frontmatter key + recall filter.)
+4. **Action-log granularity** — which actions are "consequential" enough to log? Tie to writeback trust tiers?
+5. **Index budget** — 25KB ceiling matches Claude auto-dream; comfortable, or tighter for multi-substrate projection?
+6. **Tana** — drop from the memory path entirely, or keep a one-way nightly projection of semantic/ into #ai-memory for browsing?
+
+## 13. The death map — where knowledge goes to die
+
+Forensic deep-dive (5 parallel investigators + adversarial reviewer, atime forensics validated against bulk-sweep artifacts). Ranked by value destroyed:
+
+1. **Purged transcripts with uncaptured corrections** — `~/.claude/projects/*` rolls off at ~30 days (oldest survivor 2026-05-26). Sampled 8 recent sessions: **~70% of durable, typed corrections never landed in any memory.** Gone forever: the soma-inter "you are here to oversee, don't do the work" role rule; the field-tested natural-prompt preference (whose stored recipe still encodes the *opposite* guidance); the sage-vs-persona classifier decision. Gold-grade signal on a 30-day fuse, zero recoverability. Capture is bimodal: projects with maintained auto-memory (cyphr-secwg26, 60+ files) capture nearly everything; projects without a memory dir capture nothing.
+2. **Ratings/sentiment pipeline** — 8,700+ entries; read back only as a *line count*. Content-analysis died Jan 17 (its one output, "NaN/10", fails its own reader's regex). Purpose-built consumers `OpinionTracker.ts` and `RelationshipReflect.ts` are complete, never-invoked programs. Since May the writer corrupts 50–62% of entries with timeout default rating=5.
+3. **Algorithm learning tail** — ~3,960 of 3,966 learning files reachable only via ACR's embedding index, whose hourly indexer stalled Jun 24; session-start readback surfaces just the 3 newest files; promotion pipeline dead since Jan 16 (2 files ever promoted).
+4. **The soma memory tier itself** — sole session-start reader is non-recursive (sees only `README.md`, never `ALGORITHM/` or `PROMOTED/`), and the hook launches it detached with `stdio: ignore`, discarding even that. `PROMOTED/` — the *curated best* of the tier — has no reader at all. 12 of 19 dirs README-only because writers were never repointed after the 2026-05-18 scaffold (RELATIONSHIP/OBSERVABILITY/RESEARCH signal streams live on, landing in the legacy root; 72 MB of tool activity).
+5. **Self-reflection & identity layer** — `algorithm-reflections.jsonl` write-only (zero code readers); reflection self-assessment is *anti-informative* (predicts 7.6/10 vs 4.7/10 actual, r=0.177, 96-100% self-reported criteria pass); TELOS abandoned since Feb 22 with template placeholders (`[What this problem is]`) that get injected into **every session** — the one store with actively negative value.
+
+Also never-captured entirely: ExtractWisdom/ContentAnalysis distillations (no write path exists — insights emitted into conversation, then dropped); OPINIONS.md (two complete writer tools, no scheduler).
+
+## 14. Verdict: smarter, or just accumulating?
+
+**MIXED — one hand-curated compounding loop rides on a rotting automated tier.**
+
+- **Genuinely compounding:** project auto-memory, end-to-end proven — MEMORY.md read at session start, gotcha files preventing re-paid lessons, and retrieval demonstrably changing behavior (mf-cortex applied "the network-join-broke-bus pattern from memory" to diagnose a *new* crash). Where the index is maintained, no re-derivation and no repeated user questions were found.
+- **Not compounding:** the entire automated learning tier (Groundhog Day: split-brain paths, write-only jsonl, dead synthesis, stalled index). ACR fires reliably but injects pointer-less last-action snippets and transcript garbage; zero observed cases of the agent acting on an injection.
+- **"Getting smarter" is unprovable from the harness's own instrumentation.** The apparent rating uptrend (4.78→5.13, z≈11.7) collapses under adversarial review: 62% of June entries are timeout defaults hardcoded to 5; the capture hook, rubric, and rated population were all replaced mid-series (Apr 27 / May 5); and January ran on Sonnet while June is 81% Opus 4.8 — any residual gain is confounded with model upgrades. Meanwhile the #1 failure class (claiming completion without verification) recurs in 6 of 7 months, and the named failure patterns (barge-in, consolidation-table, arc-manifest) exist only as raw captures injected as bare slug titles — **no corrective rule exists anywhere that would prevent recurrence.**
+- Even "accumulating" is too kind: artifact production fell 15× per interaction — not deliberate distillation but writer death. The system is simultaneously under-reading *and* under-writing its automated tier.
+
+Instrumentation lesson for the new design: **memory health is measured by deterministic counts (captures, verifications, index churn, recurrence), never by LLM-inferred sentiment** — the sentiment pipeline mismeasured itself into a fictional trend.
+
+## 15. Retention, decay, and promotion rules — the compounding mechanics
+
+The rules that make session N+1 strictly better-informed than session N. All computable from frontmatter by the CLI; the model supplies judgment only where marked.
+
+### Promotion ladder
+
+| Level | Surface | Enters by | Leaves by |
+|---|---|---|---|
+| L0 Signal | transcripts, `events.jsonl`, tool logs | exists automatically | purged at TTL; only consolidation may mine it first. **Telemetry is not memory** |
+| L1 Episodic | `episodic/sessions|actions/` | session-end digest (1/session); action entries at approval time | digest → archive (see decay) |
+| L2 Durable | `semantic/`, `procedural/` | **P-promote**: principal correction/"remember" → written *same turn*, trust `principal`. **C-promote**: consolidation finds pattern ≥3 occurrences across ≥2 sessions → draft, quarantined until principal approves. **S-promote**: contradiction → supersede (close validity window, link) | superseded or refuted (see decay) |
+| L3 Index line | `INDEX.md` (always loaded) | earned: resurfaced-and-verified ≥2×, OR principal-marked, OR created <7d (recency grace) | evicted by retention score when budget hit |
+| L4 Identity | projected profile/purpose | principal-approved only, rare | principal edit only |
+
+### The five compounding invariants
+
+1. **Correction-capture-same-turn.** Any correction or stated preference becomes a procedural/semantic write *in the session where it happens* — the transcript's 30-day fuse means the session IS the capture window. The write must recall-first and **update contradicting memory** (the natural-prompt case: a stale recipe survived a field-tested correction because nothing forced the update).
+2. **Every session ends with exactly one digest** (write gate) — never zero (soma-inter's evaporated sessions), never 6,363 JSON droppings (state spray).
+3. **Every resurfaced-and-used memory bumps `last_verified`** (one CLI call). Usage is the retention signal; the loop the old systems never closed.
+4. **Consolidation cadence ≤ weekly** — must outrun the L0 purge cycle (30d), or minable signal dies unmined. Consolidation converts failure captures into *corrective rules routed to where they'd fire* (the arc-manifest lesson lived in mf-blueprint's memory, invisible to the soma repo where the miss happened → rules carry `project:` scope or go global-procedural).
+5. **No self-graded memory.** Store principal signal (corrections, approvals, explicit ratings) and deterministic outcomes (test passed, deploy verified); never store the agent's own satisfaction predictions (r=0.177 — noise).
+
+### Decay rules (per type; invalidate, never silently delete)
+
+| Type | Rule |
+|---|---|
+| L0 signal | ratings/tool logs 90d then delete; transcripts stay on their native purge |
+| episodic/sessions | raw >90d → folded into monthly digest → raw archived |
+| episodic/actions | raw 180d (audit value) → digest → archive |
+| semantic | no TTL. Staleness = now − `last_verified`, always rendered at read. Unverified >180d AND never resurfaced → index eviction, archive-candidate flagged at next consolidation review |
+| procedural | decays **only by refutation**: 2 contradicting outcomes → flagged for principal review; unused >1y → dormant pool (greppable, not indexed) |
+| state | GC at session end + weekly sweep (kills the 6,363-file pattern) |
+
+### Retention score (index eviction, deterministic)
+
+`score = trust × recency(last_verified) × type_weight × resurface_count`
+with trust: principal 3 / agent 1 / quarantined 0 — and type_weight: procedural 3 / semantic 2 / episodic 1. When INDEX exceeds budget, lowest scores evict first (file remains; only the always-loaded line is lost). No model call needed.
+
+### Health metrics (deterministic, replaces sentiment pipeline)
+
+Weekly consolidation report: corrections captured vs detected (target: 100% same-turn); % of index lines with `last_verified` <30d; recurrence count of failure classes in action log (the real "getting smarter" metric: does the same failure class re-appear after a corrective rule exists?); index budget headroom; quarantine queue age.
+
+## 16. Sources
+
+- Memora: infoworld.com/article/4191031 · Context rot: research.trychroma.com/context-rot · ACE: arxiv.org/abs/2510.04618 · Zep/Graphiti: arxiv.org/abs/2501.13956 · Letta sleep-time: letta.com/blog/sleep-time-compute · Anthropic context engineering: anthropic.com/engineering/effective-context-engineering-for-ai-agents · Claude Code memory: code.claude.com/docs/en/memory · autoDream: claudefa.st/blog/guide/mechanics/auto-dream · Copilot memory: github.blog (1/15/2026) · MINJA: arxiv.org/abs/2601.05504 · Survey: arxiv.org/abs/2512.13564 · Generative Agents: arxiv.org/abs/2304.03442 · Reflexion: arxiv.org/abs/2303.11366 · anup.io memory-architecture series (5-6/2026) · Video: youtube.com/watch?v=HgAQOkG_v8c (Tana node hS1HEbSQiZZU)

--- a/Plans/2026-07-01-memory-skill-design.md
+++ b/Plans/2026-07-01-memory-skill-design.md
@@ -27,7 +27,7 @@ Systems-thinking framing: the old landscape is the "Fixes That Fail" archetype �
 
 ## 2. What research and the video contribute
 
-External findings (confidence-tagged, full citations in §10):
+External findings (confidence-tagged; sources listed in §16):
 
 1. **Write is the hard part, not retrieval.** Microsoft Memora beat RAG/Mem0/Zep/LangMem on LoCoMo (86.3%) while storing *half* as many entries — merged under stable abstractions instead of fragmenting. [HIGH]
 2. **Tiny index + just-in-time bodies.** Anthropic's own pattern (memory tool, auto-memory, "smallest set of high-signal tokens"): a pointer layer that is always loaded, bodies fetched by tool call. Context rot makes the marketed window unusable as memory residence — even 1M-token models degrade sharply past ~150-400K. [HIGH]
@@ -42,7 +42,7 @@ External findings (confidence-tagged, full citations in §10):
 From the video ("own the memory, rent the intelligence"):
 
 - Memory is the **portable, substrate-independent layer** — exactly Soma's thesis; the prize is "owning the context every future agent will need, so when an agent comes, you can just plug it right in."
-- Memory has shifted from "remember me" to **action platform**: store the *context that would change an answer*, plus what the agent may do with it.
+- Memory has shifted from "remember me" to **action platform**: store the *context that would change an answer*, plus what the assistant may do with it.
 - **Action memory** is a distinct type: a visible, queryable record of what the agent did and why (the ticket/approval primitive) — "an agent that can prove that it did what it did on purpose." Not hidden in chat logs or chain-of-thought.
 - **Break-in loop**: memory quality comes from repeated correction on recurring situations, not bulk ingestion. Human stays the write-approval authority.
 - The video supplies principles but zero mechanics (no schema, scoring, forgetting) — those come from §3–§7 below.

--- a/Plans/2026-07-01-memory-skill-design.md
+++ b/Plans/2026-07-01-memory-skill-design.md
@@ -207,7 +207,7 @@ Migration: **deferred by prior agreement.** Single note: `src/pai-memory-migrato
 
 ## 13. The death map — where knowledge goes to die
 
-Forensic deep-dive (5 parallel investigators + adversarial reviewer, atime forensics validated against bulk-sweep artifacts). Ranked by value destroyed:
+Forensic deep-dive (5 parallel investigators + adversarial reviewer). The figures below come from a **sampled** investigation (e.g. n=8 recent sessions for the transcript-capture rate); the raw atime/bulk-sweep artifacts are local session outputs, not attached here, so treat the percentages as investigative estimates, not audited totals. Ranked by value destroyed:
 
 1. **Purged transcripts with uncaptured corrections** — `~/.claude/projects/*` rolls off at ~30 days (oldest survivor 2026-05-26). Sampled 8 recent sessions: **~70% of durable, typed corrections never landed in any memory.** Gone forever: the soma-inter "you are here to oversee, don't do the work" role rule; the field-tested natural-prompt preference (whose stored recipe still encodes the *opposite* guidance); the sage-vs-persona classifier decision. Gold-grade signal on a 30-day fuse, zero recoverability. Capture is bimodal: projects with maintained auto-memory (cyphr-secwg26, 60+ files) capture nearly everything; projects without a memory dir capture nothing.
 2. **Ratings/sentiment pipeline** — 8,700+ entries; read back only as a *line count*. Content-analysis died Jan 17 (its one output, "NaN/10", fails its own reader's regex). Purpose-built consumers `OpinionTracker.ts` and `RelationshipReflect.ts` are complete, never-invoked programs. Since May the writer corrupts 50–62% of entries with timeout default rating=5.

--- a/Plans/2026-07-02-memory-subsystem-implementation-plan-v2.md
+++ b/Plans/2026-07-02-memory-subsystem-implementation-plan-v2.md
@@ -1,0 +1,146 @@
+# Soma Memory Subsystem — Implementation Plan v2 (recall-informed)
+
+**Date:** 2026-07-02
+**Status:** Active. **Supersedes** [`Plans/2026-07-02-memory-subsystem-implementation-plan.md`](2026-07-02-memory-subsystem-implementation-plan.md) (v1).
+**Rationale:** [`Plans/2026-07-02-recall-adoption-analysis.md`](2026-07-02-recall-adoption-analysis.md) — three-lens fit analysis + three-judge panel on adopting `~/work/mf/recall` (Andreas Aastroem's between-session cognition layer).
+**Precedence rule (unchanged from v1):** where this plan and the design doc ([`Plans/2026-07-01-memory-skill-design.md`](2026-07-01-memory-skill-design.md)) disagree on mechanics, this plan wins.
+
+---
+
+## 1. Verdict on recall
+
+**Adoption strategy: `concepts_only` — unanimous** (pragmatist 8.5, architect 9, skeptic 7; all three recommended it; `all_in` scored 1.5–2.5, `engine_dependency` 3–4). Soma keeps its own M0–M7 skeleton and owned code, and takes from recall exactly four surgical transplants (ideas and formulas, not verbatim files), two named plan amendments, and its falsification corpus as design evidence.
+
+**Decisive reasons:**
+
+1. **No LICENSE exists.** `~/work/mf/recall` has no LICENSE file on disk today; recall's ADR 0023 public/MIT flip is still operator-gated. Any code dependency or vendoring is legally unfounded now — porting *ideas* is the only clean move, which is what this plan does.
+2. **Recall's canon is SQLite, soma's commitment is files.** `session_summaries`, `memories`, `edges`, `proposals` exist only in `~/.recall/recall.db` with no file representation and no rebuild-from-files path. Adopting it breaks soma's stated commitment "Keep memory filesystem-native" (`src/soma-home.ts:63`, projected into `~/.claude/rules/soma/PURPOSE.md`).
+3. **~80% of recall's cognition surface is falsified by its own author.** ADR 0019 flag-disabled the proposal gate ("theatre", flat 0.95 confidence), decay/consolidation ("fired hundreds of times producing nothing"), the knowledge graph, and the InsightDetector. Wholesale adoption imports the corpse alongside the working 20%.
+4. **The proven 20% is small and portable.** Freshness math (`freshness-score.ts`, 102 lines), dedup (`dedup.ts`/`proposals.ts`, ~131 lines), inject budget mechanics, and sub-agent suppression are deterministic, dependency-free ideas that fold into soma's existing milestones in days — most of recall's surviving philosophy (summaries-as-primary-unit, read-path-first, budget-bounded injection) soma had already converged on independently.
+5. **Recall's tempo layer is Claude-Code-shaped.** Its retention signal is ~1,949 access-events/day from hot-path hooks (UserPromptSubmit/PostToolUse/PreCompact/SubagentStop) with no Pi or Codex equivalent — a memory kernel that behaves differently per substrate violates "substrate adapters translate; they do not own core concepts."
+
+**Fatal flaws avoided by this choice:** SQLite-as-canon (loses memory with the DB, nothing migrates as files); the 7-hook Claude-Code tempo coupling that starves on hookless substrates; dual-write governance poison (recall's autonomous capture pipeline vs soma's 5-explicit-trigger invariant); the missing-LICENSE dependency on a single-maintainer private repo; ops inheritance (Homebrew libsqlite3 dylib, 86MB ONNX, LLM detectors) against soma's no-new-deps/deterministic ground rules; and the silent-failure dependency class (three documented "shipped but silently broken in prod" incidents, each caught only by manual live-DB audit).
+
+**On SQLite explicitly:** the architect's judgment is that a *rebuildable derived index* over markdown canon would be constitutional — but recall as-built is not that, and soma v1 does not need it. **This plan introduces no SQLite at all.** A BM25-style derived index (rebuildable from files, loss = telemetry only) is a named memory-v2 trigger: revisit only after the corpus exceeds ~5K files AND recall's LICENSE has landed (§6).
+
+---
+
+## 2. Fixed contracts (carried from v1, unchanged — judges did not overturn any)
+
+- **Note schema** (v1 §2.2): 12 frontmatter keys — `id, type, created, last_verified, valid_until, provenance, trust, source_of_truth, project, links, resurface_count`, optional `hook:`/`review:`. Hand-written parser, tiny grammar, reject unknown keys, round-trip law `parse(serialize(n)) == n`.
+- **Filesystem-native source of truth**: markdown under `~/.soma/memory/` — `INDEX.md`, `semantic/<id>.md`, `episodic/{sessions,actions}/YYYY-MM/`, `episodic/digests/YYYY-MM.md`, `procedural/<id>.md`, `archive/`, `state/` — git-versioned, no database.
+- **INDEX contract** (v1 §2.3): generated, ≤200 lines AND ≤25KB; line grammar `- [<id>] <hook ≤120ch> (<type>, verified <N>d ago)`; inclusion is *earned* (L3 ladder), never given.
+- **Retention score** (v1 §2.4): `trustWeight × typeWeight × recency × (1 + log2(1 + resurface_count))`; `valid_until ≠ null → 0`; deterministic tiebreaks. **Amended** in M3 to adopt recall's freshness curve for the recency term (§3, M3).
+- **Event kinds** (v1 §2.5): 9 kinds appended via `appendSomaMemoryEvent` to `memory/STATE/events.jsonl`; one event per mutating CLI call.
+- **Ground rules**: TypeScript/Bun, zero new runtime deps, deterministic only (no LLM calls M0–M7), injected `now?: Date`, never write outside `~/.soma/memory/`, never delete memory files (except state GC), 19 legacy dirs untouched.
+- **Write policy**: exactly 5 triggers, recall-first refusal, merge/supersede/create, invalidate-never-delete.
+
+---
+
+## 3. Milestones
+
+Ordering unchanged: M0→M1→M2→M3→M4; M5 needs M0–M1; M6 needs M0–M3+M5; M7 needs all; M4 ∥ M5. One PR per milestone, each independently mergeable with binary probes.
+
+### M0 — Note schema, parser, serializer
+- **Delivers:** `src/memory-note.ts` (~250 LOC): parse/serialize/validate per §2 contract, round-trip tested.
+- **Reuses from recall:** nothing — recall has no file-native note layer (its M0-equivalent is SQLite migrations, a different artifact class).
+- **Soma builds:** everything. TDD; property test for round-trip law.
+- **Acceptance:** `parse(serialize(n)) == n` on generated corpus; unknown key → typed error; `bun test` green.
+
+### M1 — Write + verify CLI with recall-first refusal
+- **Delivers:** `src/memory-write.ts` (~350 LOC): `soma memory write|verify`; create-mode refuses when candidates exist; merge appends `**Update (date):**`; supersede sets `valid_until` + links; verify bumps `last_verified` + `resurface_count`.
+- **Reuses from recall (transplant #1 — highest value):** the **dedup engine idea** from `recall/src/lib/proposals.ts` + `dedup.ts` — sha256 exact-hash + Jaccard ≥ 0.6 near-match — reimplemented over a file corpus (walk `semantic/` + `procedural/`, hash normalized bodies, Jaccard on token sets) to power the refusal gate: error lists candidate ids + "re-run with `--merge`/`--supersede`/`--force`". Idea-port, not code copy (license).
+- **Soma builds:** trust tiers, merge/supersede semantics, refusal UX — recall has none of these.
+- **Acceptance:** create against a ≥0.6-similar existing note refuses with candidate ids; `--force` overrides; one event per mutation; verify-bump visible in frontmatter.
+
+### M2 — Recall command with verification banners
+- **Delivers:** `src/memory-recall.ts` (~250 LOC): `soma memory recall <query>` — term scoring, whole-file retrieval (limit 3), 1-hop links, superseded excluded, banner `⚠ Nd old · trust · provenance · verify against <source_of_truth>`, QUARANTINED warning.
+- **Reuses from recall:** the **3-layer progressive disclosure shape** (`search-l1.ts` → `expand.ts` → `transcript.ts`) as design validation for soma's Tier-1-pointers → Tier-2-whole-file split. No code: recall's L1 is FTS5/BM25 over SQLite.
+- **Soma builds:** read-time verification banner and superseded-exclusion via `valid_until` — recall has neither concept.
+- **Acceptance:** superseded notes never returned; quarantined notes carry the warning; banner ages derive from injected `now`.
+
+### M3 — Index renderer (earned inclusion)
+- **Delivers:** `src/memory-index.ts` (~200 LOC): `retentionScore`, `collectAllNotes`, `renderMemoryIndex`, `rebuildMemoryIndex`.
+- **Reuses from recall (transplants #2 and #3):**
+  - **Freshness formula** from `recall/src/lib/freshness-score.ts:87-102`: `count × 0.5^(daysSince/halflifeDays)` with future-timestamp clamp — adopted as the recency term of `retentionScore`, operating on frontmatter `last_verified`/`resurface_count` instead of `access_events` rows. Battle-tested, deterministic, dependency-free; soma's trust/type weights stay on top. This *amends* v1's linear `max(0.1, 1−days/365)` recency term.
+  - **Budget/truncation mechanics** from `recall/src/lib/inject.ts` (chars/4 token estimate, per-section shares, shed-longest-tail, min-1-item-per-section) for enforcing the ≤200-line/≤25KB INDEX budget gracefully instead of hard-cutting.
+- **Soma builds:** the earned-inclusion admission ladder (resurfaced-verified ≥2×, principal-marked, or <7d grace) — recall's hot-zone ranks by behavioral heat, soma's INDEX admits by governed promotion; the semantics are deliberately different.
+- **Acceptance:** quarantined score 0 and never in INDEX; budget enforcement sheds lowest-score lines first with deterministic output; golden-file test for `INDEX.md` given a fixture tree and fixed `now`.
+
+### M4 — Claude Code projection
+- **Delivers:** projection of `INDEX.md` → `~/.claude/rules/soma/MEMORY.md` wired into `src/adapters/claude-code.ts` (array AND map; `ProjectionInput` gains `profile.memory.indexContent`; ~120 LOC). `MEMORY_LAYOUT.md` untouched.
+- **Reuses from recall (transplant #4a):** the **soft-fail exit-0 contract + kill-switch hierarchy pattern** (recall's `RECALL_DISABLE`/`RECALL_DISABLE_INJECT` tiers) → `SOMA_MEMORY_DISABLE=1` (all memory behavior) and `SOMA_MEMORY_DISABLE_PROJECT=1` (projection only). Pattern copy, zero code.
+- **Soma builds:** idempotency — projected content is verbatim stored content, **no wall clock in projected output** (hard invariant AC-4; "verified Nd ago" is computed at index *rebuild* time, not projection time).
+- **Acceptance:** two consecutive `soma install claude-code` runs with unchanged source write identical bytes; uninstall removes cleanly.
+
+### M5 — Episodic digest + action log + single SessionEnd hook
+- **Delivers:** `src/memory-episodic.ts` (~250 LOC): `soma memory digest|action`, ids `YYYYMMDD-<slug>`, exactly one 8–15-line digest per session; one SessionEnd hook for Claude Code, skip-silently on failure.
+- **Reuses from recall (transplant #4b — recall's single biggest capture-quality fix):** **ADR 0014 sub-agent suppression.** Pre-fix, 52.9% of recall's facts were sub-agent noise and Stop events double-fire. Soma's hook adopts the doc-grounded markers: skip when `hook_event_name === 'SubagentStop'` or `agent_type`/`agent_id` is non-empty; overrides `SOMA_MEMORY_FORCE_PRIMARY`/`FORCE_SUBAGENT`. Without this the one-digest invariant breaks on day one in any sub-agent workflow. This was **missing from v1**.
+- **Named accepted gap (recall ADR 0018):** SessionEnd fires only 1–4×/day against long-lived sessions, so the exactly-one-digest invariant **will under-capture multi-day sessions**. v2 accepts this explicitly rather than discovering it; the fix (a PreCompact-equivalent accumulation point) is a named `TODO(memory-v2)` trigger, not silent scope creep.
+- **Soma builds:** the first-class action log (intent→approval→outcome) — no recall equivalent exists.
+- **Acceptance:** digest CLI called twice for one session id → second call no-ops with event; sub-agent-marked invocation writes nothing; hook failure never blocks the session (exit 0 always).
+
+### M6 — Deterministic consolidation
+- **Delivers:** `src/memory-consolidate.ts` (~300 LOC) with `--dry-run`: prune episodic 90d/actions 180d → monthly digest → `archive/` (preserving relative path); mark `review: stale` (semantic `last_verified > 180d` AND `resurface_count == 0`, never auto-archive); mechanical contradiction listing (no auto-merge); state GC (`current-work-*.json > 7d` — the one true deletion); INDEX rebuild; reviewable git diff.
+- **Reuses from recall:** **archive-before-prune + rescue-band** as convergent validation of invalidate-never-delete (recall shipped and hardened it — ADR 0016's 360-row id-collision documents the failure mode; soma's archive preserves paths, avoiding shared-id contracts entirely). And **ADR 0019 as the scope guard**: recall's LLM-driven consolidate "fired hundreds of times producing nothing" — this is the empirical proof that v1's deterministic-only consolidation was right. No LLM step enters M6.
+- **Soma builds:** everything; contradiction listing reuses M1's Jaccard machinery.
+- **Acceptance:** `--dry-run` output equals subsequent real-run diff; no file deleted except state GC; run is idempotent (second run = no-op diff).
+
+### M7 — Memory skill + audit
+- **Delivers:** `src/skills/Memory/` mirroring VSA layout (`SKILL.md` + `Workflows/{Remember,Recall,Consolidate,Audit}.md`, pack-id `soma-memory-v0.1.0`, plain-portable route like the-algorithm), plus `src/memory-audit.ts` (~150 LOC).
+- **Reuses from recall (ops hardening, pattern only):** **ADR 0020's lesson** — recall 1.8 was a silent prod no-op for 13 days because a startup guard was missing. `memory-audit.ts` therefore probes **filesystem ground truth with deterministic counts only**: notes per type, INDEX freshness (mtime vs newest note), digest coverage (sessions with vs without digests), orphaned archive entries, event-line/mutation ratio. Recall's three silent-failure incidents were each caught only by manual live-DB audit — soma's audit automates the equivalent. Matches the no-self-graded-memory invariant (never LLM sentiment).
+- **Acceptance:** audit exits non-zero on stale INDEX or schema-invalid note; all §15 design invariants traceable to a probe.
+
+### Substrate-adapter story (degradation ladder)
+
+Per-substrate, recorded as adapter limitations per soma operating rules:
+
+| Substrate | Tier 0 (INDEX) | Tier 2 (recall) | Capture (digest) |
+|---|---|---|---|
+| **Claude Code** | projected `~/.claude/rules/soma/MEMORY.md` (M4) | `soma memory recall` via Bash | SessionEnd hook (M5), sub-agent-suppressed |
+| **Pi** (`src/adapters/pi-dev/adapter.ts`) | extend `soma_context` with `action=memory_index` | existing `action=memory_search` pattern (`adapter.ts:181-186`) gains `memory_recall`; pull, not push | no hooks: prompt-rule instructs agent to call `soma memory digest` at wrap-up; reduced mode, recorded |
+| **Codex** | static projection file regenerated at consolidation (M6) | CLI directly | none automatic; manual/cron `soma memory digest`; recorded limitation |
+
+The kernel (M0–M3, M6) is identical on all three — only injection and capture tempo degrade. This is the inverse of recall's design, where the retention signal itself was hook-dependent.
+
+---
+
+## 4. What we deliberately do NOT take from recall
+
+1. **SQLite storage, sqlite-vec, FTS5, Homebrew libsqlite3** — canon must be files (stated commitment); the dylib is macOS-coupled; v1 ground rule "no new runtime deps" stands. Not even as a derived index in v1 (gated, §6).
+2. **The proposal/confidence gate** — recall's own ADR 0013 proved it was theatre (flat 0.95 confidence gated nothing). Soma's firewall is the 5-trigger write policy + `trust: quarantined`, human-gated by construction.
+3. **Decay/consolidation daemon, knowledge graph, InsightDetector, multi-type ontology** — the exact machinery recall's ADR 0019 flag-disabled after it produced nothing. We adopt the *deferred-not-deleted-with-named-re-enable-triggers* discipline, not the features.
+4. **Atomic fact extraction** — ADR 0017: "atomic facts shorn of context" = noise; summaries are the primary cognition unit. Soma's digest-first design is the same conclusion.
+5. **The 7-hook tempo layer and passive access capture** — hot-path 30ms hooks, PreCompact, hot-zone/preconscious surfacing all assume Claude Code owns tempo and starve elsewhere (ADR 0021's worker-starvation incident shows the failure mode). Soma ships exactly one SessionEnd hook.
+6. **LLM detectors / inference transport** — recall's summary pipeline is LLM-produced via `inference-transport.ts` (default hardcodes `~/.claude/PAI/Tools/Inference.ts`); soma M0–M7 are deterministic and the digest is principal/agent-authored text.
+7. **ONNX/OpenAI embeddings and semantic search** — additive-never-load-bearing in recall, out of scope in soma until >5K files (design §6).
+8. **Verbatim code of any kind** — no LICENSE file exists; until MIT lands, only idea-ports with attribution comments (`// adapted from recall freshness-score concept, see Plans/2026-07-02-recall-adoption-analysis.md`).
+
+---
+
+## 5. Named memory-v2 escape hatches (recall's re-enable-trigger discipline)
+
+- **Passive verify-bump channel** — trigger: after ~90 days, audit shows corpus-wide `resurface_count` stuck at 0 (the earned-index ladder starving; recall's data says the loop only closes reliably with passive signal). Remedy: adapt recall's **file-native Obsidian-JSONL-drain pattern** (append access events to a JSONL file, drain at next session start) — zero hot-path hooks, zero DB, fits filesystem commitments.
+- **Mid-session accumulation point** — trigger: audit shows long-lived sessions systematically missing digests (ADR 0018 class). Remedy: PreCompact-equivalent accumulator on Claude Code only, recorded as adapter enhancement.
+- **Derived search index** — trigger: corpus >5K files AND recall LICENSE landed. Remedy: BM25 layer strictly as a **rebuildable index** over markdown canon (`soma memory reindex` rebuilds from files; index loss = telemetry loss only). Only then is SQLite acceptable, and only in that role.
+
+---
+
+## 6. Risks
+
+- **Upstream single-maintainer (accepted, mitigated by strategy choice):** recall is one author, 50 commits, tuned to his Obsidian vault and long-lived sessions, already executed one architectural whiplash (1.5). `concepts_only` means soma inherits *zero* version-skew from future pivots — ideas already ported cannot be un-shipped. Residual: the §5 escape hatches reference recall patterns; if the repo vanishes, the analysis doc preserves what we need.
+- **Inference/embedding deps (avoided):** no LLM, ONNX, or libsqlite3 enters soma. Residual risk is temptation drift — M6/M7 reviews must reject any nondeterministic step (the `TODO(memory-v2)` markers are the sanctioned pressure valve).
+- **Doc drift:** recall's README still says "Design phase. No code yet." over 37K lines — proof that docs rot fast in solo projects. Countermeasure: `memory-audit.ts` probes ground truth, not docs; this plan supersedes v1 explicitly at the top; `CONTEXT.md`/ADR updates land in the same PR as the milestone they describe (per soma convention).
+- **Divergence:** ported formulas (freshness, Jaccard threshold 0.6) will drift from upstream tuning. Accepted: soma owns its constants after port; record each port with source-commit reference in the analysis doc so future reconciliation is possible but never required.
+- **Verify-loop starvation (skeptic's strongest concepts_only flaw):** with one hook and explicit verify only, `resurface_count` may sit at 0 and L3 ships dead. Mitigation: M3 grace window (<7d) and principal-marked entries keep the INDEX alive meanwhile; the 90-day audit trigger (§5) is the tripwire, checked by M7's deterministic counts.
+- **Solo-capacity delivery risk:** soma's own death map shows this ecosystem abandons memory systems half-built (13/19 dirs README-only), and C0 capacity is the principal's central blocker. Mitigation unchanged from v1 and endorsed by all judges: independently-mergeable milestones with binary probes — every merged milestone is standalone value even if the sequence stalls.
+
+---
+
+## 7. Acceptance (unchanged from v1, plus v2 deltas)
+
+1. Scripted integration test `test/memory-subsystem.test.ts`: write→recall→verify→index→install-projection→digest+action→age→consolidate→audit.
+2. `bun test` + `tsc` + `eslint` clean.
+3. Exactly one `events.jsonl` line per mutating CLI call.
+4. Design §15 invariants traceable: recall-first refusal (M1), verify-bumps (M1), index-earned-not-given (M3), digest-per-session **with sub-agent suppression** (M5), deterministic health metrics (M7).
+5. **v2 additions:** dedup refusal fires on a Jaccard-0.6 fixture pair (M1); retention recency term matches the half-life curve within float tolerance (M3); sub-agent-marked hook invocation writes zero files (M5); audit detects a deliberately staled INDEX fixture (M7).

--- a/Plans/2026-07-02-memory-subsystem-implementation-plan-v2.md
+++ b/Plans/2026-07-02-memory-subsystem-implementation-plan-v2.md
@@ -50,7 +50,7 @@ Ordering unchanged: M0→M1→M2→M3→M4; M5 needs M0–M1; M6 needs M0–M3+M
 ### M1 — Write + verify CLI with recall-first refusal
 - **Delivers:** `src/memory-write.ts` (~350 LOC): `soma memory write|verify`; create-mode refuses when candidates exist; merge appends `**Update (date):**`; supersede sets `valid_until` + links; verify bumps `last_verified` + `resurface_count`.
 - **Reuses from recall (transplant #1 — highest value):** the **dedup engine idea** from `recall/src/lib/proposals.ts` + `dedup.ts` — sha256 exact-hash + Jaccard ≥ 0.6 near-match — reimplemented over a file corpus (walk `semantic/` + `procedural/`, hash normalized bodies, Jaccard on token sets) to power the refusal gate: error lists candidate ids + "re-run with `--merge`/`--supersede`/`--force`". Idea-port, not code copy (license).
-- **Soma builds:** trust tiers, merge/supersede semantics, refusal UX — recall has none of these.
+- **Soma builds:** trust tiers, merge/supersede semantics, refusal UX — recall has none of these. **Trust is NOT a free caller flag** (superseding v1's `--trust <t>`, which let a caller self-assert `principal` and bypass the poisoning defense): trust is derived from the write *trigger* — principal-authored writes require an explicit human-approval path, tool/import/agent-derived writes default to `quarantined`. `--trust principal` from an agent is refused.
 - **Acceptance:** create against a ≥0.6-similar existing note refuses with candidate ids; `--force` overrides; one event per mutation; verify-bump visible in frontmatter.
 
 ### M2 — Recall command with verification banners

--- a/Plans/2026-07-02-memory-subsystem-implementation-plan-v2.md
+++ b/Plans/2026-07-02-memory-subsystem-implementation-plan-v2.md
@@ -13,7 +13,7 @@
 
 **Decisive reasons:**
 
-1. **No LICENSE exists.** `~/work/mf/recall` has no LICENSE file on disk today; recall's ADR 0023 public/MIT flip is still operator-gated. Any code dependency or vendoring is legally unfounded now — porting *ideas* is the only clean move, which is what this plan does.
+1. **No LICENSE exists.** As analyzed at recall commit `c57a196` (2026-07-03), `~/work/mf/recall` has no LICENSE file; recall's ADR 0023 public/MIT flip is still operator-gated. Any code dependency or vendoring is legally unfounded at that revision — porting *ideas* is the only clean move, which is what this plan does. (Pinned to a commit so the claim is auditable and re-checkable if upstream adds a license later.)
 2. **Recall's canon is SQLite, soma's commitment is files.** `session_summaries`, `memories`, `edges`, `proposals` exist only in `~/.recall/recall.db` with no file representation and no rebuild-from-files path. Adopting it breaks soma's stated commitment "Keep memory filesystem-native" (`src/soma-home.ts:63`, projected into `~/.claude/rules/soma/PURPOSE.md`).
 3. **~80% of recall's cognition surface is falsified by its own author.** ADR 0019 flag-disabled the proposal gate ("theatre", flat 0.95 confidence), decay/consolidation ("fired hundreds of times producing nothing"), the knowledge graph, and the InsightDetector. Wholesale adoption imports the corpse alongside the working 20%.
 4. **The proven 20% is small and portable.** Freshness math (`freshness-score.ts`, 102 lines), dedup (`dedup.ts`/`proposals.ts`, ~131 lines), inject budget mechanics, and sub-agent suppression are deterministic, dependency-free ideas that fold into soma's existing milestones in days — most of recall's surviving philosophy (summaries-as-primary-unit, read-path-first, budget-bounded injection) soma had already converged on independently.
@@ -25,7 +25,9 @@
 
 ---
 
-## 2. Fixed contracts (carried from v1, unchanged — judges did not overturn any)
+## 2. Fixed contracts (carried from v1 — judges did not overturn the storage/schema/index contracts)
+
+Note: the *storage, note-schema, and INDEX* contracts below are unchanged from v1. The write-path **trust** governance is the one refinement (see M1): v1's self-assertable `--trust` flag is superseded — trust is derived from the write trigger. The section header scopes to the data contracts, not the trust CLI.
 
 - **Note schema** (v1 §2.2): 12 frontmatter keys — `id, type, created, last_verified, valid_until, provenance, trust, source_of_truth, project, links, resurface_count`, optional `hook:`/`review:`. Hand-written parser, tiny grammar, reject unknown keys, round-trip law `parse(serialize(n)) == n`.
 - **Filesystem-native source of truth**: markdown under `~/.soma/memory/` — `INDEX.md`, `semantic/<id>.md`, `episodic/{sessions,actions}/YYYY-MM/`, `episodic/digests/YYYY-MM.md`, `procedural/<id>.md`, `archive/`, `state/` — git-versioned, no database.
@@ -68,7 +70,7 @@ Ordering unchanged: M0→M1→M2→M3→M4; M5 needs M0–M1; M6 needs M0–M3+M
 - **Acceptance:** quarantined score 0 and never in INDEX; budget enforcement sheds lowest-score lines first with deterministic output; golden-file test for `INDEX.md` given a fixture tree and fixed `now`.
 
 ### M4 — Claude Code projection
-- **Delivers:** projection of `INDEX.md` → `~/.claude/rules/soma/MEMORY.md` wired into `src/adapters/claude-code.ts` (array AND map; `ProjectionInput` gains `profile.memory.indexContent`; ~120 LOC). `MEMORY_LAYOUT.md` untouched.
+- **Delivers:** projection of `INDEX.md` → `~/.claude/rules/soma/MEMORY.md` wired into `src/adapters/claude-code.ts` (array AND map; `ProjectionInput` gains `memory.indexContent` — a sibling surface, NOT under `profile`, since docs/architecture.md makes Identity and Memory peer compartments; ~120 LOC). `MEMORY_LAYOUT.md` untouched.
 - **Reuses from recall (transplant #4a):** the **soft-fail exit-0 contract + kill-switch hierarchy pattern** (recall's `RECALL_DISABLE`/`RECALL_DISABLE_INJECT` tiers) → `SOMA_MEMORY_DISABLE=1` (all memory behavior) and `SOMA_MEMORY_DISABLE_PROJECT=1` (projection only). Pattern copy, zero code.
 - **Soma builds:** idempotency — projected content is verbatim stored content, **no wall clock in projected output** (hard invariant AC-4; "verified Nd ago" is computed at index *rebuild* time, not projection time).
 - **Acceptance:** two consecutive `soma install claude-code` runs with unchanged source write identical bytes; uninstall removes cleanly.

--- a/Plans/2026-07-02-memory-subsystem-implementation-plan-v2.md
+++ b/Plans/2026-07-02-memory-subsystem-implementation-plan-v2.md
@@ -33,7 +33,7 @@ Note: the *storage, note-schema, and INDEX* contracts below are unchanged from v
 - **Filesystem-native source of truth**: markdown under `~/.soma/memory/` — `INDEX.md`, `semantic/<id>.md`, `episodic/{sessions,actions}/YYYY-MM/`, `episodic/digests/YYYY-MM.md`, `procedural/<id>.md`, `archive/`, `state/` — git-versioned, no database.
 - **INDEX contract** (v1 §2.3): generated, ≤200 lines AND ≤25KB; line grammar `- [<id>] <hook ≤120ch> (<type>, verified <N>d ago)`; inclusion is *earned* (L3 ladder), never given.
 - **Retention score** (v1 §2.4): `trustWeight × typeWeight × recency × (1 + log2(1 + resurface_count))`; `valid_until ≠ null → 0`; deterministic tiebreaks. **Amended** in M3 to adopt recall's freshness curve for the recency term (§3, M3).
-- **Event kinds** (v1 §2.5): 9 kinds appended via `appendSomaMemoryEvent` to `memory/STATE/events.jsonl`; one event per mutating CLI call.
+- **Event kinds** (v1 §2.5): 9 kinds appended via `appendSomaMemoryEvent` to `state/events.jsonl` (the lowercase `state/` path from the storage layout above, one canonical spelling — not the legacy uppercase `STATE/` tree); one event per mutating CLI call.
 - **Ground rules**: TypeScript/Bun, zero new runtime deps, deterministic only (no LLM calls M0–M7), injected `now?: Date`, never write outside `~/.soma/memory/`, never delete memory files (except state GC), 19 legacy dirs untouched.
 - **Write policy**: exactly 5 triggers, recall-first refusal, merge/supersede/create, invalidate-never-delete.
 
@@ -70,7 +70,7 @@ Ordering unchanged: M0→M1→M2→M3→M4; M5 needs M0–M1; M6 needs M0–M3+M
 - **Acceptance:** quarantined score 0 and never in INDEX; budget enforcement sheds lowest-score lines first with deterministic output; golden-file test for `INDEX.md` given a fixture tree and fixed `now`.
 
 ### M4 — Claude Code projection
-- **Delivers:** projection of `INDEX.md` → `~/.claude/rules/soma/MEMORY.md` wired into `src/adapters/claude-code.ts` (array AND map; `ProjectionInput` gains `memory.indexContent` — a sibling surface, NOT under `profile`, since docs/architecture.md makes Identity and Memory peer compartments; ~120 LOC). `MEMORY_LAYOUT.md` untouched.
+- **Delivers:** projection of `INDEX.md` → `~/.claude/rules/soma/MEMORY.md` wired into `src/adapters/claude-code.ts` (array AND map; `ProjectionInput` gains `memory.indexContent` — a sibling surface, NOT under `profile`, keeping Memory a peer compartment to Identity rather than a sub-field of the profile; ~120 LOC). `MEMORY_LAYOUT.md` untouched.
 - **Reuses from recall (transplant #4a):** the **soft-fail exit-0 contract + kill-switch hierarchy pattern** (recall's `RECALL_DISABLE`/`RECALL_DISABLE_INJECT` tiers) → `SOMA_MEMORY_DISABLE=1` (all memory behavior) and `SOMA_MEMORY_DISABLE_PROJECT=1` (projection only). Pattern copy, zero code.
 - **Soma builds:** idempotency — projected content is verbatim stored content, **no wall clock in projected output** (hard invariant AC-4; "verified Nd ago" is computed at index *rebuild* time, not projection time).
 - **Acceptance:** two consecutive `soma install claude-code` runs with unchanged source write identical bytes; uninstall removes cleanly.

--- a/Plans/2026-07-02-memory-subsystem-implementation-plan.md
+++ b/Plans/2026-07-02-memory-subsystem-implementation-plan.md
@@ -1,0 +1,277 @@
+> **SUPERSEDED 2026-07-02** by [2026-07-02-memory-subsystem-implementation-plan-v2.md](2026-07-02-memory-subsystem-implementation-plan-v2.md) (recall-informed). Kept for contract lineage — v2 carries the fixed contracts forward. Analysis: [2026-07-02-recall-adoption-analysis.md](2026-07-02-recall-adoption-analysis.md).
+
+# Soma Memory Subsystem — Implementation Plan
+
+**Date:** 2026-07-02
+**Status:** Ready for implementation
+**Audience:** An implementing agent (Sonnet-class). Follow milestones in order. Each milestone is independently mergeable and ends with binary verification probes. Do not skip probes. Do not improvise beyond the contracts in §2.
+**Design rationale:** `Plans/2026-07-01-memory-skill-design.md` — read §3 (principles), §4 (taxonomy), §5 (layout), §6 (resurfacing), §7 (write policy), §15 (rules) before starting. This plan turns that design into code; when this plan and the design doc disagree on mechanics, this plan wins.
+
+## 0. Required reading before any code
+
+1. `Plans/2026-07-01-memory-skill-design.md` (§3–§7, §15)
+2. `docs/memory-policy-v0.md` — existing memory contract; we extend, never violate
+3. `src/memory.ts` — existing event append + search (patterns to copy)
+4. `src/cli/memory.ts` — existing CLI parse/run/format pattern (copy this shape exactly for new subcommands)
+5. `src/adapters/claude-code.ts:170-215` — projection bundle rules (`CLAUDE_CODE_RULES_FILES` + `CLAUDE_RULES_CONTENT_BUILDERS`; adding a file = update array AND map, the header comment says so)
+6. One existing test file for conventions: `test/relationship-tools.test.ts` or `test/claude-code-install.test.ts` (fixtures via `test/fixtures.ts`, temp soma homes)
+
+## 1. Ground rules
+
+- **Stack:** TypeScript, Bun. `bun test` for tests. No new runtime dependencies. No frontmatter library — write the parser by hand (§2.2 grammar is deliberately tiny).
+- **TDD:** write the milestone's test file first, red → green.
+- **Copy existing patterns:** CLI subcommands mirror `parseMemoryArgs`/`runMemoryCli`/`formatMemorySearchResult` in `src/cli/memory.ts`. Path handling via `createPaths` (`src/paths.ts`). Every mutating operation appends a `SomaMemoryEvent` via `appendSomaMemoryEvent` (`src/memory.ts:35`).
+- **Never write outside `~/.soma/memory/`** (tests: temp dirs). Never write to `~/.claude/MEMORY` or `~/.claude/PAI/MEMORY` — those are the legacy split-brain trees this subsystem replaces.
+- **Never delete memory files.** Superseding sets `valid_until` and moves nothing. Archiving moves files to `memory/archive/` preserving relative path. Deletion happens only for `state/` GC.
+- **Delta edits only:** operations modify specific frontmatter keys or append body sections. Never regenerate a whole note body from scratch.
+- **Determinism:** all M0–M7 code is deterministic (no LLM calls). Same input → same output. `new Date()` allowed only at the CLI boundary, injected as a parameter everywhere else (testability).
+- **Existing dirs are untouched.** The 19 category dirs (WORK, KNOWLEDGE, …) stay as-is. New subsystem lives in NEW dirs alongside them (`semantic/`, `episodic/`, `procedural/`, `state/` already exists, `archive/`, `INDEX.md`). Migration is explicitly out of scope.
+
+## 2. Data contracts (fixed — do not redesign)
+
+### 2.1 Directory layout (under `<somaHome>/memory/`)
+
+```
+INDEX.md                          # generated, never hand-edited (M3)
+semantic/<id>.md                  # one fact per file
+episodic/sessions/YYYY-MM/<date>-<id>.md
+episodic/actions/YYYY-MM/<date>-<id>.md
+episodic/digests/YYYY-MM.md       # consolidation output (M6)
+procedural/<id>.md
+archive/<original relative path>  # invalidated/pruned notes
+STATE/                            # existing dir, unchanged
+```
+
+### 2.2 Note format
+
+`<id>` = kebab-case slug, `^[a-z0-9]+(-[a-z0-9]+)*$`, max 64 chars, equals filename without `.md`. File = frontmatter + body:
+
+```markdown
+---
+id: prefers-colon-over-emdash
+type: procedural
+created: 2026-04-12
+last_verified: 2026-06-28
+valid_until: null
+provenance: conversation
+trust: principal
+source_of_truth: null
+project: null
+links: [ai-writing-tells]
+resurface_count: 3
+---
+One assertion, written for a future model with no other context.
+**Why:** reason it matters.
+**Applies when:** trigger conditions.
+```
+
+Frontmatter grammar: exactly `---\n`, then `key: value` lines, then `---\n`. Values: strings (unquoted), `null`, integers, and `links` as inline array `[a, b]` (may be empty `[]`). No nesting, no multiline values, no quotes. Reject anything else with a clear error.
+
+TypeScript type (add to `src/types.ts`):
+
+```ts
+export type SomaMemoryNoteType = "semantic" | "episodic" | "procedural";
+export type SomaMemoryTrust = "principal" | "agent" | "quarantined";
+
+export interface SomaMemoryNote {
+  id: string;
+  type: SomaMemoryNoteType;
+  created: string;            // YYYY-MM-DD
+  last_verified: string;      // YYYY-MM-DD
+  valid_until: string | null; // YYYY-MM-DD when superseded/expired
+  provenance: string;         // "conversation" | "consolidation" | "import" | "tool:<name>"
+  trust: SomaMemoryTrust;
+  source_of_truth: string | null; // path or URL to verify against
+  project: string | null;     // scope key, e.g. "soma", "paroli"
+  links: string[];            // ids of related notes
+  resurface_count: number;
+  body: string;               // markdown after closing ---
+}
+```
+
+Validation rules (enforce in `parseMemoryNote`, throw with field name):
+- `id` matches slug regex and equals filename stem (checked at read/write call sites)
+- `type` in enum; `trust` in enum; dates match `^\d{4}-\d{2}-\d{2}$`; `valid_until` null or date
+- `links` entries match slug regex; `resurface_count` integer ≥ 0; `body` non-empty trimmed
+
+### 2.3 INDEX.md format
+
+```markdown
+# Soma Memory Index
+<!-- generated by `soma memory index` — do not hand-edit -->
+
+- [prefers-colon-over-emdash] Andreas reads em-dashes as AI tell; use colon/comma (procedural, verified 3d ago)
+- [andreas-mellanon] Andreas GitHub handle is mellanon; NZ timezone (semantic, verified 40d ago)
+```
+
+Line grammar: `- [<id>] <hook, max 120 chars> (<type>, verified <N>d ago)`. Budget: **max 200 entry lines AND max 25 KB total** — whichever is hit first. Hook text = first sentence of note body, truncated at 120 chars (deterministic; a better hook can be set later via optional frontmatter key `hook:` — supported by parser from M0, used by renderer if present).
+
+### 2.4 Retention score (deterministic, M3)
+
+```
+trustWeight:  principal=3, agent=1, quarantined=0
+typeWeight:   procedural=3, semantic=2, episodic=1
+recency:      max(0.1, 1 - daysSince(last_verified)/365)
+score = trustWeight * typeWeight * recency * (1 + log2(1 + resurface_count))
+```
+
+Notes with `valid_until != null` score 0. Index inclusion: score-descending until budget; ties broken by `created` descending then `id` ascending (stable output — projection idempotency depends on this, so `verified Nd ago` rendering must derive from a `now` parameter passed in, not wall clock at render).
+
+### 2.5 Event kinds (appended to existing `events.jsonl` via `appendSomaMemoryEvent`)
+
+`memory.note.created` | `memory.note.merged` | `memory.note.superseded` | `memory.note.verified` | `memory.note.archived` | `memory.digest.written` | `memory.action.logged` | `memory.index.rebuilt` | `memory.consolidation.run`. Each event: `summary` = one line incl. note id(s); `artifactPaths` = affected file(s); `metadata.trust`, `metadata.type` where applicable.
+
+## 3. Milestones
+
+Sizes are guidance; if a milestone balloons past ~2× estimate, stop and flag rather than improvise.
+
+### M0 — Note schema, parser, serializer  (~250 LOC + tests)
+
+**Create:** `src/memory-note.ts`, `test/memory-note.test.ts`. **Modify:** `src/types.ts` (types from §2.2).
+
+Functions (exact signatures):
+
+```ts
+export function parseMemoryNote(raw: string, expectedId?: string): SomaMemoryNote;
+export function serializeMemoryNote(note: SomaMemoryNote): string;   // canonical key order as in §2.2
+export function memoryNotePath(somaHome: string, note: Pick<SomaMemoryNote, "id"|"type"|"created">): string; // §2.1 rules; episodic goes under sessions/ by default — callers for actions pass an explicit subkind, see M5
+export function noteAgeDays(note: SomaMemoryNote, now: Date): number; // days since last_verified
+```
+
+Round-trip law: `parseMemoryNote(serializeMemoryNote(n))` deep-equals `n` — property-test with 5+ hand-built notes including edge cases (empty links, null fields, `hook:` present).
+
+Tests must cover: every validation rule rejecting with field name in message; unknown frontmatter key → error; missing closing `---` → error; id/filename mismatch → error.
+
+**Done when:** `bun test test/memory-note.test.ts` green; `bun run lint` (eslint) and `bunx tsc --noEmit` clean.
+
+### M1 — Write path: `soma memory write | verify` (~350 LOC + tests)
+
+**Create:** `src/memory-write.ts`, `test/memory-write.test.ts`. **Modify:** `src/cli/memory.ts` (extend `ParsedMemoryArgs` union + help + parse + run, same shape as existing `search`/`promote`), `src/cli.ts` (no change needed if dispatch is via `parseMemoryArgs` — verify lines 268/503 route by action union; extend types only).
+
+```ts
+export interface MemoryWriteOptions { somaHome?: string; homeDir?: string; now?: Date;
+  id: string; type: SomaMemoryNoteType; body: string; trust: SomaMemoryTrust;
+  provenance: string; project?: string; links?: string[]; sourceOfTruth?: string; hook?: string;
+  mode: "create" | "merge" | "supersede"; targetId?: string; force?: boolean; substrate: string; }
+export async function writeMemoryNote(opts: MemoryWriteOptions): Promise<{ path: string; note: SomaMemoryNote; event: SomaMemoryEvent }>;
+export async function verifyMemoryNote(opts: { somaHome?: string; homeDir?: string; id: string; now?: Date; substrate: string }): Promise<SomaMemoryNote>; // bumps last_verified to today, resurface_count += 1, appends memory.note.verified
+```
+
+**Recall-first enforcement (the design's dedup rule):** on `mode: "create"`, run `searchSomaMemory` with the note's first body sentence + id terms over the new dirs; if any match scores ≥ 2 in `semantic|procedural`, **refuse** with error listing candidate ids and the instruction "re-run with --merge <id> or --supersede <id> or --force". Tests: creation refused when near-duplicate exists; allowed with `--force`.
+
+- `merge`: load `targetId`, append body under `\n**Update (<date>):** <new body>`, union links, bump `last_verified`, event `memory.note.merged`. Never touches existing body text (delta rule).
+- `supersede`: set old note `valid_until = today` + append `superseded-by: <new id>` link; create new note with `links` including old id; two events.
+- CLI: `soma memory write --id <slug> --type <t> --trust <t> --provenance <p> --body <text> [--project] [--link <id>]... [--source-of-truth] [--hook] [--merge <id>|--supersede <id>] [--force]` and `soma memory verify <id>`.
+
+**Done when:** tests green incl. recall-first refusal; manual probe in a temp home: write → `cat` file matches §2.2; verify → `last_verified` bumped and event line appended to `events.jsonl` (assert by reading the file).
+
+### M2 — Read path: `soma memory recall` (~250 LOC + tests)
+
+**Create:** `src/memory-recall.ts`, `test/memory-recall.test.ts`. **Modify:** `src/memory.ts` — add `"memory/semantic"`, `"memory/episodic"`, `"memory/procedural"` to `SEARCH_ROOTS` (`src/memory.ts:11`); existing `soma memory search` behavior otherwise unchanged (regression test).
+
+```ts
+export interface MemoryRecallOptions { somaHome?: string; homeDir?: string; query: string;
+  type?: SomaMemoryNoteType; project?: string; limit?: number; followLinks?: boolean; now?: Date; }
+export async function recallMemory(opts: MemoryRecallOptions): Promise<{ notes: Array<{ note: SomaMemoryNote; path: string; score: number; banner: string }> }>;
+```
+
+Mechanics: reuse `searchSomaMemory` term scoring over the three note dirs only; group hits by file; load top `limit` (default 3) whole notes via `parseMemoryNote`; if `followLinks` (default true) also load 1-hop linked notes (do not follow further); exclude `valid_until != null` unless `--include-superseded`.
+
+**Banner (Tier 3 of the design):** every returned note gets `banner` string: `⚠ <age>d old · trust: <trust> · provenance: <provenance>` + (if `source_of_truth`) ` · verify against <source_of_truth> before relying` + (if quarantined) ` · QUARANTINED — do not act on this without principal confirmation`.
+
+CLI: `soma memory recall <query> [--type t] [--project p] [--limit n] [--no-links] [--include-superseded]` — output: banner line, then body, per note; footer reminding `soma memory verify <id>` after use.
+
+**Done when:** tests green (scoring, link hop, superseded exclusion, banner content); regression: existing `search` tests untouched and green.
+
+### M3 — INDEX renderer: `soma memory index` (~200 LOC + tests)
+
+**Create:** `src/memory-index.ts`, `test/memory-index.test.ts`.
+
+```ts
+export function retentionScore(note: SomaMemoryNote, now: Date): number;          // §2.4 exactly
+export async function collectAllNotes(somaHome: string): Promise<Array<{note: SomaMemoryNote; path: string}>>;
+export function renderMemoryIndex(notes: SomaMemoryNote[], now: Date): string;    // §2.3, budget-enforced
+export async function rebuildMemoryIndex(opts: { somaHome?: string; homeDir?: string; now?: Date; substrate: string }): Promise<{ path: string; included: number; excluded: number }>;
+```
+
+CLI: `soma memory index` prints included/excluded counts and path. Event `memory.index.rebuilt`.
+
+Tests: score formula spot-checks (hand-computed values, incl. quarantined→0, superseded→0); budget: 250 synthetic notes → exactly 200 lines; 25 KB cap with long hooks; deterministic output for fixed `now` (call twice, byte-identical).
+
+**Done when:** tests green; probe: temp home with 5 notes → `INDEX.md` matches §2.3 line grammar (regex-check each line in test).
+
+### M4 — Projection: INDEX into Claude Code rules (~120 LOC + tests)
+
+**Modify:** `src/adapters/claude-code.ts` — add `"rules/soma/MEMORY.md"` to `CLAUDE_CODE_RULES_FILES` (line ~174) AND a builder in `CLAUDE_RULES_CONTENT_BUILDERS` (per the file's own header comment: array AND map). Builder reads rendered index content passed through `ProjectionInput` (extend `ProjectionInput['profile'].memory` with optional `indexContent: string`; populated by the install pipeline from `<somaHome>/memory/INDEX.md` if present, else a one-line placeholder `"No memory index yet — run soma memory index."`). Keep `MEMORY_LAYOUT.md` untouched (deprecation is a later decision, not this plan).
+**Modify tests:** `test/claude-code-install.test.ts` — bundle now contains the new file; idempotency (AC-4) test must still pass: same input → byte-identical bundle. That means projection uses the stored INDEX.md content verbatim — it never re-renders with a live clock.
+
+**Done when:** install tests green; probe: run `soma install claude-code --home-dir <tmp>` (see existing install test harness) → `<tmp>/.claude/rules/soma/MEMORY.md` exists with index content.
+
+### M5 — Episodic capture: `soma memory digest | action` (~250 LOC + tests)
+
+**Create:** `src/memory-episodic.ts`, `test/memory-episodic.test.ts`.
+
+```ts
+export async function writeSessionDigest(opts: { somaHome?: string; homeDir?: string; substrate: string; now?: Date;
+  summary: string; changed?: string[]; openLoops?: string[]; project?: string; sessionId?: string }): Promise<{ path: string }>;
+export async function logAction(opts: { somaHome?: string; homeDir?: string; substrate: string; now?: Date;
+  intent: string; approval: "principal" | "policy" | "none"; outcome: "done" | "failed" | "pending"; project?: string }): Promise<{ path: string }>;
+```
+
+Both write episodic notes per §2.1/§2.2 (`type: episodic`, trust `agent`, provenance `tool:cli`; id auto-generated `YYYYMMDD-<slug-from-summary>`), under `episodic/sessions/YYYY-MM/` and `episodic/actions/YYYY-MM/` respectively (extend `memoryNotePath` with a subkind param, default `sessions`). Digest body template: `**What happened:** … / **Changed:** … / **Open loops:** …`. Events `memory.digest.written` / `memory.action.logged`.
+
+CLI: `soma memory digest --summary <text> [--changed <x>]... [--open <x>]... [--project p]` and `soma memory action --intent <text> --approval <a> --outcome <o>`.
+
+**Hook wiring (minimal, this milestone):** in the Claude Code adapter's SessionEnd hook path (`soma-claude-code-hook.mjs` lifecycle — locate its SessionEnd handler), invoke `soma memory digest` with the session summary it already has access to; if no summary is available, skip silently (do NOT block session end). One integration test at the lifecycle level if the existing hook tests permit; otherwise unit-test the exported handler function.
+
+**Done when:** tests green; probe: run digest CLI in temp home → file exists at correct dated path, `recall` finds it.
+
+### M6 — Consolidation v1, deterministic only: `soma memory consolidate` (~300 LOC + tests)
+
+**Create:** `src/memory-consolidate.ts`, `test/memory-consolidate.test.ts`.
+
+Pipeline (all deterministic; each step returns a report entry, `--dry-run` prints without writing):
+1. **Prune episodic:** sessions/actions older than 90/180 days (from `created`, vs injected `now`) → append one line each (`- <date> <id>: <first body line>`) to `episodic/digests/YYYY-MM.md` (create if missing), then move raw note to `archive/episodic/...`. Event per moved batch.
+2. **Expire index candidates:** semantic notes with `last_verified` older than 180d AND `resurface_count == 0` → add frontmatter key `review: stale` (parser: optional key, M0 already tolerates via explicit allowlist — add `review` and `hook` to allowed optional keys). Never auto-archive semantic notes.
+3. **Contradiction sweep (mechanical only):** group notes sharing any link or ≥3 common id terms; if a group contains ≥2 non-superseded notes of same `type`, list them in the report for human/LLM review. No auto-merge.
+4. **State GC:** delete `memory/STATE/current-work-*.json` older than 7 days (this is the one true deletion; guard with filename regex `^current-work-.*\.json$`).
+5. **Rebuild index** (M3 function).
+6. Event `memory.consolidation.run` with counts in metadata; print report.
+
+LLM-assisted merge/promotion is **explicitly out of scope** (later layer behind the same CLI; leave a `// TODO(memory-v2)` marker).
+
+**Done when:** tests green per step (fixture homes with pre-aged notes — build dates relative to injected `now`); `--dry-run` writes nothing (assert file tree unchanged).
+
+### M7 — Skill + audit (~150 LOC + skill markdown + tests)
+
+**Create:** `src/skills/Memory/SKILL.md` + `Workflows/{Remember,Recall,Consolidate,Audit}.md`, mirroring `src/skills/VSA/` structure and frontmatter exactly (name `Memory`, `effort: low`, `version: 0.1.0`, `pack-id: soma-memory-v0.1.0`). SKILL.md content: condensed contract from design doc §4–§7 — the four types, the five write triggers (design §7), recall-before-write, verify-after-use, banners are law, "telemetry is not memory". Workflows are step lists that call the CLI; no logic in prose that contradicts the CLI's enforcement.
+**Create:** `src/memory-audit.ts` + test: `soma memory audit` prints health metrics (design §15): notes per type, % index entries verified <30d, quarantine queue count+oldest age, index budget headroom, archive counts, broken links (link target id with no file — report only).
+**Modify:** whatever registers bundled skills for projection (find how VSA registers via `vsa-skill-installer.ts` / `projectableSkills` in `src/adapters/shared/index.ts:22` — note VSA is *excluded* there as managed; Memory should go the plain-portable route via the standard skills registry, i.e. land in `~/.soma/skills/Memory` on install like other bundled skills — copy whatever mechanism `the-algorithm` skill uses in `src/skills/`).
+
+**Done when:** skill projected into a temp install (probe: `<tmp>/.soma/skills/Memory/SKILL.md` exists + appears in rendered `SKILLS.md`); audit CLI output snapshot-tested.
+
+## 4. Milestone order & dependencies
+
+M0 → M1 → M2 → M3 → M4; M5 needs M0–M1; M6 needs M0–M3+M5; M7 needs all. M4 can run parallel to M5. One PR per milestone, conventional commit style used in repo.
+
+## 5. Gotchas (read twice)
+
+- **Idempotent projection is a hard invariant (AC-4).** Anything time-derived in projected content must come from stored file content, not wall clock (M4). If `claude-code-install.test.ts` idempotency fails, you broke this.
+- **Array AND map** when adding a projected rules file (`claude-code.ts` header comment) — miss one and the planner/writer drift guard fails.
+- **Do not "fix" the 19-dir taxonomy, legacy readers, or the non-recursive `readRecentMarkdown`** (`lifecycle.ts:134`) in these PRs. Known issues, separate work. Scope discipline.
+- **`events.jsonl` is append-only** — never rewrite it; consolidation reports derive from filesystem state, not event replay.
+- **`memory promote` (existing) stays untouched.** PROMOTED/ dirs are a parallel legacy path; ignore them.
+- **All new code takes `now?: Date`** and defaults at the CLI boundary only. Tests never sleep, never depend on real dates.
+- **Slug collisions:** `writeMemoryNote` create-mode must fail if file exists (that's what merge/supersede are for).
+- **Quarantined notes** never enter INDEX (score 0) and recall prints the quarantine banner — both are tested, not assumed.
+
+## 6. Out of scope (do not build even if tempting)
+
+Migration of any legacy memory · embeddings/vector index · LLM-assisted consolidation · Tana projection · hooks beyond the single SessionEnd digest call · deleting/deprecating MEMORY_LAYOUT.md · touching `~/.claude/*` trees.
+
+## 7. Final acceptance (whole subsystem)
+
+1. Fresh temp home: `write` (semantic + procedural) → `recall` returns both with banners → `verify` bumps → `index` includes both → `install claude-code` projects INDEX → `digest`+`action` land → age fixtures → `consolidate` prunes/reports → `audit` reports sane numbers. Scripted as one integration test: `test/memory-subsystem.test.ts`.
+2. `bun test` fully green, `bunx tsc --noEmit` clean, eslint clean.
+3. Every mutating CLI call produced exactly one event line (assert count in integration test).
+4. Design-doc §15 invariants traceable: recall-first refusal (M1), verify-bumps-usage (M1), index-earned-not-given (M3), digest-per-session (M5), deterministic health metrics (M7).

--- a/Plans/2026-07-02-recall-adoption-analysis.md
+++ b/Plans/2026-07-02-recall-adoption-analysis.md
@@ -39,11 +39,11 @@ recall is battle-tested (23 ADRs, 2,185 tests, 5,807 prod sessions) but its retr
 
 1. **Freshness/recency curve** → M3 retention recency term (replaces v1's linear recency).
 2. **Jaccard dedup (0.6 threshold)** → M1 write-path refusal.
-3. **Injection budget mechanics** → M4 projection (hard byte/line caps, drop-lowest-scored).
+3. **Injection budget mechanics** → M3 index renderer (INDEX ≤200-line/≤25KB budget, shed lowest-scored). M4 owns projection idempotency + the kill-switch, not the budget.
 4. **Sub-agent suppression** → M5 digest capture (sub-agent sessions write nothing).
 
 Plus two amendments: file-native JSONL access-event drain as a named v2 escape hatch (not v1); PreCompact accumulator as Claude-Code adapter enhancement (not kernel).
 
 ## Full agent outputs
 
-Workflow run `wf_63240eac-542`; per-agent results in the session transcript journal. Fit corpus + votes archived in this doc's tables above.
+Workflow run `wf_63240eac-542`. Per-agent results are a **local session artifact**, not committed: `~/.claude/projects/<session>/subagents/workflows/wf_63240eac-542/journal.jsonl` (one result line per agent). The judge scores and fit-lens verdicts that drove the verdict are reproduced verbatim in this doc's tables above; the raw transcript is not attachable to the repo, so those tables are the auditable record here.

--- a/Plans/2026-07-02-recall-adoption-analysis.md
+++ b/Plans/2026-07-02-recall-adoption-analysis.md
@@ -37,6 +37,8 @@ recall is battle-tested (23 ADRs, 2,185 tests, 5,807 prod sessions) but its retr
 
 ## What Soma takes (the four transplants)
 
+All source references below are pinned to recall commit `c57a196` (2026-07-03), the revision analyzed; line numbers are as of that commit.
+
 1. **Freshness/recency curve** → M3 retention recency term (replaces v1's linear recency).
 2. **Jaccard dedup (0.6 threshold)** → M1 write-path refusal.
 3. **Injection budget mechanics** → M3 index renderer (INDEX ≤200-line/≤25KB budget, shed lowest-scored). M4 owns projection idempotency + the kill-switch, not the budget.

--- a/Plans/2026-07-02-recall-adoption-analysis.md
+++ b/Plans/2026-07-02-recall-adoption-analysis.md
@@ -1,0 +1,49 @@
+# Recall Adoption Analysis — for Soma Memory Subsystem
+
+**Date:** 2026-07-02. Deep analysis of `~/work/mf/recall` (github.com/the-metafactory/recall, Andreas's between-session memory layer for PAI) as candidate for Soma's memory implementation.
+**Method:** 12-agent workflow — 5 parallel readers (recall design/src/hooks+23 ADRs, soma plans, soma live state) → 3 fit lenses → 3 adversarial judges → synthesis.
+**Outcome:** unanimous `concepts_only`. Plan rewritten: [2026-07-02-memory-subsystem-implementation-plan-v2.md](2026-07-02-memory-subsystem-implementation-plan-v2.md).
+
+## Judge panel
+
+| Judge | all_in | engine_dependency | concepts_only | Recommends |
+|---|---|---|---|---|
+| pragmatist | 2.5 | 4 | 8.5 | concepts_only |
+| architect | 1.5 | 4 | 9 | concepts_only |
+| skeptic | 1.5 | 3 | 7 | concepts_only |
+
+## Fit lens verdicts
+
+### portability
+
+Recall's engine architecture (library-not-daemon, CLI-shelling hooks, configurable inference/vault, no SDK imports) is a strong fit for Soma's adapter model, and its empirical evolution (ADR 0019) independently converged on Soma's read-first, summaries-as-cognition philosophy. But as-built it violates "keep memory filesystem-native": session_summaries, memories, edges, and proposals live only in SQLite with no file canon and no rebuild path, making the DB a second source of truth rather than an index. Adoptable if durable content is re-homed to markdown canon with SQLite demoted to a rebuildable index+telemetry layer, and the 7-hook tempo layer is extracted into a per-substrate adapter with graceful degradation (pull tools on Pi, static projection + cron worker on Codex).
+
+### architecture-mapping
+
+recall is a convergent, production-hardened implementation of the same read-path-first thesis soma's memory plan codifies — but on a conflicting substrate (SQLite+sqlite-vec vs filesystem-native markdown) and a conflicting write-governance model (autonomous confidence-gated capture vs five explicit triggers with recall-first refusal). Milestone coverage: M5 (episodic capture/SessionEnd digest) and M2 (layered retrieval) are essentially solved in recall; M6/M1 are partially solved with directly portable deterministic pieces (dedup, archive-before-prune, freshness math); M0/M3/M4 — the file-native note schema, budgeted earned-inclusion INDEX.md, and idempotent install-time projection — have no recall counterpart and must be built fresh. Recall's biggest gift is not code but its falsification record (ADRs 0013/0017/0019): every mechanism soma's plan deliberately excludes (LLM detectors, proposal gate, decay/KG on by default) is one recall shipped and then empirically walked back.
+
+### maturity-risk
+
+recall is battle-tested (23 ADRs, 2,185 tests, 5,807 prod sessions) but its retro record mostly falsifies the elaborate cognition layer — ADR 0019 flag-disabled ~80% of it (proposal gate, decay, KG, InsightDetector) after empirical failure, and what survived (capture + session summaries + BM25 injection) sits on a SQLite/sqlite-vec/ONNX substrate that directly violates soma's filesystem-native commitment and no-new-deps/deterministic ground rules. Concepts-only reimplementation (option c, days of effort, largely already in soma's M0-M7 plan) is the right risk point; all-in (a) or engine-as-dependency (b) inherit macOS-coupled libsqlite3 ops, LLM detector dependencies, and a single-maintainer repo whose MIT license is decided but not yet landed (no LICENSE file; public flip hard-gated on JC review per ADR 0023). recall's greatest value to soma is as a falsification corpus: it already ran the experiment soma's design doc warns against, and the drops (fact extraction 0017, proposal-gate theatre 0013, sub-agent pollution 0014) map one-for-one onto soma's already-chosen constraints.
+
+## Key facts driving the verdict
+
+- **No LICENSE on disk** — recall ADR 0023 (MIT flip) is decided but not landed; code reuse legally unfounded today. Idea-ports only, with attribution.
+- **SQLite is recall's canon, not an index** — session_summaries/memories/edges/proposals live only in `~/.recall/recall.db`, no file representation, no rebuild-from-files path. Direct conflict with Soma's 'keep memory filesystem-native' commitment.
+- **ADR 0019 ('strategic simplification 1.5') flag-disabled ~80% of recall's cognition layer** after empirical failure: proposal gate ('theatre', flat 0.95 confidence), decay/consolidation ('fired hundreds of times producing nothing'), knowledge graph, InsightDetector. What survived: capture + session summaries + BM25-budgeted injection.
+- **The surviving 20% is small + portable**: freshness curve (freshness-score.ts, 102 lines), Jaccard dedup (~131 lines), inject token-budget mechanics, sub-agent suppression (ADR 0014).
+- **Tempo layer is Claude-Code-shaped**: ~1,949 access-events/day via 7 hot-path hooks; no Pi/Codex equivalent → per-substrate behavioral divergence, violating the adapter principle.
+- **Battle-tested where it counts**: 2,185 tests, 5,807 prod sessions, 23 ADRs — the falsification record maps 1:1 onto constraints Soma's design doc had already chosen (no LLM detectors, no autonomous capture, explicit write triggers).
+
+## What Soma takes (the four transplants)
+
+1. **Freshness/recency curve** → M3 retention recency term (replaces v1's linear recency).
+2. **Jaccard dedup (0.6 threshold)** → M1 write-path refusal.
+3. **Injection budget mechanics** → M4 projection (hard byte/line caps, drop-lowest-scored).
+4. **Sub-agent suppression** → M5 digest capture (sub-agent sessions write nothing).
+
+Plus two amendments: file-native JSONL access-event drain as a named v2 escape hatch (not v1); PreCompact accumulator as Claude-Code adapter enhancement (not kernel).
+
+## Full agent outputs
+
+Workflow run `wf_63240eac-542`; per-agent results in the session transcript journal. Fit corpus + votes archived in this doc's tables above.


### PR DESCRIPTION
Adds the memory subsystem planning docs referenced by issues #369, #370, #375.

- Plans/2026-07-01-memory-skill-design.md: the design doc (4-type taxonomy, resurfacing as the design center, write policy, retention mechanics)
- Plans/2026-07-02-memory-subsystem-implementation-plan.md: v1 plan, marked superseded at the top, kept for contract lineage
- Plans/2026-07-02-memory-subsystem-implementation-plan-v2.md: the authoritative plan. Verdict on the-metafactory/recall: concepts_only (unanimous 3-judge panel). Keeps v1 fixed contracts and M0-M7 skeleton; transplants 4 recall concepts (freshness curve into M3 retention, Jaccard 0.6 dedup into M1 write refusal, injection budget mechanics into M4, sub-agent suppression into M5). No SQLite in v1; BM25 derived index is a named v2 trigger (corpus over 5K files AND recall LICENSE landed).
- Plans/2026-07-02-recall-adoption-analysis.md: rationale (judge table, fit lens verdicts, key facts, the four transplants)

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)