### PR TITLE
fix(memory): reject unsafe-integer resurface_count (sage M0 r7 follow-up)

### DIFF
--- a/src/memory-note.ts
+++ b/src/memory-note.ts
@@ -168,7 +168,11 @@ export function parseMemoryNote(content: string): SomaMemoryNote {
   assert(raw.valid_until === "null" || isCalendarDate(raw.valid_until), `valid_until must be null or a valid YYYY-MM-DD date`, "valid_until");
 
   const resurface = Number(raw.resurface_count);
-  assert(/^\d+$/.test(raw.resurface_count) && Number.isInteger(resurface), `resurface_count must be an integer >= 0`, "resurface_count");
+  assert(
+    /^\d+$/.test(raw.resurface_count) && Number.isSafeInteger(resurface),
+    `resurface_count must be a safe integer >= 0`,
+    "resurface_count",
+  );
   assert(
     PROVENANCE_LITERALS.has(raw.provenance) || /^tool:.+/.test(raw.provenance),
     `provenance "${raw.provenance}" must be conversation, consolidation, import, or tool:<name>`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2325,7 +2325,7 @@ export interface SomaMemoryNote {
   last_verified: string;      // YYYY-MM-DD
   valid_until: string | null; // YYYY-MM-DD when superseded/expired, else null
   provenance: string;         // "conversation" | "consolidation" | "import" | "tool:<name>"
-  trust: SomaMemoryTrust;     // who vouched: principal (human) | assistant (Ivy) | quarantined.
+  trust: SomaMemoryTrust;     // who vouched: principal | assistant | quarantined.
                               // "assistant" not "agent" — CONTEXT.md reserves `agent` for substrate concepts.
   source_of_truth: string | null; // path/URL to verify against, or null
   project: string | null;     // scope key, e.g. "soma", or null

--- a/test/memory-note.test.ts
+++ b/test/memory-note.test.ts
@@ -168,6 +168,11 @@ test("negative resurface_count throws", () => {
   expect(() => parseMemoryNote(bad)).toThrow("resurface_count");
 });
 
+test("resurface_count past MAX_SAFE_INTEGER throws (no silent precision loss)", () => {
+  const bad = serializedMinimal().replace("resurface_count: 3", "resurface_count: 9007199254740993");
+  expect(() => parseMemoryNote(bad)).toThrow("resurface_count");
+});
+
 test("empty provenance throws", () => {
   const bad = serializedMinimal().replace("provenance: tool:consolidate", "provenance:");
   expect(() => parseMemoryNote(bad)).toThrow("provenance");


### PR DESCRIPTION
Follow-up to #391. The sage round-7 fix was committed locally but the squash-merge of #391 happened before it was pushed, so it missed the merge window. This re-applies it (cherry-picked from the recovered commit).

### Changes
- **[important]** `resurface_count` used `Number.isInteger`, so a value past `MAX_SAFE_INTEGER` (e.g. `9007199254740993`) parsed but silently rounded to `…992` — a validated field corrupted on parse. Now requires `Number.isSafeInteger`.
- **[nit]** Dropped the `(human)` synonym gloss on the `trust` type comment — CONTEXT.md reserves `principal` as the canonical term.

### Verified at HEAD (off current main)
```
$ npx tsc --noEmit                                   → No errors found
$ bun test test/memory-note.test.ts                  → 44 pass  0 fail
$ npx eslint src/memory-note.ts src/types.ts test/…  → No issues found
```
+1 test (unsafe-integer count rejected).

> Deferred sage suggestion (unify REQUIRED_KEYS / ROUND_TRIP_SCALARS / serialize field list into one spec table) intentionally not taken — over-abstraction for 14 stable fields under M0's "do not redesign" guardrail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)