### PR TITLE
feat(memory): file-native note schema, parser, serializer (M0)

### DIFF
--- a/Plans/2026-07-01-memory-skill-design.md
+++ b/Plans/2026-07-01-memory-skill-design.md
@@ -103,7 +103,7 @@ created: 2026-04-12
 last_verified: 2026-06-28   # bumped when resurfaced-and-confirmed
 valid_until: null           # set instead of deleting; bi-temporal close
 provenance: conversation    # conversation | consolidation | import | tool:<name>
-trust: principal            # principal | agent | quarantined
+trust: principal            # principal | assistant | quarantined
 source_of_truth: null       # optional pointer to verify against (file, URL, calendar)
 links: [ai-writing-tells, andreas-style-feedback]
 ---
@@ -138,7 +138,7 @@ Triggers (exhaustive — anything else is SKIP):
 1. **Principal says remember** / corrects the agent ("no, always X") → procedural or semantic, trust `principal`.
 2. **Session end** → exactly one episodic digest (8-15 lines: what happened, what changed, open loops). Replaces today's 6,363-file `current-work-*.json` spray.
 3. **Consequential action** (sent, deployed, deleted, paid, published) → one action-log entry at approval time.
-4. **Consolidation** promotes/merges (see §8), trust `agent`.
+4. **Consolidation** promotes/merges (see §8), trust `assistant`.
 5. **Import** (migration, external docs) → trust `quarantined` until human-reviewed. Web/tool content NEVER writes directly (MINJA defense).
 
 Write procedure (skill-enforced, CLI-assisted):
@@ -264,7 +264,7 @@ The rules that make session N+1 strictly better-informed than session N. All com
 ### Retention score (index eviction, deterministic)
 
 `score = trust × recency(last_verified) × type_weight × resurface_count`
-with trust: principal 3 / agent 1 / quarantined 0 — and type_weight: procedural 3 / semantic 2 / episodic 1. When INDEX exceeds budget, lowest scores evict first (file remains; only the always-loaded line is lost). No model call needed.
+with trust: principal 3 / assistant 1 / quarantined 0 — and type_weight: procedural 3 / semantic 2 / episodic 1. When INDEX exceeds budget, lowest scores evict first (file remains; only the always-loaded line is lost). No model call needed.
 
 ### Health metrics (deterministic, replaces sentiment pipeline)
 

--- a/Plans/2026-07-02-memory-subsystem-implementation-plan.md
+++ b/Plans/2026-07-02-memory-subsystem-implementation-plan.md
@@ -71,7 +71,7 @@ TypeScript type (add to `src/types.ts`):
 
 ```ts
 export type SomaMemoryNoteType = "semantic" | "episodic" | "procedural";
-export type SomaMemoryTrust = "principal" | "agent" | "quarantined";
+export type SomaMemoryTrust = "principal" | "assistant" | "quarantined";
 
 export interface SomaMemoryNote {
   id: string;
@@ -109,7 +109,7 @@ Line grammar: `- [<id>] <hook, max 120 chars> (<type>, verified <N>d ago)`. Budg
 ### 2.4 Retention score (deterministic, M3)
 
 ```
-trustWeight:  principal=3, agent=1, quarantined=0
+trustWeight:  principal=3, assistant=1, quarantined=0
 typeWeight:   procedural=3, semantic=2, episodic=1
 recency:      max(0.1, 1 - daysSince(last_verified)/365)
 score = trustWeight * typeWeight * recency * (1 + log2(1 + resurface_count))
@@ -218,7 +218,7 @@ export async function logAction(opts: { somaHome?: string; homeDir?: string; sub
   intent: string; approval: "principal" | "policy" | "none"; outcome: "done" | "failed" | "pending"; project?: string }): Promise<{ path: string }>;
 ```
 
-Both write episodic notes per §2.1/§2.2 (`type: episodic`, trust `agent`, provenance `tool:cli`; id auto-generated `YYYYMMDD-<slug-from-summary>`), under `episodic/sessions/YYYY-MM/` and `episodic/actions/YYYY-MM/` respectively (extend `memoryNotePath` with a subkind param, default `sessions`). Digest body template: `**What happened:** … / **Changed:** … / **Open loops:** …`. Events `memory.digest.written` / `memory.action.logged`.
+Both write episodic notes per §2.1/§2.2 (`type: episodic`, trust `assistant`, provenance `tool:cli`; id auto-generated `YYYYMMDD-<slug-from-summary>`), under `episodic/sessions/YYYY-MM/` and `episodic/actions/YYYY-MM/` respectively (extend `memoryNotePath` with a subkind param, default `sessions`). Digest body template: `**What happened:** … / **Changed:** … / **Open loops:** …`. Events `memory.digest.written` / `memory.action.logged`.
 
 CLI: `soma memory digest --summary <text> [--changed <x>]... [--open <x>]... [--project p]` and `soma memory action --intent <text> --approval <a> --outcome <o>`.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ export type {
   WrittenProjection,
 } from "./types";
 export { SOMA_RESULT_EVENT_KINDS } from "./types";
+export { SOMA_MEMORY_NOTE_TYPES, SOMA_MEMORY_TRUSTS } from "./types";
 export type { SomaMemoryNote, SomaMemoryNoteType, SomaMemoryTrust } from "./types";
 
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ export type {
   WrittenProjection,
 } from "./types";
 export { SOMA_RESULT_EVENT_KINDS } from "./types";
+export type { SomaMemoryNote, SomaMemoryNoteType, SomaMemoryTrust } from "./types";
 
 export {
   addAlgorithmCapabilities,
@@ -431,6 +432,7 @@ export {
 } from "./lifecycle";
 export { captureSomaFeedback, classifySomaFeedback, maybeSomaFeedbackPrompt } from "./feedback";
 export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from "./memory";
+export { MemoryNoteError, parseMemoryNote, serializeMemoryNote } from "./memory-note";
 export { createSomaSnapshot, listSomaSnapshots, rollbackSomaSnapshot } from "./snapshots";
 export { querySomaTelemetryEvents, summarizeSomaTelemetry } from "./observability";
 export {

--- a/src/memory-note.ts
+++ b/src/memory-note.ts
@@ -28,6 +28,22 @@ const DATE = /^\d{4}-\d{2}-\d{2}$/;
 const NOTE_TYPES: readonly SomaMemoryNoteType[] = ["semantic", "episodic", "procedural"];
 const TRUSTS: readonly SomaMemoryTrust[] = ["principal", "agent", "quarantined"];
 
+// Provenance is a closed set plus the open `tool:<name>` family (plan v2 §2.2,
+// design doc line 105): conversation | consolidation | import | tool:<name>.
+const PROVENANCE_LITERALS = new Set(["conversation", "consolidation", "import"]);
+
+/**
+ * True iff `s` is `YYYY-MM-DD` AND a real calendar date. The shape regex alone
+ * accepts impossible dates like `2026-99-99`; round-tripping through a UTC Date
+ * rejects them (Feb 30, month 13, day 00, …).
+ */
+function isCalendarDate(s: string): boolean {
+  if (!DATE.test(s)) return false;
+  const [y, m, d] = s.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === m - 1 && dt.getUTCDate() === d;
+}
+
 // Required frontmatter keys in canonical serialization order.
 const REQUIRED_KEYS = [
   "id",
@@ -97,13 +113,17 @@ export function parseMemoryNote(content: string): SomaMemoryNote {
   assert(SLUG.test(id) && id.length <= 64, `id "${id}" is not a valid slug (<=64 chars)`, "id");
   assert((NOTE_TYPES as readonly string[]).includes(raw.type), `type "${raw.type}" is not valid`, "type");
   assert((TRUSTS as readonly string[]).includes(raw.trust), `trust "${raw.trust}" is not valid`, "trust");
-  assert(DATE.test(raw.created), `created "${raw.created}" must be YYYY-MM-DD`, "created");
-  assert(DATE.test(raw.last_verified), `last_verified "${raw.last_verified}" must be YYYY-MM-DD`, "last_verified");
-  assert(raw.valid_until === "null" || DATE.test(raw.valid_until), `valid_until must be null or YYYY-MM-DD`, "valid_until");
+  assert(isCalendarDate(raw.created), `created "${raw.created}" must be a valid YYYY-MM-DD date`, "created");
+  assert(isCalendarDate(raw.last_verified), `last_verified "${raw.last_verified}" must be a valid YYYY-MM-DD date`, "last_verified");
+  assert(raw.valid_until === "null" || isCalendarDate(raw.valid_until), `valid_until must be null or a valid YYYY-MM-DD date`, "valid_until");
 
   const resurface = Number(raw.resurface_count);
   assert(/^\d+$/.test(raw.resurface_count) && Number.isInteger(resurface), `resurface_count must be an integer >= 0`, "resurface_count");
-  assert(raw.provenance.length > 0, "provenance must not be empty", "provenance");
+  assert(
+    PROVENANCE_LITERALS.has(raw.provenance) || /^tool:.+/.test(raw.provenance),
+    `provenance "${raw.provenance}" must be conversation, consolidation, import, or tool:<name>`,
+    "provenance",
+  );
   assert(body.length > 0, "body must not be empty", "body");
 
   const note: SomaMemoryNote = {

--- a/src/memory-note.ts
+++ b/src/memory-note.ts
@@ -7,7 +7,10 @@ import type { SomaMemoryNote, SomaMemoryNoteType, SomaMemoryTrust } from "./type
  * frontmatter + markdown body, with a tiny hand-written grammar (no YAML lib —
  * zero new runtime deps). The round-trip law `parse(serialize(n)) === n` holds
  * for any note whose body is already trimmed; both sides normalize the body by
- * trimming, so a parsed note re-serializes byte-stably.
+ * trimming, so a parsed note re-serializes byte-stably. The quote-less grammar
+ * uses bare `null` as the null sentinel, so a nullable string field cannot also
+ * carry the literal string "null" — `serializeMemoryNote` rejects that value up
+ * front, keeping the law total rather than caveated.
  *
  * Frontmatter grammar: `---\n`, then `key: value` lines, then `---\n`. Values
  * are unquoted strings, `null`, integers, or an inline `links` array `[a, b]`
@@ -82,8 +85,25 @@ function formatLinks(links: string[]): string {
 }
 
 /**
+ * Guard a nullable string field against the reserved literal "null", which the
+ * quote-less grammar cannot distinguish from the `null` sentinel. Rejecting it
+ * on serialize makes the round-trip law total.
+ */
+function assertNotReservedNull(value: string | null, field: string): void {
+  assert(
+    value !== "null",
+    `${field} cannot be the reserved literal "null" (collides with the null sentinel)`,
+    field,
+  );
+}
+
+/**
  * Parse a memory-note file (frontmatter + body) into a validated
  * `SomaMemoryNote`. Throws `MemoryNoteError` (with `field`) on any violation.
+ *
+ * Validates the `id` slug *shape* only; the id==filename-stem invariant is the
+ * storage layer's contract (M1 `memoryNotePath`), since a pure content parser
+ * has no filename to compare against.
  */
 export function parseMemoryNote(content: string): SomaMemoryNote {
   assert(content.startsWith("---\n"), "note must start with a frontmatter block (---)");
@@ -148,10 +168,13 @@ export function parseMemoryNote(content: string): SomaMemoryNote {
 /**
  * Serialize a note to its canonical file form. `parse(serialize(n)) === n` for
  * any note whose body is already trimmed (the parser trims, so parsed notes
- * round-trip byte-stably). Validates by round-tripping through the parser's
- * rules is the caller's job; this emits exactly what the grammar accepts.
+ * round-trip byte-stably). Throws `MemoryNoteError` if a nullable string field
+ * holds the reserved literal "null" — the one value the quote-less grammar
+ * cannot round-trip — so the law is total, not caveated.
  */
 export function serializeMemoryNote(note: SomaMemoryNote): string {
+  assertNotReservedNull(note.source_of_truth, "source_of_truth");
+  assertNotReservedNull(note.project, "project");
   const lines = [
     "---",
     `id: ${note.id}`,

--- a/src/memory-note.ts
+++ b/src/memory-note.ts
@@ -9,9 +9,9 @@ import type { SomaMemoryNote, SomaMemoryNoteType, SomaMemoryTrust } from "./type
  * zero new runtime deps). The round-trip law `parse(serialize(n)) === n` holds
  * for any note whose body is already trimmed (both sides trim the body, so a
  * parsed note re-serializes byte-stably; an untrimmed body is the one lossy
- * case). `serializeMemoryNote` validates its whole input and throws rather than
- * emit a file `parse` would reject, so it can never produce an unparseable
- * note — see its docstring for the exact contract.
+ * case). `serializeMemoryNote` throws rather than emit a file that `parse`
+ * would reject *or* that would parse back to a different note (it re-parses and
+ * compares before returning) — see its docstring for the exact contract.
  *
  * Frontmatter grammar: `---\n`, then `key: value` lines, then `---\n`. Values
  * are unquoted strings, `null`, integers, or an inline `links` array `[a, b]`
@@ -85,17 +85,46 @@ function formatLinks(links: string[]): string {
   return `[${links.join(", ")}]`;
 }
 
+// Fields compared verbatim between an input note and its re-parsed form to
+// enforce the round-trip law by construction (body handled separately — it is
+// the one field serialize normalizes, by trimming).
+const ROUND_TRIP_SCALARS = [
+  "id",
+  "type",
+  "created",
+  "last_verified",
+  "valid_until",
+  "provenance",
+  "trust",
+  "source_of_truth",
+  "project",
+  "resurface_count",
+  "hook",
+  "review",
+] as const;
+
 /**
- * Guard a nullable string field against the reserved literal "null", which the
- * quote-less grammar cannot distinguish from the `null` sentinel. Rejecting it
- * on serialize makes the round-trip law total.
+ * Return the first field whose value would not survive `serialize`→`parse`
+ * unchanged, or `null` if the note round-trips exactly (body compared trimmed).
+ *
+ * This is what makes the round-trip law total: any field value that the
+ * quote-less grammar would normalize or reinterpret — a newline forging extra
+ * keys, stray leading/trailing whitespace the parser trims, or the reserved
+ * literal "null" collapsing to the null sentinel — shows up here as a mismatch
+ * between the input and its re-parsed form.
  */
-function assertNotReservedNull(value: string | null, field: string): void {
-  assert(
-    value !== "null",
-    `${field} cannot be the reserved literal "null" (collides with the null sentinel)`,
-    field,
-  );
+function roundTripMismatch(input: SomaMemoryNote, reparsed: SomaMemoryNote): string | null {
+  for (const field of ROUND_TRIP_SCALARS) {
+    if (reparsed[field] !== input[field]) return field;
+  }
+  if (reparsed.body !== input.body.trim()) return "body";
+  if (
+    reparsed.links.length !== input.links.length ||
+    reparsed.links.some((link, i) => link !== input.links[i])
+  ) {
+    return "links";
+  }
+  return null;
 }
 
 /**
@@ -169,24 +198,20 @@ export function parseMemoryNote(content: string): SomaMemoryNote {
 /**
  * Serialize a note to its canonical file form.
  *
- * Round-trip law: for any note this function *accepts*, `parse(serialize(n))`
- * equals `n` — with one normalization: the body is trimmed (`serialize` writes
- * `body.trim()`), so a note whose body has leading/trailing whitespace loses it
- * and does not compare equal. Pass an already-trimmed body for exact equality.
+ * Round-trip law, enforced by construction: for any note this function
+ * *accepts*, `parse(serialize(n))` equals `n` — with one normalization, the
+ * body is trimmed (`serialize` writes `body.trim()`), so pass an already-trimmed
+ * body for exact equality.
  *
- * `serialize` validates its whole input and throws `MemoryNoteError` rather than
- * emit a file that `parse` would reject: the reserved literal "null" in a
- * nullable string field (which the quote-less grammar cannot round-trip) is
- * caught up front, and every other field (id slug, dates, provenance, links,
- * count) is validated by re-parsing the output before it is returned.
+ * `serialize` throws `MemoryNoteError` rather than emit a file that fails to
+ * parse or that parses back to a *different* note. After building the output it
+ * re-parses it (rejecting a bad slug/date/links/count/provenance) and compares
+ * the result field-by-field against the input, so any value the grammar would
+ * normalize or reinterpret — a newline forging extra keys, stray whitespace the
+ * parser trims, or the reserved literal "null" collapsing to the null sentinel —
+ * is caught here, naming the offending field.
  */
 export function serializeMemoryNote(note: SomaMemoryNote): string {
-  // Every field the parser maps `"null" -> null` needs this guard: the emitted
-  // bare `null` reparses cleanly, so the reparse below can't catch a literal
-  // "null" string — only this up-front check keeps the round-trip total.
-  assertNotReservedNull(note.valid_until, "valid_until");
-  assertNotReservedNull(note.source_of_truth, "source_of_truth");
-  assertNotReservedNull(note.project, "project");
   const lines = [
     "---",
     `id: ${note.id}`,
@@ -205,8 +230,16 @@ export function serializeMemoryNote(note: SomaMemoryNote): string {
   if (note.review !== undefined) lines.push(`review: ${note.review}`);
   lines.push("---", "", note.body.trim(), "");
   const output = lines.join("\n");
-  // Never emit a note that fails to parse: re-parsing validates the full field
-  // surface (bad slug/date/links/count/provenance all throw here, not later).
-  parseMemoryNote(output);
+  // Enforce the round-trip law by construction: re-parse (validates every field)
+  // and confirm the note survives unchanged. A mismatch means a value would be
+  // normalized or reinterpreted (newline, whitespace, reserved "null") — refuse
+  // to emit it rather than silently produce a note that won't round-trip.
+  const mismatch = roundTripMismatch(note, parseMemoryNote(output));
+  assert(
+    mismatch === null,
+    `field "${mismatch}" would not survive serialization unchanged ` +
+      `(a newline, stray whitespace, or the reserved literal "null")`,
+    mismatch ?? undefined,
+  );
   return output;
 }

--- a/src/memory-note.ts
+++ b/src/memory-note.ts
@@ -7,11 +7,11 @@ import type { SomaMemoryNote, SomaMemoryNoteType, SomaMemoryTrust } from "./type
  * Contract is fixed by the plan v2 §2 (do not redesign): one note = strict
  * frontmatter + markdown body, with a tiny hand-written grammar (no YAML lib —
  * zero new runtime deps). The round-trip law `parse(serialize(n)) === n` holds
- * for any note whose body is already trimmed; both sides normalize the body by
- * trimming, so a parsed note re-serializes byte-stably. The quote-less grammar
- * uses bare `null` as the null sentinel, so a nullable string field cannot also
- * carry the literal string "null" — `serializeMemoryNote` rejects that value up
- * front, keeping the law total rather than caveated.
+ * for any note whose body is already trimmed (both sides trim the body, so a
+ * parsed note re-serializes byte-stably; an untrimmed body is the one lossy
+ * case). `serializeMemoryNote` validates its whole input and throws rather than
+ * emit a file `parse` would reject, so it can never produce an unparseable
+ * note — see its docstring for the exact contract.
  *
  * Frontmatter grammar: `---\n`, then `key: value` lines, then `---\n`. Values
  * are unquoted strings, `null`, integers, or an inline `links` array `[a, b]`
@@ -167,11 +167,18 @@ export function parseMemoryNote(content: string): SomaMemoryNote {
 }
 
 /**
- * Serialize a note to its canonical file form. `parse(serialize(n)) === n` for
- * any note whose body is already trimmed (the parser trims, so parsed notes
- * round-trip byte-stably). Throws `MemoryNoteError` if a nullable string field
- * holds the reserved literal "null" — the one value the quote-less grammar
- * cannot round-trip — so the law is total, not caveated.
+ * Serialize a note to its canonical file form.
+ *
+ * Round-trip law: for any note this function *accepts*, `parse(serialize(n))`
+ * equals `n` — with one normalization: the body is trimmed (`serialize` writes
+ * `body.trim()`), so a note whose body has leading/trailing whitespace loses it
+ * and does not compare equal. Pass an already-trimmed body for exact equality.
+ *
+ * `serialize` validates its whole input and throws `MemoryNoteError` rather than
+ * emit a file that `parse` would reject: the reserved literal "null" in a
+ * nullable string field (which the quote-less grammar cannot round-trip) is
+ * caught up front, and every other field (id slug, dates, provenance, links,
+ * count) is validated by re-parsing the output before it is returned.
  */
 export function serializeMemoryNote(note: SomaMemoryNote): string {
   assertNotReservedNull(note.source_of_truth, "source_of_truth");
@@ -193,5 +200,9 @@ export function serializeMemoryNote(note: SomaMemoryNote): string {
   if (note.hook !== undefined) lines.push(`hook: ${note.hook}`);
   if (note.review !== undefined) lines.push(`review: ${note.review}`);
   lines.push("---", "", note.body.trim(), "");
-  return lines.join("\n");
+  const output = lines.join("\n");
+  // Never emit a note that fails to parse: re-parsing validates the full field
+  // surface (bad slug/date/links/count/provenance all throw here, not later).
+  parseMemoryNote(output);
+  return output;
 }

--- a/src/memory-note.ts
+++ b/src/memory-note.ts
@@ -181,6 +181,10 @@ export function parseMemoryNote(content: string): SomaMemoryNote {
  * count) is validated by re-parsing the output before it is returned.
  */
 export function serializeMemoryNote(note: SomaMemoryNote): string {
+  // Every field the parser maps `"null" -> null` needs this guard: the emitted
+  // bare `null` reparses cleanly, so the reparse below can't catch a literal
+  // "null" string — only this up-front check keeps the round-trip total.
+  assertNotReservedNull(note.valid_until, "valid_until");
   assertNotReservedNull(note.source_of_truth, "source_of_truth");
   assertNotReservedNull(note.project, "project");
   const lines = [

--- a/src/memory-note.ts
+++ b/src/memory-note.ts
@@ -1,0 +1,153 @@
+import type { SomaMemoryNote, SomaMemoryNoteType, SomaMemoryTrust } from "./types";
+
+/**
+ * File-native memory note parser + serializer (memory subsystem M0).
+ *
+ * Contract is fixed by the plan v2 §2 (do not redesign): one note = strict
+ * frontmatter + markdown body, with a tiny hand-written grammar (no YAML lib —
+ * zero new runtime deps). The round-trip law `parse(serialize(n)) === n` holds
+ * for any note whose body is already trimmed; both sides normalize the body by
+ * trimming, so a parsed note re-serializes byte-stably.
+ *
+ * Frontmatter grammar: `---\n`, then `key: value` lines, then `---\n`. Values
+ * are unquoted strings, `null`, integers, or an inline `links` array `[a, b]`
+ * (possibly `[]`). No nesting, no quotes, no multiline values. Unknown or
+ * duplicate keys, missing required keys, and any malformed value throw a
+ * `MemoryNoteError` naming the offending field.
+ */
+
+export class MemoryNoteError extends Error {
+  constructor(message: string, readonly field?: string) {
+    super(message);
+    this.name = "MemoryNoteError";
+  }
+}
+
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const DATE = /^\d{4}-\d{2}-\d{2}$/;
+const NOTE_TYPES: readonly SomaMemoryNoteType[] = ["semantic", "episodic", "procedural"];
+const TRUSTS: readonly SomaMemoryTrust[] = ["principal", "agent", "quarantined"];
+
+// Required frontmatter keys in canonical serialization order.
+const REQUIRED_KEYS = [
+  "id",
+  "type",
+  "created",
+  "last_verified",
+  "valid_until",
+  "provenance",
+  "trust",
+  "source_of_truth",
+  "project",
+  "links",
+  "resurface_count",
+] as const;
+const OPTIONAL_KEYS = ["hook", "review"] as const;
+const ALLOWED_KEYS = new Set<string>([...REQUIRED_KEYS, ...OPTIONAL_KEYS]);
+
+function assert(condition: unknown, message: string, field?: string): asserts condition {
+  if (!condition) throw new MemoryNoteError(message, field);
+}
+
+/** Parse the inline `links` array grammar: `[]`, `[a]`, `[a, b]`. */
+function parseLinks(raw: string): string[] {
+  assert(raw.startsWith("[") && raw.endsWith("]"), `links must be an inline array [a, b]`, "links");
+  const inner = raw.slice(1, -1).trim();
+  if (inner === "") return [];
+  const items = inner.split(",").map((s) => s.trim());
+  for (const item of items) {
+    assert(SLUG.test(item), `links entry "${item}" is not a valid slug`, "links");
+  }
+  return items;
+}
+
+function formatLinks(links: string[]): string {
+  return `[${links.join(", ")}]`;
+}
+
+/**
+ * Parse a memory-note file (frontmatter + body) into a validated
+ * `SomaMemoryNote`. Throws `MemoryNoteError` (with `field`) on any violation.
+ */
+export function parseMemoryNote(content: string): SomaMemoryNote {
+  assert(content.startsWith("---\n"), "note must start with a frontmatter block (---)");
+  const closeIdx = content.indexOf("\n---\n", 3);
+  assert(closeIdx !== -1, "frontmatter block is not closed with ---");
+
+  const frontmatter = content.slice(4, closeIdx + 1); // between the two --- markers, keep trailing \n
+  const body = content.slice(closeIdx + 5).trim();
+
+  const raw: Record<string, string> = {};
+  for (const line of frontmatter.split("\n")) {
+    if (line === "") continue;
+    const sep = line.indexOf(":");
+    assert(sep !== -1, `malformed frontmatter line (no key): ${line}`);
+    const key = line.slice(0, sep).trim();
+    const value = line.slice(sep + 1).trim();
+    assert(ALLOWED_KEYS.has(key), `unknown frontmatter key: ${key}`, key);
+    assert(!(key in raw), `duplicate frontmatter key: ${key}`, key);
+    raw[key] = value;
+  }
+
+  for (const key of REQUIRED_KEYS) {
+    assert(key in raw, `missing required frontmatter key: ${key}`, key);
+  }
+
+  const id = raw.id;
+  assert(SLUG.test(id) && id.length <= 64, `id "${id}" is not a valid slug (<=64 chars)`, "id");
+  assert((NOTE_TYPES as readonly string[]).includes(raw.type), `type "${raw.type}" is not valid`, "type");
+  assert((TRUSTS as readonly string[]).includes(raw.trust), `trust "${raw.trust}" is not valid`, "trust");
+  assert(DATE.test(raw.created), `created "${raw.created}" must be YYYY-MM-DD`, "created");
+  assert(DATE.test(raw.last_verified), `last_verified "${raw.last_verified}" must be YYYY-MM-DD`, "last_verified");
+  assert(raw.valid_until === "null" || DATE.test(raw.valid_until), `valid_until must be null or YYYY-MM-DD`, "valid_until");
+
+  const resurface = Number(raw.resurface_count);
+  assert(/^\d+$/.test(raw.resurface_count) && Number.isInteger(resurface), `resurface_count must be an integer >= 0`, "resurface_count");
+  assert(raw.provenance.length > 0, "provenance must not be empty", "provenance");
+  assert(body.length > 0, "body must not be empty", "body");
+
+  const note: SomaMemoryNote = {
+    id,
+    type: raw.type as SomaMemoryNoteType,
+    created: raw.created,
+    last_verified: raw.last_verified,
+    valid_until: raw.valid_until === "null" ? null : raw.valid_until,
+    provenance: raw.provenance,
+    trust: raw.trust as SomaMemoryTrust,
+    source_of_truth: raw.source_of_truth === "null" ? null : raw.source_of_truth,
+    project: raw.project === "null" ? null : raw.project,
+    links: parseLinks(raw.links),
+    resurface_count: resurface,
+    body,
+  };
+  if ("hook" in raw) note.hook = raw.hook;
+  if ("review" in raw) note.review = raw.review;
+  return note;
+}
+
+/**
+ * Serialize a note to its canonical file form. `parse(serialize(n)) === n` for
+ * any note whose body is already trimmed (the parser trims, so parsed notes
+ * round-trip byte-stably). Validates by round-tripping through the parser's
+ * rules is the caller's job; this emits exactly what the grammar accepts.
+ */
+export function serializeMemoryNote(note: SomaMemoryNote): string {
+  const lines = [
+    "---",
+    `id: ${note.id}`,
+    `type: ${note.type}`,
+    `created: ${note.created}`,
+    `last_verified: ${note.last_verified}`,
+    `valid_until: ${note.valid_until ?? "null"}`,
+    `provenance: ${note.provenance}`,
+    `trust: ${note.trust}`,
+    `source_of_truth: ${note.source_of_truth ?? "null"}`,
+    `project: ${note.project ?? "null"}`,
+    `links: ${formatLinks(note.links)}`,
+    `resurface_count: ${note.resurface_count}`,
+  ];
+  if (note.hook !== undefined) lines.push(`hook: ${note.hook}`);
+  if (note.review !== undefined) lines.push(`review: ${note.review}`);
+  lines.push("---", "", note.body.trim(), "");
+  return lines.join("\n");
+}

--- a/src/memory-note.ts
+++ b/src/memory-note.ts
@@ -1,3 +1,4 @@
+import { SOMA_MEMORY_NOTE_TYPES, SOMA_MEMORY_TRUSTS } from "./types";
 import type { SomaMemoryNote, SomaMemoryNoteType, SomaMemoryTrust } from "./types";
 
 /**
@@ -28,8 +29,8 @@ export class MemoryNoteError extends Error {
 
 const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const DATE = /^\d{4}-\d{2}-\d{2}$/;
-const NOTE_TYPES: readonly SomaMemoryNoteType[] = ["semantic", "episodic", "procedural"];
-const TRUSTS: readonly SomaMemoryTrust[] = ["principal", "agent", "quarantined"];
+const NOTE_TYPES: readonly SomaMemoryNoteType[] = SOMA_MEMORY_NOTE_TYPES;
+const TRUSTS: readonly SomaMemoryTrust[] = SOMA_MEMORY_TRUSTS;
 
 // Provenance is a closed set plus the open `tool:<name>` family (plan v2 §2.2,
 // design doc line 105): conversation | consolidation | import | tool:<name>.

--- a/src/types.ts
+++ b/src/types.ts
@@ -2299,3 +2299,28 @@ export interface SomaAdapter {
   project(input: ProjectionInput): Promise<Projection>;
   run(task: SomaTask): Promise<SomaRunResult>;
 }
+
+// ── Memory subsystem (Track B, M0) ──────────────────────────────────────────
+// File-native memory note schema. Contract fixed in the memory-subsystem plan
+// v2 §2 (do not redesign). One note = one markdown file: strict frontmatter +
+// markdown body. Parser/serializer live in src/memory-note.ts and obey the
+// round-trip law parse(serialize(n)) == n.
+export type SomaMemoryNoteType = "semantic" | "episodic" | "procedural";
+export type SomaMemoryTrust = "principal" | "agent" | "quarantined";
+
+export interface SomaMemoryNote {
+  id: string;                 // kebab slug, equals filename stem
+  type: SomaMemoryNoteType;
+  created: string;            // YYYY-MM-DD
+  last_verified: string;      // YYYY-MM-DD
+  valid_until: string | null; // YYYY-MM-DD when superseded/expired, else null
+  provenance: string;         // "conversation" | "consolidation" | "import" | "tool:<name>"
+  trust: SomaMemoryTrust;
+  source_of_truth: string | null; // path/URL to verify against, or null
+  project: string | null;     // scope key, e.g. "soma", or null
+  links: string[];            // ids of related notes (may be empty)
+  resurface_count: number;    // integer >= 0
+  hook?: string;              // optional: recall-trigger phrase
+  review?: string;            // optional: review directive
+  body: string;               // markdown after the closing ---
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2305,8 +2305,13 @@ export interface SomaAdapter {
 // v2 §2 (do not redesign). One note = one markdown file: strict frontmatter +
 // markdown body. Parser/serializer live in src/memory-note.ts and obey the
 // round-trip law parse(serialize(n)) == n.
-export type SomaMemoryNoteType = "semantic" | "episodic" | "procedural";
-export type SomaMemoryTrust = "principal" | "agent" | "quarantined";
+// Single source of truth for the note enums: the validator arrays in
+// memory-note.ts import these, and the union types derive from them, so the
+// literals live in exactly one place.
+export const SOMA_MEMORY_NOTE_TYPES = ["semantic", "episodic", "procedural"] as const;
+export type SomaMemoryNoteType = (typeof SOMA_MEMORY_NOTE_TYPES)[number];
+export const SOMA_MEMORY_TRUSTS = ["principal", "agent", "quarantined"] as const;
+export type SomaMemoryTrust = (typeof SOMA_MEMORY_TRUSTS)[number];
 
 export interface SomaMemoryNote {
   id: string;                 // kebab slug; storage layer (M1) binds it to the filename stem

--- a/src/types.ts
+++ b/src/types.ts
@@ -2310,7 +2310,10 @@ export interface SomaAdapter {
 // literals live in exactly one place.
 export const SOMA_MEMORY_NOTE_TYPES = ["semantic", "episodic", "procedural"] as const;
 export type SomaMemoryNoteType = (typeof SOMA_MEMORY_NOTE_TYPES)[number];
-export const SOMA_MEMORY_TRUSTS = ["principal", "agent", "quarantined"] as const;
+// Trust tier = who vouched for a memory. "assistant" (not "agent") per
+// CONTEXT.md, which reserves `agent` for substrate concepts and forbids it as a
+// Soma core noun; the plan's `agent` tier is renamed here at first codification.
+export const SOMA_MEMORY_TRUSTS = ["principal", "assistant", "quarantined"] as const;
 export type SomaMemoryTrust = (typeof SOMA_MEMORY_TRUSTS)[number];
 
 export interface SomaMemoryNote {
@@ -2320,7 +2323,8 @@ export interface SomaMemoryNote {
   last_verified: string;      // YYYY-MM-DD
   valid_until: string | null; // YYYY-MM-DD when superseded/expired, else null
   provenance: string;         // "conversation" | "consolidation" | "import" | "tool:<name>"
-  trust: SomaMemoryTrust;
+  trust: SomaMemoryTrust;     // who vouched: principal (human) | assistant (Ivy) | quarantined.
+                              // "assistant" not "agent" — CONTEXT.md reserves `agent` for substrate concepts.
   source_of_truth: string | null; // path/URL to verify against, or null
   project: string | null;     // scope key, e.g. "soma", or null
   links: string[];            // ids of related notes (may be empty)

--- a/src/types.ts
+++ b/src/types.ts
@@ -2304,7 +2304,9 @@ export interface SomaAdapter {
 // File-native memory note schema. Contract fixed in the memory-subsystem plan
 // v2 §2 (do not redesign). One note = one markdown file: strict frontmatter +
 // markdown body. Parser/serializer live in src/memory-note.ts and obey the
-// round-trip law parse(serialize(n)) == n.
+// round-trip law parse(serialize(n)) == n for any note serialize accepts whose
+// body is already trimmed (serialize trims the body — the one lossy
+// normalization; see serializeMemoryNote for the exact contract).
 // Single source of truth for the note enums: the validator arrays in
 // memory-note.ts import these, and the union types derive from them, so the
 // literals live in exactly one place.

--- a/src/types.ts
+++ b/src/types.ts
@@ -2309,7 +2309,7 @@ export type SomaMemoryNoteType = "semantic" | "episodic" | "procedural";
 export type SomaMemoryTrust = "principal" | "agent" | "quarantined";
 
 export interface SomaMemoryNote {
-  id: string;                 // kebab slug, equals filename stem
+  id: string;                 // kebab slug; storage layer (M1) binds it to the filename stem
   type: SomaMemoryNoteType;
   created: string;            // YYYY-MM-DD
   last_verified: string;      // YYYY-MM-DD

--- a/test/memory-note.test.ts
+++ b/test/memory-note.test.ts
@@ -227,6 +227,32 @@ test("a genuine null source_of_truth/project still serializes and round-trips", 
   expect(parseMemoryNote(serializeMemoryNote(n))).toEqual(n);
 });
 
+test("serialize rejects a note with an invalid link slug (no poison file)", () => {
+  const n = { ...minimalNote(), links: ["BAD_SLUG"] };
+  expect(() => serializeMemoryNote(n)).toThrow(MemoryNoteError);
+  expect(() => serializeMemoryNote(n)).toThrow("links");
+});
+
+test("serialize rejects a note with an invalid id slug", () => {
+  const n = { ...minimalNote(), id: "Not A Slug" };
+  expect(() => serializeMemoryNote(n)).toThrow("id");
+});
+
+test("serialize rejects a note with an impossible date", () => {
+  const n = { ...minimalNote(), created: "2026-99-99" };
+  expect(() => serializeMemoryNote(n)).toThrow("created");
+});
+
+test("serialize rejects a note with a negative resurface_count", () => {
+  const n = { ...minimalNote(), resurface_count: -1 };
+  expect(() => serializeMemoryNote(n)).toThrow("resurface_count");
+});
+
+test("serialize preserves an already-trimmed body exactly (round-trip law)", () => {
+  const n = { ...minimalNote(), body: "already trimmed" };
+  expect(parseMemoryNote(serializeMemoryNote(n))).toEqual(n);
+});
+
 test("multi-entry links round-trip", () => {
   const n = { ...minimalNote(), links: ["a", "b-two", "c3"] };
   expect(parseMemoryNote(serializeMemoryNote(n)).links).toEqual(["a", "b-two", "c3"]);

--- a/test/memory-note.test.ts
+++ b/test/memory-note.test.ts
@@ -33,7 +33,7 @@ function minimalNote(): SomaMemoryNote {
     last_verified: "2026-07-03",
     valid_until: "2026-08-01",
     provenance: "tool:consolidate",
-    trust: "agent",
+    trust: "assistant",
     source_of_truth: null,
     project: null,
     links: [],
@@ -129,7 +129,7 @@ test("invalid type throws", () => {
 });
 
 test("invalid trust throws", () => {
-  const bad = serializedMinimal().replace("trust: agent", "trust: root");
+  const bad = serializedMinimal().replace("trust: assistant", "trust: root");
   expect(() => parseMemoryNote(bad)).toThrow("trust");
 });
 

--- a/test/memory-note.test.ts
+++ b/test/memory-note.test.ts
@@ -211,6 +211,22 @@ test("links without brackets throws", () => {
   expect(() => parseMemoryNote(bad)).toThrow("links");
 });
 
+test("serialize rejects the reserved literal \"null\" as source_of_truth", () => {
+  const n = { ...minimalNote(), source_of_truth: "null" };
+  expect(() => serializeMemoryNote(n)).toThrow(MemoryNoteError);
+  expect(() => serializeMemoryNote(n)).toThrow("source_of_truth");
+});
+
+test("serialize rejects the reserved literal \"null\" as project", () => {
+  const n = { ...minimalNote(), project: "null" };
+  expect(() => serializeMemoryNote(n)).toThrow("project");
+});
+
+test("a genuine null source_of_truth/project still serializes and round-trips", () => {
+  const n = { ...minimalNote(), source_of_truth: null, project: null };
+  expect(parseMemoryNote(serializeMemoryNote(n))).toEqual(n);
+});
+
 test("multi-entry links round-trip", () => {
   const n = { ...minimalNote(), links: ["a", "b-two", "c3"] };
   expect(parseMemoryNote(serializeMemoryNote(n)).links).toEqual(["a", "b-two", "c3"]);

--- a/test/memory-note.test.ts
+++ b/test/memory-note.test.ts
@@ -222,6 +222,17 @@ test("serialize rejects the reserved literal \"null\" as project", () => {
   expect(() => serializeMemoryNote(n)).toThrow("project");
 });
 
+test("serialize rejects the reserved literal \"null\" as valid_until", () => {
+  const n = { ...minimalNote(), valid_until: "null" };
+  expect(() => serializeMemoryNote(n)).toThrow(MemoryNoteError);
+  expect(() => serializeMemoryNote(n)).toThrow("valid_until");
+});
+
+test("a genuine null valid_until still serializes and round-trips", () => {
+  const n = { ...minimalNote(), valid_until: null };
+  expect(parseMemoryNote(serializeMemoryNote(n))).toEqual(n);
+});
+
 test("a genuine null source_of_truth/project still serializes and round-trips", () => {
   const n = { ...minimalNote(), source_of_truth: null, project: null };
   expect(parseMemoryNote(serializeMemoryNote(n))).toEqual(n);

--- a/test/memory-note.test.ts
+++ b/test/memory-note.test.ts
@@ -233,6 +233,22 @@ test("a genuine null valid_until still serializes and round-trips", () => {
   expect(parseMemoryNote(serializeMemoryNote(n))).toEqual(n);
 });
 
+test("serialize rejects a newline in a scalar field (frontmatter injection)", () => {
+  const n = { ...minimalNote(), hook: "a\nreview: forged" };
+  expect(() => serializeMemoryNote(n)).toThrow(MemoryNoteError);
+  expect(() => serializeMemoryNote(n)).toThrow("hook");
+});
+
+test("serialize rejects a newline in source_of_truth", () => {
+  const n = { ...minimalNote(), source_of_truth: "path\nproject: forged" };
+  expect(() => serializeMemoryNote(n)).toThrow(MemoryNoteError);
+});
+
+test("serialize rejects trailing whitespace the parser would trim away", () => {
+  const n = { ...minimalNote(), project: "soma " };
+  expect(() => serializeMemoryNote(n)).toThrow("project");
+});
+
 test("a genuine null source_of_truth/project still serializes and round-trips", () => {
   const n = { ...minimalNote(), source_of_truth: null, project: null };
   expect(parseMemoryNote(serializeMemoryNote(n))).toEqual(n);

--- a/test/memory-note.test.ts
+++ b/test/memory-note.test.ts
@@ -1,0 +1,180 @@
+import { expect, test } from "bun:test";
+import {
+  MemoryNoteError,
+  parseMemoryNote,
+  serializeMemoryNote,
+  type SomaMemoryNote,
+} from "../src/index";
+
+function fullNote(): SomaMemoryNote {
+  return {
+    id: "soma-memory-schema",
+    type: "semantic",
+    created: "2026-07-03",
+    last_verified: "2026-07-03",
+    valid_until: null,
+    provenance: "conversation",
+    trust: "principal",
+    source_of_truth: "src/memory-note.ts",
+    project: "soma",
+    links: ["memory-recall", "memory-consolidation"],
+    resurface_count: 0,
+    hook: "how does memory note parse",
+    review: "verify against src/memory-note.ts",
+    body: "One note = strict frontmatter + markdown body.",
+  };
+}
+
+function minimalNote(): SomaMemoryNote {
+  return {
+    id: "min",
+    type: "episodic",
+    created: "2026-07-03",
+    last_verified: "2026-07-03",
+    valid_until: "2026-08-01",
+    provenance: "tool:consolidate",
+    trust: "agent",
+    source_of_truth: null,
+    project: null,
+    links: [],
+    resurface_count: 3,
+    body: "Body text.",
+  };
+}
+
+// ── round-trip law ──────────────────────────────────────────────────────────
+
+test("parse(serialize(n)) === n for a full note", () => {
+  const n = fullNote();
+  expect(parseMemoryNote(serializeMemoryNote(n))).toEqual(n);
+});
+
+test("parse(serialize(n)) === n for a minimal note (nulls, empty links, no optionals)", () => {
+  const n = minimalNote();
+  expect(parseMemoryNote(serializeMemoryNote(n))).toEqual(n);
+});
+
+test("serialize(parse(s)) === s is byte-stable for a canonical string", () => {
+  const s = serializeMemoryNote(fullNote());
+  expect(serializeMemoryNote(parseMemoryNote(s))).toBe(s);
+});
+
+test("optional keys are omitted from output when undefined", () => {
+  const s = serializeMemoryNote(minimalNote());
+  expect(s).not.toContain("hook:");
+  expect(s).not.toContain("review:");
+});
+
+test("body is trimmed on parse so re-serialization is stable", () => {
+  const n = { ...minimalNote(), body: "  spaced body  " };
+  const parsed = parseMemoryNote(serializeMemoryNote(n));
+  expect(parsed.body).toBe("spaced body");
+});
+
+// ── validation ──────────────────────────────────────────────────────────────
+
+function serializedMinimal(): string {
+  return serializeMemoryNote(minimalNote());
+}
+
+test("missing frontmatter block throws", () => {
+  expect(() => parseMemoryNote("no frontmatter here")).toThrow(MemoryNoteError);
+  expect(() => parseMemoryNote("no frontmatter here")).toThrow("frontmatter block");
+});
+
+test("unclosed frontmatter throws", () => {
+  expect(() => parseMemoryNote("---\nid: x\n")).toThrow("not closed");
+});
+
+test("unknown frontmatter key throws naming the field", () => {
+  const bad = serializedMinimal().replace("project: null", "project: null\nbogus: 1");
+  try {
+    parseMemoryNote(bad);
+    throw new Error("should have thrown");
+  } catch (e) {
+    expect(e).toBeInstanceOf(MemoryNoteError);
+    expect((e as MemoryNoteError).field).toBe("bogus");
+  }
+});
+
+test("duplicate frontmatter key throws", () => {
+  const bad = serializedMinimal().replace("project: null", "project: null\nproject: soma");
+  expect(() => parseMemoryNote(bad)).toThrow("duplicate");
+});
+
+test("missing required key throws naming the field", () => {
+  const bad = serializedMinimal().replace("resurface_count: 3\n", "");
+  try {
+    parseMemoryNote(bad);
+    throw new Error("should have thrown");
+  } catch (e) {
+    expect((e as MemoryNoteError).field).toBe("resurface_count");
+  }
+});
+
+test("invalid id slug throws", () => {
+  const bad = serializedMinimal().replace("id: min", "id: Not_A_Slug");
+  expect(() => parseMemoryNote(bad)).toThrow("id");
+});
+
+test("id over 64 chars throws", () => {
+  const long = "a".repeat(65);
+  const bad = serializedMinimal().replace("id: min", `id: ${long}`);
+  expect(() => parseMemoryNote(bad)).toThrow("id");
+});
+
+test("invalid type throws", () => {
+  const bad = serializedMinimal().replace("type: episodic", "type: bogus");
+  expect(() => parseMemoryNote(bad)).toThrow("type");
+});
+
+test("invalid trust throws", () => {
+  const bad = serializedMinimal().replace("trust: agent", "trust: root");
+  expect(() => parseMemoryNote(bad)).toThrow("trust");
+});
+
+test("non-date created throws", () => {
+  const bad = serializedMinimal().replace("created: 2026-07-03", "created: yesterday");
+  expect(() => parseMemoryNote(bad)).toThrow("created");
+});
+
+test("valid_until accepts null or a date, rejects garbage", () => {
+  const bad = serializedMinimal().replace("valid_until: 2026-08-01", "valid_until: soon");
+  expect(() => parseMemoryNote(bad)).toThrow("valid_until");
+});
+
+test("non-integer resurface_count throws", () => {
+  const bad = serializedMinimal().replace("resurface_count: 3", "resurface_count: 2.5");
+  expect(() => parseMemoryNote(bad)).toThrow("resurface_count");
+});
+
+test("negative resurface_count throws", () => {
+  const bad = serializedMinimal().replace("resurface_count: 3", "resurface_count: -1");
+  expect(() => parseMemoryNote(bad)).toThrow("resurface_count");
+});
+
+test("empty provenance throws", () => {
+  const bad = serializedMinimal().replace("provenance: tool:consolidate", "provenance:");
+  expect(() => parseMemoryNote(bad)).toThrow("provenance");
+});
+
+test("empty body throws", () => {
+  const bad = serializedMinimal().replace("Body text.", "");
+  expect(() => parseMemoryNote(bad)).toThrow("body");
+});
+
+test("links with an invalid slug entry throws", () => {
+  const n = { ...minimalNote(), links: ["ok"] };
+  const bad = serializeMemoryNote(n).replace("links: [ok]", "links: [ok, BAD_SLUG]");
+  expect(() => parseMemoryNote(bad)).toThrow("links");
+});
+
+test("links without brackets throws", () => {
+  const bad = serializedMinimal().replace("links: []", "links: a, b");
+  expect(() => parseMemoryNote(bad)).toThrow("links");
+});
+
+test("multi-entry links round-trip", () => {
+  const n = { ...minimalNote(), links: ["a", "b-two", "c3"] };
+  expect(parseMemoryNote(serializeMemoryNote(n)).links).toEqual(["a", "b-two", "c3"]);
+});

--- a/test/memory-note.test.ts
+++ b/test/memory-note.test.ts
@@ -138,6 +138,21 @@ test("non-date created throws", () => {
   expect(() => parseMemoryNote(bad)).toThrow("created");
 });
 
+test("shape-valid but impossible calendar date throws (2026-99-99)", () => {
+  const bad = serializedMinimal().replace("created: 2026-07-03", "created: 2026-99-99");
+  expect(() => parseMemoryNote(bad)).toThrow("created");
+});
+
+test("Feb 30 is rejected as an impossible date", () => {
+  const bad = serializedMinimal().replace("last_verified: 2026-07-03", "last_verified: 2026-02-30");
+  expect(() => parseMemoryNote(bad)).toThrow("last_verified");
+});
+
+test("valid_until rejects an impossible date", () => {
+  const bad = serializedMinimal().replace("valid_until: 2026-08-01", "valid_until: 2026-13-01");
+  expect(() => parseMemoryNote(bad)).toThrow("valid_until");
+});
+
 test("valid_until accepts null or a date, rejects garbage", () => {
   const bad = serializedMinimal().replace("valid_until: 2026-08-01", "valid_until: soon");
   expect(() => parseMemoryNote(bad)).toThrow("valid_until");
@@ -156,6 +171,28 @@ test("negative resurface_count throws", () => {
 test("empty provenance throws", () => {
   const bad = serializedMinimal().replace("provenance: tool:consolidate", "provenance:");
   expect(() => parseMemoryNote(bad)).toThrow("provenance");
+});
+
+test("provenance outside the closed set throws", () => {
+  const bad = serializedMinimal().replace("provenance: tool:consolidate", "provenance: hearsay");
+  expect(() => parseMemoryNote(bad)).toThrow("provenance");
+});
+
+test("bare 'tool:' with no name throws", () => {
+  const bad = serializedMinimal().replace("provenance: tool:consolidate", "provenance: tool:");
+  expect(() => parseMemoryNote(bad)).toThrow("provenance");
+});
+
+test("each documented provenance literal is accepted", () => {
+  for (const p of ["conversation", "consolidation", "import"]) {
+    const n = { ...minimalNote(), provenance: p };
+    expect(parseMemoryNote(serializeMemoryNote(n)).provenance).toBe(p);
+  }
+});
+
+test("tool:<name> provenance round-trips", () => {
+  const n = { ...minimalNote(), provenance: "tool:daily-briefing" };
+  expect(parseMemoryNote(serializeMemoryNote(n)).provenance).toBe("tool:daily-briefing");
 });
 
 test("empty body throws", () => {


### PR DESCRIPTION
## M0 — Note schema, parser, serializer

First slice of the memory subsystem (plan v2 §M0). One note = one markdown file: strict frontmatter + markdown body, parsed/serialized by a **zero-dep hand-written grammar** (no YAML lib, no new runtime deps).

### What's here
- **`src/types.ts`** — `SomaMemoryNote`, `SomaMemoryNoteType` (`semantic`/`episodic`/`procedural`), `SomaMemoryTrust` (`principal`/`assistant`/`quarantined` — `assistant` not `agent`, per CONTEXT.md's reserved-word rule). Enum literals are single-sourced via `SOMA_MEMORY_NOTE_TYPES` / `SOMA_MEMORY_TRUSTS` (`as const`), with the unions derived from them.
- **`src/memory-note.ts`** — `parseMemoryNote` / `serializeMemoryNote` / `MemoryNoteError`. Typed errors name the offending field. Rejects unknown/duplicate/missing keys, bad slugs, **impossible calendar dates** (`2026-99-99`, Feb 30, month 13), non-integer/negative counts, **provenance outside the closed set** (`conversation | consolidation | import | tool:<name>`), malformed `links`, empty body, and the **reserved literal `"null"`** in nullable string fields.
- **`src/index.ts`** — re-exports the parser API, note types, and enum arrays.
- **`test/memory-note.test.ts`** — round-trip law + full validation surface.

### Contract (fixed by plan §2 — not redesigned here)
- Frontmatter grammar: `---`, `key: value` lines, `---`. Values are unquoted strings, `null`, integers, or inline `links` array `[a, b]`. No nesting, no quotes, no multiline.
- **Round-trip law:** `parse(serialize(n)) === n` for any note `serialize` accepts, provided the body is already trimmed (the body-trim is the one normalization). `serializeMemoryNote` validates its full input by re-parsing its own output, so it throws `MemoryNoteError` on any invalid field and can never emit an unparseable file.
- The `id`==filename-stem binding is the M1 storage layer's contract; the pure content parser validates slug *shape* only.

### Acceptance (plan §M0) — verified at `HEAD`
```
$ npx tsc --noEmit
  TypeScript: No errors found

$ bun test test/memory-note.test.ts
  43 pass  0 fail

$ npx eslint src/memory-note.ts src/types.ts src/index.ts test/memory-note.test.ts
  ESLint: No issues found
```
- ✅ `parse(serialize(n)) == n` (full + minimal notes, null/tool provenance, multi-entry links)
- ✅ unknown key → typed `MemoryNoteError` naming the field
- ✅ 43/43 memory-note tests green

### Review
Sage code-review rounds 1–6 addressed: calendar-date validation, closed provenance set, **round-trip law enforced by construction** (serialize re-parses and compares field-by-field, rejecting newlines/whitespace/reserved-`null` — closing the frontmatter-injection class), id-contract honesty, single-sourced enums, and the `agent`→`assistant` trust-tier rename for CONTEXT.md vocab.

> Full suite: the only failure is the pre-existing `pai-pack-importer-issue-109` smoke test, which reads a live `~/work/PAI/Releases/v6.0.0` tree missing `DOCUMENTATION/` on this machine. Fails identically on `main`; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
