### PR TITLE
feat(memory): write+verify CLI with recall-first refusal (M1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,8 +104,8 @@ The seven compartments:
 
 Within the **Memory** compartment, the `work/knowledge/learning/relationship/state`
 stores hold curated free-form material. The **memory-note subsystem** is a
-further store *within* Memory (not a new compartment): schema-governed, atomic,
-trust- and decay-tracked notes. Mechanics (paths, frontmatter, the
+further store *within* Memory (not a new compartment): schema-governed,
+single-fact, trust- and decay-tracked notes. Mechanics (paths, frontmatter, the
 `soma memory write|verify` surface) live in `docs/architecture.md`.
 
 **Why:** Coheres with the cellular metaphor (a cell body has compartments — nucleus, mitochondria, etc., each doing its own job, not stacked or ordered). Captures the right shape: seven peer subdivisions, each with its own contract, no implied ordering. `layer` implies a stack (wrong); `store` implies storage and breaks for Policy and Learning; `domain` collides with DDD vocabulary already in use across the codebase.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -103,13 +103,10 @@ The seven compartments:
 **Not synonyms:** Do not use `layer`, `store`, `domain`, `component`, `module`, `section`, `part` as glossary terms for these. `compartment` is the only word.
 
 Within the **Memory** compartment, the `work/knowledge/learning/relationship/state`
-stores hold curated free-form material. Alongside them lives the **memory-note
-subsystem** (plan v2, milestones M0–M7): a schema-governed durable store of
-atomic notes under `memory/{semantic,procedural,episodic}/`, each with
-bi-temporal frontmatter (trust, provenance, `valid_until`, `last_verified`,
-`resurface_count`). It is a store *within* Memory, not a new compartment; its
-sole write path is `soma memory write|verify` (trust derived from the write
-trigger, dedup-gated, one event per mutation). See `docs/architecture.md`.
+stores hold curated free-form material. The **memory-note subsystem** is a
+further store *within* Memory (not a new compartment): schema-governed, atomic,
+trust- and decay-tracked notes. Mechanics (paths, frontmatter, the
+`soma memory write|verify` surface) live in `docs/architecture.md`.
 
 **Why:** Coheres with the cellular metaphor (a cell body has compartments — nucleus, mitochondria, etc., each doing its own job, not stacked or ordered). Captures the right shape: seven peer subdivisions, each with its own contract, no implied ordering. `layer` implies a stack (wrong); `store` implies storage and breaks for Policy and Learning; `domain` collides with DDD vocabulary already in use across the codebase.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -102,6 +102,15 @@ The seven compartments:
 
 **Not synonyms:** Do not use `layer`, `store`, `domain`, `component`, `module`, `section`, `part` as glossary terms for these. `compartment` is the only word.
 
+Within the **Memory** compartment, the `work/knowledge/learning/relationship/state`
+stores hold curated free-form material. Alongside them lives the **memory-note
+subsystem** (plan v2, milestones M0–M7): a schema-governed durable store of
+atomic notes under `memory/{semantic,procedural,episodic}/`, each with
+bi-temporal frontmatter (trust, provenance, `valid_until`, `last_verified`,
+`resurface_count`). It is a store *within* Memory, not a new compartment; its
+sole write path is `soma memory write|verify` (trust derived from the write
+trigger, dedup-gated, one event per mutation). See `docs/architecture.md`.
+
 **Why:** Coheres with the cellular metaphor (a cell body has compartments — nucleus, mitochondria, etc., each doing its own job, not stacked or ordered). Captures the right shape: seven peer subdivisions, each with its own contract, no implied ordering. `layer` implies a stack (wrong); `store` implies storage and breaks for Policy and Learning; `domain` collides with DDD vocabulary already in use across the codebase.
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,8 +131,11 @@ memory/
 
 Each note is one file: strict frontmatter (id, type, trust, provenance,
 bi-temporal `valid_until`, `last_verified`, `resurface_count`, links) plus a
-markdown body. `soma memory write|verify` (M1) is the only write path — trust is
-derived from the write trigger, writes are dedup-gated (recall-first refusal),
+markdown body. `soma memory write|verify` (M1) is the only *governed* write path
+(a convention, not a filesystem-enforced guarantee — nothing stops out-of-band
+edits to the markdown, which is why every recalled note carries a verification
+banner). Through it, trust is derived from the write trigger, writes are
+dedup-gated (recall-first refusal),
 and each mutation appends one event to the **existing** `memory/STATE/events.jsonl`
 stream (the same journal the Observability section reads — note mutations do not
 fork a second event stream). The write/event coupling is best-effort, not

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,8 +115,9 @@ MEMORY/
 The initial version should avoid requiring a vector database. Search can start
 with filenames, frontmatter, ripgrep, and small deterministic indexes.
 
-The `MEMORY/*` compartments above are the legacy tier (free-form markdown per
-compartment, searched by `soma memory search`). The **memory-note subsystem**
+The `MEMORY/*` stores above are the legacy tier (free-form markdown per store,
+searched by `soma memory search`) — sub-stores within the single Memory
+compartment, not peer Soma compartments. The **memory-note subsystem**
 (plan v2, milestones M0–M7) is a *separate*, schema-governed durable store that
 lives alongside them under lowercase `memory/`:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,11 +133,15 @@ Each note is one file: strict frontmatter (id, type, trust, provenance,
 bi-temporal `valid_until`, `last_verified`, `resurface_count`, links) plus a
 markdown body. `soma memory write|verify` (M1) is the only write path — trust is
 derived from the write trigger, writes are dedup-gated (recall-first refusal),
-and every mutation appends exactly one event to the **existing**
-`memory/STATE/events.jsonl` stream (the same journal the Observability section
-reads — note mutations do not fork a second event stream). This taxonomy is intentionally
-distinct from the `MEMORY/*` stores: those stores hold curated free-form
-material; the note store holds atomic, governed, decay-tracked notes.
+and each mutation appends one event to the **existing** `memory/STATE/events.jsonl`
+stream (the same journal the Observability section reads — note mutations do not
+fork a second event stream). The write/event coupling is best-effort, not
+crash-atomic: an event-append *failure* rolls the file mutation back, but a hard
+process crash in the window between the two can still orphan a file from its
+event (a documented gap reconciled by the M7 audit; soma has no WAL/2PC). This
+taxonomy is intentionally distinct from the `MEMORY/*` stores: those stores hold
+curated free-form material; the note store holds single-fact, governed,
+decay-tracked notes.
 
 Cross-machine Soma state uses **Home replication**, not projection refresh or
 substrate writeback. The design is Git-backed first, policy-gated per scope,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,14 +126,15 @@ memory/
   procedural/<id>.md     # playbooks / how-to   (dedup-gated, verifiable)
   episodic/…             # session digests + action log (M5)
   INDEX.md               # earned-inclusion index (M3)
-  state/events.jsonl     # append-only mutation journal
 ```
 
 Each note is one file: strict frontmatter (id, type, trust, provenance,
 bi-temporal `valid_until`, `last_verified`, `resurface_count`, links) plus a
 markdown body. `soma memory write|verify` (M1) is the only write path — trust is
 derived from the write trigger, writes are dedup-gated (recall-first refusal),
-and every mutation appends exactly one event. This taxonomy is intentionally
+and every mutation appends exactly one event to the **existing**
+`memory/STATE/events.jsonl` stream (the same journal the Observability section
+reads — note mutations do not fork a second event stream). This taxonomy is intentionally
 distinct from the `MEMORY/*` compartments: the compartments hold curated
 free-form material; the note store holds atomic, governed, decay-tracked notes.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -136,8 +136,8 @@ derived from the write trigger, writes are dedup-gated (recall-first refusal),
 and every mutation appends exactly one event to the **existing**
 `memory/STATE/events.jsonl` stream (the same journal the Observability section
 reads — note mutations do not fork a second event stream). This taxonomy is intentionally
-distinct from the `MEMORY/*` compartments: the compartments hold curated
-free-form material; the note store holds atomic, governed, decay-tracked notes.
+distinct from the `MEMORY/*` stores: those stores hold curated free-form
+material; the note store holds atomic, governed, decay-tracked notes.
 
 Cross-machine Soma state uses **Home replication**, not projection refresh or
 substrate writeback. The design is Git-backed first, policy-gated per scope,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,6 +115,28 @@ MEMORY/
 The initial version should avoid requiring a vector database. Search can start
 with filenames, frontmatter, ripgrep, and small deterministic indexes.
 
+The `MEMORY/*` compartments above are the legacy tier (free-form markdown per
+compartment, searched by `soma memory search`). The **memory-note subsystem**
+(plan v2, milestones M0–M7) is a *separate*, schema-governed durable store that
+lives alongside them under lowercase `memory/`:
+
+```text
+memory/
+  semantic/<id>.md      # durable facts        (dedup-gated, verifiable)
+  procedural/<id>.md     # playbooks / how-to   (dedup-gated, verifiable)
+  episodic/…             # session digests + action log (M5)
+  INDEX.md               # earned-inclusion index (M3)
+  state/events.jsonl     # append-only mutation journal
+```
+
+Each note is one file: strict frontmatter (id, type, trust, provenance,
+bi-temporal `valid_until`, `last_verified`, `resurface_count`, links) plus a
+markdown body. `soma memory write|verify` (M1) is the only write path — trust is
+derived from the write trigger, writes are dedup-gated (recall-first refusal),
+and every mutation appends exactly one event. This taxonomy is intentionally
+distinct from the `MEMORY/*` compartments: the compartments hold curated
+free-form material; the note store holds atomic, governed, decay-tracked notes.
+
 Cross-machine Soma state uses **Home replication**, not projection refresh or
 substrate writeback. The design is Git-backed first, policy-gated per scope,
 and only auto-merges stores with deterministic merge semantics. See

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,33 +101,32 @@ registries, while the personal Soma home remains owned by one principal. See
 
 ### Memory
 
-Memory is structured as files first:
+Memory is structured as files first, under a single lowercase `memory/` root
+(one canonical root — the layout never relies on distinguishing `memory` from
+`MEMORY`, which case-insensitive filesystems collapse):
 
 ```text
-MEMORY/
-  WORK/
+memory/
+  WORK/            # legacy free-form stores (searched by `soma memory search`)
   KNOWLEDGE/
   LEARNING/
   RELATIONSHIP/
-  STATE/
+  STATE/           # events.jsonl lives here
+  semantic/<id>.md   # memory-note subsystem (M0–M7): durable facts   (dedup-gated)
+  procedural/<id>.md #   playbooks / how-to                            (dedup-gated)
+  episodic/…         #   session digests + action log (M5)
+  INDEX.md           #   earned-inclusion index (M3)
 ```
 
 The initial version should avoid requiring a vector database. Search can start
 with filenames, frontmatter, ripgrep, and small deterministic indexes.
 
-The `MEMORY/*` stores above are the legacy tier (free-form markdown per store,
-searched by `soma memory search`) — sub-stores within the single Memory
-compartment, not peer Soma compartments. The **memory-note subsystem**
-(plan v2, milestones M0–M7) is a *separate*, schema-governed durable store that
-lives alongside them under lowercase `memory/`:
-
-```text
-memory/
-  semantic/<id>.md      # durable facts        (dedup-gated, verifiable)
-  procedural/<id>.md     # playbooks / how-to   (dedup-gated, verifiable)
-  episodic/…             # session digests + action log (M5)
-  INDEX.md               # earned-inclusion index (M3)
-```
+The uppercase-named legacy stores (`WORK`, `KNOWLEDGE`, …) hold free-form
+markdown; the **memory-note subsystem** (plan v2, milestones M0–M7) is a
+*separate*, schema-governed durable store whose lowercase-named directories
+(`semantic`, `procedural`, `episodic`) sit as siblings under the same `memory/`
+root. Both are sub-stores within the single Memory compartment, not peer Soma
+compartments.
 
 Each note is one file: strict frontmatter (id, type, trust, provenance,
 bi-temporal `valid_until`, `last_verified`, `resurface_count`, links) plus a

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -4,7 +4,7 @@ import {
   verifyMemoryNote,
   writeMemoryNote,
 } from "../index";
-import { SOMA_MEMORY_WRITE_TRIGGERS } from "../types";
+import { WRITABLE_NOTE_TYPES, isWritableNoteType } from "../memory-write";
 import type {
   SomaMemoryNoteType,
   SomaMemoryPromotionOptions,
@@ -60,14 +60,15 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
     search: "Usage: soma memory search [query] [--query <text>] [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
     promote: "Usage: soma memory promote --from-run <run-id> --store <learning|knowledge|relationship|work> --title <text> [--lesson <text>] [--applies-when <text>]",
     write:
-      "Usage: soma memory write --trigger <principal-correction|import|consolidation> --body <text> " +
+      "Usage: soma memory write --trigger <principal-correction|import> --body <text> " +
       "(create: --id <slug> --type <semantic|procedural> [--force]) " +
       "(--merge <id> | --supersede <id>) " +
       "[--principal-authority] [--project <key>] [--source-of-truth <ref>] [--links a,b] " +
       "[--recall-trigger <text>] [--review <text>] " +
       "[--provenance <import|tool:name>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
       "Trust is DERIVED from --trigger; there is no --trust flag. principal-correction requires " +
-      "--principal-authority. The consolidation trigger is an internal (M6) SDK path, not available on the public CLI.",
+      "--principal-authority. (The consolidation trigger, which mints assistant trust, is an internal " +
+      "M6 SDK path and is not accepted on the public CLI.)",
     verify:
       "Usage: soma memory verify <id> [--id <id>] [--principal-authority] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
       "Verifying a principal-trust note requires --principal-authority (assistant-trust notes are an internal SDK path).",
@@ -208,15 +209,21 @@ function parseMemoryPromotionStore(value: string): SomaMemoryPromotionStore {
 }
 
 function parseWriteTrigger(value: string): SomaMemoryWriteTrigger {
-  if ((SOMA_MEMORY_WRITE_TRIGGERS as readonly string[]).includes(value)) {
-    return value as SomaMemoryWriteTrigger;
+  // `consolidation` is a valid SDK trigger but not a public-CLI one — it needs
+  // consolidationAuthority, which is SDK-only. Reject it here with a clear parse
+  // error instead of letting it fail later inside the writer.
+  if (value === "consolidation") {
+    throw new Error("--trigger consolidation is an internal (M6) SDK path, not available on the public CLI.");
   }
-  throw new Error(`--trigger must be one of ${SOMA_MEMORY_WRITE_TRIGGERS.join(", ")}.`);
+  if (value === "principal-correction" || value === "import") {
+    return value;
+  }
+  throw new Error(`--trigger must be principal-correction or import (consolidation is SDK-only).`);
 }
 
 function parseWriteType(value: string): SomaMemoryNoteType {
-  if (value !== "semantic" && value !== "procedural") {
-    throw new Error(`--type must be semantic or procedural (episodic writes go through digest/action, M5).`);
+  if (!isWritableNoteType(value)) {
+    throw new Error(`--type must be ${WRITABLE_NOTE_TYPES.join(" or ")} (episodic writes go through digest/action, M5).`);
   }
   return value;
 }
@@ -315,13 +322,18 @@ function parseMemoryWriteArgs(args: string[]): SomaMemoryWriteOptions {
     throw new Error("soma memory write accepts --merge or --supersede, not both.");
   }
   if (!options.trigger) {
-    throw new Error("soma memory write needs --trigger <principal-correction|import|consolidation>.");
+    throw new Error("soma memory write needs --trigger <principal-correction|import>.");
   }
   if (options.body === undefined) {
     throw new Error("soma memory write needs --body <text>.");
   }
 
   if (mergeTarget !== undefined) {
+    // merge edits an existing note in place — it takes neither a new id nor a
+    // type. Reject them rather than silently ignoring (the target is --merge <id>).
+    if (options.id !== undefined || options.type !== undefined) {
+      throw new Error("soma memory write --merge takes neither --id nor --type; the target is --merge <id>.");
+    }
     options.mode = "merge";
     options.targetId = mergeTarget;
   } else if (supersedeTarget !== undefined) {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -67,7 +67,9 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
       "[--provenance <import|tool:name>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
       "Trust is DERIVED from --trigger; there is no --trust flag. principal-correction " +
       "additionally requires --principal-authority (a deliberate, logged escalation to principal trust).",
-    verify: "Usage: soma memory verify <id> [--id <id>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]",
+    verify:
+      "Usage: soma memory verify <id> [--id <id>] [--principal-authority] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
+      "Verifying a principal-trust note requires --principal-authority.",
   },
 };
 
@@ -362,6 +364,9 @@ function parseMemoryVerifyArgs(args: string[]): SomaMemoryVerifyOptions {
       case "--id":
         options.id = readOption(args, index, arg);
         index += 1;
+        break;
+      case "--principal-authority":
+        options.principalAuthority = true;
         break;
       default:
         if (arg.startsWith("-")) {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -63,14 +63,14 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
       "Usage: soma memory write --trigger <principal-correction|import|consolidation> --body <text> " +
       "(create: --id <slug> --type <semantic|procedural> [--force]) " +
       "(--merge <id> | --supersede <id>) " +
-      "[--principal-authority] [--consolidation-authority] [--project <key>] [--source-of-truth <ref>] [--links a,b] " +
+      "[--principal-authority] [--project <key>] [--source-of-truth <ref>] [--links a,b] " +
       "[--recall-trigger <text>] [--review <text>] " +
       "[--provenance <import|tool:name>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
       "Trust is DERIVED from --trigger; there is no --trust flag. principal-correction requires " +
-      "--principal-authority and consolidation requires --consolidation-authority (deliberate, logged escalations).",
+      "--principal-authority. The consolidation trigger is an internal (M6) SDK path, not available on the public CLI.",
     verify:
-      "Usage: soma memory verify <id> [--id <id>] [--principal-authority] [--consolidation-authority] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
-      "Verifying a non-quarantined note requires that tier's authority.",
+      "Usage: soma memory verify <id> [--id <id>] [--principal-authority] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
+      "Verifying a principal-trust note requires --principal-authority (assistant-trust notes are an internal SDK path).",
   },
 };
 
@@ -301,9 +301,6 @@ function parseMemoryWriteArgs(args: string[]): SomaMemoryWriteOptions {
       case "--principal-authority":
         options.principalAuthority = true;
         break;
-      case "--consolidation-authority":
-        options.consolidationAuthority = true;
-        break;
       case "--trust":
         throw new Error(
           "soma memory write has no --trust flag: trust is derived from --trigger " +
@@ -373,9 +370,6 @@ function parseMemoryVerifyArgs(args: string[]): SomaMemoryVerifyOptions {
         break;
       case "--principal-authority":
         options.principalAuthority = true;
-        break;
-      case "--consolidation-authority":
-        options.consolidationAuthority = true;
         break;
       default:
         if (arg.startsWith("-")) {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1,10 +1,22 @@
-import { promoteAlgorithmRunMemory, searchSomaMemory } from "../index";
+import {
+  promoteAlgorithmRunMemory,
+  searchSomaMemory,
+  verifyMemoryNote,
+  writeMemoryNote,
+} from "../index";
+import { SOMA_MEMORY_WRITE_TRIGGERS } from "../types";
 import type {
+  SomaMemoryNoteType,
   SomaMemoryPromotionOptions,
   SomaMemoryPromotionResult,
   SomaMemoryPromotionStore,
   SomaMemorySearchOptions,
   SomaMemorySearchResult,
+  SomaMemoryVerifyOptions,
+  SomaMemoryVerifyResult,
+  SomaMemoryWriteOptions,
+  SomaMemoryWriteResult,
+  SomaMemoryWriteTrigger,
 } from "../types";
 import { readOption } from "./parse-utils";
 import { parseSubstrate } from "./substrate";
@@ -21,36 +33,64 @@ export interface ParsedMemoryPromoteArgs {
   options: SomaMemoryPromotionOptions;
 }
 
-export type ParsedMemoryArgs = ParsedMemorySearchArgs | ParsedMemoryPromoteArgs;
+export interface ParsedMemoryWriteArgs {
+  command: "memory";
+  action: "write";
+  options: SomaMemoryWriteOptions;
+}
 
-export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<ParsedMemoryArgs["action"], string> } = {
-  usage: "Usage: soma memory <search|promote> ...",
+export interface ParsedMemoryVerifyArgs {
+  command: "memory";
+  action: "verify";
+  options: SomaMemoryVerifyOptions;
+}
+
+export type ParsedMemoryArgs =
+  | ParsedMemorySearchArgs
+  | ParsedMemoryPromoteArgs
+  | ParsedMemoryWriteArgs
+  | ParsedMemoryVerifyArgs;
+
+const MEMORY_ACTIONS = ["search", "promote", "write", "verify"] as const;
+type MemoryAction = (typeof MEMORY_ACTIONS)[number];
+
+export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAction, string> } = {
+  usage: "Usage: soma memory <search|promote|write|verify> ...",
   subcommands: {
     search: "Usage: soma memory search [query] [--query <text>] [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
     promote: "Usage: soma memory promote --from-run <run-id> --store <learning|knowledge|relationship|work> --title <text> [--lesson <text>] [--applies-when <text>]",
+    write:
+      "Usage: soma memory write --trigger <principal-correction|import|consolidation> --body <text> " +
+      "(create: --id <slug> --type <semantic|procedural> [--force]) " +
+      "(--merge <id> | --supersede <id>) " +
+      "[--project <key>] [--source-of-truth <ref>] [--links a,b] [--hook <text>] [--review <text>] " +
+      "[--provenance <import|tool:name>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
+      "Trust is DERIVED from --trigger; there is no --trust flag.",
+    verify: "Usage: soma memory verify <id> [--id <id>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]",
   },
 };
+
+function isMemoryAction(value: string): value is MemoryAction {
+  return (MEMORY_ACTIONS as readonly string[]).includes(value);
+}
 
 export function parseMemoryArgs(args: string[]): ParsedMemoryArgs {
   const [command, action, ...rest] = args;
 
-  if (command !== "memory" || (action !== "search" && action !== "promote")) {
+  if (command !== "memory" || !isMemoryAction(action)) {
     throw new Error(MEMORY_COMMAND_HELP.usage);
   }
 
-  if (action === "search") {
-    return {
-      command,
-      action,
-      options: parseMemorySearchArgs(rest),
-    };
+  switch (action) {
+    case "search":
+      return { command, action, options: parseMemorySearchArgs(rest) };
+    case "promote":
+      return { command, action, options: parseMemoryPromoteArgs(rest) };
+    case "write":
+      return { command, action, options: parseMemoryWriteArgs(rest) };
+    case "verify":
+      return { command, action, options: parseMemoryVerifyArgs(rest) };
   }
-
-  return {
-    command,
-    action,
-    options: parseMemoryPromoteArgs(rest),
-  };
 }
 
 function parseMemorySearchArgs(args: string[]): SomaMemorySearchOptions {
@@ -163,12 +203,217 @@ function parseMemoryPromotionStore(value: string): SomaMemoryPromotionStore {
   throw new Error("--store must be one of learning, knowledge, relationship, or work.");
 }
 
-export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
-  if (parsed.action === "promote") {
-    return formatMemoryPromotionResult(await promoteAlgorithmRunMemory(parsed.options));
+function parseWriteTrigger(value: string): SomaMemoryWriteTrigger {
+  if ((SOMA_MEMORY_WRITE_TRIGGERS as readonly string[]).includes(value)) {
+    return value as SomaMemoryWriteTrigger;
+  }
+  throw new Error(`--trigger must be one of ${SOMA_MEMORY_WRITE_TRIGGERS.join(", ")}.`);
+}
+
+function parseWriteType(value: string): SomaMemoryNoteType {
+  if (value !== "semantic" && value !== "procedural") {
+    throw new Error(`--type must be semantic or procedural (episodic writes go through digest/action, M5).`);
+  }
+  return value;
+}
+
+function parseMemoryWriteArgs(args: string[]): SomaMemoryWriteOptions {
+  const options: Partial<SomaMemoryWriteOptions> = {};
+  let mergeTarget: string | undefined;
+  let supersedeTarget: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--substrate":
+        options.substrate = parseSubstrate(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--trigger":
+        options.trigger = parseWriteTrigger(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--id":
+        options.id = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--type":
+        options.type = parseWriteType(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--body":
+        options.body = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--project":
+        options.project = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--source-of-truth":
+        options.sourceOfTruth = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--links":
+        options.links = readOption(args, index, arg)
+          .split(",")
+          .map((entry) => entry.trim())
+          .filter((entry) => entry.length > 0);
+        index += 1;
+        break;
+      case "--hook":
+        options.hook = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--review":
+        options.review = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--provenance":
+        options.provenance = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--merge":
+        mergeTarget = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--supersede":
+        supersedeTarget = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--force":
+        options.force = true;
+        break;
+      case "--trust":
+        throw new Error(
+          "soma memory write has no --trust flag: trust is derived from --trigger " +
+            "(principal-correction→principal, import→quarantined, consolidation→assistant).",
+        );
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
   }
 
-  return formatMemorySearchResult(await searchSomaMemory(parsed.options));
+  if (mergeTarget !== undefined && supersedeTarget !== undefined) {
+    throw new Error("soma memory write accepts --merge or --supersede, not both.");
+  }
+  if (!options.trigger) {
+    throw new Error("soma memory write needs --trigger <principal-correction|import|consolidation>.");
+  }
+  if (options.body === undefined) {
+    throw new Error("soma memory write needs --body <text>.");
+  }
+
+  if (mergeTarget !== undefined) {
+    options.mode = "merge";
+    options.targetId = mergeTarget;
+  } else if (supersedeTarget !== undefined) {
+    options.mode = "supersede";
+    options.targetId = supersedeTarget;
+  } else {
+    options.mode = "create";
+  }
+
+  // create + supersede both mint a new note and need id + type.
+  if (options.mode !== "merge") {
+    const missing: string[] = [];
+    if (!options.id) missing.push("--id");
+    if (!options.type) missing.push("--type");
+    if (missing.length > 0) {
+      throw new Error(`soma memory ${options.mode} is missing required option(s): ${missing.join(", ")}.`);
+    }
+  }
+
+  return options as SomaMemoryWriteOptions;
+}
+
+function parseMemoryVerifyArgs(args: string[]): SomaMemoryVerifyOptions {
+  const options: Partial<SomaMemoryVerifyOptions> = {};
+  let positionalId: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--substrate":
+        options.substrate = parseSubstrate(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--id":
+        options.id = readOption(args, index, arg);
+        index += 1;
+        break;
+      default:
+        if (arg.startsWith("-")) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+        if (positionalId !== undefined) {
+          throw new Error(`soma memory verify accepts only one positional id; unexpected argument: ${arg}`);
+        }
+        positionalId = arg;
+    }
+  }
+
+  options.id ??= positionalId;
+  if (!options.id) {
+    throw new Error("soma memory verify needs a note id; pass it as the first argument or --id <id>.");
+  }
+
+  return options as SomaMemoryVerifyOptions;
+}
+
+export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
+  switch (parsed.action) {
+    case "promote":
+      return formatMemoryPromotionResult(await promoteAlgorithmRunMemory(parsed.options));
+    case "write":
+      return formatMemoryWriteResult(await writeMemoryNote(parsed.options));
+    case "verify":
+      return formatMemoryVerifyResult(await verifyMemoryNote(parsed.options));
+    case "search":
+      return formatMemorySearchResult(await searchSomaMemory(parsed.options));
+  }
+}
+
+function formatMemoryWriteResult(result: SomaMemoryWriteResult): string {
+  const lines = [
+    `Soma memory ${result.mode}`,
+    `id: ${result.note.id}`,
+    `type: ${result.note.type}`,
+    `trust: ${result.note.trust}`,
+    `provenance: ${result.note.provenance}`,
+    `path: ${result.path}`,
+  ];
+  if (result.supersededId) lines.push(`superseded: ${result.supersededId} (valid_until set)`);
+  lines.push(`event: ${result.event.id}`);
+  return lines.join("\n");
+}
+
+function formatMemoryVerifyResult(result: SomaMemoryVerifyResult): string {
+  return [
+    "Soma memory verify",
+    `id: ${result.note.id}`,
+    `last_verified: ${result.note.last_verified}`,
+    `resurface_count: ${result.note.resurface_count}`,
+    `path: ${result.path}`,
+    `event: ${result.event.id}`,
+  ].join("\n");
 }
 
 function formatMemorySearchResult(result: SomaMemorySearchResult): string {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -63,13 +63,14 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
       "Usage: soma memory write --trigger <principal-correction|import|consolidation> --body <text> " +
       "(create: --id <slug> --type <semantic|procedural> [--force]) " +
       "(--merge <id> | --supersede <id>) " +
-      "[--principal-authority] [--project <key>] [--source-of-truth <ref>] [--links a,b] [--hook <text>] [--review <text>] " +
+      "[--principal-authority] [--consolidation-authority] [--project <key>] [--source-of-truth <ref>] [--links a,b] " +
+      "[--recall-trigger <text>] [--review <text>] " +
       "[--provenance <import|tool:name>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
-      "Trust is DERIVED from --trigger; there is no --trust flag. principal-correction " +
-      "additionally requires --principal-authority (a deliberate, logged escalation to principal trust).",
+      "Trust is DERIVED from --trigger; there is no --trust flag. principal-correction requires " +
+      "--principal-authority and consolidation requires --consolidation-authority (deliberate, logged escalations).",
     verify:
-      "Usage: soma memory verify <id> [--id <id>] [--principal-authority] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
-      "Verifying a principal-trust note requires --principal-authority.",
+      "Usage: soma memory verify <id> [--id <id>] [--principal-authority] [--consolidation-authority] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
+      "Verifying a non-quarantined note requires that tier's authority.",
   },
 };
 
@@ -272,7 +273,9 @@ function parseMemoryWriteArgs(args: string[]): SomaMemoryWriteOptions {
           .filter((entry) => entry.length > 0);
         index += 1;
         break;
-      case "--hook":
+      case "--recall-trigger":
+        // Maps to the note's `hook` frontmatter field (M0 schema). The
+        // user-facing flag avoids the reserved `hook` term (CONTEXT.md).
         options.hook = readOption(args, index, arg);
         index += 1;
         break;
@@ -297,6 +300,9 @@ function parseMemoryWriteArgs(args: string[]): SomaMemoryWriteOptions {
         break;
       case "--principal-authority":
         options.principalAuthority = true;
+        break;
+      case "--consolidation-authority":
+        options.consolidationAuthority = true;
         break;
       case "--trust":
         throw new Error(
@@ -367,6 +373,9 @@ function parseMemoryVerifyArgs(args: string[]): SomaMemoryVerifyOptions {
         break;
       case "--principal-authority":
         options.principalAuthority = true;
+        break;
+      case "--consolidation-authority":
+        options.consolidationAuthority = true;
         break;
       default:
         if (arg.startsWith("-")) {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -379,6 +379,11 @@ function parseMemoryVerifyArgs(args: string[]): SomaMemoryVerifyOptions {
     }
   }
 
+  // Reject a conflicting positional + --id rather than silently preferring one —
+  // verify is a mutating command, so an ignored id must not slip through.
+  if (options.id !== undefined && positionalId !== undefined && options.id !== positionalId) {
+    throw new Error(`soma memory verify got two different ids ("${positionalId}" and --id "${options.id}"); pass only one.`);
+  }
   options.id ??= positionalId;
   if (!options.id) {
     throw new Error("soma memory verify needs a note id; pass it as the first argument or --id <id>.");

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -63,9 +63,10 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
       "Usage: soma memory write --trigger <principal-correction|import|consolidation> --body <text> " +
       "(create: --id <slug> --type <semantic|procedural> [--force]) " +
       "(--merge <id> | --supersede <id>) " +
-      "[--project <key>] [--source-of-truth <ref>] [--links a,b] [--hook <text>] [--review <text>] " +
+      "[--principal-authority] [--project <key>] [--source-of-truth <ref>] [--links a,b] [--hook <text>] [--review <text>] " +
       "[--provenance <import|tool:name>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
-      "Trust is DERIVED from --trigger; there is no --trust flag.",
+      "Trust is DERIVED from --trigger; there is no --trust flag. principal-correction " +
+      "additionally requires --principal-authority (a deliberate, logged escalation to principal trust).",
     verify: "Usage: soma memory verify <id> [--id <id>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]",
   },
 };
@@ -291,6 +292,9 @@ function parseMemoryWriteArgs(args: string[]): SomaMemoryWriteOptions {
         break;
       case "--force":
         options.force = true;
+        break;
+      case "--principal-authority":
+        options.principalAuthority = true;
         break;
       case "--trust":
         throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -444,13 +444,11 @@ export {
 export { captureSomaFeedback, classifySomaFeedback, maybeSomaFeedbackPrompt } from "./feedback";
 export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from "./memory";
 export { MemoryNoteError, parseMemoryNote, serializeMemoryNote } from "./memory-note";
-export {
-  writeMemoryNote,
-  verifyMemoryNote,
-  findDuplicateCandidates,
-  memoryNotePath,
-  MEMORY_DEDUP_JACCARD_THRESHOLD,
-} from "./memory-write";
+// Public write surface only. Path/dedup helpers (memoryNotePath,
+// findDuplicateCandidates, MEMORY_DEDUP_JACCARD_THRESHOLD) stay module-private so
+// the storage layout and dedup threshold are not frozen as stable API — internal
+// soma modules (M2/M3/M6) and tests import them from "./memory-write" directly.
+export { writeMemoryNote, verifyMemoryNote } from "./memory-write";
 export { createSomaSnapshot, listSomaSnapshots, rollbackSomaSnapshot } from "./snapshots";
 export { querySomaTelemetryEvents, summarizeSomaTelemetry } from "./observability";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,17 @@ export type {
 } from "./types";
 export { SOMA_RESULT_EVENT_KINDS } from "./types";
 export { SOMA_MEMORY_NOTE_TYPES, SOMA_MEMORY_TRUSTS } from "./types";
+export { SOMA_MEMORY_WRITE_TRIGGERS, SOMA_MEMORY_TRIGGER_TRUST } from "./types";
 export type { SomaMemoryNote, SomaMemoryNoteType, SomaMemoryTrust } from "./types";
+export type {
+  SomaMemoryWriteTrigger,
+  SomaMemoryWriteMode,
+  SomaMemoryWriteOptions,
+  SomaMemoryWriteResult,
+  SomaMemoryVerifyOptions,
+  SomaMemoryVerifyResult,
+  SomaMemoryDuplicateCandidate,
+} from "./types";
 
 export {
   addAlgorithmCapabilities,
@@ -434,6 +444,13 @@ export {
 export { captureSomaFeedback, classifySomaFeedback, maybeSomaFeedbackPrompt } from "./feedback";
 export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from "./memory";
 export { MemoryNoteError, parseMemoryNote, serializeMemoryNote } from "./memory-note";
+export {
+  writeMemoryNote,
+  verifyMemoryNote,
+  findDuplicateCandidates,
+  memoryNotePath,
+  MEMORY_DEDUP_JACCARD_THRESHOLD,
+} from "./memory-write";
 export { createSomaSnapshot, listSomaSnapshots, rollbackSomaSnapshot } from "./snapshots";
 export { querySomaTelemetryEvents, summarizeSomaTelemetry } from "./observability";
 export {

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -161,23 +161,24 @@ export function memoryNotePath(somaHome: string, type: WritableType, id: string)
 
 // --- dedup engine (transplant #1) --------------------------------------------
 
-/** Normalized body for exact-hash comparison: lowercased, whitespace-collapsed. */
-function normalizeBody(body: string): string {
-  return body.toLowerCase().replace(/\s+/g, " ").trim();
-}
-
-function bodyHash(body: string): string {
-  return createHash("sha256").update(normalizeBody(body)).digest("hex");
+// Hash + token set both start from ONE lowercased pass over the body — the
+// lower-aware variants (`*FromLower`) let the scan loop lowercase each note once
+// and derive both from it, instead of two `.toLowerCase()` passes per note.
+function hashFromLower(lower: string): string {
+  return createHash("sha256").update(lower.replace(/\s+/g, " ").trim()).digest("hex");
 }
 
 /** Token set for Jaccard near-match — 3+ char alnum tokens, same floor as search. */
+function tokensFromLower(lower: string): Set<string> {
+  return new Set(lower.split(/[^a-z0-9À-ɏ]+/i).filter((token) => token.length >= 3));
+}
+
+function bodyHash(body: string): string {
+  return hashFromLower(body.toLowerCase());
+}
+
 function bodyTokens(body: string): Set<string> {
-  return new Set(
-    body
-      .toLowerCase()
-      .split(/[^a-z0-9À-ɏ]+/i)
-      .filter((token) => token.length >= 3),
-  );
+  return tokensFromLower(body.toLowerCase());
 }
 
 function jaccard(a: Set<string>, b: Set<string>): number {
@@ -324,8 +325,9 @@ export async function findDuplicateCandidates(somaHome: string, body: string): P
   const { notes, unreadable } = await collectDurableNotes(somaHome);
   for (const { path, type, note } of notes) {
     if (note.valid_until !== null) continue;
-    const exact = bodyHash(note.body) === hash;
-    const score = exact ? 1 : jaccard(tokens, bodyTokens(note.body));
+    const lower = note.body.toLowerCase(); // one pass, feeds both hash and tokens
+    const exact = hashFromLower(lower) === hash;
+    const score = exact ? 1 : jaccard(tokens, tokensFromLower(lower));
     if (exact || score >= MEMORY_DEDUP_JACCARD_THRESHOLD) {
       candidates.push({ id: note.id, type, path, score, exact });
     }
@@ -411,8 +413,18 @@ async function loadNoteById(somaHome: string, id: string): Promise<LoadedNote> {
   assertNoteId(id); // a lookup id is also a path segment — never probe an unsafe one
   for (const type of WRITABLE_TYPES) {
     const path = memoryNotePath(somaHome, type, id);
-    const raw = await readFile(path, "utf8").catch(() => undefined);
-    if (raw === undefined) continue;
+    let raw: string;
+    try {
+      raw = await readFile(path, "utf8");
+    } catch (error) {
+      // Only a genuinely-absent file (ENOENT) is "not here, try the next type".
+      // Any OTHER read failure must NOT masquerade as absence — that would break
+      // the global-id guarantee (fall through to a same-id note of the other
+      // type, or wrongly report not-found on an existing-but-unreadable note).
+      const code = error instanceof Error && "code" in error ? error.code : undefined;
+      if (code === "ENOENT") continue;
+      throw new MemoryNoteError(`Soma memory note ${id} exists at ${path} but is unreadable: ${String(error)}`, "id");
+    }
     return { path, type, note: parseMemoryNote(raw), raw };
   }
   throw new MemoryNoteError(`Soma memory note not found: ${id}`, "id");

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -22,16 +22,18 @@ import type {
  * Memory write + verify (subsystem M1). Plan v2 §M1 (do not redesign the
  * governance model):
  *
- * - **Trust is derived from the trigger**, never a caller flag — and any tier
- *   above `quarantined` needs that tier's explicit, logged authority signal, so a
- *   caller cannot mint (or carry) trust by choosing a trigger alone.
- *   `principal-correction` → `principal` (needs `principalAuthority`, the human's
- *   `--principal-authority` escalation); `consolidation` → `assistant` (needs
- *   `consolidationAuthority`, an internal M6 SDK capability — NOT a public CLI
- *   flag); `import` → `quarantined`, free (MINJA defense).
- *   Escalations are sudo-style (deliberate + logged, refused by default) — not
- *   cryptographic auth, which soma has no primitive for. Mutating an existing
- *   note needs the TARGET tier's authority (merge/supersede/verify).
+ * - **Trust is derived from the trigger**, never a caller flag. Any tier above
+ *   `quarantined` needs that tier's explicit authority signal to be minted (or an
+ *   existing note of that tier to be mutated): `principal-correction` →
+ *   `principal` (needs `principalAuthority`); `consolidation` → `assistant`
+ *   (needs `consolidationAuthority`); `import` → `quarantined`, free (MINJA
+ *   defense). Two honest limits: (1) the signals are sudo-style deliberate
+ *   booleans, NOT cryptographic capabilities — the ENFORCED surface is the CLI
+ *   (no `--*-authority` self-assert path for consolidation; `--trigger
+ *   consolidation` refused), while an in-process SDK caller can set the boolean,
+ *   as soma has no capability primitive. (2) Authorization is CHECKED at the gate
+ *   (`assertTierAuthority`); it is separately RECORDED in the mutation's event on
+ *   success — the audit trail exists only if the mutation reaches event append.
  * - **Recall-first refusal** — `create` walks the durable corpus (`semantic/` +
  *   `procedural/`), hashes normalized bodies, and refuses when an active note is
  *   an exact-body match OR Jaccard ≥ 0.6 (transplant #1 from recall's dedup
@@ -725,7 +727,11 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
       await restoreBytes(somaHome, old.path, old.raw);
       await unlink(newPath);
     } catch (undoError) {
-      throw new Error(
+      // Carry BOTH failures — `cause` is the undo error (the one just caught),
+      // the errors array holds the original close failure; both are needed to
+      // debug the inconsistent state.
+      throw new AggregateError(
+        [closeError],
         `Soma memory supersede failed to close ${old.note.id} AND the undo failed — ` +
           `memory may be inconsistent; reconcile manually.`,
         { cause: undoError },

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { access, lstat, mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { createPaths } from "./paths";
 import { runBoundedConcurrent } from "./internal-concurrency";
@@ -24,9 +24,10 @@ import type {
  * - **Trust is derived from the trigger**, never a caller flag — and any tier
  *   above `quarantined` needs that tier's explicit, logged authority signal, so a
  *   caller cannot mint (or carry) trust by choosing a trigger alone.
- *   `principal-correction` → `principal` (needs `principalAuthority`);
- *   `consolidation` → `assistant` (needs `consolidationAuthority`, the M6
- *   consolidator's capability); `import` → `quarantined`, free (MINJA defense).
+ *   `principal-correction` → `principal` (needs `principalAuthority`, the human's
+ *   `--principal-authority` escalation); `consolidation` → `assistant` (needs
+ *   `consolidationAuthority`, an internal M6 SDK capability — NOT a public CLI
+ *   flag); `import` → `quarantined`, free (MINJA defense).
  *   Escalations are sudo-style (deliberate + logged, refused by default) — not
  *   cryptographic auth, which soma has no primitive for. Mutating an existing
  *   note needs the TARGET tier's authority (merge/supersede/verify).
@@ -224,8 +225,9 @@ function assertTierAuthority(tier: SomaMemoryTrust, auth: AuthoritySignals, cont
   }
   if (tier === "assistant" && auth.consolidationAuthority !== true) {
     throw new MemoryNoteError(
-      `${context} requires --consolidation-authority (the internal consolidator's capability, ` +
-        `not selectable by choosing --trigger consolidation).`,
+      `${context} requires consolidation authority — an internal (M6) SDK capability set via ` +
+        `SomaMemoryWriteOptions.consolidationAuthority, NOT a public CLI flag and not selectable ` +
+        `by choosing --trigger consolidation.`,
       "consolidationAuthority",
     );
   }
@@ -466,18 +468,23 @@ async function loadNoteById(somaHome: string, id: string): Promise<LoadedNote> {
 
 /**
  * True iff a note FILE with this id already exists under either durable type.
- * A pure presence check (`access`), NOT a parse — a malformed `semantic/<id>.md`
- * must still block a colliding `procedural/<id>.md`, so id uniqueness holds even
- * over a hand-corrupted corpus.
+ * A pure presence check (`lstat`), NOT a parse — a malformed or symlinked
+ * `semantic/<id>.md` must still block a colliding `procedural/<id>.md`, so id
+ * uniqueness holds even over a hand-corrupted corpus. Only ENOENT counts as
+ * absent; any other stat failure is surfaced (an unreadable path must not be
+ * mistaken for a free id).
  */
 async function noteIdExists(somaHome: string, id: string): Promise<boolean> {
   assertNoteId(id);
   for (const type of WRITABLE_TYPES) {
-    const exists = await access(memoryNotePath(somaHome, type, id)).then(
-      () => true,
-      () => false,
-    );
-    if (exists) return true;
+    try {
+      await lstat(memoryNotePath(somaHome, type, id));
+      return true;
+    } catch (error) {
+      const code = error instanceof Error && "code" in error ? error.code : undefined;
+      if (code === "ENOENT") continue;
+      throw new MemoryNoteError(`Soma memory id ${id} path is unstattable: ${String(error)}`, "id");
+    }
   }
   return false;
 }
@@ -708,9 +715,15 @@ export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promis
   const now = options.now ?? new Date();
   const { path, type, note, raw } = await loadNoteById(somaHome, options.id);
 
+  // A superseded note is closed — reinforcing its freshness signal is meaningless
+  // (and would resurrect it in retention scoring). Refuse.
+  if (note.valid_until !== null) {
+    throw new MemoryNoteError(`Cannot verify superseded note ${note.id} (valid_until set ${note.valid_until}).`, "id");
+  }
+
   // Verifying refreshes a note's decay signal — a mutation — so a non-quarantined
   // note needs its tier's authority (principal→--principal-authority,
-  // assistant→--consolidation-authority).
+  // assistant→internal consolidator authority).
   assertTierAuthority(note.trust, options, `Verifying ${note.trust}-trust note ${note.id}`);
 
   const verified: SomaMemoryNote = {

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -122,6 +122,24 @@ async function appendMutationEvent(
   });
 }
 
+/**
+ * Fill the shared event envelope (timestamp + substrate) for a note mutation so
+ * the four mutation paths can't drift on journal shape, then append-with-rollback.
+ */
+async function appendNoteMutationEvent(
+  somaHome: string,
+  now: Date,
+  substrate: SomaMemoryWriteOptions["substrate"],
+  fields: { kind: string; summary: string; artifactPaths: string[]; metadata: Record<string, unknown> },
+  rollback: () => Promise<void>,
+): ReturnType<typeof appendSomaMemoryEvent> {
+  return appendMutationEvent(
+    somaHome,
+    { timestamp: now.toISOString(), substrate: substrate ?? "custom", ...fields },
+    rollback,
+  );
+}
+
 /** YYYY-MM-DD in UTC — matches the note schema's calendar-date grammar. */
 function isoDate(now: Date): string {
   return now.toISOString().slice(0, 10);
@@ -244,10 +262,22 @@ async function collectDurableNotes(somaHome: string): Promise<CorpusScan> {
   // bounded concurrency window (shared helper) rather than one unbounded
   // Promise.all over the whole tree.
   const targets: { path: string; type: WritableType }[] = [];
+  const unreadableDirs: string[] = [];
   for (const type of WRITABLE_TYPES) {
     const dir = typeDir(somaHome, type);
-    const entries = (await readdir(dir).catch(() => [] as string[])).filter((entry) => entry.endsWith(".md"));
-    for (const entry of entries) targets.push({ path: join(dir, entry), type });
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch (error) {
+      // A missing dir is genuinely empty; any OTHER error (e.g. permissions) is
+      // an unscanned blind spot and must be surfaced, not treated as empty.
+      const code = error instanceof Error && "code" in error ? error.code : undefined;
+      if (code !== "ENOENT") unreadableDirs.push(dir);
+      continue;
+    }
+    for (const entry of entries.filter((entry) => entry.endsWith(".md"))) {
+      targets.push({ path: join(dir, entry), type });
+    }
   }
 
   const scanned = await runBoundedConcurrent(
@@ -265,7 +295,7 @@ async function collectDurableNotes(somaHome: string): Promise<CorpusScan> {
   );
 
   const notes: ScannedNote[] = [];
-  const unreadable: string[] = [];
+  const unreadable: string[] = [...unreadableDirs]; // dir-level blind spots count too
   for (const entry of scanned) {
     if ("unreadable" in entry) unreadable.push(entry.unreadable);
     else notes.push(entry);
@@ -459,26 +489,31 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
     throw new MemoryNoteError(`Soma memory note id already exists: ${note.id}`, "id");
   }
 
-  // Scan unconditionally so the unreadable-file count is on record even under
-  // --force (the gate's blind spot must always be auditable, never silent).
-  const { candidates, unreadable } = await findDuplicateCandidates(somaHome, note.body);
-  if (!options.force && candidates.length > 0) {
-    const list = candidates.map((c) => `${c.id} (${c.exact ? "exact" : c.score.toFixed(2)})`).join(", ");
-    const blindSpot = unreadable.length > 0 ? ` (${unreadable.length} note(s) were unreadable and not checked)` : "";
-    throw new MemoryNoteError(
-      `Recall-first refusal: ${candidates.length} similar note(s) exist — ${list}${blindSpot}. ` +
-        `Re-run with --merge <id>, --supersede <id>, or --force.`,
-    );
+  // --force bypasses the gate, so skip the O(corpus) scan entirely — a forced
+  // create should not pay to read/parse every note. When we DO scan (the normal
+  // path), the unreadable count is recorded so the gate never fails open silently.
+  let unreadable: string[] = [];
+  if (!options.force) {
+    const scan = await findDuplicateCandidates(somaHome, note.body);
+    unreadable = scan.unreadable;
+    if (scan.candidates.length > 0) {
+      const list = scan.candidates.map((c) => `${c.id} (${c.exact ? "exact" : c.score.toFixed(2)})`).join(", ");
+      const blindSpot = unreadable.length > 0 ? ` (${unreadable.length} note(s)/dir(s) were unreadable and not checked)` : "";
+      throw new MemoryNoteError(
+        `Recall-first refusal: ${scan.candidates.length} similar note(s) exist — ${list}${blindSpot}. ` +
+          `Re-run with --merge <id>, --supersede <id>, or --force.`,
+      );
+    }
   }
 
   const path = memoryNotePath(somaHome, note.type as WritableType, note.id);
   await writeNoteFile(path, note, "wx");
 
-  const event = await appendMutationEvent(
+  const event = await appendNoteMutationEvent(
     somaHome,
+    now,
+    options.substrate,
     {
-      timestamp: now.toISOString(),
-      substrate: options.substrate ?? "custom",
       kind: "memory.write.create",
       summary: `Created memory note ${note.id} (${note.type}, trust ${note.trust})`,
       artifactPaths: [path],
@@ -516,11 +551,11 @@ async function mergeNote(somaHome: string, options: SomaMemoryWriteOptions, now:
   };
   await writeNoteFile(path, merged, "w");
 
-  const event = await appendMutationEvent(
+  const event = await appendNoteMutationEvent(
     somaHome,
+    now,
+    options.substrate,
     {
-      timestamp: now.toISOString(),
-      substrate: options.substrate ?? "custom",
       kind: "memory.write.merge",
       summary: `Merged update into memory note ${merged.id} (${type})`,
       artifactPaths: [path],
@@ -571,11 +606,11 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
     throw error;
   }
 
-  const event = await appendMutationEvent(
+  const event = await appendNoteMutationEvent(
     somaHome,
+    now,
+    options.substrate,
     {
-      timestamp: now.toISOString(),
-      substrate: options.substrate ?? "custom",
       kind: "memory.write.supersede",
       summary: `Note ${newNote.id} supersedes ${closed.id} (closed ${closed.valid_until})`,
       artifactPaths: [newPath, old.path],
@@ -615,9 +650,12 @@ export async function writeMemoryNote(options: SomaMemoryWriteOptions): Promise<
 // --- verify ------------------------------------------------------------------
 
 /**
- * Close the reinforcing loop: a resurfaced note that proved correct bumps
- * `last_verified` to today and increments `resurface_count`. This is the decay
- * signal M3's retention score reads.
+ * Close the reinforcing loop: the caller ASSERTS a resurfaced note still holds,
+ * bumping `last_verified` to today and incrementing `resurface_count`. This
+ * records the assertion only — verify captures no evidence/source/proof, so
+ * `last_verified` is a caller-asserted freshness signal (the same caller-asserted
+ * model as EvidenceKind elsewhere), not a machine-checked correctness proof. It
+ * is the decay signal M3's retention score reads.
  */
 export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promise<SomaMemoryVerifyResult> {
   assertNonEmpty(options.id, "id");
@@ -644,11 +682,11 @@ export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promis
   };
   await writeNoteFile(path, verified, "w");
 
-  const event = await appendMutationEvent(
+  const event = await appendNoteMutationEvent(
     somaHome,
+    now,
+    options.substrate,
     {
-      timestamp: now.toISOString(),
-      substrate: options.substrate ?? "custom",
       kind: "memory.verify",
       summary: `Verified memory note ${verified.id} (${type}); resurface_count ${verified.resurface_count}`,
       artifactPaths: [path],

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -21,8 +21,10 @@ import type {
  *
  * - **Trust is derived from the trigger**, never a caller flag — a substrate-side
  *   caller cannot self-assert `principal`. `principal-correction` is the sole path
- *   to `principal` trust and is the documented human-authority gate; `import` is
- *   always `quarantined` (MINJA defense); `consolidation` is `assistant`.
+ *   to `principal` trust AND requires an explicit `principalAuthority` escalation
+ *   (sudo-style: deliberate + logged, refused by default — not cryptographic
+ *   auth, which soma has no primitive for); `import` is always `quarantined`
+ *   (MINJA defense); `consolidation` is `assistant`.
  * - **Recall-first refusal** — `create` walks the durable corpus (`semantic/` +
  *   `procedural/`), hashes normalized bodies, and refuses when an active note is
  *   an exact-body match OR Jaccard ≥ 0.6 (transplant #1 from recall's dedup
@@ -252,12 +254,29 @@ async function writeNoteFile(path: string, note: SomaMemoryNote, flag: "wx" | "w
   }
 }
 
-/** Find an active-or-superseded note by id across the durable corpus. */
+/**
+ * Load one note by id by probing its two possible paths directly
+ * (`semantic/<id>.md`, `procedural/<id>.md`) — O(1) I/O, not an O(corpus) scan.
+ * Ids are globally unique across types (enforced at create/supersede), so at
+ * most one path resolves; if both somehow exist, semantic wins deterministically.
+ */
 async function loadNoteById(somaHome: string, id: string): Promise<LoadedNote> {
-  for (const loaded of await collectDurableNotes(somaHome)) {
-    if (loaded.note.id === id) return loaded;
+  assertNoteId(id); // a lookup id is also a path segment — never probe an unsafe one
+  for (const type of Object.keys(WRITABLE_TYPE_DIRS) as WritableType[]) {
+    const path = memoryNotePath(somaHome, type, id);
+    const raw = await readFile(path, "utf8").catch(() => undefined);
+    if (raw === undefined) continue;
+    return { path, type, note: parseMemoryNote(raw), raw };
   }
   throw new MemoryNoteError(`Soma memory note not found: ${id}`, "id");
+}
+
+/** True iff a note with this id already exists under EITHER durable type. */
+async function noteIdExists(somaHome: string, id: string): Promise<boolean> {
+  return loadNoteById(somaHome, id).then(
+    () => true,
+    () => false,
+  );
 }
 
 // --- create / merge / supersede ----------------------------------------------
@@ -269,6 +288,18 @@ function buildNewNote(options: SomaMemoryWriteOptions, now: Date): SomaMemoryNot
     throw new MemoryNoteError(`type must be "semantic" or "procedural" (episodic writes go through digest/action, M5).`, "type");
   }
   assertNonEmpty(options.body, "body");
+
+  // The deliberate-escalation gate: `principal` trust is never the incidental
+  // result of a bare trigger flag. Without an explicit authority signal, a
+  // principal-correction write is REFUSED (not downgraded) — an automated/agent
+  // invocation defaults safe.
+  if (options.trigger === "principal-correction" && options.principalAuthority !== true) {
+    throw new MemoryNoteError(
+      `principal-correction mints principal trust and requires explicit principal authority ` +
+        `(--principal-authority). This is a deliberate, logged escalation — not automatic from the trigger.`,
+      "trigger",
+    );
+  }
 
   const today = isoDate(now);
   const note: SomaMemoryNote = {
@@ -304,6 +335,13 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
     }
   }
 
+  // Ids are globally unique across types — reject `procedural/foo` when
+  // `semantic/foo` exists, so id-based lookups (verify/merge/supersede) are
+  // never ambiguous. (`wx` below only catches a same-path collision.)
+  if (await noteIdExists(somaHome, note.id)) {
+    throw new MemoryNoteError(`Soma memory note id already exists: ${note.id}`, "id");
+  }
+
   const path = memoryNotePath(somaHome, note.type as WritableType, note.id);
   await writeNoteFile(path, note, "wx");
 
@@ -315,7 +353,14 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
       kind: "memory.write.create",
       summary: `Created memory note ${note.id} (${note.type}, trust ${note.trust})`,
       artifactPaths: [path],
-      metadata: { id: note.id, type: note.type, trust: note.trust, trigger: options.trigger },
+      metadata: {
+        id: note.id,
+        type: note.type,
+        trust: note.trust,
+        trigger: options.trigger,
+        // Audit the principal-trust escalation when it happened.
+        ...(options.trigger === "principal-correction" ? { principalAuthority: true } : {}),
+      },
     },
     () => unlink(path), // roll back: remove the freshly created file
   );
@@ -360,6 +405,10 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
   const newNote = buildNewNote(options, now);
   if (newNote.id === options.targetId) {
     throw new MemoryNoteError(`A note cannot supersede itself (${newNote.id}).`, "id");
+  }
+
+  if (await noteIdExists(somaHome, newNote.id)) {
+    throw new MemoryNoteError(`Soma memory note id already exists: ${newNote.id}`, "id");
   }
 
   const old = await loadNoteById(somaHome, options.targetId);

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { access, mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createPaths } from "./paths";
+import { runBoundedConcurrent } from "./internal-concurrency";
 import { appendSomaMemoryEvent } from "./memory";
 import { parseMemoryNote, serializeMemoryNote, MemoryNoteError } from "./memory-note";
 import { SOMA_MEMORY_TRIGGER_TRUST } from "./types";
@@ -33,10 +34,12 @@ import type {
  * - **Invalidate, never delete** — `supersede` sets the old note's `valid_until`
  *   and cross-links; nothing is unlinked. `merge` delta-appends (ACE-style,
  *   never regenerates).
- * - One mutating call → exactly one events journal line: the file write and its
- *   event append are atomic — if the append fails, the file mutation is rolled
- *   back (created files unlinked, edited files restored to prior bytes), so the
- *   journal never under- or over-counts a mutation.
+ * - One mutating call → one events journal line: if the event append fails, the
+ *   file mutation is rolled back (created files unlinked, edited files restored
+ *   to prior bytes), so an append failure never leaves a note without its event.
+ *   This is NOT crash-atomic — a process kill in the window between the file
+ *   write and the append can still orphan a file from its event (a documented
+ *   gap reconciled by the M7 audit; soma has no WAL/2PC primitive).
  *
  * Deterministic: dates come from an injected `now` (UTC), no LLM calls, writes
  * stay within the Soma memory tree under `memory/semantic/` + `memory/procedural/`.
@@ -76,19 +79,34 @@ function assertNoteId(id: string): void {
 }
 
 /**
- * Append the mutation's event; on failure, roll the file mutation back so the
- * "one mutation → one event" invariant holds. `rollback` restores disk to its
- * pre-mutation state (unlink a created file, or rewrite an edited one's prior
- * bytes).
+ * Append the mutation's event; if the append fails, roll the file mutation back
+ * so no file mutation is ever left without its event. `rollback` restores disk
+ * to its pre-mutation state (unlink a created file, or rewrite an edited one's
+ * prior bytes) and MUST throw if it cannot — a swallowed rollback failure would
+ * report "rolled back" while leaving the note in a mutated state.
+ *
+ * NOTE (honest limitation): this guards against an append *rejection*, not a
+ * process crash/kill in the window between the file write and this append. A
+ * hard crash there can still leave a file without an event; the journal is
+ * best-effort append-only and that gap is reconciled by a later audit (M7), not
+ * prevented here. Soma has no write-ahead-log / 2-phase-commit primitive.
  */
 async function appendMutationEvent(
   somaHome: string,
   input: Parameters<typeof appendSomaMemoryEvent>[1],
   rollback: () => Promise<void>,
 ): ReturnType<typeof appendSomaMemoryEvent> {
-  return appendSomaMemoryEvent(somaHome, input).catch(async (error: unknown) => {
-    await rollback().catch(() => undefined);
-    throw new Error(`Soma memory ${input.kind} event append failed; rolled back the file mutation.`, { cause: error });
+  return appendSomaMemoryEvent(somaHome, input).catch(async (appendError: unknown) => {
+    try {
+      await rollback();
+    } catch (rollbackError) {
+      throw new Error(
+        `Soma memory ${input.kind} event append failed AND the rollback failed — ` +
+          `memory may be inconsistent; reconcile manually.`,
+        { cause: rollbackError },
+      );
+    }
+    throw new Error(`Soma memory ${input.kind} event append failed; rolled back the file mutation.`, { cause: appendError });
   });
 }
 
@@ -169,34 +187,40 @@ function assertMayMutatePrincipal(target: SomaMemoryNote, options: SomaMemoryWri
   );
 }
 
+// Bounded read concurrency for the dedup scan — parallel enough to not serialize
+// on every note, capped so a large corpus can't spike FDs on the write path.
+const DEDUP_SCAN_CONCURRENCY = 16;
+
 /**
  * Parse every `.md` note under the durable corpus; skip unreadable/malformed.
  * Returns `ScannedNote` (no `raw`) — the only caller is the dedup scan, which
  * never needs the bytes; `loadNoteById` reads raw itself for its rollback path.
  */
 async function collectDurableNotes(somaHome: string): Promise<ScannedNote[]> {
-  // Read files with per-directory parallelism (matches src/memory.ts's search
-  // walk) — a create against a large corpus must not serialize on every read.
-  const perType = await Promise.all(
-    (Object.keys(WRITABLE_TYPE_DIRS) as WritableType[]).map(async (type) => {
-      const dir = typeDir(somaHome, type);
-      const entries = (await readdir(dir).catch(() => [] as string[])).filter((entry) => entry.endsWith(".md"));
-      const notes = await Promise.all(
-        entries.map(async (entry): Promise<ScannedNote | undefined> => {
-          const path = join(dir, entry);
-          const content = await readFile(path, "utf8").catch(() => undefined);
-          if (content === undefined) return undefined;
-          try {
-            return { path, type, note: parseMemoryNote(content) };
-          } catch {
-            return undefined; // a hand-broken note must not block a legitimate write
-          }
-        }),
-      );
-      return notes.filter((entry): entry is ScannedNote => entry !== undefined);
-    }),
+  // Enumerate all note files across both durable dirs, then read them with a
+  // bounded concurrency window (shared helper) rather than one unbounded
+  // Promise.all over the whole tree.
+  const targets: { path: string; type: WritableType }[] = [];
+  for (const type of Object.keys(WRITABLE_TYPE_DIRS) as WritableType[]) {
+    const dir = typeDir(somaHome, type);
+    const entries = (await readdir(dir).catch(() => [] as string[])).filter((entry) => entry.endsWith(".md"));
+    for (const entry of entries) targets.push({ path: join(dir, entry), type });
+  }
+
+  const scanned = await runBoundedConcurrent(
+    targets,
+    async ({ path, type }): Promise<ScannedNote | undefined> => {
+      const content = await readFile(path, "utf8").catch(() => undefined);
+      if (content === undefined) return undefined;
+      try {
+        return { path, type, note: parseMemoryNote(content) };
+      } catch {
+        return undefined; // a hand-broken note must not block a legitimate write
+      }
+    },
+    DEDUP_SCAN_CONCURRENCY,
   );
-  return perType.flat();
+  return scanned.filter((entry): entry is ScannedNote => entry !== undefined);
 }
 
 /**
@@ -253,8 +277,11 @@ function resolveProvenance(options: SomaMemoryWriteOptions): string {
       return "consolidation";
     case "import": {
       const provenance = options.provenance ?? "import";
-      if (provenance !== "import" && !/^tool:.+/.test(provenance)) {
-        throw new MemoryNoteError(`import provenance must be "import" or "tool:<name>".`, "provenance");
+      // Anchored safe grammar at the trust boundary: a `tool:` name is a bounded
+      // slug, so untrusted import input can't smuggle a newline/extra frontmatter
+      // field (e.g. `tool:x\ntrust: principal`) through this check.
+      if (provenance !== "import" && !/^tool:[a-z0-9][a-z0-9._-]{0,63}$/i.test(provenance)) {
+        throw new MemoryNoteError(`import provenance must be "import" or "tool:<name>" (name: [a-z0-9._-], <=64 chars).`, "provenance");
       }
       return provenance;
     }
@@ -478,10 +505,12 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
       artifactPaths: [newPath, old.path],
       metadata: { id: newNote.id, supersededId: closed.id },
     },
-    // roll back BOTH sides: drop the new note AND reopen the closed one.
+    // roll back BOTH sides — reopen the closed note FIRST (the trusted state we
+    // most need to restore), then drop the new one. Failures are NOT swallowed:
+    // appendMutationEvent surfaces them as an inconsistency error.
     async () => {
-      await unlink(newPath).catch(() => undefined);
-      await writeFile(old.path, old.raw, "utf8").catch(() => undefined);
+      await writeFile(old.path, old.raw, "utf8");
+      await unlink(newPath);
     },
   );
 

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { access, mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { createPaths } from "./paths";
 import { runBoundedConcurrent } from "./internal-concurrency";
 import { appendSomaMemoryEvent } from "./memory";
@@ -31,8 +31,10 @@ import type {
  * - **Recall-first refusal** — `create` walks the durable corpus (`semantic/` +
  *   `procedural/`), hashes normalized bodies, and refuses when an active note is
  *   an exact-body match OR Jaccard ≥ 0.6 (transplant #1 from recall's dedup
- *   idea; reimplemented over files, not copied). `--force` overrides; `merge` /
- *   `supersede` name a target explicitly and skip the gate.
+ *   idea; reimplemented over files, not copied). Unreadable/malformed notes
+ *   can't be scanned, so their count is surfaced (in the refusal message and the
+ *   create event) — the gate never fails open silently. `--force` overrides;
+ *   `merge` / `supersede` name a target explicitly and skip the gate.
  * - **Invalidate, never delete** — `supersede` sets the old note's `valid_until`
  *   and cross-links; nothing is unlinked. `merge` delta-appends (ACE-style,
  *   never regenerates).
@@ -223,12 +225,21 @@ function principalAuthorityMeta(trust: SomaMemoryTrust): Record<string, unknown>
 // on every note, capped so a large corpus can't spike FDs on the write path.
 const DEDUP_SCAN_CONCURRENCY = 16;
 
+interface CorpusScan {
+  notes: ScannedNote[];
+  /** Paths that exist but could not be read or parsed — invisible to dedup. */
+  unreadable: string[];
+}
+
 /**
- * Parse every `.md` note under the durable corpus; skip unreadable/malformed.
- * Returns `ScannedNote` (no `raw`) — the only caller is the dedup scan, which
- * never needs the bytes; `loadNoteById` reads raw itself for its rollback path.
+ * Parse every `.md` note under the durable corpus. Unreadable/malformed files
+ * cannot block a legitimate write, but they are NOT silently dropped: their
+ * paths are returned so the caller can surface that the corpus was only
+ * partially scanned (the dedup gate would otherwise fail open on a corrupt
+ * near-duplicate). Returns `ScannedNote` (no `raw`) — the dedup scan never needs
+ * the bytes; `loadNoteById` reads raw itself for its rollback path.
  */
-async function collectDurableNotes(somaHome: string): Promise<ScannedNote[]> {
+async function collectDurableNotes(somaHome: string): Promise<CorpusScan> {
   // Enumerate all note files across both durable dirs, then read them with a
   // bounded concurrency window (shared helper) rather than one unbounded
   // Promise.all over the whole tree.
@@ -241,34 +252,47 @@ async function collectDurableNotes(somaHome: string): Promise<ScannedNote[]> {
 
   const scanned = await runBoundedConcurrent(
     targets,
-    async ({ path, type }): Promise<ScannedNote | undefined> => {
+    async ({ path, type }): Promise<ScannedNote | { unreadable: string }> => {
       const content = await readFile(path, "utf8").catch(() => undefined);
-      if (content === undefined) return undefined;
+      if (content === undefined) return { unreadable: path };
       try {
         return { path, type, note: parseMemoryNote(content) };
       } catch {
-        return undefined; // a hand-broken note must not block a legitimate write
+        return { unreadable: path };
       }
     },
     DEDUP_SCAN_CONCURRENCY,
   );
-  return scanned.filter((entry): entry is ScannedNote => entry !== undefined);
+
+  const notes: ScannedNote[] = [];
+  const unreadable: string[] = [];
+  for (const entry of scanned) {
+    if ("unreadable" in entry) unreadable.push(entry.unreadable);
+    else notes.push(entry);
+  }
+  return { notes, unreadable };
+}
+
+export interface DuplicateScanResult {
+  candidates: SomaMemoryDuplicateCandidate[];
+  /** Active-corpus files that could not be scanned — the gate's blind spot. */
+  unreadable: string[];
 }
 
 /**
  * Candidates that would make `create` a duplicate. Only ACTIVE notes
  * (`valid_until === null`) count — a superseded note is already closed, so a new
- * note overlapping it is the intended replacement, not a duplicate.
+ * note overlapping it is the intended replacement, not a duplicate. Also returns
+ * the unreadable-file list so callers never treat "no candidates" as "corpus
+ * fully checked" (the gate must not fail open silently).
  */
-export async function findDuplicateCandidates(
-  somaHome: string,
-  body: string,
-): Promise<SomaMemoryDuplicateCandidate[]> {
+export async function findDuplicateCandidates(somaHome: string, body: string): Promise<DuplicateScanResult> {
   const hash = bodyHash(body);
   const tokens = bodyTokens(body);
   const candidates: SomaMemoryDuplicateCandidate[] = [];
 
-  for (const { path, type, note } of await collectDurableNotes(somaHome)) {
+  const { notes, unreadable } = await collectDurableNotes(somaHome);
+  for (const { path, type, note } of notes) {
     if (note.valid_until !== null) continue;
     const exact = bodyHash(note.body) === hash;
     const score = exact ? 1 : jaccard(tokens, bodyTokens(note.body));
@@ -277,7 +301,8 @@ export async function findDuplicateCandidates(
     }
   }
 
-  return candidates.sort((left, right) => right.score - left.score || left.id.localeCompare(right.id));
+  candidates.sort((left, right) => right.score - left.score || left.id.localeCompare(right.id));
+  return { candidates, unreadable };
 }
 
 // --- trust / provenance derivation -------------------------------------------
@@ -324,7 +349,7 @@ function resolveProvenance(options: SomaMemoryWriteOptions): string {
 
 async function writeNoteFile(path: string, note: SomaMemoryNote, flag: "wx" | "w"): Promise<void> {
   const content = serializeMemoryNote(note); // enforces the round-trip law before any byte hits disk
-  await mkdir(join(path, ".."), { recursive: true });
+  await mkdir(dirname(path), { recursive: true });
   try {
     await writeFile(path, content, { encoding: "utf8", flag });
   } catch (error) {
@@ -334,6 +359,16 @@ async function writeNoteFile(path: string, note: SomaMemoryNote, flag: "wx" | "w
     }
     throw error;
   }
+}
+
+/**
+ * Restore raw bytes to `path` on a rollback, recreating the parent dir first —
+ * a normal write always recreates parents (writeNoteFile), so the restore path
+ * must too, or an externally-removed directory would defeat the rollback.
+ */
+async function restoreBytes(path: string, raw: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, raw, "utf8");
 }
 
 /**
@@ -383,8 +418,8 @@ function buildNewNote(options: SomaMemoryWriteOptions, now: Date): SomaMemoryNot
 
   // The deliberate-escalation gate: `principal` trust is never the incidental
   // result of a bare trigger flag. Without an explicit authority signal, a
-  // principal-correction write is REFUSED (not downgraded) — an automated/agent
-  // invocation defaults safe.
+  // principal-correction write is REFUSED (not downgraded) — an automated
+  // assistant invocation defaults safe.
   if (options.trigger === "principal-correction" && options.principalAuthority !== true) {
     throw new MemoryNoteError(
       `principal-correction mints principal trust and requires explicit principal authority ` +
@@ -424,15 +459,16 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
     throw new MemoryNoteError(`Soma memory note id already exists: ${note.id}`, "id");
   }
 
-  if (!options.force) {
-    const candidates = await findDuplicateCandidates(somaHome, note.body);
-    if (candidates.length > 0) {
-      const list = candidates.map((c) => `${c.id} (${c.exact ? "exact" : c.score.toFixed(2)})`).join(", ");
-      throw new MemoryNoteError(
-        `Recall-first refusal: ${candidates.length} similar note(s) exist — ${list}. ` +
-          `Re-run with --merge <id>, --supersede <id>, or --force.`,
-      );
-    }
+  // Scan unconditionally so the unreadable-file count is on record even under
+  // --force (the gate's blind spot must always be auditable, never silent).
+  const { candidates, unreadable } = await findDuplicateCandidates(somaHome, note.body);
+  if (!options.force && candidates.length > 0) {
+    const list = candidates.map((c) => `${c.id} (${c.exact ? "exact" : c.score.toFixed(2)})`).join(", ");
+    const blindSpot = unreadable.length > 0 ? ` (${unreadable.length} note(s) were unreadable and not checked)` : "";
+    throw new MemoryNoteError(
+      `Recall-first refusal: ${candidates.length} similar note(s) exist — ${list}${blindSpot}. ` +
+        `Re-run with --merge <id>, --supersede <id>, or --force.`,
+    );
   }
 
   const path = memoryNotePath(somaHome, note.type as WritableType, note.id);
@@ -452,6 +488,9 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
         trust: note.trust,
         trigger: options.trigger,
         ...principalAuthorityMeta(note.trust), // audit the escalation when principal
+        // Record the dedup gate's blind spot so "dedup-gated" is never a silent
+        // overstatement when part of the corpus was unreadable.
+        ...(unreadable.length > 0 ? { dedupUnreadable: unreadable.length } : {}),
       },
     },
     () => unlink(path), // roll back: remove the freshly created file
@@ -488,7 +527,7 @@ async function mergeNote(somaHome: string, options: SomaMemoryWriteOptions, now:
       // Log the escalation so an audit can prove a principal-note mutation was authorized.
       metadata: { id: merged.id, type, trust: merged.trust, trigger: options.trigger, ...principalAuthorityMeta(merged.trust) },
     },
-    () => writeFile(path, raw, "utf8"), // roll back: restore the pre-merge bytes
+    () => restoreBytes(path, raw), // roll back: restore the pre-merge bytes
   );
 
   return { somaHome, mode: "merge", path, note: merged, event };
@@ -552,7 +591,7 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
     // most need to restore), then drop the new one. Failures are NOT swallowed:
     // appendMutationEvent surfaces them as an inconsistency error.
     async () => {
-      await writeFile(old.path, old.raw, "utf8");
+      await restoreBytes(old.path, old.raw);
       await unlink(newPath);
     },
   );
@@ -615,7 +654,7 @@ export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promis
       artifactPaths: [path],
       metadata: { id: verified.id, type, resurfaceCount: verified.resurface_count, ...principalAuthorityMeta(note.trust) },
     },
-    () => writeFile(path, raw, "utf8"), // roll back: restore the pre-verify bytes
+    () => restoreBytes(path, raw), // roll back: restore the pre-verify bytes
   );
 
   return { somaHome, path, note: verified, event };

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
-import { lstat, mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { lstat, mkdir, readdir, readFile, realpath, unlink, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, sep } from "node:path";
 import { createPaths } from "./paths";
 import { runBoundedConcurrent } from "./internal-concurrency";
 import { appendSomaMemoryEvent } from "./memory";
@@ -67,8 +67,15 @@ const WRITABLE_TYPE_DIRS: Record<Exclude<SomaMemoryNoteType, "episodic">, string
 type WritableType = Exclude<SomaMemoryNoteType, "episodic">;
 
 // One source of truth for the writable-type enumeration — every helper that
-// walks both durable dirs reuses this instead of re-casting Object.keys.
-const WRITABLE_TYPES = Object.keys(WRITABLE_TYPE_DIRS) as WritableType[];
+// walks both durable dirs reuses this instead of re-casting Object.keys. Exported
+// so the CLI validates `--type` against the same list the writer routes on.
+export const WRITABLE_NOTE_TYPES = Object.keys(WRITABLE_TYPE_DIRS) as WritableType[];
+const WRITABLE_TYPES = WRITABLE_NOTE_TYPES;
+
+/** True iff `value` is a note type the write path accepts (semantic|procedural). */
+export function isWritableNoteType(value: string): value is WritableType {
+  return (WRITABLE_NOTE_TYPES as readonly string[]).includes(value);
+}
 
 // Trust ordering for the mutation gate: content may never be injected into a
 // note of HIGHER trust than the mutation's own trigger carries.
@@ -409,9 +416,27 @@ function resolveProvenance(options: SomaMemoryWriteOptions): string {
 
 // --- shared write helpers -----------------------------------------------------
 
-async function writeNoteFile(path: string, note: SomaMemoryNote, flag: "wx" | "w"): Promise<void> {
+/**
+ * Containment: after the parent dir exists, resolve its realpath (following ANY
+ * symlinked component — not just the final note path) and require it to stay
+ * under the real memory root. This closes the parent-symlink escape: a planted
+ * `memory/semantic` → /elsewhere symlink can no longer redirect a write out of
+ * the tree. lstat on the final path (loadNoteById) guards the leaf; this guards
+ * the directory chain.
+ */
+async function assertWriteContained(somaHome: string, path: string): Promise<void> {
+  const realRoot = await realpath(createPaths(somaHome).memory());
+  const realParent = await realpath(dirname(path));
+  const rel = relative(realRoot, realParent);
+  if (rel !== "" && (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel))) {
+    throw new MemoryNoteError(`Refusing write: ${path} resolves outside the memory tree (a symlinked path component).`, "id");
+  }
+}
+
+async function writeNoteFile(somaHome: string, path: string, note: SomaMemoryNote, flag: "wx" | "w"): Promise<void> {
   const content = serializeMemoryNote(note); // enforces the round-trip law before any byte hits disk
   await mkdir(dirname(path), { recursive: true });
+  await assertWriteContained(somaHome, path);
   try {
     await writeFile(path, content, { encoding: "utf8", flag });
   } catch (error) {
@@ -428,16 +453,19 @@ async function writeNoteFile(path: string, note: SomaMemoryNote, flag: "wx" | "w
  * a normal write always recreates parents (writeNoteFile), so the restore path
  * must too, or an externally-removed directory would defeat the rollback.
  */
-async function restoreBytes(path: string, raw: string): Promise<void> {
+async function restoreBytes(somaHome: string, path: string, raw: string): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
+  await assertWriteContained(somaHome, path);
   await writeFile(path, raw, "utf8");
 }
 
 /**
  * Load one note by id by probing its two possible paths directly
  * (`semantic/<id>.md`, `procedural/<id>.md`) — O(1) I/O, not an O(corpus) scan.
- * Ids are globally unique across types (enforced at create/supersede), so at
- * most one path resolves; if both somehow exist, semantic wins deterministically.
+ * Create/supersede run a preflight id-uniqueness check across types, so in the
+ * single-process CLI at most one path resolves; if both exist (e.g. a race
+ * between two concurrent writers, which the preflight is not atomic against, or
+ * a hand-placed file), semantic wins deterministically.
  */
 async function loadNoteById(somaHome: string, id: string): Promise<LoadedNote> {
   assertNoteId(id); // a lookup id is also a path segment — never probe an unsafe one
@@ -526,10 +554,12 @@ function buildNewNote(options: SomaMemoryWriteOptions, now: Date): SomaMemoryNot
 async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now: Date): Promise<SomaMemoryWriteResult> {
   const note = buildNewNote(options, now);
 
-  // Cheap path-existence check FIRST — reject an id collision before paying for
-  // the whole-corpus dedup scan. Ids are globally unique across types, so this
-  // also rejects `procedural/foo` when `semantic/foo` exists (`wx` below only
-  // catches a same-path collision).
+  // Cheap path-existence PREFLIGHT — reject an id collision before paying for
+  // the whole-corpus dedup scan, and reject `procedural/foo` when `semantic/foo`
+  // exists so id-based lookups stay unambiguous. This is a preflight, not a lock:
+  // it is best-effort against two concurrent writers racing the same id into
+  // different types (the CLI is single-process; `wx` below still guards the
+  // same-path case atomically).
   if (await noteIdExists(somaHome, note.id)) {
     throw new MemoryNoteError(`Soma memory note id already exists: ${note.id}`, "id");
   }
@@ -552,7 +582,7 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
   }
 
   const path = memoryNotePath(somaHome, note.type as WritableType, note.id);
-  await writeNoteFile(path, note, "wx");
+  await writeNoteFile(somaHome, path, note, "wx");
 
   const event = await appendNoteMutationEvent(
     somaHome,
@@ -601,7 +631,7 @@ async function mergeNote(somaHome: string, options: SomaMemoryWriteOptions, now:
     last_verified: today,
     body: `${note.body}\n\n**Update (${today}):** ${options.body.trim()}`,
   };
-  await writeNoteFile(path, merged, "w");
+  await writeNoteFile(somaHome, path, merged, "w");
 
   const event = await appendNoteMutationEvent(
     somaHome,
@@ -614,7 +644,7 @@ async function mergeNote(somaHome: string, options: SomaMemoryWriteOptions, now:
       // Log the escalation so an audit can prove a principal-note mutation was authorized.
       metadata: { id: merged.id, type, trust: merged.trust, trigger: options.trigger, ...authorityMeta(merged.trust) },
     },
-    () => restoreBytes(path, raw), // roll back: restore the pre-merge bytes
+    () => restoreBytes(somaHome, path, raw), // roll back: restore the pre-merge bytes
   );
 
   return { somaHome, mode: "merge", path, note: merged, event };
@@ -650,9 +680,9 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
   };
 
   const newPath = memoryNotePath(somaHome, newNote.type as WritableType, newNote.id);
-  await writeNoteFile(newPath, newNote, "wx");
+  await writeNoteFile(somaHome, newPath, newNote, "wx");
   try {
-    await writeNoteFile(old.path, closed, "w");
+    await writeNoteFile(somaHome, old.path, closed, "w");
   } catch (error) {
     await unlink(newPath).catch(() => undefined); // keep the supersede atomic-ish
     throw error;
@@ -682,7 +712,7 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
     // most need to restore), then drop the new one. Failures are NOT swallowed:
     // appendMutationEvent surfaces them as an inconsistency error.
     async () => {
-      await restoreBytes(old.path, old.raw);
+      await restoreBytes(somaHome, old.path, old.raw);
       await unlink(newPath);
     },
   );
@@ -735,7 +765,7 @@ export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promis
     last_verified: isoDate(now),
     resurface_count: note.resurface_count + 1,
   };
-  await writeNoteFile(path, verified, "w");
+  await writeNoteFile(somaHome, path, verified, "w");
 
   const event = await appendNoteMutationEvent(
     somaHome,
@@ -747,7 +777,7 @@ export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promis
       artifactPaths: [path],
       metadata: { id: verified.id, type, resurfaceCount: verified.resurface_count, ...authorityMeta(note.trust) },
     },
-    () => restoreBytes(path, raw), // roll back: restore the pre-verify bytes
+    () => restoreBytes(somaHome, path, raw), // roll back: restore the pre-verify bytes
   );
 
   return { somaHome, path, note: verified, event };

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { access, mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { access, lstat, mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { createPaths } from "./paths";
 import { runBoundedConcurrent } from "./internal-concurrency";
@@ -15,19 +15,21 @@ import type {
   SomaMemoryVerifyResult,
   SomaMemoryWriteOptions,
   SomaMemoryWriteResult,
-  SomaMemoryWriteTrigger,
 } from "./types";
 
 /**
  * Memory write + verify (subsystem M1). Plan v2 §M1 (do not redesign the
  * governance model):
  *
- * - **Trust is derived from the trigger**, never a caller flag — a substrate-side
- *   caller cannot self-assert `principal`. `principal-correction` is the sole path
- *   to `principal` trust AND requires an explicit `principalAuthority` escalation
- *   (sudo-style: deliberate + logged, refused by default — not cryptographic
- *   auth, which soma has no primitive for); `import` is always `quarantined`
- *   (MINJA defense); `consolidation` is `assistant`.
+ * - **Trust is derived from the trigger**, never a caller flag — and any tier
+ *   above `quarantined` needs that tier's explicit, logged authority signal, so a
+ *   caller cannot mint (or carry) trust by choosing a trigger alone.
+ *   `principal-correction` → `principal` (needs `principalAuthority`);
+ *   `consolidation` → `assistant` (needs `consolidationAuthority`, the M6
+ *   consolidator's capability); `import` → `quarantined`, free (MINJA defense).
+ *   Escalations are sudo-style (deliberate + logged, refused by default) — not
+ *   cryptographic auth, which soma has no primitive for. Mutating an existing
+ *   note needs the TARGET tier's authority (merge/supersede/verify).
  * - **Recall-first refusal** — `create` walks the durable corpus (`semantic/` +
  *   `procedural/`), hashes normalized bodies, and refuses when an active note is
  *   an exact-body match OR Jaccard ≥ 0.6 (transplant #1 from recall's dedup
@@ -202,42 +204,68 @@ interface LoadedNote extends ScannedNote {
   raw: string;
 }
 
+// The authority signals a caller can hold. Both write and verify options carry
+// these fields; the tier gate reads only this narrow shape.
+interface AuthoritySignals {
+  principalAuthority?: boolean;
+  consolidationAuthority?: boolean;
+}
+
+/**
+ * A trust tier above `quarantined` is never conferred by choosing a trigger
+ * alone — it requires that tier's explicit, logged authority signal. `principal`
+ * needs `--principal-authority`; `assistant` (the consolidation tier) needs
+ * `--consolidation-authority`; `quarantined` is free. `context` names the act
+ * (mint / mutate) for the error.
+ */
+function assertTierAuthority(tier: SomaMemoryTrust, auth: AuthoritySignals, context: string): void {
+  if (tier === "principal" && auth.principalAuthority !== true) {
+    throw new MemoryNoteError(`${context} requires --principal-authority (a deliberate, logged escalation).`, "principalAuthority");
+  }
+  if (tier === "assistant" && auth.consolidationAuthority !== true) {
+    throw new MemoryNoteError(
+      `${context} requires --consolidation-authority (the internal consolidator's capability, ` +
+        `not selectable by choosing --trigger consolidation).`,
+      "consolidationAuthority",
+    );
+  }
+}
+
+/** Minting a note: the trigger's derived tier needs that tier's authority. */
+function assertMintAuthority(options: SomaMemoryWriteOptions): void {
+  const tier = SOMA_MEMORY_TRIGGER_TRUST[options.trigger];
+  assertTierAuthority(tier, options, `${options.trigger} mints ${tier} trust and`);
+}
+
 /**
  * Guard every mutation of an EXISTING note (merge body, supersede-close). Two
  * rules, both anti-injection:
  *   1. The mutation's trigger-trust must be ≥ the target's trust — a tool/import
  *      caller (quarantined) can never inject content into an assistant/principal
- *      note while the note keeps its higher trust ("import is always quarantined"
- *      would otherwise be a lie for merges).
- *   2. Mutating a `principal` note additionally needs the explicit
- *      `principalAuthority` escalation — the same deliberate, logged act that
- *      minted it.
+ *      note ("import is always quarantined" would otherwise be a lie for merges).
+ *   2. Mutating a non-quarantined note needs the TARGET tier's authority — the
+ *      same signal that minted it.
  */
-function assertMayMutate(target: SomaMemoryNote, trigger: SomaMemoryWriteTrigger, principalAuthority: boolean): void {
-  const incoming = SOMA_MEMORY_TRIGGER_TRUST[trigger];
+function assertMayMutate(target: SomaMemoryNote, options: SomaMemoryWriteOptions): void {
+  const incoming = SOMA_MEMORY_TRIGGER_TRUST[options.trigger];
   if (TRUST_RANK[incoming] < TRUST_RANK[target.trust]) {
     throw new MemoryNoteError(
       `Cannot mutate ${target.trust}-trust note ${target.id} with ${incoming}-trust content ` +
-        `(trigger ${trigger}) — a mutation may not inject lower-trust content.`,
+        `(trigger ${options.trigger}) — a mutation may not inject lower-trust content.`,
       "trigger",
     );
   }
-  if (target.trust === "principal" && !principalAuthority) {
-    throw new MemoryNoteError(
-      `Mutating principal-trust note ${target.id} requires --principal-authority ` +
-        `(the same deliberate escalation that minted it).`,
-      "principalAuthority",
-    );
-  }
+  assertTierAuthority(target.trust, options, `Mutating ${target.trust}-trust note ${target.id}`);
 }
 
 /**
- * Event metadata that records the principal-authority escalation, so an audit
- * can prove from the journal alone that a principal-trust mutation was
- * authorized. Emitted whenever the resulting/target note is principal-trust.
+ * Event metadata recording the authority escalation, so an audit can prove from
+ * the journal alone that a non-quarantined mutation was authorized.
  */
-function principalAuthorityMeta(trust: SomaMemoryTrust): Record<string, unknown> {
-  return trust === "principal" ? { principalAuthority: true } : {};
+function authorityMeta(trust: SomaMemoryTrust): Record<string, unknown> {
+  if (trust === "principal") return { principalAuthority: true };
+  if (trust === "assistant") return { consolidationAuthority: true };
+  return {};
 }
 
 // Bounded read concurrency for the dedup scan — parallel enough to not serialize
@@ -413,18 +441,24 @@ async function loadNoteById(somaHome: string, id: string): Promise<LoadedNote> {
   assertNoteId(id); // a lookup id is also a path segment — never probe an unsafe one
   for (const type of WRITABLE_TYPES) {
     const path = memoryNotePath(somaHome, type, id);
-    let raw: string;
+    let stats;
     try {
-      raw = await readFile(path, "utf8");
+      stats = await lstat(path);
     } catch (error) {
       // Only a genuinely-absent file (ENOENT) is "not here, try the next type".
-      // Any OTHER read failure must NOT masquerade as absence — that would break
+      // Any OTHER stat failure must NOT masquerade as absence — that would break
       // the global-id guarantee (fall through to a same-id note of the other
       // type, or wrongly report not-found on an existing-but-unreadable note).
       const code = error instanceof Error && "code" in error ? error.code : undefined;
       if (code === "ENOENT") continue;
-      throw new MemoryNoteError(`Soma memory note ${id} exists at ${path} but is unreadable: ${String(error)}`, "id");
+      throw new MemoryNoteError(`Soma memory note ${id} exists at ${path} but is unstattable: ${String(error)}`, "id");
     }
+    // Containment: a note path that is a symlink would let a subsequent "w"
+    // overwrite (merge/verify/supersede-close) escape the memory tree. Refuse it.
+    if (stats.isSymbolicLink()) {
+      throw new MemoryNoteError(`Soma memory note ${id} at ${path} is a symlink; refusing to follow it out of the memory tree.`, "id");
+    }
+    const raw = await readFile(path, "utf8");
     return { path, type, note: parseMemoryNote(raw), raw };
   }
   throw new MemoryNoteError(`Soma memory note not found: ${id}`, "id");
@@ -458,17 +492,9 @@ function buildNewNote(options: SomaMemoryWriteOptions, now: Date): SomaMemoryNot
   }
   assertNonEmpty(options.body, "body");
 
-  // The deliberate-escalation gate: `principal` trust is never the incidental
-  // result of a bare trigger flag. Without an explicit authority signal, a
-  // principal-correction write is REFUSED (not downgraded) — an automated
-  // assistant invocation defaults safe.
-  if (options.trigger === "principal-correction" && options.principalAuthority !== true) {
-    throw new MemoryNoteError(
-      `principal-correction mints principal trust and requires explicit principal authority ` +
-        `(--principal-authority). This is a deliberate, logged escalation — not automatic from the trigger.`,
-      "trigger",
-    );
-  }
+  // Minting a tier above quarantined needs that tier's authority — no caller can
+  // mint principal/assistant trust by choosing a trigger alone; import defaults safe.
+  assertMintAuthority(options);
 
   const today = isoDate(now);
   const note: SomaMemoryNote = {
@@ -534,7 +560,7 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
         type: note.type,
         trust: note.trust,
         trigger: options.trigger,
-        ...principalAuthorityMeta(note.trust), // audit the escalation when principal
+        ...authorityMeta(note.trust), // audit the escalation when non-quarantined
         // Record the dedup gate's blind spot so "dedup-gated" is never a silent
         // overstatement when part of the corpus was unreadable.
         ...(unreadable.length > 0 ? { dedupUnreadable: unreadable.length } : {}),
@@ -549,11 +575,18 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
 async function mergeNote(somaHome: string, options: SomaMemoryWriteOptions, now: Date): Promise<SomaMemoryWriteResult> {
   assertNonEmpty(options.targetId, "targetId");
   assertNonEmpty(options.body, "body");
+  // merge edits an existing note IN PLACE, preserving its provenance — so a
+  // provenance flag would be silently ignored. Refuse it rather than pretend
+  // (this is also what makes "tool/import content is refused" honest for merge:
+  // you cannot attach a tool provenance to a merge at all).
+  if (options.provenance !== undefined) {
+    throw new MemoryNoteError(`--provenance is not valid with --merge; merge preserves the target note's provenance.`, "provenance");
+  }
   const { path, type, note, raw } = await loadNoteById(somaHome, options.targetId);
   if (note.valid_until !== null) {
     throw new MemoryNoteError(`Cannot merge into superseded note ${note.id} (valid_until set).`, "targetId");
   }
-  assertMayMutate(note, options.trigger, options.principalAuthority === true);
+  assertMayMutate(note, options);
 
   const today = isoDate(now);
   const merged: SomaMemoryNote = {
@@ -572,7 +605,7 @@ async function mergeNote(somaHome: string, options: SomaMemoryWriteOptions, now:
       summary: `Merged update into memory note ${merged.id} (${type})`,
       artifactPaths: [path],
       // Log the escalation so an audit can prove a principal-note mutation was authorized.
-      metadata: { id: merged.id, type, trust: merged.trust, trigger: options.trigger, ...principalAuthorityMeta(merged.trust) },
+      metadata: { id: merged.id, type, trust: merged.trust, trigger: options.trigger, ...authorityMeta(merged.trust) },
     },
     () => restoreBytes(path, raw), // roll back: restore the pre-merge bytes
   );
@@ -599,7 +632,7 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
   // (can't close a higher-trust note with lower-trust content; principal needs
   // the escalation). The new replacement note's own trust was already gated in
   // buildNewNote.
-  assertMayMutate(old.note, options.trigger, options.principalAuthority === true);
+  assertMayMutate(old.note, options);
 
   // New note points back at what it replaces; the closed note points forward.
   if (!newNote.links.includes(old.note.id)) newNote.links = [...newNote.links, old.note.id];
@@ -631,7 +664,7 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
         id: newNote.id,
         supersededId: closed.id,
         trigger: options.trigger,
-        ...principalAuthorityMeta(TRUST_RANK[newNote.trust] >= TRUST_RANK[closed.trust] ? newNote.trust : closed.trust),
+        ...authorityMeta(TRUST_RANK[newNote.trust] >= TRUST_RANK[closed.trust] ? newNote.trust : closed.trust),
       },
     },
     // roll back BOTH sides — reopen the closed note FIRST (the trusted state we
@@ -675,17 +708,10 @@ export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promis
   const now = options.now ?? new Date();
   const { path, type, note, raw } = await loadNoteById(somaHome, options.id);
 
-  // Verifying a principal note refreshes its decay signal — a principal-note
-  // mutation, so it needs the same escalation. (Verify has no trigger; a
-  // principal note verified WITH authority is treated as a principal-correction
-  // for the trust-rank check.)
-  if (note.trust === "principal" && options.principalAuthority !== true) {
-    throw new MemoryNoteError(
-      `Verifying principal-trust note ${note.id} requires --principal-authority ` +
-        `(refreshing its decay signal is a principal-note mutation).`,
-      "principalAuthority",
-    );
-  }
+  // Verifying refreshes a note's decay signal — a mutation — so a non-quarantined
+  // note needs its tier's authority (principal→--principal-authority,
+  // assistant→--consolidation-authority).
+  assertTierAuthority(note.trust, options, `Verifying ${note.trust}-trust note ${note.id}`);
 
   const verified: SomaMemoryNote = {
     ...note,
@@ -702,7 +728,7 @@ export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promis
       kind: "memory.verify",
       summary: `Verified memory note ${verified.id} (${type}); resurface_count ${verified.resurface_count}`,
       artifactPaths: [path],
-      metadata: { id: verified.id, type, resurfaceCount: verified.resurface_count, ...principalAuthorityMeta(note.trust) },
+      metadata: { id: verified.id, type, resurfaceCount: verified.resurface_count, ...authorityMeta(note.trust) },
     },
     () => restoreBytes(path, raw), // roll back: restore the pre-verify bytes
   );

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -1,0 +1,401 @@
+import { createHash } from "node:crypto";
+import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createPaths } from "./paths";
+import { appendSomaMemoryEvent } from "./memory";
+import { parseMemoryNote, serializeMemoryNote, MemoryNoteError } from "./memory-note";
+import { SOMA_MEMORY_TRIGGER_TRUST } from "./types";
+import type {
+  SomaMemoryDuplicateCandidate,
+  SomaMemoryNote,
+  SomaMemoryNoteType,
+  SomaMemoryVerifyOptions,
+  SomaMemoryVerifyResult,
+  SomaMemoryWriteOptions,
+  SomaMemoryWriteResult,
+} from "./types";
+
+/**
+ * Memory write + verify (subsystem M1). Plan v2 §M1 (do not redesign the
+ * governance model):
+ *
+ * - **Trust is derived from the trigger**, never a caller flag — an agent cannot
+ *   self-assert `principal`. `principal-correction` is the sole path to
+ *   `principal` trust and is the documented human-authority gate; `import` is
+ *   always `quarantined` (MINJA defense); `consolidation` is `assistant`.
+ * - **Recall-first refusal** — `create` walks the durable corpus (`semantic/` +
+ *   `procedural/`), hashes normalized bodies, and refuses when an active note is
+ *   an exact-body match OR Jaccard ≥ 0.6 (transplant #1 from recall's dedup
+ *   idea; reimplemented over files, not copied). `--force` overrides; `merge` /
+ *   `supersede` name a target explicitly and skip the gate.
+ * - **Invalidate, never delete** — `supersede` sets the old note's `valid_until`
+ *   and cross-links; nothing is unlinked. `merge` delta-appends (ACE-style,
+ *   never regenerates).
+ * - One mutating call → exactly one events journal line.
+ *
+ * Deterministic: dates come from an injected `now` (UTC), no LLM calls, writes
+ * stay within the Soma memory tree under `memory/semantic/` + `memory/procedural/`.
+ */
+
+// The recall-first refusal fires at/above this Jaccard token-set overlap.
+// Adapted from recall's dedup concept (see Plans/2026-07-02-recall-adoption-analysis.md);
+// Soma owns the constant after port.
+export const MEMORY_DEDUP_JACCARD_THRESHOLD = 0.6;
+
+// The durable, dedup-gated corpus. Episodic notes live elsewhere (M5) and are
+// not written through this path.
+const WRITABLE_TYPE_DIRS: Record<Exclude<SomaMemoryNoteType, "episodic">, string> = {
+  semantic: "semantic",
+  procedural: "procedural",
+};
+
+type WritableType = Exclude<SomaMemoryNoteType, "episodic">;
+
+function assertNonEmpty(value: string | undefined, field: string): asserts value is string {
+  if (value === undefined || value.trim().length === 0) {
+    throw new MemoryNoteError(`Soma memory write ${field} must not be empty.`, field);
+  }
+}
+
+/** YYYY-MM-DD in UTC — matches the note schema's calendar-date grammar. */
+function isoDate(now: Date): string {
+  return now.toISOString().slice(0, 10);
+}
+
+/** Directory holding notes of a writable type. */
+function typeDir(somaHome: string, type: WritableType): string {
+  return createPaths(somaHome).resolve("memory", WRITABLE_TYPE_DIRS[type]);
+}
+
+/**
+ * Canonical on-disk path for a note. The id==filename-stem invariant that the M0
+ * parser documents but cannot enforce (a content parser has no filename) is
+ * bound here.
+ */
+export function memoryNotePath(somaHome: string, type: WritableType, id: string): string {
+  return join(typeDir(somaHome, type), `${id}.md`);
+}
+
+// --- dedup engine (transplant #1) --------------------------------------------
+
+/** Normalized body for exact-hash comparison: lowercased, whitespace-collapsed. */
+function normalizeBody(body: string): string {
+  return body.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function bodyHash(body: string): string {
+  return createHash("sha256").update(normalizeBody(body)).digest("hex");
+}
+
+/** Token set for Jaccard near-match — 3+ char alnum tokens, same floor as search. */
+function bodyTokens(body: string): Set<string> {
+  return new Set(
+    body
+      .toLowerCase()
+      .split(/[^a-z0-9À-ɏ]+/i)
+      .filter((token) => token.length >= 3),
+  );
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  let intersection = 0;
+  for (const token of a) {
+    if (b.has(token)) intersection += 1;
+  }
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+interface LoadedNote {
+  path: string;
+  type: WritableType;
+  note: SomaMemoryNote;
+}
+
+/** Parse every `.md` note under the durable corpus; skip unreadable/malformed. */
+async function collectDurableNotes(somaHome: string): Promise<LoadedNote[]> {
+  const loaded: LoadedNote[] = [];
+  for (const type of Object.keys(WRITABLE_TYPE_DIRS) as WritableType[]) {
+    const dir = typeDir(somaHome, type);
+    const entries = await readdir(dir).catch(() => [] as string[]);
+    for (const entry of entries) {
+      if (!entry.endsWith(".md")) continue;
+      const path = join(dir, entry);
+      const content = await readFile(path, "utf8").catch(() => undefined);
+      if (content === undefined) continue;
+      let note: SomaMemoryNote;
+      try {
+        note = parseMemoryNote(content);
+      } catch {
+        continue; // a hand-broken note must not block a legitimate write
+      }
+      loaded.push({ path, type, note });
+    }
+  }
+  return loaded;
+}
+
+/**
+ * Candidates that would make `create` a duplicate. Only ACTIVE notes
+ * (`valid_until === null`) count — a superseded note is already closed, so a new
+ * note overlapping it is the intended replacement, not a duplicate.
+ */
+export async function findDuplicateCandidates(
+  somaHome: string,
+  body: string,
+): Promise<SomaMemoryDuplicateCandidate[]> {
+  const hash = bodyHash(body);
+  const tokens = bodyTokens(body);
+  const candidates: SomaMemoryDuplicateCandidate[] = [];
+
+  for (const { path, type, note } of await collectDurableNotes(somaHome)) {
+    if (note.valid_until !== null) continue;
+    const exact = bodyHash(note.body) === hash;
+    const score = exact ? 1 : jaccard(tokens, bodyTokens(note.body));
+    if (exact || score >= MEMORY_DEDUP_JACCARD_THRESHOLD) {
+      candidates.push({ id: note.id, type, path, score, exact });
+    }
+  }
+
+  return candidates.sort((left, right) => right.score - left.score || left.id.localeCompare(right.id));
+}
+
+// --- trust / provenance derivation -------------------------------------------
+
+/**
+ * Resolve provenance from trigger, closing the smuggling hole where tool/web
+ * content rides in under `principal` trust:
+ * - `principal-correction` → forced `conversation` (a correction happens in the
+ *   conversation; a tool-sourced fact is not a principal correction).
+ * - `consolidation` → forced `consolidation`.
+ * - `import` → caller may pass `import` (default) or `tool:<name>`; anything else
+ *   is refused. Either way the derived trust is `quarantined`.
+ */
+function resolveProvenance(options: SomaMemoryWriteOptions): string {
+  switch (options.trigger) {
+    case "principal-correction":
+      if (options.provenance !== undefined && options.provenance !== "conversation") {
+        throw new MemoryNoteError(
+          `principal-correction writes are provenance "conversation"; refusing "${options.provenance}" ` +
+            `(tool/import content cannot ride in under principal trust).`,
+          "provenance",
+        );
+      }
+      return "conversation";
+    case "consolidation":
+      if (options.provenance !== undefined && options.provenance !== "consolidation") {
+        throw new MemoryNoteError(`consolidation writes are provenance "consolidation".`, "provenance");
+      }
+      return "consolidation";
+    case "import": {
+      const provenance = options.provenance ?? "import";
+      if (provenance !== "import" && !/^tool:.+/.test(provenance)) {
+        throw new MemoryNoteError(`import provenance must be "import" or "tool:<name>".`, "provenance");
+      }
+      return provenance;
+    }
+  }
+}
+
+// --- shared write helpers -----------------------------------------------------
+
+async function writeNoteFile(path: string, note: SomaMemoryNote, flag: "wx" | "w"): Promise<void> {
+  const content = serializeMemoryNote(note); // enforces the round-trip law before any byte hits disk
+  await mkdir(join(path, ".."), { recursive: true });
+  try {
+    await writeFile(path, content, { encoding: "utf8", flag });
+  } catch (error) {
+    const code = error instanceof Error && "code" in error ? error.code : undefined;
+    if (code === "EEXIST") {
+      throw new MemoryNoteError(`Soma memory note already exists: ${path}`, "id");
+    }
+    throw error;
+  }
+}
+
+/** Find an active-or-superseded note by id across the durable corpus. */
+async function loadNoteById(somaHome: string, id: string): Promise<LoadedNote> {
+  for (const loaded of await collectDurableNotes(somaHome)) {
+    if (loaded.note.id === id) return loaded;
+  }
+  throw new MemoryNoteError(`Soma memory note not found: ${id}`, "id");
+}
+
+// --- create / merge / supersede ----------------------------------------------
+
+function buildNewNote(options: SomaMemoryWriteOptions, now: Date): SomaMemoryNote {
+  assertNonEmpty(options.id, "id");
+  if (options.type === undefined || options.type === "episodic") {
+    throw new MemoryNoteError(`type must be "semantic" or "procedural" (episodic writes go through digest/action, M5).`, "type");
+  }
+  assertNonEmpty(options.body, "body");
+
+  const today = isoDate(now);
+  const note: SomaMemoryNote = {
+    id: options.id,
+    type: options.type,
+    created: today,
+    last_verified: today,
+    valid_until: null,
+    provenance: resolveProvenance(options),
+    trust: SOMA_MEMORY_TRIGGER_TRUST[options.trigger],
+    source_of_truth: options.sourceOfTruth ?? null,
+    project: options.project ?? null,
+    links: options.links ?? [],
+    resurface_count: 0,
+    body: options.body,
+  };
+  if (options.hook !== undefined) note.hook = options.hook;
+  if (options.review !== undefined) note.review = options.review;
+  return note;
+}
+
+async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now: Date): Promise<SomaMemoryWriteResult> {
+  const note = buildNewNote(options, now);
+
+  if (!options.force) {
+    const candidates = await findDuplicateCandidates(somaHome, note.body);
+    if (candidates.length > 0) {
+      const list = candidates.map((c) => `${c.id} (${c.exact ? "exact" : c.score.toFixed(2)})`).join(", ");
+      throw new MemoryNoteError(
+        `Recall-first refusal: ${candidates.length} similar note(s) exist — ${list}. ` +
+          `Re-run with --merge <id>, --supersede <id>, or --force.`,
+      );
+    }
+  }
+
+  const path = memoryNotePath(somaHome, note.type as WritableType, note.id);
+  await writeNoteFile(path, note, "wx");
+
+  const event = await appendSomaMemoryEvent(somaHome, {
+    timestamp: now.toISOString(),
+    substrate: options.substrate ?? "custom",
+    kind: "memory.write.create",
+    summary: `Created memory note ${note.id} (${note.type}, trust ${note.trust})`,
+    artifactPaths: [path],
+    metadata: { id: note.id, type: note.type, trust: note.trust, trigger: options.trigger },
+  }).catch(async (error: unknown) => {
+    await unlink(path).catch(() => undefined);
+    throw new Error(`Soma memory write event append failed; removed note: ${path}`, { cause: error });
+  });
+
+  return { somaHome, mode: "create", path, note, event };
+}
+
+async function mergeNote(somaHome: string, options: SomaMemoryWriteOptions, now: Date): Promise<SomaMemoryWriteResult> {
+  assertNonEmpty(options.targetId, "targetId");
+  assertNonEmpty(options.body, "body");
+  const { path, type, note } = await loadNoteById(somaHome, options.targetId);
+  if (note.valid_until !== null) {
+    throw new MemoryNoteError(`Cannot merge into superseded note ${note.id} (valid_until set).`, "targetId");
+  }
+
+  const today = isoDate(now);
+  const merged: SomaMemoryNote = {
+    ...note,
+    last_verified: today,
+    body: `${note.body}\n\n**Update (${today}):** ${options.body.trim()}`,
+  };
+  await writeNoteFile(path, merged, "w");
+
+  const event = await appendSomaMemoryEvent(somaHome, {
+    timestamp: now.toISOString(),
+    substrate: options.substrate ?? "custom",
+    kind: "memory.write.merge",
+    summary: `Merged update into memory note ${merged.id} (${type})`,
+    artifactPaths: [path],
+    metadata: { id: merged.id, type },
+  });
+
+  return { somaHome, mode: "merge", path, note: merged, event };
+}
+
+async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, now: Date): Promise<SomaMemoryWriteResult> {
+  assertNonEmpty(options.targetId, "targetId");
+  const newNote = buildNewNote(options, now);
+  if (newNote.id === options.targetId) {
+    throw new MemoryNoteError(`A note cannot supersede itself (${newNote.id}).`, "id");
+  }
+
+  const old = await loadNoteById(somaHome, options.targetId);
+  if (old.note.valid_until !== null) {
+    throw new MemoryNoteError(`Note ${old.note.id} is already superseded (valid_until set).`, "targetId");
+  }
+
+  // New note points back at what it replaces; the closed note points forward.
+  if (!newNote.links.includes(old.note.id)) newNote.links = [...newNote.links, old.note.id];
+  const closed: SomaMemoryNote = {
+    ...old.note,
+    valid_until: isoDate(now),
+    links: old.note.links.includes(newNote.id) ? old.note.links : [...old.note.links, newNote.id],
+  };
+
+  const newPath = memoryNotePath(somaHome, newNote.type as WritableType, newNote.id);
+  await writeNoteFile(newPath, newNote, "wx");
+  try {
+    await writeNoteFile(old.path, closed, "w");
+  } catch (error) {
+    await unlink(newPath).catch(() => undefined); // keep the supersede atomic-ish
+    throw error;
+  }
+
+  const event = await appendSomaMemoryEvent(somaHome, {
+    timestamp: now.toISOString(),
+    substrate: options.substrate ?? "custom",
+    kind: "memory.write.supersede",
+    summary: `Note ${newNote.id} supersedes ${closed.id} (closed ${closed.valid_until})`,
+    artifactPaths: [newPath, old.path],
+    metadata: { id: newNote.id, supersededId: closed.id },
+  }).catch(async (error: unknown) => {
+    await unlink(newPath).catch(() => undefined);
+    throw new Error(`Soma memory supersede event append failed; rolled back new note: ${newPath}`, { cause: error });
+  });
+
+  return { somaHome, mode: "supersede", path: newPath, note: newNote, supersededId: closed.id, event };
+}
+
+export async function writeMemoryNote(options: SomaMemoryWriteOptions): Promise<SomaMemoryWriteResult> {
+  const somaHome = createPaths(options).root();
+  const now = options.now ?? new Date();
+  switch (options.mode) {
+    case "create":
+      return createNote(somaHome, options, now);
+    case "merge":
+      return mergeNote(somaHome, options, now);
+    case "supersede":
+      return supersedeNote(somaHome, options, now);
+  }
+}
+
+// --- verify ------------------------------------------------------------------
+
+/**
+ * Close the reinforcing loop: a resurfaced note that proved correct bumps
+ * `last_verified` to today and increments `resurface_count`. This is the decay
+ * signal M3's retention score reads.
+ */
+export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promise<SomaMemoryVerifyResult> {
+  assertNonEmpty(options.id, "id");
+  const somaHome = createPaths(options).root();
+  const now = options.now ?? new Date();
+  const { path, type, note } = await loadNoteById(somaHome, options.id);
+
+  const verified: SomaMemoryNote = {
+    ...note,
+    last_verified: isoDate(now),
+    resurface_count: note.resurface_count + 1,
+  };
+  await writeNoteFile(path, verified, "w");
+
+  const event = await appendSomaMemoryEvent(somaHome, {
+    timestamp: now.toISOString(),
+    substrate: options.substrate ?? "custom",
+    kind: "memory.verify",
+    summary: `Verified memory note ${verified.id} (${type}); resurface_count ${verified.resurface_count}`,
+    artifactPaths: [path],
+    metadata: { id: verified.id, type, resurfaceCount: verified.resurface_count },
+  });
+
+  return { somaHome, path, note: verified, event };
+}

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -511,7 +511,19 @@ async function loadNoteById(somaHome: string, id: string): Promise<LoadedNote> {
       throw new MemoryNoteError(`Soma memory note ${id} at ${path} is a symlink; refusing to follow it out of the memory tree.`, "id");
     }
     const raw = await readFile(path, "utf8");
-    return { path, type, note: parseMemoryNote(raw), raw };
+    const note = parseMemoryNote(raw);
+    // Bind the id==filename-stem (and type==dir) invariant the M0 parser
+    // documents but cannot enforce (a content parser has no path). Without this,
+    // `semantic/foo.md` containing `id: bar` would let verify/merge target a
+    // different logical note than the caller named.
+    if (note.id !== id || note.type !== type) {
+      throw new MemoryNoteError(
+        `Soma memory note at ${path} has mismatched frontmatter (id/type "${note.id}"/"${note.type}" ` +
+          `≠ path "${id}"/"${type}"); refusing to mutate a mis-filed note.`,
+        "id",
+      );
+    }
+    return { path, type, note, raw };
   }
   throw new MemoryNoteError(`Soma memory note not found: ${id}`, "id");
 }

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -10,10 +10,12 @@ import type {
   SomaMemoryDuplicateCandidate,
   SomaMemoryNote,
   SomaMemoryNoteType,
+  SomaMemoryTrust,
   SomaMemoryVerifyOptions,
   SomaMemoryVerifyResult,
   SomaMemoryWriteOptions,
   SomaMemoryWriteResult,
+  SomaMemoryWriteTrigger,
 } from "./types";
 
 /**
@@ -58,6 +60,14 @@ const WRITABLE_TYPE_DIRS: Record<Exclude<SomaMemoryNoteType, "episodic">, string
 };
 
 type WritableType = Exclude<SomaMemoryNoteType, "episodic">;
+
+// One source of truth for the writable-type enumeration — every helper that
+// walks both durable dirs reuses this instead of re-casting Object.keys.
+const WRITABLE_TYPES = Object.keys(WRITABLE_TYPE_DIRS) as WritableType[];
+
+// Trust ordering for the mutation gate: content may never be injected into a
+// note of HIGHER trust than the mutation's own trigger carries.
+const TRUST_RANK: Record<SomaMemoryTrust, number> = { quarantined: 0, assistant: 1, principal: 2 };
 
 function assertNonEmpty(value: string | undefined, field: string): asserts value is string {
   if (value === undefined || value.trim().length === 0) {
@@ -172,19 +182,41 @@ interface LoadedNote extends ScannedNote {
 }
 
 /**
- * A mutation of an existing `principal`-trust note (merge body, or supersede-close)
- * carries the same weight as minting principal trust — it must go through the
- * same deliberate escalation, or a tool/import caller could inject into (or
- * invalidate) trusted memory while preserving its trust.
+ * Guard every mutation of an EXISTING note (merge body, supersede-close). Two
+ * rules, both anti-injection:
+ *   1. The mutation's trigger-trust must be ≥ the target's trust — a tool/import
+ *      caller (quarantined) can never inject content into an assistant/principal
+ *      note while the note keeps its higher trust ("import is always quarantined"
+ *      would otherwise be a lie for merges).
+ *   2. Mutating a `principal` note additionally needs the explicit
+ *      `principalAuthority` escalation — the same deliberate, logged act that
+ *      minted it.
  */
-function assertMayMutatePrincipal(target: SomaMemoryNote, options: SomaMemoryWriteOptions): void {
-  if (target.trust !== "principal") return;
-  if (options.trigger === "principal-correction" && options.principalAuthority === true) return;
-  throw new MemoryNoteError(
-    `Mutating principal-trust note ${target.id} requires --trigger principal-correction and --principal-authority ` +
-      `(the same deliberate escalation that minted it).`,
-    "trigger",
-  );
+function assertMayMutate(target: SomaMemoryNote, trigger: SomaMemoryWriteTrigger, principalAuthority: boolean): void {
+  const incoming = SOMA_MEMORY_TRIGGER_TRUST[trigger];
+  if (TRUST_RANK[incoming] < TRUST_RANK[target.trust]) {
+    throw new MemoryNoteError(
+      `Cannot mutate ${target.trust}-trust note ${target.id} with ${incoming}-trust content ` +
+        `(trigger ${trigger}) — a mutation may not inject lower-trust content.`,
+      "trigger",
+    );
+  }
+  if (target.trust === "principal" && !principalAuthority) {
+    throw new MemoryNoteError(
+      `Mutating principal-trust note ${target.id} requires --principal-authority ` +
+        `(the same deliberate escalation that minted it).`,
+      "principalAuthority",
+    );
+  }
+}
+
+/**
+ * Event metadata that records the principal-authority escalation, so an audit
+ * can prove from the journal alone that a principal-trust mutation was
+ * authorized. Emitted whenever the resulting/target note is principal-trust.
+ */
+function principalAuthorityMeta(trust: SomaMemoryTrust): Record<string, unknown> {
+  return trust === "principal" ? { principalAuthority: true } : {};
 }
 
 // Bounded read concurrency for the dedup scan — parallel enough to not serialize
@@ -201,7 +233,7 @@ async function collectDurableNotes(somaHome: string): Promise<ScannedNote[]> {
   // bounded concurrency window (shared helper) rather than one unbounded
   // Promise.all over the whole tree.
   const targets: { path: string; type: WritableType }[] = [];
-  for (const type of Object.keys(WRITABLE_TYPE_DIRS) as WritableType[]) {
+  for (const type of WRITABLE_TYPES) {
     const dir = typeDir(somaHome, type);
     const entries = (await readdir(dir).catch(() => [] as string[])).filter((entry) => entry.endsWith(".md"));
     for (const entry of entries) targets.push({ path: join(dir, entry), type });
@@ -312,7 +344,7 @@ async function writeNoteFile(path: string, note: SomaMemoryNote, flag: "wx" | "w
  */
 async function loadNoteById(somaHome: string, id: string): Promise<LoadedNote> {
   assertNoteId(id); // a lookup id is also a path segment — never probe an unsafe one
-  for (const type of Object.keys(WRITABLE_TYPE_DIRS) as WritableType[]) {
+  for (const type of WRITABLE_TYPES) {
     const path = memoryNotePath(somaHome, type, id);
     const raw = await readFile(path, "utf8").catch(() => undefined);
     if (raw === undefined) continue;
@@ -329,7 +361,7 @@ async function loadNoteById(somaHome: string, id: string): Promise<LoadedNote> {
  */
 async function noteIdExists(somaHome: string, id: string): Promise<boolean> {
   assertNoteId(id);
-  for (const type of Object.keys(WRITABLE_TYPE_DIRS) as WritableType[]) {
+  for (const type of WRITABLE_TYPES) {
     const exists = await access(memoryNotePath(somaHome, type, id)).then(
       () => true,
       () => false,
@@ -384,6 +416,14 @@ function buildNewNote(options: SomaMemoryWriteOptions, now: Date): SomaMemoryNot
 async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now: Date): Promise<SomaMemoryWriteResult> {
   const note = buildNewNote(options, now);
 
+  // Cheap path-existence check FIRST — reject an id collision before paying for
+  // the whole-corpus dedup scan. Ids are globally unique across types, so this
+  // also rejects `procedural/foo` when `semantic/foo` exists (`wx` below only
+  // catches a same-path collision).
+  if (await noteIdExists(somaHome, note.id)) {
+    throw new MemoryNoteError(`Soma memory note id already exists: ${note.id}`, "id");
+  }
+
   if (!options.force) {
     const candidates = await findDuplicateCandidates(somaHome, note.body);
     if (candidates.length > 0) {
@@ -393,13 +433,6 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
           `Re-run with --merge <id>, --supersede <id>, or --force.`,
       );
     }
-  }
-
-  // Ids are globally unique across types — reject `procedural/foo` when
-  // `semantic/foo` exists, so id-based lookups (verify/merge/supersede) are
-  // never ambiguous. (`wx` below only catches a same-path collision.)
-  if (await noteIdExists(somaHome, note.id)) {
-    throw new MemoryNoteError(`Soma memory note id already exists: ${note.id}`, "id");
   }
 
   const path = memoryNotePath(somaHome, note.type as WritableType, note.id);
@@ -418,8 +451,7 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
         type: note.type,
         trust: note.trust,
         trigger: options.trigger,
-        // Audit the principal-trust escalation when it happened.
-        ...(options.trigger === "principal-correction" ? { principalAuthority: true } : {}),
+        ...principalAuthorityMeta(note.trust), // audit the escalation when principal
       },
     },
     () => unlink(path), // roll back: remove the freshly created file
@@ -435,7 +467,7 @@ async function mergeNote(somaHome: string, options: SomaMemoryWriteOptions, now:
   if (note.valid_until !== null) {
     throw new MemoryNoteError(`Cannot merge into superseded note ${note.id} (valid_until set).`, "targetId");
   }
-  assertMayMutatePrincipal(note, options); // injecting into a principal note needs the escalation
+  assertMayMutate(note, options.trigger, options.principalAuthority === true);
 
   const today = isoDate(now);
   const merged: SomaMemoryNote = {
@@ -453,7 +485,8 @@ async function mergeNote(somaHome: string, options: SomaMemoryWriteOptions, now:
       kind: "memory.write.merge",
       summary: `Merged update into memory note ${merged.id} (${type})`,
       artifactPaths: [path],
-      metadata: { id: merged.id, type },
+      // Log the escalation so an audit can prove a principal-note mutation was authorized.
+      metadata: { id: merged.id, type, trust: merged.trust, trigger: options.trigger, ...principalAuthorityMeta(merged.trust) },
     },
     () => writeFile(path, raw, "utf8"), // roll back: restore the pre-merge bytes
   );
@@ -476,7 +509,11 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
   if (old.note.valid_until !== null) {
     throw new MemoryNoteError(`Note ${old.note.id} is already superseded (valid_until set).`, "targetId");
   }
-  assertMayMutatePrincipal(old.note, options); // closing a principal note needs the escalation
+  // Closing an existing note is a mutation of it — same trust gate as merge
+  // (can't close a higher-trust note with lower-trust content; principal needs
+  // the escalation). The new replacement note's own trust was already gated in
+  // buildNewNote.
+  assertMayMutate(old.note, options.trigger, options.principalAuthority === true);
 
   // New note points back at what it replaces; the closed note points forward.
   if (!newNote.links.includes(old.note.id)) newNote.links = [...newNote.links, old.note.id];
@@ -503,7 +540,13 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
       kind: "memory.write.supersede",
       summary: `Note ${newNote.id} supersedes ${closed.id} (closed ${closed.valid_until})`,
       artifactPaths: [newPath, old.path],
-      metadata: { id: newNote.id, supersededId: closed.id },
+      // Log the escalation when either the new note or the closed one is principal-trust.
+      metadata: {
+        id: newNote.id,
+        supersededId: closed.id,
+        trigger: options.trigger,
+        ...principalAuthorityMeta(TRUST_RANK[newNote.trust] >= TRUST_RANK[closed.trust] ? newNote.trust : closed.trust),
+      },
     },
     // roll back BOTH sides — reopen the closed note FIRST (the trusted state we
     // most need to restore), then drop the new one. Failures are NOT swallowed:
@@ -543,6 +586,18 @@ export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promis
   const now = options.now ?? new Date();
   const { path, type, note, raw } = await loadNoteById(somaHome, options.id);
 
+  // Verifying a principal note refreshes its decay signal — a principal-note
+  // mutation, so it needs the same escalation. (Verify has no trigger; a
+  // principal note verified WITH authority is treated as a principal-correction
+  // for the trust-rank check.)
+  if (note.trust === "principal" && options.principalAuthority !== true) {
+    throw new MemoryNoteError(
+      `Verifying principal-trust note ${note.id} requires --principal-authority ` +
+        `(refreshing its decay signal is a principal-note mutation).`,
+      "principalAuthority",
+    );
+  }
+
   const verified: SomaMemoryNote = {
     ...note,
     last_verified: isoDate(now),
@@ -558,7 +613,7 @@ export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promis
       kind: "memory.verify",
       summary: `Verified memory note ${verified.id} (${type}); resurface_count ${verified.resurface_count}`,
       artifactPaths: [path],
-      metadata: { id: verified.id, type, resurfaceCount: verified.resurface_count },
+      metadata: { id: verified.id, type, resurfaceCount: verified.resurface_count, ...principalAuthorityMeta(note.trust) },
     },
     () => writeFile(path, raw, "utf8"), // roll back: restore the pre-verify bytes
   );

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -19,9 +19,9 @@ import type {
  * Memory write + verify (subsystem M1). Plan v2 §M1 (do not redesign the
  * governance model):
  *
- * - **Trust is derived from the trigger**, never a caller flag — an agent cannot
- *   self-assert `principal`. `principal-correction` is the sole path to
- *   `principal` trust and is the documented human-authority gate; `import` is
+ * - **Trust is derived from the trigger**, never a caller flag — a substrate-side
+ *   caller cannot self-assert `principal`. `principal-correction` is the sole path
+ *   to `principal` trust and is the documented human-authority gate; `import` is
  *   always `quarantined` (MINJA defense); `consolidation` is `assistant`.
  * - **Recall-first refusal** — `create` walks the durable corpus (`semantic/` +
  *   `procedural/`), hashes normalized bodies, and refuses when an active note is
@@ -31,7 +31,10 @@ import type {
  * - **Invalidate, never delete** — `supersede` sets the old note's `valid_until`
  *   and cross-links; nothing is unlinked. `merge` delta-appends (ACE-style,
  *   never regenerates).
- * - One mutating call → exactly one events journal line.
+ * - One mutating call → exactly one events journal line: the file write and its
+ *   event append are atomic — if the append fails, the file mutation is rolled
+ *   back (created files unlinked, edited files restored to prior bytes), so the
+ *   journal never under- or over-counts a mutation.
  *
  * Deterministic: dates come from an injected `now` (UTC), no LLM calls, writes
  * stay within the Soma memory tree under `memory/semantic/` + `memory/procedural/`.
@@ -55,6 +58,36 @@ function assertNonEmpty(value: string | undefined, field: string): asserts value
   if (value === undefined || value.trim().length === 0) {
     throw new MemoryNoteError(`Soma memory write ${field} must not be empty.`, field);
   }
+}
+
+// Same slug grammar the M0 parser enforces on `id`. Validated HERE at the write
+// boundary — before the id is ever joined into a filesystem path — so a
+// traversal id (`../../evil`) is refused up front rather than incidentally by
+// serialize's round-trip re-parse. Defense in depth: memoryNotePath must never
+// receive an unvalidated id.
+const NOTE_ID_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+function assertNoteId(id: string): void {
+  if (!NOTE_ID_SLUG.test(id) || id.length > 64) {
+    throw new MemoryNoteError(`id "${id}" is not a valid slug (lowercase [a-z0-9-], <=64 chars).`, "id");
+  }
+}
+
+/**
+ * Append the mutation's event; on failure, roll the file mutation back so the
+ * "one mutation → one event" invariant holds. `rollback` restores disk to its
+ * pre-mutation state (unlink a created file, or rewrite an edited one's prior
+ * bytes).
+ */
+async function appendMutationEvent(
+  somaHome: string,
+  input: Parameters<typeof appendSomaMemoryEvent>[1],
+  rollback: () => Promise<void>,
+): ReturnType<typeof appendSomaMemoryEvent> {
+  return appendSomaMemoryEvent(somaHome, input).catch(async (error: unknown) => {
+    await rollback().catch(() => undefined);
+    throw new Error(`Soma memory ${input.kind} event append failed; rolled back the file mutation.`, { cause: error });
+  });
 }
 
 /** YYYY-MM-DD in UTC — matches the note schema's calendar-date grammar. */
@@ -111,29 +144,34 @@ interface LoadedNote {
   path: string;
   type: WritableType;
   note: SomaMemoryNote;
+  /** The exact on-disk bytes — used to restore the file on event-append rollback. */
+  raw: string;
 }
 
 /** Parse every `.md` note under the durable corpus; skip unreadable/malformed. */
 async function collectDurableNotes(somaHome: string): Promise<LoadedNote[]> {
-  const loaded: LoadedNote[] = [];
-  for (const type of Object.keys(WRITABLE_TYPE_DIRS) as WritableType[]) {
-    const dir = typeDir(somaHome, type);
-    const entries = await readdir(dir).catch(() => [] as string[]);
-    for (const entry of entries) {
-      if (!entry.endsWith(".md")) continue;
-      const path = join(dir, entry);
-      const content = await readFile(path, "utf8").catch(() => undefined);
-      if (content === undefined) continue;
-      let note: SomaMemoryNote;
-      try {
-        note = parseMemoryNote(content);
-      } catch {
-        continue; // a hand-broken note must not block a legitimate write
-      }
-      loaded.push({ path, type, note });
-    }
-  }
-  return loaded;
+  // Read files with per-directory parallelism (matches src/memory.ts's search
+  // walk) — a create against a large corpus must not serialize on every read.
+  const perType = await Promise.all(
+    (Object.keys(WRITABLE_TYPE_DIRS) as WritableType[]).map(async (type) => {
+      const dir = typeDir(somaHome, type);
+      const entries = (await readdir(dir).catch(() => [] as string[])).filter((entry) => entry.endsWith(".md"));
+      const notes = await Promise.all(
+        entries.map(async (entry): Promise<LoadedNote | undefined> => {
+          const path = join(dir, entry);
+          const content = await readFile(path, "utf8").catch(() => undefined);
+          if (content === undefined) return undefined;
+          try {
+            return { path, type, note: parseMemoryNote(content), raw: content };
+          } catch {
+            return undefined; // a hand-broken note must not block a legitimate write
+          }
+        }),
+      );
+      return notes.filter((entry): entry is LoadedNote => entry !== undefined);
+    }),
+  );
+  return perType.flat();
 }
 
 /**
@@ -226,6 +264,7 @@ async function loadNoteById(somaHome: string, id: string): Promise<LoadedNote> {
 
 function buildNewNote(options: SomaMemoryWriteOptions, now: Date): SomaMemoryNote {
   assertNonEmpty(options.id, "id");
+  assertNoteId(options.id);
   if (options.type === undefined || options.type === "episodic") {
     throw new MemoryNoteError(`type must be "semantic" or "procedural" (episodic writes go through digest/action, M5).`, "type");
   }
@@ -268,17 +307,18 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
   const path = memoryNotePath(somaHome, note.type as WritableType, note.id);
   await writeNoteFile(path, note, "wx");
 
-  const event = await appendSomaMemoryEvent(somaHome, {
-    timestamp: now.toISOString(),
-    substrate: options.substrate ?? "custom",
-    kind: "memory.write.create",
-    summary: `Created memory note ${note.id} (${note.type}, trust ${note.trust})`,
-    artifactPaths: [path],
-    metadata: { id: note.id, type: note.type, trust: note.trust, trigger: options.trigger },
-  }).catch(async (error: unknown) => {
-    await unlink(path).catch(() => undefined);
-    throw new Error(`Soma memory write event append failed; removed note: ${path}`, { cause: error });
-  });
+  const event = await appendMutationEvent(
+    somaHome,
+    {
+      timestamp: now.toISOString(),
+      substrate: options.substrate ?? "custom",
+      kind: "memory.write.create",
+      summary: `Created memory note ${note.id} (${note.type}, trust ${note.trust})`,
+      artifactPaths: [path],
+      metadata: { id: note.id, type: note.type, trust: note.trust, trigger: options.trigger },
+    },
+    () => unlink(path), // roll back: remove the freshly created file
+  );
 
   return { somaHome, mode: "create", path, note, event };
 }
@@ -286,7 +326,7 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
 async function mergeNote(somaHome: string, options: SomaMemoryWriteOptions, now: Date): Promise<SomaMemoryWriteResult> {
   assertNonEmpty(options.targetId, "targetId");
   assertNonEmpty(options.body, "body");
-  const { path, type, note } = await loadNoteById(somaHome, options.targetId);
+  const { path, type, note, raw } = await loadNoteById(somaHome, options.targetId);
   if (note.valid_until !== null) {
     throw new MemoryNoteError(`Cannot merge into superseded note ${note.id} (valid_until set).`, "targetId");
   }
@@ -299,14 +339,18 @@ async function mergeNote(somaHome: string, options: SomaMemoryWriteOptions, now:
   };
   await writeNoteFile(path, merged, "w");
 
-  const event = await appendSomaMemoryEvent(somaHome, {
-    timestamp: now.toISOString(),
-    substrate: options.substrate ?? "custom",
-    kind: "memory.write.merge",
-    summary: `Merged update into memory note ${merged.id} (${type})`,
-    artifactPaths: [path],
-    metadata: { id: merged.id, type },
-  });
+  const event = await appendMutationEvent(
+    somaHome,
+    {
+      timestamp: now.toISOString(),
+      substrate: options.substrate ?? "custom",
+      kind: "memory.write.merge",
+      summary: `Merged update into memory note ${merged.id} (${type})`,
+      artifactPaths: [path],
+      metadata: { id: merged.id, type },
+    },
+    () => writeFile(path, raw, "utf8"), // roll back: restore the pre-merge bytes
+  );
 
   return { somaHome, mode: "merge", path, note: merged, event };
 }
@@ -340,17 +384,22 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
     throw error;
   }
 
-  const event = await appendSomaMemoryEvent(somaHome, {
-    timestamp: now.toISOString(),
-    substrate: options.substrate ?? "custom",
-    kind: "memory.write.supersede",
-    summary: `Note ${newNote.id} supersedes ${closed.id} (closed ${closed.valid_until})`,
-    artifactPaths: [newPath, old.path],
-    metadata: { id: newNote.id, supersededId: closed.id },
-  }).catch(async (error: unknown) => {
-    await unlink(newPath).catch(() => undefined);
-    throw new Error(`Soma memory supersede event append failed; rolled back new note: ${newPath}`, { cause: error });
-  });
+  const event = await appendMutationEvent(
+    somaHome,
+    {
+      timestamp: now.toISOString(),
+      substrate: options.substrate ?? "custom",
+      kind: "memory.write.supersede",
+      summary: `Note ${newNote.id} supersedes ${closed.id} (closed ${closed.valid_until})`,
+      artifactPaths: [newPath, old.path],
+      metadata: { id: newNote.id, supersededId: closed.id },
+    },
+    // roll back BOTH sides: drop the new note AND reopen the closed one.
+    async () => {
+      await unlink(newPath).catch(() => undefined);
+      await writeFile(old.path, old.raw, "utf8").catch(() => undefined);
+    },
+  );
 
   return { somaHome, mode: "supersede", path: newPath, note: newNote, supersededId: closed.id, event };
 }
@@ -379,7 +428,7 @@ export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promis
   assertNonEmpty(options.id, "id");
   const somaHome = createPaths(options).root();
   const now = options.now ?? new Date();
-  const { path, type, note } = await loadNoteById(somaHome, options.id);
+  const { path, type, note, raw } = await loadNoteById(somaHome, options.id);
 
   const verified: SomaMemoryNote = {
     ...note,
@@ -388,14 +437,18 @@ export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promis
   };
   await writeNoteFile(path, verified, "w");
 
-  const event = await appendSomaMemoryEvent(somaHome, {
-    timestamp: now.toISOString(),
-    substrate: options.substrate ?? "custom",
-    kind: "memory.verify",
-    summary: `Verified memory note ${verified.id} (${type}); resurface_count ${verified.resurface_count}`,
-    artifactPaths: [path],
-    metadata: { id: verified.id, type, resurfaceCount: verified.resurface_count },
-  });
+  const event = await appendMutationEvent(
+    somaHome,
+    {
+      timestamp: now.toISOString(),
+      substrate: options.substrate ?? "custom",
+      kind: "memory.verify",
+      summary: `Verified memory note ${verified.id} (${type}); resurface_count ${verified.resurface_count}`,
+      artifactPaths: [path],
+      metadata: { id: verified.id, type, resurfaceCount: verified.resurface_count },
+    },
+    () => writeFile(path, raw, "utf8"), // roll back: restore the pre-verify bytes
+  );
 
   return { somaHome, path, note: verified, event };
 }

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createPaths } from "./paths";
 import { appendSomaMemoryEvent } from "./memory";
@@ -142,16 +142,39 @@ function jaccard(a: Set<string>, b: Set<string>): number {
   return union === 0 ? 0 : intersection / union;
 }
 
-interface LoadedNote {
+interface ScannedNote {
   path: string;
   type: WritableType;
   note: SomaMemoryNote;
+}
+
+interface LoadedNote extends ScannedNote {
   /** The exact on-disk bytes — used to restore the file on event-append rollback. */
   raw: string;
 }
 
-/** Parse every `.md` note under the durable corpus; skip unreadable/malformed. */
-async function collectDurableNotes(somaHome: string): Promise<LoadedNote[]> {
+/**
+ * A mutation of an existing `principal`-trust note (merge body, or supersede-close)
+ * carries the same weight as minting principal trust — it must go through the
+ * same deliberate escalation, or a tool/import caller could inject into (or
+ * invalidate) trusted memory while preserving its trust.
+ */
+function assertMayMutatePrincipal(target: SomaMemoryNote, options: SomaMemoryWriteOptions): void {
+  if (target.trust !== "principal") return;
+  if (options.trigger === "principal-correction" && options.principalAuthority === true) return;
+  throw new MemoryNoteError(
+    `Mutating principal-trust note ${target.id} requires --trigger principal-correction and --principal-authority ` +
+      `(the same deliberate escalation that minted it).`,
+    "trigger",
+  );
+}
+
+/**
+ * Parse every `.md` note under the durable corpus; skip unreadable/malformed.
+ * Returns `ScannedNote` (no `raw`) — the only caller is the dedup scan, which
+ * never needs the bytes; `loadNoteById` reads raw itself for its rollback path.
+ */
+async function collectDurableNotes(somaHome: string): Promise<ScannedNote[]> {
   // Read files with per-directory parallelism (matches src/memory.ts's search
   // walk) — a create against a large corpus must not serialize on every read.
   const perType = await Promise.all(
@@ -159,18 +182,18 @@ async function collectDurableNotes(somaHome: string): Promise<LoadedNote[]> {
       const dir = typeDir(somaHome, type);
       const entries = (await readdir(dir).catch(() => [] as string[])).filter((entry) => entry.endsWith(".md"));
       const notes = await Promise.all(
-        entries.map(async (entry): Promise<LoadedNote | undefined> => {
+        entries.map(async (entry): Promise<ScannedNote | undefined> => {
           const path = join(dir, entry);
           const content = await readFile(path, "utf8").catch(() => undefined);
           if (content === undefined) return undefined;
           try {
-            return { path, type, note: parseMemoryNote(content), raw: content };
+            return { path, type, note: parseMemoryNote(content) };
           } catch {
             return undefined; // a hand-broken note must not block a legitimate write
           }
         }),
       );
-      return notes.filter((entry): entry is LoadedNote => entry !== undefined);
+      return notes.filter((entry): entry is ScannedNote => entry !== undefined);
     }),
   );
   return perType.flat();
@@ -271,12 +294,22 @@ async function loadNoteById(somaHome: string, id: string): Promise<LoadedNote> {
   throw new MemoryNoteError(`Soma memory note not found: ${id}`, "id");
 }
 
-/** True iff a note with this id already exists under EITHER durable type. */
+/**
+ * True iff a note FILE with this id already exists under either durable type.
+ * A pure presence check (`access`), NOT a parse — a malformed `semantic/<id>.md`
+ * must still block a colliding `procedural/<id>.md`, so id uniqueness holds even
+ * over a hand-corrupted corpus.
+ */
 async function noteIdExists(somaHome: string, id: string): Promise<boolean> {
-  return loadNoteById(somaHome, id).then(
-    () => true,
-    () => false,
-  );
+  assertNoteId(id);
+  for (const type of Object.keys(WRITABLE_TYPE_DIRS) as WritableType[]) {
+    const exists = await access(memoryNotePath(somaHome, type, id)).then(
+      () => true,
+      () => false,
+    );
+    if (exists) return true;
+  }
+  return false;
 }
 
 // --- create / merge / supersede ----------------------------------------------
@@ -375,6 +408,7 @@ async function mergeNote(somaHome: string, options: SomaMemoryWriteOptions, now:
   if (note.valid_until !== null) {
     throw new MemoryNoteError(`Cannot merge into superseded note ${note.id} (valid_until set).`, "targetId");
   }
+  assertMayMutatePrincipal(note, options); // injecting into a principal note needs the escalation
 
   const today = isoDate(now);
   const merged: SomaMemoryNote = {
@@ -415,6 +449,7 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
   if (old.note.valid_until !== null) {
     throw new MemoryNoteError(`Note ${old.note.id} is already superseded (valid_until set).`, "targetId");
   }
+  assertMayMutatePrincipal(old.note, options); // closing a principal note needs the escalation
 
   // New note points back at what it replaces; the closed note points forward.
   if (!newNote.links.includes(old.note.id)) newNote.links = [...newNote.links, old.note.id];

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import { lstat, mkdir, readdir, readFile, realpath, unlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, open, readdir, readFile, realpath, unlink, writeFile } from "node:fs/promises";
+import { constants as FS } from "node:fs";
 import { dirname, isAbsolute, join, relative, sep } from "node:path";
 import { createPaths } from "./paths";
 import { runBoundedConcurrent } from "./internal-concurrency";
@@ -433,16 +434,36 @@ async function assertWriteContained(somaHome: string, path: string): Promise<voi
   }
 }
 
+/**
+ * Overwrite an EXISTING note's bytes with O_NOFOLLOW, closing the leaf-symlink
+ * TOCTOU: after the containment check, an attacker could swap the leaf for a
+ * symlink before the write. `wx` (create) is immune — O_CREAT|O_EXCL refuses a
+ * pre-existing symlink — but an overwrite ("w") would follow one, so open the
+ * leaf with O_NOFOLLOW and let `open` fail (ELOOP) rather than escape.
+ */
+async function overwriteNoFollow(path: string, content: string): Promise<void> {
+  const fh = await open(path, FS.O_WRONLY | FS.O_CREAT | FS.O_TRUNC | FS.O_NOFOLLOW, 0o644);
+  try {
+    await fh.writeFile(content, "utf8");
+  } finally {
+    await fh.close();
+  }
+}
+
 async function writeNoteFile(somaHome: string, path: string, note: SomaMemoryNote, flag: "wx" | "w"): Promise<void> {
   const content = serializeMemoryNote(note); // enforces the round-trip law before any byte hits disk
   await mkdir(dirname(path), { recursive: true });
-  await assertWriteContained(somaHome, path);
+  await assertWriteContained(somaHome, path); // parent-dir symlink guard
   try {
-    await writeFile(path, content, { encoding: "utf8", flag });
+    if (flag === "w") await overwriteNoFollow(path, content); // leaf-symlink guard
+    else await writeFile(path, content, { encoding: "utf8", flag });
   } catch (error) {
     const code = error instanceof Error && "code" in error ? error.code : undefined;
     if (code === "EEXIST") {
       throw new MemoryNoteError(`Soma memory note already exists: ${path}`, "id");
+    }
+    if (code === "ELOOP") {
+      throw new MemoryNoteError(`Refusing write: ${path} is a symlink (O_NOFOLLOW).`, "id");
     }
     throw error;
   }
@@ -451,12 +472,13 @@ async function writeNoteFile(somaHome: string, path: string, note: SomaMemoryNot
 /**
  * Restore raw bytes to `path` on a rollback, recreating the parent dir first —
  * a normal write always recreates parents (writeNoteFile), so the restore path
- * must too, or an externally-removed directory would defeat the rollback.
+ * must too, or an externally-removed directory would defeat the rollback. Uses
+ * the same O_NOFOLLOW overwrite as an edit so a rollback can't be redirected.
  */
 async function restoreBytes(somaHome: string, path: string, raw: string): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   await assertWriteContained(somaHome, path);
-  await writeFile(path, raw, "utf8");
+  await overwriteNoFollow(path, raw);
 }
 
 /**
@@ -683,9 +705,21 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
   await writeNoteFile(somaHome, newPath, newNote, "wx");
   try {
     await writeNoteFile(somaHome, old.path, closed, "w");
-  } catch (error) {
-    await unlink(newPath).catch(() => undefined); // keep the supersede atomic-ish
-    throw error;
+  } catch (closeError) {
+    // Closing the old note failed (possibly after truncating it) and no event
+    // exists yet — fully undo: restore the old note's bytes AND drop the new one.
+    // Do NOT swallow the undo's own failures; surface them as an inconsistency.
+    try {
+      await restoreBytes(somaHome, old.path, old.raw);
+      await unlink(newPath);
+    } catch (undoError) {
+      throw new Error(
+        `Soma memory supersede failed to close ${old.note.id} AND the undo failed — ` +
+          `memory may be inconsistent; reconcile manually.`,
+        { cause: undoError },
+      );
+    }
+    throw closeError;
   }
 
   const event = await appendNoteMutationEvent(

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -666,12 +666,16 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
       kind: "memory.write.supersede",
       summary: `Note ${newNote.id} supersedes ${closed.id} (closed ${closed.valid_until})`,
       artifactPaths: [newPath, old.path],
-      // Log the escalation when either the new note or the closed one is principal-trust.
+      // Supersede validates TWO authorities — minting the new note (its tier) and
+      // closing the old one (its tier). Log BOTH so the journal can prove every
+      // required signal was present (e.g. principal replacement of an assistant
+      // note carries both principalAuthority and consolidationAuthority).
       metadata: {
         id: newNote.id,
         supersededId: closed.id,
         trigger: options.trigger,
-        ...authorityMeta(TRUST_RANK[newNote.trust] >= TRUST_RANK[closed.trust] ? newNote.trust : closed.trust),
+        ...authorityMeta(newNote.trust),
+        ...authorityMeta(closed.trust),
       },
     },
     // roll back BOTH sides — reopen the closed note FIRST (the trusted state we

--- a/src/types.ts
+++ b/src/types.ts
@@ -2405,7 +2405,8 @@ export interface SomaMemoryWriteOptions {
    * mints `assistant` trust, so it too requires an explicit signal — the internal
    * M6 consolidator's capability, not a tier an arbitrary CLI caller can select
    * by choosing the trigger. Without it, `--trigger consolidation` is refused.
-   * CLI flag `--consolidation-authority`. Ignored for principal/import triggers.
+   * This is an SDK-only option (set programmatically by the M6 consolidator) —
+   * intentionally NOT a public CLI flag. Ignored for principal/import triggers.
    */
   consolidationAuthority?: boolean;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2337,9 +2337,13 @@ export interface SomaMemoryNote {
 }
 
 // Memory subsystem M1 (write + verify). Plan v2 §M1 (do not redesign the
-// governance model): trust is NOT a self-assertable caller flag — it is DERIVED
-// from the write trigger, so a substrate-side caller cannot smuggle `principal`
-// trust (CONTEXT.md reserves bare `agent`; use `assistant`/substrate). THREE of
+// governance model): trust is NOT selectable via a `--trust` flag — it is DERIVED
+// from the write trigger, and elevating above `quarantined` needs a deliberate
+// authority signal. Honest scope: the ENFORCED boundary is the CLI surface (no
+// public self-assert path), not the SDK — an in-process caller can still set the
+// `principalAuthority`/`consolidationAuthority` booleans, as soma has no
+// cryptographic capability primitive (CONTEXT.md reserves bare `agent`; use
+// `assistant`/substrate). THREE of
 // design §7's five triggers reach the `write` path (principal-correction, import,
 // consolidation); the other two — session-end and consequential-action — are
 // M5's episodic `digest`/`action`, NOT `write`. M1 owns the durable, dedup-gated

--- a/src/types.ts
+++ b/src/types.ts
@@ -2349,8 +2349,8 @@ export interface SomaMemoryNote {
  * The governed write trigger (design §7). Trust is a pure function of this value
  * (see {@link SOMA_MEMORY_TRIGGER_TRUST}); there is no `--trust` flag. Only these
  * three reach the `write` path in M1:
- * - `principal-correction` — the human said "remember"/"no, always X". The ONLY
- *   path to `principal` trust, and the documented human-authority gate.
+ * - `principal-correction` — the principal said "remember"/"no, always X". The
+ *   ONLY path to `principal` trust, and the documented principal-authority gate.
  * - `import` — migration / external doc. Untrusted source → `quarantined` (MINJA
  *   defense: tool/web content never lands trusted).
  * - `consolidation` — the M6 consolidator promoting/merging → `assistant`.

--- a/src/types.ts
+++ b/src/types.ts
@@ -2438,6 +2438,13 @@ export interface SomaMemoryVerifyOptions {
   substrate?: SubstrateId;
   now?: Date;
   id: string;
+  /**
+   * Verifying mutates a note's decay signals (`last_verified`, `resurface_count`),
+   * so verifying a `principal`-trust note needs the same escalation as any other
+   * principal-note mutation — otherwise a tool caller could keep a principal note
+   * artificially fresh in the index. Ignored for non-principal notes.
+   */
+  principalAuthority?: boolean;
 }
 
 export interface SomaMemoryVerifyResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2427,7 +2427,7 @@ export interface SomaMemoryWriteResult {
   mode: SomaMemoryWriteMode;
   path: string;
   note: SomaMemoryNote;
-  /** supersede: the closed note's new path/state; merge: the pre-edit note. */
+  /** supersede only: the id of the note that was closed (valid_until set). Undefined for create/merge. */
   supersededId?: string;
   event: SomaMemoryEvent;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2335,3 +2335,101 @@ export interface SomaMemoryNote {
   review?: string;            // optional: review directive
   body: string;               // markdown after the closing ---
 }
+
+// Memory subsystem M1 (write + verify). Plan v2 §M1 (do not redesign the
+// governance model): trust is NOT a self-assertable caller flag — it is DERIVED
+// from the write trigger, so an agent cannot smuggle `principal` trust. The five
+// write triggers of design §7 map onto write-CLI actions; M1 owns the durable,
+// dedup-gated types (semantic + procedural). Episodic capture (session digest /
+// action log) is M5's `digest`/`action`, not `write`.
+
+/**
+ * The governed write trigger (design §7). Trust is a pure function of this value
+ * (see {@link SOMA_MEMORY_TRIGGER_TRUST}); there is no `--trust` flag. Only these
+ * three reach the `write` path in M1:
+ * - `principal-correction` — the human said "remember"/"no, always X". The ONLY
+ *   path to `principal` trust, and the documented human-authority gate.
+ * - `import` — migration / external doc. Untrusted source → `quarantined` (MINJA
+ *   defense: tool/web content never lands trusted).
+ * - `consolidation` — the M6 consolidator promoting/merging → `assistant`.
+ * (`session-end` and `consequential-action` are the other two design-§7 triggers;
+ * they belong to M5's episodic path, not `write`.)
+ */
+export const SOMA_MEMORY_WRITE_TRIGGERS = ["principal-correction", "import", "consolidation"] as const;
+export type SomaMemoryWriteTrigger = (typeof SOMA_MEMORY_WRITE_TRIGGERS)[number];
+
+/** Trust derived from trigger — the whole M1 governance model in one table. */
+export const SOMA_MEMORY_TRIGGER_TRUST: Record<SomaMemoryWriteTrigger, SomaMemoryTrust> = {
+  "principal-correction": "principal",
+  import: "quarantined",
+  consolidation: "assistant",
+};
+
+/** Create (dedup-gated), merge (delta-edit target), or supersede (close old + create new). */
+export type SomaMemoryWriteMode = "create" | "merge" | "supersede";
+
+/** A near-duplicate surfaced by the recall-first refusal gate (Jaccard ≥ 0.6 or exact-body hash). */
+export interface SomaMemoryDuplicateCandidate {
+  id: string;
+  type: SomaMemoryNoteType;
+  path: string;
+  /** 1.0 for an exact normalized-body hash match, else the Jaccard token-set score. */
+  score: number;
+  exact: boolean;
+}
+
+export interface SomaMemoryWriteOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate?: SubstrateId;
+  /** Injected clock for deterministic `created`/`last_verified`. Defaults to now. */
+  now?: Date;
+
+  mode: SomaMemoryWriteMode;
+  trigger: SomaMemoryWriteTrigger;
+
+  /** create/supersede: the new note's id. merge: unused (target is `--merge <id>`). */
+  id?: string;
+  type?: SomaMemoryNoteType;
+  body: string;
+  project?: string | null;
+  sourceOfTruth?: string | null;
+  links?: string[];
+  hook?: string;
+  review?: string;
+  /**
+   * Only meaningful for `import` (`import` or `tool:<name>`); forced to
+   * `conversation` for principal-correction and `consolidation` otherwise.
+   */
+  provenance?: string;
+
+  /** merge: id of the note to delta-edit. supersede: id of the note to close. */
+  targetId?: string;
+  /** create only: bypass the recall-first refusal gate. */
+  force?: boolean;
+}
+
+export interface SomaMemoryWriteResult {
+  somaHome: string;
+  mode: SomaMemoryWriteMode;
+  path: string;
+  note: SomaMemoryNote;
+  /** supersede: the closed note's new path/state; merge: the pre-edit note. */
+  supersededId?: string;
+  event: SomaMemoryEvent;
+}
+
+export interface SomaMemoryVerifyOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate?: SubstrateId;
+  now?: Date;
+  id: string;
+}
+
+export interface SomaMemoryVerifyResult {
+  somaHome: string;
+  path: string;
+  note: SomaMemoryNote;
+  event: SomaMemoryEvent;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2338,7 +2338,8 @@ export interface SomaMemoryNote {
 
 // Memory subsystem M1 (write + verify). Plan v2 §M1 (do not redesign the
 // governance model): trust is NOT a self-assertable caller flag — it is DERIVED
-// from the write trigger, so an agent cannot smuggle `principal` trust. The five
+// from the write trigger, so a substrate-side caller cannot smuggle `principal`
+// trust (CONTEXT.md reserves bare `agent`; use `assistant`/substrate). The five
 // write triggers of design §7 map onto write-CLI actions; M1 owns the durable,
 // dedup-gated types (semantic + procedural). Episodic capture (session digest /
 // action log) is M5's `digest`/`action`, not `write`.

--- a/src/types.ts
+++ b/src/types.ts
@@ -2400,6 +2400,14 @@ export interface SomaMemoryWriteOptions {
    * this gate exists to close). Ignored for import/consolidation triggers.
    */
   principalAuthority?: boolean;
+  /**
+   * The consolidation counterpart of {@link principalAuthority}: `consolidation`
+   * mints `assistant` trust, so it too requires an explicit signal — the internal
+   * M6 consolidator's capability, not a tier an arbitrary CLI caller can select
+   * by choosing the trigger. Without it, `--trigger consolidation` is refused.
+   * CLI flag `--consolidation-authority`. Ignored for principal/import triggers.
+   */
+  consolidationAuthority?: boolean;
 
   /** create/supersede: the new note's id. merge: unused (target is `--merge <id>`). */
   id?: string;
@@ -2440,11 +2448,13 @@ export interface SomaMemoryVerifyOptions {
   id: string;
   /**
    * Verifying mutates a note's decay signals (`last_verified`, `resurface_count`),
-   * so verifying a `principal`-trust note needs the same escalation as any other
-   * principal-note mutation — otherwise a tool caller could keep a principal note
-   * artificially fresh in the index. Ignored for non-principal notes.
+   * so verifying a non-quarantined note needs that tier's authority — otherwise a
+   * tool caller could keep a trusted note artificially fresh in the index.
+   * `principal` notes need this; ignored for quarantined notes.
    */
   principalAuthority?: boolean;
+  /** As above, for `assistant`-trust notes. Ignored for principal/quarantined notes. */
+  consolidationAuthority?: boolean;
 }
 
 export interface SomaMemoryVerifyResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2339,10 +2339,11 @@ export interface SomaMemoryNote {
 // Memory subsystem M1 (write + verify). Plan v2 §M1 (do not redesign the
 // governance model): trust is NOT a self-assertable caller flag — it is DERIVED
 // from the write trigger, so a substrate-side caller cannot smuggle `principal`
-// trust (CONTEXT.md reserves bare `agent`; use `assistant`/substrate). The five
-// write triggers of design §7 map onto write-CLI actions; M1 owns the durable,
-// dedup-gated types (semantic + procedural). Episodic capture (session digest /
-// action log) is M5's `digest`/`action`, not `write`.
+// trust (CONTEXT.md reserves bare `agent`; use `assistant`/substrate). THREE of
+// design §7's five triggers reach the `write` path (principal-correction, import,
+// consolidation); the other two — session-end and consequential-action — are
+// M5's episodic `digest`/`action`, NOT `write`. M1 owns the durable, dedup-gated
+// types (semantic + procedural).
 
 /**
  * The governed write trigger (design §7). Trust is a pure function of this value
@@ -2388,6 +2389,17 @@ export interface SomaMemoryWriteOptions {
 
   mode: SomaMemoryWriteMode;
   trigger: SomaMemoryWriteTrigger;
+  /**
+   * The deliberate-escalation gate for `principal` trust. `principal-correction`
+   * mints a `principal` note only when this is set — otherwise it is REFUSED, so
+   * an automated/agent invocation can never mint principal trust incidentally
+   * from the trigger alone. This is a sudo-style deliberate + logged escalation,
+   * NOT cryptographic principal authentication (soma has no such primitive — a
+   * recorded limitation). The CLI sets it from an explicit `--principal-authority`
+   * flag; it is intentionally NOT an env var (ambient authority is the footgun
+   * this gate exists to close). Ignored for import/consolidation triggers.
+   */
+  principalAuthority?: boolean;
 
   /** create/supersede: the new note's id. merge: unused (target is `--merge <id>`). */
   id?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2402,11 +2402,15 @@ export interface SomaMemoryWriteOptions {
   principalAuthority?: boolean;
   /**
    * The consolidation counterpart of {@link principalAuthority}: `consolidation`
-   * mints `assistant` trust, so it too requires an explicit signal — the internal
-   * M6 consolidator's capability, not a tier an arbitrary CLI caller can select
-   * by choosing the trigger. Without it, `--trigger consolidation` is refused.
-   * This is an SDK-only option (set programmatically by the M6 consolidator) —
-   * intentionally NOT a public CLI flag. Ignored for principal/import triggers.
+   * mints `assistant` trust, so it too requires an explicit signal. Like
+   * `principalAuthority`, this is a sudo-style deliberate flag, NOT a
+   * cryptographically enforced capability — at the SDK layer an in-process caller
+   * (intended: the M6 consolidator) sets it, exactly as they would set
+   * `principalAuthority`; soma has no capability primitive to make it
+   * unforgeable. What IS enforced is the surface: it is intentionally NOT exposed
+   * as a public CLI flag and `--trigger consolidation` is refused on the CLI, so
+   * the public command-line cannot mint assistant trust. Ignored for
+   * principal/import triggers.
    */
   consolidationAuthority?: boolean;
 

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -225,10 +225,15 @@ test("merging into a principal-trust note requires the principal-authority escal
   await withTempSoma(async (somaHome) => {
     await writeMemoryNote(createOpts(somaHome, { id: "principal-note" })); // trust principal
 
-    // A merge that doesn't carry the escalation cannot inject into trusted memory.
+    // Lower-trust content (import) can't inject at all — the trust-rank gate.
     await expect(
       writeMemoryNote({ somaHome, mode: "merge", trigger: "import", targetId: "principal-note", body: "sneaky injected text", now: LATER }),
-    ).rejects.toThrow(/Mutating principal-trust note/);
+    ).rejects.toThrow(/Cannot mutate principal-trust note/);
+
+    // A principal-correction merge WITHOUT authority is refused by the escalation gate.
+    await expect(
+      writeMemoryNote({ somaHome, mode: "merge", trigger: "principal-correction", targetId: "principal-note", body: "no authority", now: LATER }),
+    ).rejects.toThrow(/requires --principal-authority/);
 
     // With the escalation it goes through.
     const ok = await writeMemoryNote({
@@ -244,6 +249,16 @@ test("merging into a principal-trust note requires the principal-authority escal
   });
 });
 
+test("a lower-trust merge cannot inject into a higher-trust note (import into assistant)", async () => {
+  await withTempSoma(async (somaHome) => {
+    // assistant-trust note via consolidation trigger.
+    await writeMemoryNote(createOpts(somaHome, { id: "assistant-note", trigger: "consolidation", principalAuthority: false, body: "assistant fact iota kappa" }));
+    await expect(
+      writeMemoryNote({ somaHome, mode: "merge", trigger: "import", targetId: "assistant-note", body: "imported injection", now: LATER }),
+    ).rejects.toThrow(/Cannot mutate assistant-trust note .* with quarantined-trust content/);
+  });
+});
+
 test("superseding (closing) a principal-trust note requires the escalation", async () => {
   await withTempSoma(async (somaHome) => {
     await writeMemoryNote(createOpts(somaHome, { id: "trusted" }));
@@ -256,7 +271,7 @@ test("superseding (closing) a principal-trust note requires the escalation", asy
         principalAuthority: false,
         body: "replacement via import trigger phi chi",
       })),
-    ).rejects.toThrow(/Mutating principal-trust note/);
+    ).rejects.toThrow(/Cannot mutate principal-trust note/);
   });
 });
 
@@ -312,8 +327,8 @@ test("a note cannot supersede itself", async () => {
 
 test("verify bumps last_verified and increments resurface_count with one event", async () => {
   await withTempSoma(async (somaHome) => {
-    await writeMemoryNote(createOpts(somaHome, { id: "note" }));
-    const result = await verifyMemoryNote({ somaHome, id: "note", now: LATER });
+    await writeMemoryNote(createOpts(somaHome, { id: "note" })); // principal
+    const result = await verifyMemoryNote({ somaHome, id: "note", principalAuthority: true, now: LATER });
 
     expect(result.note.last_verified).toBe("2026-08-01");
     expect(result.note.resurface_count).toBe(1);
@@ -322,8 +337,19 @@ test("verify bumps last_verified and increments resurface_count with one event",
     expect(persisted.resurface_count).toBe(1);
     expect(await countEvents(somaHome)).toBe(2); // create + verify
 
-    const again = await verifyMemoryNote({ somaHome, id: "note", now: LATER });
+    const again = await verifyMemoryNote({ somaHome, id: "note", principalAuthority: true, now: LATER });
     expect(again.note.resurface_count).toBe(2);
+  });
+});
+
+test("verifying a principal note needs authority; a quarantined note does not", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "trusted" })); // principal
+    await expect(verifyMemoryNote({ somaHome, id: "trusted", now: LATER })).rejects.toThrow(/requires --principal-authority/);
+
+    await writeMemoryNote(createOpts(somaHome, { id: "imported", trigger: "import", principalAuthority: false, body: "imported fact mu nu xi" }));
+    const ok = await verifyMemoryNote({ somaHome, id: "imported", now: LATER }); // no authority needed
+    expect(ok.note.resurface_count).toBe(1);
   });
 });
 
@@ -387,7 +413,7 @@ test("verify rolls back when the event append fails", async () => {
     await writeMemoryNote(createOpts(somaHome, { id: "note" }));
     await breakEvents(somaHome);
 
-    await expect(verifyMemoryNote({ somaHome, id: "note", now: LATER })).rejects.toThrow();
+    await expect(verifyMemoryNote({ somaHome, id: "note", principalAuthority: true, now: LATER })).rejects.toThrow();
     const note = await readNote(memoryNotePath(somaHome, "semantic", "note"));
     expect(note.resurface_count).toBe(0); // the bump was rolled back
   });

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -120,7 +120,7 @@ test("import needs no authority; consolidation needs consolidation-authority", a
     // consolidation without its authority is refused (can't self-select assistant trust).
     await expect(
       writeMemoryNote(createOpts(somaHome, { id: "c", trigger: "consolidation", principalAuthority: false, body: "consolidated fact delta epsilon" })),
-    ).rejects.toThrow(/requires --consolidation-authority/);
+    ).rejects.toThrow(/requires consolidation authority/);
 
     // With the capability it mints assistant trust.
     const consolidated = await writeMemoryNote(createOpts(somaHome, { id: "c", trigger: "consolidation", consolidationAuthority: true, body: "consolidated fact delta epsilon" }));
@@ -383,10 +383,18 @@ test("verify on a missing id throws a typed error", async () => {
   });
 });
 
+test("verifying a superseded (closed) note is refused", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "old" }));
+    await writeMemoryNote(createOpts(somaHome, { mode: "supersede", id: "new", targetId: "old", body: "replacement body upsilon phi" }));
+    await expect(verifyMemoryNote({ somaHome, id: "old", principalAuthority: true, now: LATER })).rejects.toThrow(/Cannot verify superseded note/);
+  });
+});
+
 test("verifying an assistant note needs consolidation-authority", async () => {
   await withTempSoma(async (somaHome) => {
     await writeMemoryNote(createOpts(somaHome, { id: "asst", trigger: "consolidation", consolidationAuthority: true, body: "assistant fact for verify pi rho" }));
-    await expect(verifyMemoryNote({ somaHome, id: "asst", now: LATER })).rejects.toThrow(/requires --consolidation-authority/);
+    await expect(verifyMemoryNote({ somaHome, id: "asst", now: LATER })).rejects.toThrow(/requires consolidation authority/);
     const ok = await verifyMemoryNote({ somaHome, id: "asst", consolidationAuthority: true, now: LATER });
     expect(ok.note.resurface_count).toBe(1);
   });

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -1,0 +1,250 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { expect, test } from "bun:test";
+import {
+  MEMORY_DEDUP_JACCARD_THRESHOLD,
+  MemoryNoteError,
+  findDuplicateCandidates,
+  memoryNotePath,
+  parseMemoryNote,
+  somaMemoryEventsPath,
+  verifyMemoryNote,
+  writeMemoryNote,
+  type SomaMemoryNote,
+  type SomaMemoryWriteOptions,
+} from "../src/index";
+
+const NOW = new Date("2026-07-03T10:00:00.000Z");
+const LATER = new Date("2026-08-01T12:00:00.000Z");
+
+async function withTempSoma<T>(fn: (somaHome: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "soma-memwrite-"));
+  const somaHome = join(dir, ".soma");
+  try {
+    return await fn(somaHome);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function createOpts(somaHome: string, overrides: Partial<SomaMemoryWriteOptions> = {}): SomaMemoryWriteOptions {
+  return {
+    somaHome,
+    now: NOW,
+    mode: "create",
+    trigger: "principal-correction",
+    id: "prefers-colon-over-emdash",
+    type: "semantic",
+    body: "Andreas reads em-dashes as an AI tell; use a colon or comma instead.",
+    ...overrides,
+  };
+}
+
+async function readNote(path: string): Promise<SomaMemoryNote> {
+  return parseMemoryNote(await readFile(path, "utf8"));
+}
+
+async function countEvents(somaHome: string): Promise<number> {
+  const content = await readFile(somaMemoryEventsPath(somaHome), "utf8").catch(() => "");
+  return content.trim() === "" ? 0 : content.trim().split("\n").length;
+}
+
+test("create writes a semantic note with principal trust derived from the trigger", async () => {
+  await withTempSoma(async (somaHome) => {
+    const result = await writeMemoryNote(createOpts(somaHome));
+
+    expect(result.mode).toBe("create");
+    expect(result.path).toBe(memoryNotePath(somaHome, "semantic", "prefers-colon-over-emdash"));
+
+    const note = await readNote(result.path);
+    expect(note.id).toBe("prefers-colon-over-emdash");
+    expect(note.type).toBe("semantic");
+    expect(note.trust).toBe("principal");
+    expect(note.provenance).toBe("conversation");
+    expect(note.created).toBe("2026-07-03");
+    expect(note.last_verified).toBe("2026-07-03");
+    expect(note.valid_until).toBeNull();
+    expect(note.resurface_count).toBe(0);
+    expect(await countEvents(somaHome)).toBe(1);
+  });
+});
+
+test("trust is derived from the trigger — no --trust flag can override it", async () => {
+  await withTempSoma(async (somaHome) => {
+    const principal = await writeMemoryNote(createOpts(somaHome, { id: "a" }));
+    const imported = await writeMemoryNote(
+      createOpts(somaHome, { id: "b", trigger: "import", body: "totally different imported fact about zeta", provenance: "tool:scraper" }),
+    );
+    const consolidated = await writeMemoryNote(
+      createOpts(somaHome, { id: "c", trigger: "consolidation", body: "consolidated abstraction over gamma delta epsilon" }),
+    );
+
+    expect(principal.note.trust).toBe("principal");
+    expect(imported.note.trust).toBe("quarantined");
+    expect(imported.note.provenance).toBe("tool:scraper");
+    expect(consolidated.note.trust).toBe("assistant");
+    expect(consolidated.note.provenance).toBe("consolidation");
+  });
+});
+
+test("MINJA defense: tool/import provenance cannot ride in under a principal-correction trigger", async () => {
+  await withTempSoma(async (somaHome) => {
+    await expect(
+      writeMemoryNote(createOpts(somaHome, { provenance: "tool:web-scraper" })),
+    ).rejects.toThrow(/principal-correction writes are provenance "conversation"/);
+  });
+});
+
+test("recall-first refusal fires on a Jaccard-0.6 near-duplicate and lists candidate ids", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "original" }));
+
+    // Same fact, lightly reworded — high token overlap, above the 0.6 threshold.
+    const near = createOpts(somaHome, {
+      id: "reworded",
+      body: "Andreas reads em-dashes as an AI tell; use a colon or a comma instead please.",
+    });
+
+    const candidates = await findDuplicateCandidates(somaHome, near.body);
+    expect(candidates.length).toBeGreaterThan(0);
+    expect(candidates[0].id).toBe("original");
+    expect(candidates[0].score).toBeGreaterThanOrEqual(MEMORY_DEDUP_JACCARD_THRESHOLD);
+
+    await expect(writeMemoryNote(near)).rejects.toThrow(/Recall-first refusal.*original/s);
+    // The refused note was never written.
+    await expect(readNote(memoryNotePath(somaHome, "semantic", "reworded"))).rejects.toThrow();
+  });
+});
+
+test("--force overrides the recall-first refusal", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "original" }));
+    const forced = await writeMemoryNote(
+      createOpts(somaHome, { id: "reworded", body: "Andreas reads em-dashes as an AI tell; use a colon or a comma instead please.", force: true }),
+    );
+    expect(forced.note.id).toBe("reworded");
+    expect(await countEvents(somaHome)).toBe(2);
+  });
+});
+
+test("an exact-body duplicate is refused as an exact match", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "original" }));
+    const candidates = await findDuplicateCandidates(somaHome, createOpts(somaHome).body);
+    expect(candidates[0].exact).toBe(true);
+    expect(candidates[0].score).toBe(1);
+  });
+});
+
+test("a superseded note does not trigger the refusal gate (only active notes count)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "original" }));
+    await writeMemoryNote(createOpts(somaHome, { mode: "supersede", id: "v2", targetId: "original", body: "reworded body about epsilon zeta" }));
+
+    // The original is now closed; a note overlapping IT must not be refused.
+    const candidates = await findDuplicateCandidates(somaHome, createOpts(somaHome).body);
+    expect(candidates.find((c) => c.id === "original")).toBeUndefined();
+  });
+});
+
+test("merge delta-appends an Update block and bumps last_verified without a new file", async () => {
+  await withTempSoma(async (somaHome) => {
+    const created = await writeMemoryNote(createOpts(somaHome, { id: "note" }));
+    const merged = await writeMemoryNote({
+      somaHome,
+      now: LATER,
+      mode: "merge",
+      trigger: "principal-correction",
+      targetId: "note",
+      body: "Also applies to en-dashes.",
+    });
+
+    expect(merged.path).toBe(created.path);
+    const note = await readNote(merged.path);
+    expect(note.body).toContain("**Update (2026-08-01):** Also applies to en-dashes.");
+    expect(note.last_verified).toBe("2026-08-01");
+    expect(note.created).toBe("2026-07-03"); // created is preserved
+    expect(await countEvents(somaHome)).toBe(2); // one create, one merge
+  });
+});
+
+test("merge into a superseded note is refused", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "old" }));
+    await writeMemoryNote(createOpts(somaHome, { mode: "supersede", id: "new", targetId: "old", body: "different body kappa lambda mu" }));
+
+    await expect(
+      writeMemoryNote({ somaHome, mode: "merge", trigger: "principal-correction", targetId: "old", body: "x", now: NOW }),
+    ).rejects.toThrow(/Cannot merge into superseded note old/);
+  });
+});
+
+test("supersede closes the old note, cross-links, and mints the new one in one event", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "old-recipe" }));
+    const result = await writeMemoryNote(
+      createOpts(somaHome, { mode: "supersede", id: "new-recipe", targetId: "old-recipe", body: "the corrected recipe about pi rho sigma", now: LATER }),
+    );
+
+    expect(result.supersededId).toBe("old-recipe");
+    const closed = await readNote(memoryNotePath(somaHome, "semantic", "old-recipe"));
+    const fresh = await readNote(result.path);
+
+    expect(closed.valid_until).toBe("2026-08-01");
+    expect(closed.links).toContain("new-recipe");
+    expect(fresh.valid_until).toBeNull();
+    expect(fresh.links).toContain("old-recipe");
+    expect(await countEvents(somaHome)).toBe(2); // create + supersede (one mutation → one event)
+  });
+});
+
+test("a note cannot supersede itself", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "self" }));
+    await expect(
+      writeMemoryNote(createOpts(somaHome, { mode: "supersede", id: "self", targetId: "self", body: "x" })),
+    ).rejects.toThrow(/cannot supersede itself/);
+  });
+});
+
+test("verify bumps last_verified and increments resurface_count with one event", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "note" }));
+    const result = await verifyMemoryNote({ somaHome, id: "note", now: LATER });
+
+    expect(result.note.last_verified).toBe("2026-08-01");
+    expect(result.note.resurface_count).toBe(1);
+
+    const persisted = await readNote(result.path);
+    expect(persisted.resurface_count).toBe(1);
+    expect(await countEvents(somaHome)).toBe(2); // create + verify
+
+    const again = await verifyMemoryNote({ somaHome, id: "note", now: LATER });
+    expect(again.note.resurface_count).toBe(2);
+  });
+});
+
+test("verify on a missing id throws a typed error", async () => {
+  await withTempSoma(async (somaHome) => {
+    await expect(verifyMemoryNote({ somaHome, id: "ghost" })).rejects.toThrow(MemoryNoteError);
+  });
+});
+
+test("episodic writes are refused through the write path (they belong to M5)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await expect(
+      // episodic is a valid note type but not a valid *write* target — the runtime guard refuses it.
+      writeMemoryNote(createOpts(somaHome, { type: "episodic" })),
+    ).rejects.toThrow(/must be "semantic" or "procedural"/);
+  });
+});
+
+test("creating a note whose id already exists is refused", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "dup", body: "first body alpha beta" }));
+    await expect(
+      writeMemoryNote(createOpts(somaHome, { id: "dup", body: "unrelated body chi psi omega", force: true })),
+    ).rejects.toThrow(/already exists/);
+  });
+});

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -407,6 +407,17 @@ test("verify on a missing id throws a typed error", async () => {
   });
 });
 
+test("a mis-filed note (frontmatter id != filename) is refused, not silently retargeted", async () => {
+  await withTempSoma(async (somaHome) => {
+    // Write a valid note, then rename its FILE so the path stem no longer matches
+    // its frontmatter id.
+    const created = await writeMemoryNote(createOpts(somaHome, { id: "correct-id", body: "body for misfile test" }));
+    const raw = await readFile(created.path, "utf8");
+    await writeFile(join(somaHome, "memory", "semantic", "wrong-name.md"), raw, "utf8");
+    await expect(verifyMemoryNote({ somaHome, id: "wrong-name", principalAuthority: true, now: LATER })).rejects.toThrow(/mismatched frontmatter/);
+  });
+});
+
 test("verifying a superseded (closed) note is refused", async () => {
   await withTempSoma(async (somaHome) => {
     await writeMemoryNote(createOpts(somaHome, { id: "old" }));

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -157,7 +157,7 @@ test("recall-first refusal fires on a Jaccard-0.6 near-duplicate and lists candi
       body: "Andreas reads em-dashes as an AI tell; use a colon or a comma instead please.",
     });
 
-    const candidates = await findDuplicateCandidates(somaHome, near.body);
+    const { candidates } = await findDuplicateCandidates(somaHome, near.body);
     expect(candidates.length).toBeGreaterThan(0);
     expect(candidates[0].id).toBe("original");
     expect(candidates[0].score).toBeGreaterThanOrEqual(MEMORY_DEDUP_JACCARD_THRESHOLD);
@@ -165,6 +165,21 @@ test("recall-first refusal fires on a Jaccard-0.6 near-duplicate and lists candi
     await expect(writeMemoryNote(near)).rejects.toThrow(/Recall-first refusal.*original/s);
     // The refused note was never written.
     await expect(readNote(memoryNotePath(somaHome, "semantic", "reworded"))).rejects.toThrow();
+  });
+});
+
+test("the dedup gate surfaces unreadable notes instead of silently skipping them", async () => {
+  await withTempSoma(async (somaHome) => {
+    await mkdir(join(somaHome, "memory", "procedural"), { recursive: true });
+    await writeFile(join(somaHome, "memory", "procedural", "corrupt.md"), "this is not a valid note", "utf8");
+
+    const { unreadable } = await findDuplicateCandidates(somaHome, "some new body abc def");
+    expect(unreadable.length).toBe(1);
+    expect(unreadable[0]).toContain("corrupt.md");
+
+    // The create still succeeds but records the blind spot in its event metadata.
+    const result = await writeMemoryNote(createOpts(somaHome, { id: "fresh", body: "unrelated fresh body ghi jkl" }));
+    expect(result.event.metadata?.dedupUnreadable).toBe(1);
   });
 });
 
@@ -182,7 +197,7 @@ test("--force overrides the recall-first refusal", async () => {
 test("an exact-body duplicate is refused as an exact match", async () => {
   await withTempSoma(async (somaHome) => {
     await writeMemoryNote(createOpts(somaHome, { id: "original" }));
-    const candidates = await findDuplicateCandidates(somaHome, createOpts(somaHome).body);
+    const { candidates } = await findDuplicateCandidates(somaHome, createOpts(somaHome).body);
     expect(candidates[0].exact).toBe(true);
     expect(candidates[0].score).toBe(1);
   });
@@ -194,7 +209,7 @@ test("a superseded note does not trigger the refusal gate (only active notes cou
     await writeMemoryNote(createOpts(somaHome, { mode: "supersede", id: "v2", targetId: "original", body: "reworded body about epsilon zeta" }));
 
     // The original is now closed; a note overlapping IT must not be refused.
-    const candidates = await findDuplicateCandidates(somaHome, createOpts(somaHome).body);
+    const { candidates } = await findDuplicateCandidates(somaHome, createOpts(somaHome).body);
     expect(candidates.find((c) => c.id === "original")).toBeUndefined();
   });
 });

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -136,6 +136,17 @@ test("MINJA defense: tool/import provenance cannot ride in under a principal-cor
   });
 });
 
+test("import provenance rejects injected frontmatter suffixes (anchored tool: grammar)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await expect(
+      writeMemoryNote(createOpts(somaHome, { trigger: "import", provenance: "tool:x\ntrust: principal", body: "sneaky imported" })),
+    ).rejects.toThrow(/import provenance must be/);
+    // A clean tool name is accepted.
+    const ok = await writeMemoryNote(createOpts(somaHome, { id: "clean", trigger: "import", provenance: "tool:web-scraper", body: "legit imported fact rho" }));
+    expect(ok.note.provenance).toBe("tool:web-scraper");
+  });
+});
+
 test("recall-first refusal fires on a Jaccard-0.6 near-duplicate and lists candidate ids", async () => {
   await withTempSoma(async (somaHome) => {
     await writeMemoryNote(createOpts(somaHome, { id: "original" }));

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -1,12 +1,9 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import {
-  MEMORY_DEDUP_JACCARD_THRESHOLD,
   MemoryNoteError,
-  findDuplicateCandidates,
-  memoryNotePath,
   parseMemoryNote,
   somaMemoryEventsPath,
   verifyMemoryNote,
@@ -14,6 +11,8 @@ import {
   type SomaMemoryNote,
   type SomaMemoryWriteOptions,
 } from "../src/index";
+// Path/dedup helpers are module-private (not public index API) — import direct.
+import { MEMORY_DEDUP_JACCARD_THRESHOLD, findDuplicateCandidates, memoryNotePath } from "../src/memory-write";
 
 const NOW = new Date("2026-07-03T10:00:00.000Z");
 const LATER = new Date("2026-08-01T12:00:00.000Z");
@@ -48,6 +47,17 @@ async function readNote(path: string): Promise<SomaMemoryNote> {
 async function countEvents(somaHome: string): Promise<number> {
   const content = await readFile(somaMemoryEventsPath(somaHome), "utf8").catch(() => "");
   return content.trim() === "" ? 0 : content.trim().split("\n").length;
+}
+
+/**
+ * Force the next event append to fail: replace events.jsonl with a *directory*
+ * so `appendFile` throws EISDIR (works even as root, unlike a chmod trick). Used
+ * to prove the write→event rollback path.
+ */
+async function breakEvents(somaHome: string): Promise<void> {
+  const path = somaMemoryEventsPath(somaHome);
+  await rm(path, { force: true });
+  await mkdir(path, { recursive: true });
 }
 
 test("create writes a semantic note with principal trust derived from the trigger", async () => {
@@ -246,5 +256,64 @@ test("creating a note whose id already exists is refused", async () => {
     await expect(
       writeMemoryNote(createOpts(somaHome, { id: "dup", body: "unrelated body chi psi omega", force: true })),
     ).rejects.toThrow(/already exists/);
+  });
+});
+
+test("a path-traversal id is refused at the write boundary", async () => {
+  await withTempSoma(async (somaHome) => {
+    await expect(writeMemoryNote(createOpts(somaHome, { id: "../../evil" }))).rejects.toThrow(/not a valid slug/);
+    await expect(writeMemoryNote(createOpts(somaHome, { id: "Bad_Id" }))).rejects.toThrow(/not a valid slug/);
+  });
+});
+
+test("create rolls back the new file when the event append fails (one-event invariant)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await breakEvents(somaHome);
+    await expect(writeMemoryNote(createOpts(somaHome, { id: "note" }))).rejects.toThrow();
+    // The file mutation was rolled back — nothing left behind.
+    await expect(readNote(memoryNotePath(somaHome, "semantic", "note"))).rejects.toThrow();
+  });
+});
+
+test("merge rolls back to the prior bytes when the event append fails", async () => {
+  await withTempSoma(async (somaHome) => {
+    const created = await writeMemoryNote(createOpts(somaHome, { id: "note" }));
+    const priorRaw = await readFile(created.path, "utf8");
+    await breakEvents(somaHome);
+
+    await expect(
+      writeMemoryNote({ somaHome, mode: "merge", trigger: "principal-correction", targetId: "note", body: "delta", now: LATER }),
+    ).rejects.toThrow();
+
+    // Restored byte-for-byte: no Update block, no last_verified bump.
+    expect(await readFile(created.path, "utf8")).toBe(priorRaw);
+  });
+});
+
+test("verify rolls back when the event append fails", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "note" }));
+    await breakEvents(somaHome);
+
+    await expect(verifyMemoryNote({ somaHome, id: "note", now: LATER })).rejects.toThrow();
+    const note = await readNote(memoryNotePath(somaHome, "semantic", "note"));
+    expect(note.resurface_count).toBe(0); // the bump was rolled back
+  });
+});
+
+test("supersede rolls back both sides when the event append fails", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "old" }));
+    await breakEvents(somaHome);
+
+    await expect(
+      writeMemoryNote(createOpts(somaHome, { mode: "supersede", id: "new", targetId: "old", body: "replacement body tau upsilon" })),
+    ).rejects.toThrow();
+
+    // Old note reopened (still active), new note never persisted.
+    const old = await readNote(memoryNotePath(somaHome, "semantic", "old"));
+    expect(old.valid_until).toBeNull();
+    expect(old.links).not.toContain("new");
+    await expect(readNote(memoryNotePath(somaHome, "semantic", "new"))).rejects.toThrow();
   });
 });

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../src/index";
 // Path/dedup helpers are module-private (not public index API) — import direct.
 import { MEMORY_DEDUP_JACCARD_THRESHOLD, findDuplicateCandidates, memoryNotePath } from "../src/memory-write";
+import { parseMemoryArgs } from "../src/cli/memory";
 
 const NOW = new Date("2026-07-03T10:00:00.000Z");
 const LATER = new Date("2026-08-01T12:00:00.000Z");
@@ -372,6 +373,13 @@ test("verify on a missing id throws a typed error", async () => {
   await withTempSoma(async (somaHome) => {
     await expect(verifyMemoryNote({ somaHome, id: "ghost" })).rejects.toThrow(MemoryNoteError);
   });
+});
+
+test("verify CLI rejects a conflicting positional id and --id", () => {
+  expect(() => parseMemoryArgs(["memory", "verify", "old", "--id", "new"])).toThrow(/two different ids/);
+  // Matching positional + --id is fine.
+  const parsed = parseMemoryArgs(["memory", "verify", "same", "--id", "same"]);
+  expect(parsed.action).toBe("verify");
 });
 
 test("episodic writes are refused through the write path (they belong to M5)", async () => {

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -33,6 +33,7 @@ function createOpts(somaHome: string, overrides: Partial<SomaMemoryWriteOptions>
     now: NOW,
     mode: "create",
     trigger: "principal-correction",
+    principalAuthority: true, // most tests exercise the principal path; the gate itself is tested separately
     id: "prefers-colon-over-emdash",
     type: "semantic",
     body: "Andreas reads em-dashes as an AI tell; use a colon or comma instead.",
@@ -95,6 +96,35 @@ test("trust is derived from the trigger — no --trust flag can override it", as
     expect(imported.note.provenance).toBe("tool:scraper");
     expect(consolidated.note.trust).toBe("assistant");
     expect(consolidated.note.provenance).toBe("consolidation");
+  });
+});
+
+test("principal-correction without explicit authority is refused (no incidental principal trust)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await expect(
+      writeMemoryNote(createOpts(somaHome, { principalAuthority: false })),
+    ).rejects.toThrow(/requires explicit principal authority/);
+    // The same write WITH authority succeeds and mints principal trust.
+    const ok = await writeMemoryNote(createOpts(somaHome, { principalAuthority: true }));
+    expect(ok.note.trust).toBe("principal");
+  });
+});
+
+test("import and consolidation do not require principal authority", async () => {
+  await withTempSoma(async (somaHome) => {
+    const imported = await writeMemoryNote(createOpts(somaHome, { id: "i", trigger: "import", principalAuthority: false, body: "imported fact alpha beta gamma" }));
+    const consolidated = await writeMemoryNote(createOpts(somaHome, { id: "c", trigger: "consolidation", principalAuthority: false, body: "consolidated fact delta epsilon" }));
+    expect(imported.note.trust).toBe("quarantined");
+    expect(consolidated.note.trust).toBe("assistant");
+  });
+});
+
+test("ids are globally unique across types — a cross-type collision is refused", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "shared", type: "semantic", body: "semantic body one two three" }));
+    await expect(
+      writeMemoryNote(createOpts(somaHome, { id: "shared", type: "procedural", body: "procedural body four five six", force: true })),
+    ).rejects.toThrow(/id already exists/);
   });
 });
 

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
@@ -89,7 +89,7 @@ test("trust is derived from the trigger — no --trust flag can override it", as
       createOpts(somaHome, { id: "b", trigger: "import", body: "totally different imported fact about zeta", provenance: "tool:scraper" }),
     );
     const consolidated = await writeMemoryNote(
-      createOpts(somaHome, { id: "c", trigger: "consolidation", body: "consolidated abstraction over gamma delta epsilon" }),
+      createOpts(somaHome, { id: "c", trigger: "consolidation", consolidationAuthority: true, body: "consolidated abstraction over gamma delta epsilon" }),
     );
 
     expect(principal.note.trust).toBe("principal");
@@ -104,18 +104,26 @@ test("principal-correction without explicit authority is refused (no incidental 
   await withTempSoma(async (somaHome) => {
     await expect(
       writeMemoryNote(createOpts(somaHome, { principalAuthority: false })),
-    ).rejects.toThrow(/requires explicit principal authority/);
+    ).rejects.toThrow(/requires --principal-authority/);
     // The same write WITH authority succeeds and mints principal trust.
     const ok = await writeMemoryNote(createOpts(somaHome, { principalAuthority: true }));
     expect(ok.note.trust).toBe("principal");
   });
 });
 
-test("import and consolidation do not require principal authority", async () => {
+test("import needs no authority; consolidation needs consolidation-authority", async () => {
   await withTempSoma(async (somaHome) => {
+    // import is the only trigger a bare caller can use — it lands quarantined.
     const imported = await writeMemoryNote(createOpts(somaHome, { id: "i", trigger: "import", principalAuthority: false, body: "imported fact alpha beta gamma" }));
-    const consolidated = await writeMemoryNote(createOpts(somaHome, { id: "c", trigger: "consolidation", principalAuthority: false, body: "consolidated fact delta epsilon" }));
     expect(imported.note.trust).toBe("quarantined");
+
+    // consolidation without its authority is refused (can't self-select assistant trust).
+    await expect(
+      writeMemoryNote(createOpts(somaHome, { id: "c", trigger: "consolidation", principalAuthority: false, body: "consolidated fact delta epsilon" })),
+    ).rejects.toThrow(/requires --consolidation-authority/);
+
+    // With the capability it mints assistant trust.
+    const consolidated = await writeMemoryNote(createOpts(somaHome, { id: "c", trigger: "consolidation", consolidationAuthority: true, body: "consolidated fact delta epsilon" }));
     expect(consolidated.note.trust).toBe("assistant");
   });
 });
@@ -268,7 +276,7 @@ test("merging into a principal-trust note requires the principal-authority escal
 test("a lower-trust merge cannot inject into a higher-trust note (import into assistant)", async () => {
   await withTempSoma(async (somaHome) => {
     // assistant-trust note via consolidation trigger.
-    await writeMemoryNote(createOpts(somaHome, { id: "assistant-note", trigger: "consolidation", principalAuthority: false, body: "assistant fact iota kappa" }));
+    await writeMemoryNote(createOpts(somaHome, { id: "assistant-note", trigger: "consolidation", consolidationAuthority: true, body: "assistant fact iota kappa" }));
     await expect(
       writeMemoryNote({ somaHome, mode: "merge", trigger: "import", targetId: "assistant-note", body: "imported injection", now: LATER }),
     ).rejects.toThrow(/Cannot mutate assistant-trust note .* with quarantined-trust content/);
@@ -372,6 +380,37 @@ test("verifying a principal note needs authority; a quarantined note does not", 
 test("verify on a missing id throws a typed error", async () => {
   await withTempSoma(async (somaHome) => {
     await expect(verifyMemoryNote({ somaHome, id: "ghost" })).rejects.toThrow(MemoryNoteError);
+  });
+});
+
+test("verifying an assistant note needs consolidation-authority", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "asst", trigger: "consolidation", consolidationAuthority: true, body: "assistant fact for verify pi rho" }));
+    await expect(verifyMemoryNote({ somaHome, id: "asst", now: LATER })).rejects.toThrow(/requires --consolidation-authority/);
+    const ok = await verifyMemoryNote({ somaHome, id: "asst", consolidationAuthority: true, now: LATER });
+    expect(ok.note.resurface_count).toBe(1);
+  });
+});
+
+test("merge rejects a --provenance flag (merge preserves the target's provenance)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "note" }));
+    await expect(
+      writeMemoryNote({ somaHome, mode: "merge", trigger: "principal-correction", principalAuthority: true, targetId: "note", body: "x", provenance: "tool:web", now: LATER }),
+    ).rejects.toThrow(/--provenance is not valid with --merge/);
+  });
+});
+
+test("a symlink note path is refused rather than followed out of the tree", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "real", body: "real body sigma tau" }));
+    // Plant a symlink at procedural/evil.md → outside the memory tree.
+    const outside = join(somaHome, "..", "outside-target.md");
+    await writeFile(outside, "---\nnot: a note\n", "utf8");
+    await mkdir(join(somaHome, "memory", "procedural"), { recursive: true });
+    await symlink(outside, join(somaHome, "memory", "procedural", "evil.md"));
+
+    await expect(verifyMemoryNote({ somaHome, id: "evil", now: LATER })).rejects.toThrow(/is a symlink/);
   });
 });
 

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -340,6 +340,30 @@ test("supersede closes the old note, cross-links, and mints the new one in one e
   });
 });
 
+test("superseding an assistant note with a principal replacement logs BOTH authorities", async () => {
+  await withTempSoma(async (somaHome) => {
+    // assistant note (needs consolidation authority to mint).
+    await writeMemoryNote(createOpts(somaHome, { id: "asst", trigger: "consolidation", consolidationAuthority: true, body: "assistant fact to be replaced" }));
+    // Replace it with a principal note — closing the assistant needs consolidation
+    // authority, minting the principal needs principal authority: both required.
+    const result = await writeMemoryNote(
+      createOpts(somaHome, {
+        mode: "supersede",
+        id: "principal-repl",
+        targetId: "asst",
+        trigger: "principal-correction",
+        principalAuthority: true,
+        consolidationAuthority: true,
+        body: "the principal correction body chi psi",
+        now: LATER,
+      }),
+    );
+    // The journal proves both escalations were present.
+    expect(result.event.metadata?.principalAuthority).toBe(true);
+    expect(result.event.metadata?.consolidationAuthority).toBe(true);
+  });
+});
+
 test("a note cannot supersede itself", async () => {
   await withTempSoma(async (somaHome) => {
     await writeMemoryNote(createOpts(somaHome, { id: "self" }));

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -446,6 +446,29 @@ test("a symlink note path is refused rather than followed out of the tree", asyn
   });
 });
 
+test("a symlinked parent directory can't redirect a write out of the tree", async () => {
+  await withTempSoma(async (somaHome) => {
+    // Point memory/semantic at a dir OUTSIDE the memory tree.
+    const outsideDir = join(somaHome, "..", "escape-dir");
+    await mkdir(outsideDir, { recursive: true });
+    await mkdir(join(somaHome, "memory"), { recursive: true });
+    await symlink(outsideDir, join(somaHome, "memory", "semantic"));
+
+    await expect(
+      writeMemoryNote(createOpts(somaHome, { id: "victim", type: "semantic", body: "would escape via parent symlink" })),
+    ).rejects.toThrow(/resolves outside the memory tree/);
+  });
+});
+
+test("CLI rejects the consolidation trigger (SDK-only) and merge --id/--type", () => {
+  expect(() => parseMemoryArgs(["memory", "write", "--trigger", "consolidation", "--body", "x", "--id", "a", "--type", "semantic"])).toThrow(
+    /consolidation is an internal .* SDK path/,
+  );
+  expect(() => parseMemoryArgs(["memory", "write", "--trigger", "principal-correction", "--merge", "t", "--body", "x", "--id", "a"])).toThrow(
+    /--merge takes neither --id nor --type/,
+  );
+});
+
 test("verify CLI rejects a conflicting positional id and --id", () => {
   expect(() => parseMemoryArgs(["memory", "verify", "old", "--id", "new"])).toThrow(/two different ids/);
   // Matching positional + --id is fine.

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
@@ -196,6 +196,7 @@ test("merge delta-appends an Update block and bumps last_verified without a new 
       now: LATER,
       mode: "merge",
       trigger: "principal-correction",
+      principalAuthority: true,
       targetId: "note",
       body: "Also applies to en-dashes.",
     });
@@ -206,6 +207,56 @@ test("merge delta-appends an Update block and bumps last_verified without a new 
     expect(note.last_verified).toBe("2026-08-01");
     expect(note.created).toBe("2026-07-03"); // created is preserved
     expect(await countEvents(somaHome)).toBe(2); // one create, one merge
+  });
+});
+
+test("merging into a principal-trust note requires the principal-authority escalation", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "principal-note" })); // trust principal
+
+    // A merge that doesn't carry the escalation cannot inject into trusted memory.
+    await expect(
+      writeMemoryNote({ somaHome, mode: "merge", trigger: "import", targetId: "principal-note", body: "sneaky injected text", now: LATER }),
+    ).rejects.toThrow(/Mutating principal-trust note/);
+
+    // With the escalation it goes through.
+    const ok = await writeMemoryNote({
+      somaHome,
+      mode: "merge",
+      trigger: "principal-correction",
+      principalAuthority: true,
+      targetId: "principal-note",
+      body: "legit correction",
+      now: LATER,
+    });
+    expect(ok.note.body).toContain("legit correction");
+  });
+});
+
+test("superseding (closing) a principal-trust note requires the escalation", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "trusted" }));
+    await expect(
+      writeMemoryNote(createOpts(somaHome, {
+        mode: "supersede",
+        id: "replacement",
+        targetId: "trusted",
+        trigger: "import",
+        principalAuthority: false,
+        body: "replacement via import trigger phi chi",
+      })),
+    ).rejects.toThrow(/Mutating principal-trust note/);
+  });
+});
+
+test("a malformed note file still blocks a cross-type id collision (presence, not parse)", async () => {
+  await withTempSoma(async (somaHome) => {
+    // Hand-write a corrupt semantic/dup.md (not parseable).
+    await mkdir(join(somaHome, "memory", "semantic"), { recursive: true });
+    await writeFile(join(somaHome, "memory", "semantic", "dup.md"), "not a valid note", "utf8");
+    await expect(
+      writeMemoryNote(createOpts(somaHome, { id: "dup", type: "procedural", body: "would collide omega", force: true })),
+    ).rejects.toThrow(/id already exists/);
   });
 });
 
@@ -312,7 +363,7 @@ test("merge rolls back to the prior bytes when the event append fails", async ()
     await breakEvents(somaHome);
 
     await expect(
-      writeMemoryNote({ somaHome, mode: "merge", trigger: "principal-correction", targetId: "note", body: "delta", now: LATER }),
+      writeMemoryNote({ somaHome, mode: "merge", trigger: "principal-correction", principalAuthority: true, targetId: "note", body: "delta", now: LATER }),
     ).rejects.toThrow();
 
     // Restored byte-for-byte: no Update block, no last_verified bump.


### PR DESCRIPTION
M1 — soma memory write|verify for durable notes (semantic+procedural), plan v2 §M1.

Governance: trust DERIVED from --trigger (no --trust flag); principal-correction additionally requires --principal-authority (deliberate, logged escalation — not crypto auth; soma has no principal-auth primitive). Mutating an existing principal note (merge/supersede) needs the same escalation. import→quarantined, consolidation→assistant. tool/import provenance refused under principal-correction (MINJA). Recall-first refusal: exact-body-hash OR Jaccard≥0.6 over active notes, --force overrides. Ids globally unique across types. One mutation → one event, rolled back if the append fails.

Verification (local; repo runs no CI on this PR): 'bun test test/memory-write.test.ts' → 26 pass (deterministic, reproducible). tsc + eslint clean on changed files. Full 'bun test' suite green except (a) grok-hook tests that flake on a 5s per-test timeout under heavy parallel machine load — all 50 pass at --timeout 30000 — and (b) pre-existing fixtures that read a real ~/work/PAI tree. Neither touches the memory subsystem.