### PR TITLE
feat(claude-code): opt-in generated CLAUDE.md with preserved overlay (#368)

### DIFF
--- a/src/adapters/claude-code/claude-md.ts
+++ b/src/adapters/claude-code/claude-md.ts
@@ -15,7 +15,7 @@ import { isClaudeCodeInstallOptions } from "./install-options";
 /**
  * Generated `~/.claude/CLAUDE.md` (soma#368). Opt-in via `--claude-md`.
  *
- * The body is a thin pointer: the real projected context lives in the
+ * The body is a thin pointer: the real projection files live in the
  * auto-discovered `rules/soma/` bundle (soma#64), so CLAUDE.md only needs to
  * announce provenance and route the reader there. Everything a human wants to
  * keep in CLAUDE.md goes in the overlay block, which survives reprojection.

--- a/src/adapters/claude-code/claude-md.ts
+++ b/src/adapters/claude-code/claude-md.ts
@@ -29,14 +29,16 @@ function renderClaudeMdBody(input: ProjectionInput, overlayBody: string | null):
     `# ${assistant} — Claude Code`,
     "",
     "Soma is the source of truth for assistant identity, purpose, memory, skills, and policy.",
-    "The projected context Claude Code auto-discovers lives under `.claude/rules/soma/`:",
+    "The projection files Claude Code auto-discovers live under `.claude/rules/soma/`:",
     "",
     "- `rules/soma/CONTEXT.md` — identity, principal, purpose, operating rules",
     "- `rules/soma/PURPOSE.md` — mission, goals, principles, commitments",
     "- `rules/soma/SKILLS.md` — available skills",
     "- `rules/soma/POLICY.md` — substrate policy",
     "",
-    "Refresh this projection with `soma install claude-code --apply`.",
+    // Regenerating CLAUDE.md needs the opt-in flag (writing is gated on it), so
+    // the instruction names it explicitly (sage#378).
+    "Regenerate this file with `soma install claude-code --apply --claude-md`.",
   ].join("\n");
   return withProvenance(
     "claude-code",
@@ -56,12 +58,13 @@ async function readOrNull(path: string): Promise<string | null> {
 /**
  * Decide what overlay content to carry into the regenerated file.
  *
- * - An existing overlay block is preserved verbatim (idempotency + hand edits
- *   inside the markers survive).
- * - A pre-existing, non-Soma CLAUDE.md is preserved WHOLESALE into the overlay
- *   on first conversion — this is the lossless-migration guarantee: converting
- *   a hand-maintained CLAUDE.md never drops its content, it moves under the
- *   marker for later curation.
+ * - An existing overlay block is preserved (idempotency + hand edits inside the
+ *   markers survive).
+ * - A pre-existing, non-Soma CLAUDE.md has its full text carried into the
+ *   overlay on first conversion, so no CONTENT is dropped — it moves under the
+ *   marker for later curation. Note: surrounding blank lines are normalized by
+ *   the overlay renderer/reader, so this is content-lossless, not byte-exact
+ *   (sage#378: the earlier doc overclaimed "wholesale/byte-lossless").
  * - Otherwise (greenfield, or an already-Soma file with no overlay) there is
  *   nothing to carry.
  */
@@ -73,7 +76,7 @@ export function resolveClaudeMdOverlay(existing: string | null): string | null {
     return [
       "Preserved from the pre-Soma CLAUDE.md on first projection. Curate or move into ~/.soma.",
       "",
-      existing.trim(),
+      existing,
     ].join("\n");
   }
   return null;

--- a/src/adapters/claude-code/claude-md.ts
+++ b/src/adapters/claude-code/claude-md.ts
@@ -1,0 +1,98 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { isEnoent } from "../../fs-utils";
+import { loadSomaHome } from "../../soma-home";
+import type { InstallPostProjectionContext } from "../../install-spec";
+import type { ProjectionInput } from "../../types";
+import {
+  extractOverlay,
+  hasProvenanceHeader,
+  renderOverlay,
+  withProvenance,
+} from "../shared";
+import { isClaudeCodeInstallOptions } from "./install-options";
+
+/**
+ * Generated `~/.claude/CLAUDE.md` (soma#368). Opt-in via `--claude-md`.
+ *
+ * The body is a thin pointer: the real projected context lives in the
+ * auto-discovered `rules/soma/` bundle (soma#64), so CLAUDE.md only needs to
+ * announce provenance and route the reader there. Everything a human wants to
+ * keep in CLAUDE.md goes in the overlay block, which survives reprojection.
+ */
+export const CLAUDE_CODE_CLAUDE_MD_RELATIVE_PATH = "CLAUDE.md";
+
+function renderClaudeMdBody(input: ProjectionInput, overlayBody: string | null): string {
+  const displayName = input.profile.assistant.displayName ?? "";
+  const assistant = displayName.length > 0 ? displayName : input.profile.assistant.name;
+  const generated = [
+    `# ${assistant} — Claude Code`,
+    "",
+    "Soma is the source of truth for assistant identity, purpose, memory, skills, and policy.",
+    "The projected context Claude Code auto-discovers lives under `.claude/rules/soma/`:",
+    "",
+    "- `rules/soma/CONTEXT.md` — identity, principal, purpose, operating rules",
+    "- `rules/soma/PURPOSE.md` — mission, goals, principles, commitments",
+    "- `rules/soma/SKILLS.md` — available skills",
+    "- `rules/soma/POLICY.md` — substrate policy",
+    "",
+    "Refresh this projection with `soma install claude-code --apply`.",
+  ].join("\n");
+  return withProvenance(
+    "claude-code",
+    [generated, "", renderOverlay(overlayBody)].join("\n"),
+  );
+}
+
+async function readOrNull(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (isEnoent(error)) return null;
+    throw error;
+  }
+}
+
+/**
+ * Decide what overlay content to carry into the regenerated file.
+ *
+ * - An existing overlay block is preserved verbatim (idempotency + hand edits
+ *   inside the markers survive).
+ * - A pre-existing, non-Soma CLAUDE.md is preserved WHOLESALE into the overlay
+ *   on first conversion — this is the lossless-migration guarantee: converting
+ *   a hand-maintained CLAUDE.md never drops its content, it moves under the
+ *   marker for later curation.
+ * - Otherwise (greenfield, or an already-Soma file with no overlay) there is
+ *   nothing to carry.
+ */
+export function resolveClaudeMdOverlay(existing: string | null): string | null {
+  if (existing === null) return null;
+  const existingOverlay = extractOverlay(existing);
+  if (existingOverlay !== null) return existingOverlay;
+  if (!hasProvenanceHeader(existing) && existing.trim().length > 0) {
+    return [
+      "Preserved from the pre-Soma CLAUDE.md on first projection. Curate or move into ~/.soma.",
+      "",
+      existing.trim(),
+    ].join("\n");
+  }
+  return null;
+}
+
+/**
+ * postProjection step: write the generated CLAUDE.md when `--claude-md` is set.
+ * No-op otherwise, so the default install still leaves CLAUDE.md untouched
+ * (the soma#64 stance) until a caller explicitly opts in.
+ */
+export async function installClaudeCodeClaudeMd(context: InstallPostProjectionContext): Promise<string[]> {
+  if (!(isClaudeCodeInstallOptions(context.options) && context.options.claudeMd === true)) {
+    return [];
+  }
+  const target = join(context.substrateHome, CLAUDE_CODE_CLAUDE_MD_RELATIVE_PATH);
+  const existing = await readOrNull(target);
+  const overlay = resolveClaudeMdOverlay(existing);
+  const input = await loadSomaHome(context.somaHome);
+  await mkdir(dirname(target), { recursive: true });
+  await writeFile(target, `${renderClaudeMdBody(input, overlay).trimEnd()}\n`, "utf8");
+  return [target];
+}

--- a/src/adapters/claude-code/claude-md.ts
+++ b/src/adapters/claude-code/claude-md.ts
@@ -58,21 +58,25 @@ async function readOrNull(path: string): Promise<string | null> {
 /**
  * Decide what overlay content to carry into the regenerated file.
  *
- * - An existing overlay block is preserved (idempotency + hand edits inside the
- *   markers survive).
- * - A pre-existing, non-Soma CLAUDE.md has its full text carried into the
+ * - A genuine Soma projection (has the provenance header): its existing overlay
+ *   block is preserved (idempotency + hand edits inside the markers survive).
+ * - A pre-existing, non-Soma CLAUDE.md has its WHOLE text carried into the
  *   overlay on first conversion, so no CONTENT is dropped — it moves under the
- *   marker for later curation. Note: surrounding blank lines are normalized by
- *   the overlay renderer/reader, so this is content-lossless, not byte-exact
- *   (sage#378: the earlier doc overclaimed "wholesale/byte-lossless").
+ *   marker for later curation. The provenance-header gate matters: without it a
+ *   foreign file that merely happens to contain the marker strings would keep
+ *   only the marker body and drop the rest (sage#378). Note: surrounding blank
+ *   lines are normalized by the overlay renderer/reader, so this is
+ *   content-lossless, not byte-exact.
  * - Otherwise (greenfield, or an already-Soma file with no overlay) there is
  *   nothing to carry.
  */
 export function resolveClaudeMdOverlay(existing: string | null): string | null {
   if (existing === null) return null;
-  const existingOverlay = extractOverlay(existing);
-  if (existingOverlay !== null) return existingOverlay;
-  if (!hasProvenanceHeader(existing) && existing.trim().length > 0) {
+  // Only trust an embedded overlay block when the file is genuinely ours.
+  if (hasProvenanceHeader(existing)) {
+    return extractOverlay(existing);
+  }
+  if (existing.trim().length > 0) {
     return [
       "Preserved from the pre-Soma CLAUDE.md on first projection. Curate or move into ~/.soma.",
       "",

--- a/src/adapters/claude-code/install-options.ts
+++ b/src/adapters/claude-code/install-options.ts
@@ -3,6 +3,8 @@ import type { SomaInstallOptions } from "../../types";
 export interface ClaudeCodeInstallOptions extends SomaInstallOptions {
   modeClassifier?: boolean;
   policyGuard?: boolean;
+  /** soma#368: generate ~/.claude/CLAUDE.md as a projection (overlay-preserving). */
+  claudeMd?: boolean;
 }
 
 export function isClaudeCodeInstallOptions(options: unknown): options is ClaudeCodeInstallOptions {

--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -11,6 +11,7 @@ import {
   installClaudeCodeSomaHooks,
   removeClaudeCodeSomaHookFiles,
 } from "./hooks";
+import { CLAUDE_CODE_CLAUDE_MD_RELATIVE_PATH, installClaudeCodeClaudeMd } from "./claude-md";
 import { isClaudeCodeInstallOptions } from "./install-options";
 
 export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
@@ -32,6 +33,9 @@ export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
     ...(isClaudeCodeInstallOptions(options) && options.policyGuard === true
       ? [SOMA_CLAUDE_POLICY_GUARD_RELATIVE_PATH, SOMA_CLAUDE_POLICY_GUARD_CONFIG_RELATIVE_PATH]
       : []),
+    ...(isClaudeCodeInstallOptions(options) && options.claudeMd === true
+      ? [CLAUDE_CODE_CLAUDE_MD_RELATIVE_PATH]
+      : []),
   ],
   skillsLoaderDir: skillsLoaderUnder(),
   vsaSkillProjection: {
@@ -45,6 +49,12 @@ export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
     {
       name: "claude-code-soma-hooks",
       run: installClaudeCodeSomaHooks,
+    },
+    {
+      // soma#368: opt-in (`--claude-md`) generated CLAUDE.md with a preserved
+      // overlay. No-op without the flag, so the default install is unchanged.
+      name: "claude-code-claude-md",
+      run: installClaudeCodeClaudeMd,
     },
   ],
   uninstall: {

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -41,7 +41,7 @@ import { SomaCliError } from "./errors";
 import { readOption } from "./parse-utils";
 
 export type InstallSubstrate = Extract<SubstrateId, "codex" | "pi-dev" | "claude-code" | "cursor" | "grok">;
-type InstallCliOptions = SomaInstallOptions & Partial<Pick<ClaudeCodeInstallOptions, "modeClassifier" | "policyGuard">>;
+type InstallCliOptions = SomaInstallOptions & Partial<Pick<ClaudeCodeInstallOptions, "modeClassifier" | "policyGuard" | "claudeMd">>;
 
 export interface ParsedInstallArgs {
   command: "install";
@@ -96,7 +96,7 @@ export type ParsedSubstrateLifecycleArgs =
 export const INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code", "cursor", "grok"] as const satisfies readonly InstallSubstrate[];
 
 const substrateList = INSTALL_SUBSTRATES.join("|");
-const installOptions = "[--dry-run] [--apply] [--workspace] [--mode-classifier] [--policy-guard] [--skills <name[,name…]>] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
+const installOptions = "[--dry-run] [--apply] [--workspace] [--mode-classifier] [--policy-guard] [--claude-md] [--skills <name[,name…]>] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 // Shared by uninstall, reproject, and upgrade — all workspace-capable verbs.
 const workspaceVerbOptions = "[--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 const uninstallOptions = workspaceVerbOptions;
@@ -271,6 +271,9 @@ export function parseInstallArgs(args: string[]): ParsedInstallArgs {
       case "--policy-guard":
         parsedOptions.policyGuard = true;
         return true;
+      case "--claude-md":
+        parsedOptions.claudeMd = true;
+        return true;
     }
     return false;
   });
@@ -279,6 +282,9 @@ export function parseInstallArgs(args: string[]): ParsedInstallArgs {
   }
   if (options.policyGuard === true && substrate !== "claude-code") {
     throw new Error("--policy-guard is only supported for claude-code installs.");
+  }
+  if (options.claudeMd === true && substrate !== "claude-code") {
+    throw new Error("--claude-md is only supported for claude-code installs.");
   }
 
   return { command, substrate, apply, workspace, skills, options };

--- a/test/claude-code-claude-md.test.ts
+++ b/test/claude-code-claude-md.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { installSomaForClaudeCode } from "../src/index";
 import { resolveClaudeMdOverlay } from "../src/adapters/claude-code/claude-md";
-import { OVERLAY_BEGIN, OVERLAY_END, hasProvenanceHeader } from "../src/adapters/shared";
+import { OVERLAY_BEGIN, OVERLAY_END, hasProvenanceHeader, withProvenance } from "../src/adapters/shared";
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-368-"));
@@ -91,11 +91,22 @@ test("a pre-existing hand-maintained CLAUDE.md is preserved into the overlay (lo
   });
 });
 
-test("resolveClaudeMdOverlay: greenfield null, existing overlay preserved, foreign file wholesale", () => {
+test("resolveClaudeMdOverlay: greenfield null, Soma overlay preserved, foreign file wholesale", () => {
   expect(resolveClaudeMdOverlay(null)).toBeNull();
-  const withOverlay = [OVERLAY_BEGIN, "", "kept", "", OVERLAY_END].join("\n");
-  expect(resolveClaudeMdOverlay(withOverlay)).toBe("kept");
+  // A genuine Soma file (has the provenance header) → its overlay body survives.
+  const somaFile = withProvenance("claude-code", ["# Generated", "", OVERLAY_BEGIN, "", "kept", "", OVERLAY_END].join("\n"));
+  expect(resolveClaudeMdOverlay(somaFile)).toBe("kept");
   const foreign = resolveClaudeMdOverlay("# foreign\n\nbody");
   expect(foreign).toContain("body");
   expect(foreign).toContain("Preserved from the pre-Soma");
+});
+
+test("sage#378: a FOREIGN file that contains overlay markers is still preserved WHOLE (no header → not trusted)", () => {
+  // Pre-Soma file that happens to include the marker strings must not have only
+  // the marker body kept; the whole file is carried into the overlay.
+  const foreignWithMarkers = ["# my rules", "", OVERLAY_BEGIN, "", "inner", "", OVERLAY_END, "", "trailing rules"].join("\n");
+  const resolved = resolveClaudeMdOverlay(foreignWithMarkers);
+  expect(resolved).toContain("# my rules");
+  expect(resolved).toContain("trailing rules");
+  expect(resolved).toContain("Preserved from the pre-Soma");
 });

--- a/test/claude-code-claude-md.test.ts
+++ b/test/claude-code-claude-md.test.ts
@@ -1,0 +1,98 @@
+/**
+ * soma#368 — opt-in generated ~/.claude/CLAUDE.md with a preserved overlay.
+ */
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { installSomaForClaudeCode } from "../src/index";
+import { resolveClaudeMdOverlay } from "../src/adapters/claude-code/claude-md";
+import { OVERLAY_BEGIN, OVERLAY_END, hasProvenanceHeader } from "../src/adapters/shared";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-368-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+const claudeMdPath = (homeDir: string) => join(homeDir, ".claude/CLAUDE.md");
+
+test("default install does NOT create CLAUDE.md (opt-in only)", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir });
+    let existed = true;
+    try {
+      await readFile(claudeMdPath(homeDir), "utf8");
+    } catch {
+      existed = false;
+    }
+    expect(existed).toBe(false);
+  });
+});
+
+test("--claude-md generates CLAUDE.md with provenance header, pointer, and overlay markers", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir, claudeMd: true });
+    const content = await readFile(claudeMdPath(homeDir), "utf8");
+    expect(hasProvenanceHeader(content)).toBe(true);
+    expect(content).toContain("rules/soma/CONTEXT.md");
+    expect(content).toContain(OVERLAY_BEGIN);
+    expect(content).toContain(OVERLAY_END);
+  });
+});
+
+test("CLAUDE.md projection is byte-idempotent across reinstalls", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir, claudeMd: true });
+    const first = await readFile(claudeMdPath(homeDir), "utf8");
+    await installSomaForClaudeCode({ homeDir, claudeMd: true });
+    const second = await readFile(claudeMdPath(homeDir), "utf8");
+    expect(second).toBe(first);
+  });
+});
+
+test("a hand edit inside the overlay survives reprojection", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir, claudeMd: true });
+    const before = await readFile(claudeMdPath(homeDir), "utf8");
+    const edited = before.replace(
+      OVERLAY_END,
+      `my machine-local note\n\n${OVERLAY_END}`,
+    );
+    await writeFile(claudeMdPath(homeDir), edited, "utf8");
+
+    await installSomaForClaudeCode({ homeDir, claudeMd: true });
+    const after = await readFile(claudeMdPath(homeDir), "utf8");
+    expect(after).toContain("my machine-local note");
+    // Still exactly one overlay block (no marker duplication).
+    expect(after.split(OVERLAY_BEGIN).length - 1).toBe(1);
+    expect(after.split(OVERLAY_END).length - 1).toBe(1);
+  });
+});
+
+test("a pre-existing hand-maintained CLAUDE.md is preserved into the overlay (lossless first conversion)", async () => {
+  await withTempHome(async (homeDir) => {
+    await mkdir(join(homeDir, ".claude"), { recursive: true });
+    await writeFile(claudeMdPath(homeDir), "# My old CLAUDE.md\n\nimportant hand-written rules\n", "utf8");
+
+    await installSomaForClaudeCode({ homeDir, claudeMd: true });
+    const content = await readFile(claudeMdPath(homeDir), "utf8");
+    expect(hasProvenanceHeader(content)).toBe(true);
+    expect(content).toContain("important hand-written rules");
+    // The preserved content lives inside the overlay, not the generated body.
+    const overlayStart = content.indexOf(OVERLAY_BEGIN);
+    expect(content.indexOf("important hand-written rules")).toBeGreaterThan(overlayStart);
+  });
+});
+
+test("resolveClaudeMdOverlay: greenfield null, existing overlay preserved, foreign file wholesale", () => {
+  expect(resolveClaudeMdOverlay(null)).toBeNull();
+  const withOverlay = [OVERLAY_BEGIN, "", "kept", "", OVERLAY_END].join("\n");
+  expect(resolveClaudeMdOverlay(withOverlay)).toBe("kept");
+  const foreign = resolveClaudeMdOverlay("# foreign\n\nbody");
+  expect(foreign).toContain("body");
+  expect(foreign).toContain("Preserved from the pre-Soma");
+});

--- a/test/claude-code-claude-md.test.ts
+++ b/test/claude-code-claude-md.test.ts
@@ -41,6 +41,9 @@ test("--claude-md generates CLAUDE.md with provenance header, pointer, and overl
     expect(content).toContain("rules/soma/CONTEXT.md");
     expect(content).toContain(OVERLAY_BEGIN);
     expect(content).toContain(OVERLAY_END);
+    // sage#378: the regenerate instruction must name the opt-in flag, else it
+    // is a no-op.
+    expect(content).toContain("soma install claude-code --apply --claude-md");
   });
 });
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -237,7 +237,10 @@ test("install spec registry has adapter-owned facts for every install substrate"
     kind: "implemented",
     remove: ["rules/soma", "skills/VSA"],
   });
-  expect(installSpecFor("claude-code").postProjection?.map((step) => step.name)).toEqual(["claude-code-soma-hooks"]);
+  expect(installSpecFor("claude-code").postProjection?.map((step) => step.name)).toEqual([
+    "claude-code-soma-hooks",
+    "claude-code-claude-md",
+  ]);
   expect(installSpecFor("cursor").uninstall.kind).toBe("implemented");
 });
 


### PR DESCRIPTION
Closes #368. **Stacked on #377 (#370)** — review/merge that first; this PR targets the #370 branch so the diff is just the CLAUDE.md work.

## What

Adds `--claude-md` (`ClaudeCodeInstallOptions.claudeMd`) that generates `~/.claude/CLAUDE.md` as a projection:

- soma#370 provenance header (byte-stable, so reprojection is idempotent)
- a thin pointer body routing the reader to the auto-discovered `rules/soma/` bundle (keeps the soma#64 model — the real context lives there)
- an **overlay block** (`<!-- soma:overlay:start/end -->`) that survives reprojection

## Overlay policy (`resolveClaudeMdOverlay`)

- existing overlay → content preserved, idempotent, hand edits inside the markers survive (surrounding blank lines are normalized by the overlay reader — content-lossless, not byte-verbatim)
- a pre-existing **non-Soma** CLAUDE.md → preserved **wholesale** into the overlay on first conversion. This is the lossless-migration guarantee: converting a hand-maintained CLAUDE.md never drops content, it moves under the marker for curation.
- greenfield / already-Soma-without-overlay → empty overlay placeholder

## Safety

- **Opt-in only.** The postProjection step no-ops without `--claude-md`, so the default install still leaves CLAUDE.md untouched (the soma#64 stance). (This PR only adds the opt-in capability; any migration that turns it on is out of scope here.)
- CLI guard restricts `--claude-md` to claude-code.
- Tracked via `optionalHomeFiles`; deliberately **not** in `uninstall.remove` so preserved user content is never deleted by uninstall.

## Tests

Opt-in gate, header+pointer+markers present, byte-idempotency, overlay hand-edit survival, lossless first conversion, resolver units. Full suite: 1530 pass, 0 fail. `tsc` clean, touched files eslint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)