### PR TITLE
feat(claude-code): adapter owns the session hook fleet by default (#369)

### DIFF
--- a/src/adapters/claude-code/hooks.ts
+++ b/src/adapters/claude-code/hooks.ts
@@ -5,6 +5,21 @@ import { resolveBunExecutable } from "../../bun-probe";
 import { isEnoent } from "../../fs-errors";
 import { isClaudeCodeInstallOptions } from "./install-options";
 
+/**
+ * soma#369: adapter-owned session hooks (mode classifier, policy guard) are
+ * default-on. Enabled unless a caller explicitly passes `<hook>: false`, so an
+ * absent option or non-options value (internal reproject paths) still installs
+ * them. Shared by the hook installer and the install spec's optionalHomeFiles
+ * so the projected file list and what actually gets written stay in lockstep.
+ */
+export function claudeCodeHookEnabled(
+  options: unknown,
+  hook: "modeClassifier" | "policyGuard",
+): boolean {
+  if (!isClaudeCodeInstallOptions(options)) return true;
+  return options[hook] !== false;
+}
+
 export const SOMA_CLAUDE_HOOK_RELATIVE_PATH = "hooks/soma/soma-claude-code-hook.mjs";
 export const SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH = "hooks/soma/soma-claude-code-hook.config.json";
 export const SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH = "hooks/soma/soma-mode-classifier.mjs";
@@ -521,10 +536,14 @@ export async function installClaudeCodeSomaHooks(context: {
     config,
   });
   const settingsFiles = await patchClaudeCodeSomaHookSettings(context.substrateHome, bunPath);
-  const modeClassifierFiles = isClaudeCodeInstallOptions(context.options) && context.options.modeClassifier === true
+  // soma#369: the adapter owns the session fleet. Mode classifier and policy
+  // guard are default-on; a caller opts out with `modeClassifier: false` /
+  // `policyGuard: false` (CLI `--no-mode-classifier` / `--no-policy-guard`).
+  // Undefined options (internal reproject paths) keep the default-on behavior.
+  const modeClassifierFiles = claudeCodeHookEnabled(context.options, "modeClassifier")
     ? await installClaudeCodeModeClassifierHook(context, config, bunPath)
     : [];
-  const policyGuardFiles = isClaudeCodeInstallOptions(context.options) && context.options.policyGuard === true
+  const policyGuardFiles = claudeCodeHookEnabled(context.options, "policyGuard")
     ? await installClaudeCodePolicyGuardHook(context, config, bunPath)
     : [];
   return Array.from(new Set([hookPath, configPath, ...settingsFiles, ...modeClassifierFiles, ...policyGuardFiles]));

--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -8,10 +8,10 @@ import {
   SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH,
   SOMA_CLAUDE_POLICY_GUARD_CONFIG_RELATIVE_PATH,
   SOMA_CLAUDE_POLICY_GUARD_RELATIVE_PATH,
+  claudeCodeHookEnabled,
   installClaudeCodeSomaHooks,
   removeClaudeCodeSomaHookFiles,
 } from "./hooks";
-import { isClaudeCodeInstallOptions } from "./install-options";
 
 export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
   substrate: "claude-code",
@@ -25,11 +25,14 @@ export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
   // Owned (Soma-exclusive) dirs — see ownedSubtrees JSDoc. Subsumes the former
   // obsoleteHomeFiles for TELOS.md/ACTIVE_ISA.md, which live under rules/soma.
   ownedSubtrees: ["rules/soma", "hooks/soma"],
+  // soma#369: mode classifier + policy guard are default-on (opt out with
+  // `--no-mode-classifier` / `--no-policy-guard`). claudeCodeHookEnabled is the
+  // single gate shared with installClaudeCodeSomaHooks.
   optionalHomeFiles: (options) => [
-    ...(isClaudeCodeInstallOptions(options) && options.modeClassifier === true
+    ...(claudeCodeHookEnabled(options, "modeClassifier")
       ? [SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH, SOMA_CLAUDE_MODE_CLASSIFIER_CONFIG_RELATIVE_PATH]
       : []),
-    ...(isClaudeCodeInstallOptions(options) && options.policyGuard === true
+    ...(claudeCodeHookEnabled(options, "policyGuard")
       ? [SOMA_CLAUDE_POLICY_GUARD_RELATIVE_PATH, SOMA_CLAUDE_POLICY_GUARD_CONFIG_RELATIVE_PATH]
       : []),
   ],

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -96,7 +96,7 @@ export type ParsedSubstrateLifecycleArgs =
 export const INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code", "cursor", "grok"] as const satisfies readonly InstallSubstrate[];
 
 const substrateList = INSTALL_SUBSTRATES.join("|");
-const installOptions = "[--dry-run] [--apply] [--workspace] [--mode-classifier] [--policy-guard] [--skills <name[,name…]>] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
+const installOptions = "[--dry-run] [--apply] [--workspace] [--no-mode-classifier] [--no-policy-guard] [--skills <name[,name…]>] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 // Shared by uninstall, reproject, and upgrade — all workspace-capable verbs.
 const workspaceVerbOptions = "[--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 const uninstallOptions = workspaceVerbOptions;
@@ -265,20 +265,29 @@ export function parseInstallArgs(args: string[]): ParsedInstallArgs {
       case "--apply":
         apply = true;
         return true;
+      // soma#369: mode classifier + policy guard are default-on. The explicit
+      // enable flags remain accepted (back-compat, now no-ops); the opt-out
+      // flags disable them.
       case "--mode-classifier":
         parsedOptions.modeClassifier = true;
+        return true;
+      case "--no-mode-classifier":
+        parsedOptions.modeClassifier = false;
         return true;
       case "--policy-guard":
         parsedOptions.policyGuard = true;
         return true;
+      case "--no-policy-guard":
+        parsedOptions.policyGuard = false;
+        return true;
     }
     return false;
   });
-  if (options.modeClassifier === true && substrate !== "claude-code") {
-    throw new Error("--mode-classifier is only supported for claude-code installs.");
+  if (options.modeClassifier !== undefined && substrate !== "claude-code") {
+    throw new Error("--mode-classifier / --no-mode-classifier is only supported for claude-code installs.");
   }
-  if (options.policyGuard === true && substrate !== "claude-code") {
-    throw new Error("--policy-guard is only supported for claude-code installs.");
+  if (options.policyGuard !== undefined && substrate !== "claude-code") {
+    throw new Error("--policy-guard / --no-policy-guard is only supported for claude-code installs.");
   }
 
   return { command, substrate, apply, workspace, skills, options };

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -266,16 +266,19 @@ export function parseInstallArgs(args: string[]): ParsedInstallArgs {
         apply = true;
         return true;
       // soma#369: mode classifier + policy guard are default-on. The explicit
-      // enable flags remain accepted (back-compat, now no-ops); the opt-out
-      // flags disable them.
+      // enable flags are accepted for back-compat but behaviorally inert: they
+      // only set the (already-default) `true` when no value is set yet, so a
+      // `--no-*` flag ALWAYS wins regardless of order and the enable flag can
+      // never flip an opt-out (sage#379). They remain recognized so the
+      // non-claude-code guard below still rejects them.
       case "--mode-classifier":
-        parsedOptions.modeClassifier = true;
+        parsedOptions.modeClassifier ??= true;
         return true;
       case "--no-mode-classifier":
         parsedOptions.modeClassifier = false;
         return true;
       case "--policy-guard":
-        parsedOptions.policyGuard = true;
+        parsedOptions.policyGuard ??= true;
         return true;
       case "--no-policy-guard":
         parsedOptions.policyGuard = false;

--- a/test/claude-code-install.test.ts
+++ b/test/claude-code-install.test.ts
@@ -154,16 +154,43 @@ test("AC-2: planSomaForClaudeCodeInstall lists every file written", () => {
     "/tmp/test-home/.claude/hooks/soma/soma-claude-code-hook.mjs",
     "/tmp/test-home/.claude/hooks/soma/soma-claude-code-hook.config.json",
     "/tmp/test-home/.claude/settings.json",
+    // soma#369: mode classifier + policy guard are default-on.
+    "/tmp/test-home/.claude/hooks/soma/soma-mode-classifier.mjs",
+    "/tmp/test-home/.claude/hooks/soma/soma-mode-classifier.config.json",
+    "/tmp/test-home/.claude/hooks/soma/soma-policy-guard.mjs",
+    "/tmp/test-home/.claude/hooks/soma/soma-policy-guard.config.json",
   ]);
 });
 
-test("issue #274: mode classifier hook files are opt-in in the Claude Code install plan", () => {
+test("soma#369: mode classifier hook files are default-on in the Claude Code install plan, opt-out excludes them", () => {
   const defaultPlan = planSomaForClaudeCodeInstall({ homeDir: "/tmp/test-home" });
-  expect(defaultPlan.substrateFiles).not.toContain("/tmp/test-home/.claude/hooks/soma/soma-mode-classifier.mjs");
+  expect(defaultPlan.substrateFiles).toContain("/tmp/test-home/.claude/hooks/soma/soma-mode-classifier.mjs");
+  expect(defaultPlan.substrateFiles).toContain("/tmp/test-home/.claude/hooks/soma/soma-mode-classifier.config.json");
 
-  const plan = planSomaForClaudeCodeInstall({ homeDir: "/tmp/test-home", modeClassifier: true });
-  expect(plan.substrateFiles).toContain("/tmp/test-home/.claude/hooks/soma/soma-mode-classifier.mjs");
-  expect(plan.substrateFiles).toContain("/tmp/test-home/.claude/hooks/soma/soma-mode-classifier.config.json");
+  const optedOut = planSomaForClaudeCodeInstall({ homeDir: "/tmp/test-home", modeClassifier: false });
+  expect(optedOut.substrateFiles).not.toContain("/tmp/test-home/.claude/hooks/soma/soma-mode-classifier.mjs");
+});
+
+test("soma#369: a default install writes both the mode classifier and policy guard hooks and wires settings", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir });
+    await stat(join(homeDir, ".claude/hooks/soma/soma-mode-classifier.mjs"));
+    await stat(join(homeDir, ".claude/hooks/soma/soma-policy-guard.mjs"));
+    const settings = await readJson<{ hooks: Record<string, unknown[]> }>(join(homeDir, ".claude/settings.json"));
+    expect(JSON.stringify(settings)).toContain("soma-mode-classifier.mjs");
+    expect(JSON.stringify(settings)).toContain("soma-policy-guard.mjs");
+  });
+});
+
+test("soma#369: --no-mode-classifier / --no-policy-guard opts a default install back out", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir, modeClassifier: false, policyGuard: false });
+    await expect(stat(join(homeDir, ".claude/hooks/soma/soma-mode-classifier.mjs"))).rejects.toThrow();
+    await expect(stat(join(homeDir, ".claude/hooks/soma/soma-policy-guard.mjs"))).rejects.toThrow();
+    const settings = await readJson<{ hooks: Record<string, unknown[]> }>(join(homeDir, ".claude/settings.json"));
+    expect(JSON.stringify(settings)).not.toContain("soma-mode-classifier.mjs");
+    expect(JSON.stringify(settings)).not.toContain("soma-policy-guard.mjs");
+  });
 });
 
 test("AC-3: planSomaForClaudeCodeInstall does not write files (plan.apply === false)", async () => {
@@ -214,8 +241,11 @@ test("issue #236: claude-code install wires Soma-owned hooks without overwriting
       "utf8",
     );
 
-    await installSomaForClaudeCode({ homeDir });
-    await installSomaForClaudeCode({ homeDir });
+    // Opt out of the soma#369 default-on fleet: this test targets the base
+    // lifecycle hook wiring + user-hook preservation. Default-on fleet has its
+    // own coverage below.
+    await installSomaForClaudeCode({ homeDir, modeClassifier: false, policyGuard: false });
+    await installSomaForClaudeCode({ homeDir, modeClassifier: false, policyGuard: false });
 
     const hookInfo = await stat(join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.mjs"));
     expect((hookInfo.mode & 0o100) !== 0).toBe(true);

--- a/test/claude-code-policy-guard.test.ts
+++ b/test/claude-code-policy-guard.test.ts
@@ -51,12 +51,12 @@ function runGuard(homeDir: string, input: object): { status: number | null; stdo
   return { status: result.status, stdout: result.stdout };
 }
 
-test("policy guard: plan + install project the fail-closed guard files only when opted in", async () => {
-  const plan = planSomaForClaudeCodeInstall({ homeDir: "/tmp/test-home", policyGuard: true });
+test("soma#369: policy guard fail-closed files are default-on in the plan, opt-out excludes them", async () => {
+  const plan = planSomaForClaudeCodeInstall({ homeDir: "/tmp/test-home" });
   expect(plan.substrateFiles).toContain("/tmp/test-home/.claude/hooks/soma/soma-policy-guard.mjs");
   expect(plan.substrateFiles).toContain("/tmp/test-home/.claude/hooks/soma/soma-policy-guard.config.json");
 
-  const planOff = planSomaForClaudeCodeInstall({ homeDir: "/tmp/test-home" });
+  const planOff = planSomaForClaudeCodeInstall({ homeDir: "/tmp/test-home", policyGuard: false });
   expect(planOff.substrateFiles).not.toContain("/tmp/test-home/.claude/hooks/soma/soma-policy-guard.mjs");
 });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1972,8 +1972,9 @@ test("cli install claude-code supports opt-in mode classifier dry-run", async ()
   });
 });
 
-test("cli rejects mode classifier flag for non-Claude Code installs", async () => {
-  await expect(runSomaCli(["install", "codex", "--mode-classifier"])).rejects.toThrow("--mode-classifier is only supported");
+test("cli rejects mode classifier flags for non-Claude Code installs", async () => {
+  await expect(runSomaCli(["install", "codex", "--mode-classifier"])).rejects.toThrow("is only supported for claude-code installs");
+  await expect(runSomaCli(["install", "codex", "--no-mode-classifier"])).rejects.toThrow("is only supported for claude-code installs");
 });
 
 test("cli dry-runs and applies cursor install", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1977,6 +1977,17 @@ test("cli rejects mode classifier flags for non-Claude Code installs", async () 
   await expect(runSomaCli(["install", "codex", "--no-mode-classifier"])).rejects.toThrow("is only supported for claude-code installs");
 });
 
+test("soma#379: --no-mode-classifier wins over the inert --mode-classifier regardless of order", async () => {
+  await withTempHome(async (homeDir) => {
+    // Enable flag first, then opt-out.
+    const a = await runSomaCli(["install", "claude-code", "--mode-classifier", "--no-mode-classifier", "--home-dir", homeDir]);
+    expect(a).not.toContain("soma-mode-classifier.mjs");
+    // Opt-out first, then the (inert) enable flag must not flip it back on.
+    const b = await runSomaCli(["install", "claude-code", "--no-mode-classifier", "--mode-classifier", "--home-dir", homeDir]);
+    expect(b).not.toContain("soma-mode-classifier.mjs");
+  });
+});
+
 test("cli dry-runs and applies cursor install", async () => {
   await withTempHome(async (homeDir) => {
     const dryRun = await runSomaCli(["install", "cursor", "--home-dir", homeDir]);


### PR DESCRIPTION
Closes #369. Independent of #377/#378 (branches off main).

## What

The mode classifier and fail-closed policy guard were opt-in. Per #369 the adapter should own the session fleet, so a plain `soma install claude-code` now registers all three session hooks (lifecycle context-load + mode classifier + policy guard). A fresh session loads context, classifies mode, and enforces policy with no extra flags — the issue's core acceptance.

## Behavior change (flagged for review)

This changes the **default** install. Opt out with `--no-mode-classifier` / `--no-policy-guard`. The old `--mode-classifier` / `--policy-guard` enable flags remain accepted for back-compat but are behaviorally inert (they only set the already-default value when unset, so a `--no-*` opt-out always wins regardless of order); both families are still rejected for non-claude-code substrates.

## How

- **`claudeCodeHookEnabled(options, hook)`** — one default-on gate: enabled unless a caller passes `<hook>: false`; undefined or non-options input stays on (covers internal reproject paths). Shared by `installClaudeCodeSomaHooks` and the install spec's `optionalHomeFiles` so plan and apply never drift.
- Uninstall already removes both hooks + their settings unconditionally, so the default-on round-trip is symmetric (verified).

## Tests

- New: default-on plan + real-install coverage; opt-out coverage.
- `#236` retargeted to the base lifecycle hook (opts out of the fleet) to preserve its user-hook-preservation intent; `#274` and the policy-guard opt-in test flipped to assert default-on + opt-out.
- Full suite: 1517 pass, 0 fail. `tsc` clean, touched files eslint-clean.

## Coordination

Builds on `soma-claude-code-hook.mjs`, which memory plan v2 M5 extends with a SessionEnd digest — this PR does not touch that path. Complements #366 (hot-path runner) for whatever fleet ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Verification evidence (per sage review)

On `feat/369-hook-fleet-defaults` @ 3c3aa72: `bunx tsc --noEmit` exit 0; `bunx eslint` on touched files exit 0; `bun test` → **1517 pass, 0 fail** (5640 expect calls, 100 files). The **install/wiring half** of #369's acceptance is tested by `soma#369: a default install writes both the mode classifier and policy guard hooks and wires settings` (real temp-home install asserting both hook files exist AND settings.json registers them) plus the `--no-*` opt-out counterpart. The runtime half (a live session actually classifying mode / enforcing policy) is each hook's own behavioral contract, not claimed as measured here.