### PR TITLE
feat(memory): earned-inclusion INDEX renderer + reindex (M3)

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1,5 +1,6 @@
 import {
   promoteAlgorithmRunMemory,
+  rebuildMemoryIndex,
   recallMemory,
   searchSomaMemory,
   verifyMemoryNote,
@@ -7,6 +8,7 @@ import {
 } from "../index";
 import { WRITABLE_NOTE_TYPES, isWritableNoteType } from "../memory-write";
 import type {
+  SomaMemoryIndexResult,
   SomaMemoryNoteType,
   SomaMemoryPromotionOptions,
   SomaMemoryPromotionResult,
@@ -21,6 +23,12 @@ import type {
   SomaMemoryWriteResult,
   SomaMemoryWriteTrigger,
 } from "../types";
+
+/** Parsed `soma memory reindex` — home overrides only; rebuild uses the real clock. */
+interface MemoryReindexOptions {
+  homeDir?: string;
+  somaHome?: string;
+}
 import { readOption } from "./parse-utils";
 import { parseSubstrate } from "./substrate";
 
@@ -54,18 +62,25 @@ export interface ParsedMemoryVerifyArgs {
   options: SomaMemoryVerifyOptions;
 }
 
+export interface ParsedMemoryReindexArgs {
+  command: "memory";
+  action: "reindex";
+  options: MemoryReindexOptions;
+}
+
 export type ParsedMemoryArgs =
   | ParsedMemorySearchArgs
   | ParsedMemoryRecallArgs
   | ParsedMemoryPromoteArgs
   | ParsedMemoryWriteArgs
-  | ParsedMemoryVerifyArgs;
+  | ParsedMemoryVerifyArgs
+  | ParsedMemoryReindexArgs;
 
-const MEMORY_ACTIONS = ["search", "recall", "promote", "write", "verify"] as const;
+const MEMORY_ACTIONS = ["search", "recall", "promote", "write", "verify", "reindex"] as const;
 type MemoryAction = (typeof MEMORY_ACTIONS)[number];
 
 export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAction, string> } = {
-  usage: "Usage: soma memory <search|recall|promote|write|verify> ...",
+  usage: "Usage: soma memory <search|recall|promote|write|verify|reindex> ...",
   subcommands: {
     search: "Usage: soma memory search [query] [--query <text>] [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
     recall:
@@ -86,6 +101,9 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
     verify:
       "Usage: soma memory verify <id> [--id <id>] [--principal-authority] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
       "Verifying a principal-trust note requires --principal-authority (assistant-trust notes are an internal SDK path).",
+    reindex:
+      "Usage: soma memory reindex [--home-dir <dir>] [--soma-home <dir>]. " +
+      "Rebuild memory/INDEX.md deterministically from note frontmatter (earned-inclusion ladder, retention-score budget). Quarantined notes never appear.",
   },
 };
 
@@ -111,7 +129,29 @@ export function parseMemoryArgs(args: string[]): ParsedMemoryArgs {
       return { command, action, options: parseMemoryWriteArgs(rest) };
     case "verify":
       return { command, action, options: parseMemoryVerifyArgs(rest) };
+    case "reindex":
+      return { command, action, options: parseMemoryReindexArgs(rest) };
   }
+}
+
+function parseMemoryReindexArgs(args: string[]): MemoryReindexOptions {
+  const options: MemoryReindexOptions = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(args, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return options;
 }
 
 /**
@@ -463,7 +503,25 @@ export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
       return formatMemorySearchResult(await searchSomaMemory(parsed.options));
     case "recall":
       return formatMemoryRecallResult(await recallMemory(parsed.options));
+    case "reindex":
+      return formatMemoryReindexResult(await rebuildMemoryIndex(parsed.options));
   }
+}
+
+function formatMemoryReindexResult(result: SomaMemoryIndexResult): string {
+  const lines = [
+    "Soma memory reindex",
+    `path: ${result.path}`,
+    `rendered: ${result.rendered} line(s)`,
+    `admitted: ${result.admitted} (earned a line)`,
+    `shed: ${result.shed} (over budget)`,
+    `excluded: ${result.excluded} (quarantined / superseded / not yet earned)`,
+  ];
+  if (result.unreadable.length > 0) {
+    lines.push(`⚠ ${result.unreadable.length} corpus file(s) unreadable — index was partial:`);
+    for (const path of result.unreadable) lines.push(`  - ${path}`);
+  }
+  return lines.join("\n");
 }
 
 function formatMemoryWriteResult(result: SomaMemoryWriteResult): string {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -103,7 +103,8 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
       "Verifying a principal-trust note requires --principal-authority (assistant-trust notes are an internal SDK path).",
     reindex:
       "Usage: soma memory reindex [--home-dir <dir>] [--soma-home <dir>]. " +
-      "Rebuild memory/INDEX.md deterministically from note frontmatter (earned-inclusion ladder, retention-score budget). Quarantined notes never appear.",
+      "Rebuild memory/INDEX.md from note frontmatter (earned-inclusion ladder, retention-score budget); " +
+      "ages are computed against the current date, so 'verified Nd ago' advances day to day. Quarantined notes never appear.",
   },
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -454,7 +454,11 @@ export { MemoryNoteError, parseMemoryNote, serializeMemoryNote } from "./memory-
 // soma modules (M2/M3/M6) and tests import them from "./memory-write" directly.
 export { writeMemoryNote, verifyMemoryNote } from "./memory-write";
 export { recallMemory } from "./memory-recall";
-export { rebuildMemoryIndex, renderMemoryIndex, retentionScore, collectAllNotes, memoryIndexPath } from "./memory-index";
+// Public surface is the CLI-facing rebuild only. renderMemoryIndex / retentionScore
+// / collectAllNotes / memoryIndexPath stay module-private (the scoring model and
+// storage path are not frozen as stable API — episodic joins at M5); internal soma
+// modules and tests import them from "./memory-index" directly.
+export { rebuildMemoryIndex } from "./memory-index";
 export { createSomaSnapshot, listSomaSnapshots, rollbackSomaSnapshot } from "./snapshots";
 export { querySomaTelemetryEvents, summarizeSomaTelemetry } from "./observability";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ export type {
   SomaMemoryRecallOptions,
   SomaMemoryRecallResult,
   SomaMemoryRecalledNote,
+  SomaMemoryIndexResult,
   SomaMemorySearchMatch,
   SomaMemorySearchOptions,
   SomaMemorySearchResult,
@@ -453,6 +454,7 @@ export { MemoryNoteError, parseMemoryNote, serializeMemoryNote } from "./memory-
 // soma modules (M2/M3/M6) and tests import them from "./memory-write" directly.
 export { writeMemoryNote, verifyMemoryNote } from "./memory-write";
 export { recallMemory } from "./memory-recall";
+export { rebuildMemoryIndex, renderMemoryIndex, retentionScore, collectAllNotes, memoryIndexPath } from "./memory-index";
 export { createSomaSnapshot, listSomaSnapshots, rollbackSomaSnapshot } from "./snapshots";
 export { querySomaTelemetryEvents, summarizeSomaTelemetry } from "./observability";
 export {

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -13,9 +13,11 @@ import type { SomaMemoryIndexResult, SomaMemoryNote, SomaMemoryNoteType, SomaMem
  * Two orthogonal decisions per note:
  *
  * 1. **Admission (earned inclusion).** A note earns a line only if it is active
- *    (`valid_until === null`), NOT quarantined, and clears the ladder: resurfaced-
- *    and-verified ≥2×, OR principal-marked (trust `principal`), OR still in the
- *    <7-day creation grace window. Quarantined notes never appear (design §15 L3).
+ *    (`valid_until === null`), NOT quarantined, and either is principal-marked
+ *    (trust `principal`) OR has been resurfaced-and-verified ≥2×. Non-principal
+ *    notes get NO pure recency grace — admitting unverified imported/tool-derived
+ *    text into always-loaded memory would be a prompt-injection path. Quarantined
+ *    notes never appear (design §15 L3, tightened per sage M3 r3).
  *
  * 2. **Retention score (eviction order).** `trust_weight × type_weight ×
  *    freshness`, where freshness is recall's decay curve applied to frontmatter:
@@ -24,9 +26,10 @@ import type { SomaMemoryIndexResult, SomaMemoryNote, SomaMemoryNoteType, SomaMem
  *    Plans/2026-07-02-recall-adoption-analysis.md; this amends v1's linear recency
  *    term). When the ≤200-pointer-line / ≤25KB budget is hit the LOWEST score sheds first,
  *    except that each non-empty section is first offered its single best line
- *    (min-1-per-section), subject to the hard ceiling. Quarantined weight is 0, so
- *    even if some future path admitted one it would sink to the bottom — defense in
- *    depth behind the admission filter.
+ *    (min-1-per-section), subject to the hard ceiling. The real quarantined guard is
+ *    the admission FILTER (a quarantined note never reaches scoring); the 0 weight
+ *    is a secondary backstop, not a guarantee-by-sinking (min-1-per-section means a
+ *    lone section member is offered regardless of score).
  *
  * Determinism: every date derives from an injected `now`; ties break on a fixed
  * key (score → trust → last_verified → id), so the same tree + same `now` render
@@ -39,9 +42,9 @@ import type { SomaMemoryIndexResult, SomaMemoryNote, SomaMemoryNoteType, SomaMem
 // >180d → eviction" review rule (two half-lives ≈ a quarter of the original heat).
 const DEFAULT_HALFLIFE_DAYS = 90;
 
-// Admission-ladder thresholds (design §15 L3).
-const RESURFACE_ADMIT = 2; // resurfaced-and-verified ≥2×
-const GRACE_DAYS = 7; // creation recency grace
+// Admission-ladder threshold (design §15 L3): non-principal notes earn an
+// always-loaded line only after this many verified resurfacings.
+const RESURFACE_ADMIT = 2;
 
 // Governed weights (design §15). Quarantined is 0 on BOTH the admission filter
 // and the score, so it can never occupy an index line.
@@ -101,18 +104,21 @@ export function retentionScore(note: SomaMemoryNote, now: Date, halflifeDays = D
 }
 
 /**
- * The earned-inclusion admission ladder. Active + non-quarantined AND (resurfaced
- * ≥2× OR principal-marked OR within the creation grace window). Superseded and
- * quarantined notes never earn a line.
+ * The earned-inclusion admission ladder. Active + non-quarantined, then:
+ * - PRINCIPAL notes (same-turn corrections, trusted by construction) earn a line
+ *   immediately — this subsumes the creation-grace window for them.
+ * - NON-principal notes (assistant/consolidation, whose text can derive from
+ *   imported or tool content) earn an always-loaded line ONLY by verified
+ *   resurfacing (≥2×). A pure recency grace for them is deliberately NOT granted:
+ *   admitting unverified non-principal text into projected memory would be a
+ *   prompt-injection path (sage M3 r3). Verified usage is the trust signal.
+ * Superseded and quarantined notes never earn a line.
  */
-function isAdmitted(note: SomaMemoryNote, now: Date): boolean {
+function isAdmitted(note: SomaMemoryNote): boolean {
   if (note.trust === "quarantined") return false;
   if (note.valid_until !== null) return false;
-  return (
-    note.resurface_count >= RESURFACE_ADMIT ||
-    note.trust === "principal" ||
-    ageDays(note.created, now) < GRACE_DAYS
-  );
+  if (note.trust === "principal") return true;
+  return note.resurface_count >= RESURFACE_ADMIT;
 }
 
 /** Collapse to a single sanitized line and truncate — index descriptors are one line. */
@@ -246,7 +252,7 @@ export function renderMemoryIndex(
   now: Date,
   halflifeDays = DEFAULT_HALFLIFE_DAYS,
 ): RenderedIndex {
-  const admittedNotes = notes.filter((note) => isAdmitted(note, now));
+  const admittedNotes = notes.filter((note) => isAdmitted(note));
   const excluded = notes.length - admittedNotes.length;
 
   const scored: ScoredLine[] = admittedNotes.map((note) => ({
@@ -273,6 +279,10 @@ export function renderMemoryIndex(
   const shed = scored.length - rendered;
 
   // Assemble in fixed section order, only sections that have a selected line.
+  // Byte-budget reasoning covers BOTH branches: the empty branch is a fixed
+  // constant (header + one short placeholder ≪ MAX_INDEX_BYTES), and the rendered
+  // branch is bounded by selectIndexLines (sections ≤ byteCeiling) plus the
+  // pre-reserved footer — so the returned content is ≤ MAX_INDEX_BYTES either way.
   const parts: string[] = [INDEX_HEADER];
   if (rendered === 0) {
     parts.push("", "_No notes have earned an index line yet._");

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -251,7 +251,9 @@ function selectIndexLines(
 }
 
 /**
- * Render INDEX.md from a note set. Pure + deterministic given `notes` and `now`.
+ * Render INDEX.md from a note set. Pure + deterministic given `notes`, `now`, AND
+ * `halflifeDays` (the half-life shifts scoring and therefore selection, so two
+ * renders with different half-lives are NOT comparable).
  * Orchestrates: admit → score → bucket → budgeted select ({@link selectIndexLines})
  * → assemble markdown. Shed notes are counted and reported in a footer — never
  * silently dropped.

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -271,7 +271,9 @@ export function renderMemoryIndex(
   // included — can never exceed MAX_INDEX_BYTES. Reserve the worst case (all
   // admitted notes shed → largest count) whether or not a footer ends up rendered;
   // an unused reserve just leaves the index below its ceiling (a ceiling, not a floor).
-  const footerReserve = byteLength(`\n\n${shedFooter(scored.length)}`);
+  // Includes the document's trailing newline (content is always `${join}\n`), so a
+  // budget-filling render + footer still can't push one byte past the ceiling.
+  const footerReserve = byteLength(`\n\n${shedFooter(scored.length)}\n`);
   const byteCeiling = MAX_INDEX_BYTES - footerReserve;
 
   const selected = selectIndexLines(scored, bySection, now, byteCeiling);
@@ -285,7 +287,14 @@ export function renderMemoryIndex(
   // pre-reserved footer — so the returned content is ≤ MAX_INDEX_BYTES either way.
   const parts: string[] = [INDEX_HEADER];
   if (rendered === 0) {
-    parts.push("", "_No notes have earned an index line yet._");
+    // Distinguish "nothing earned a line" from "notes earned lines but all were
+    // shed" — the placeholder must not claim the corpus is empty of earned memory.
+    parts.push(
+      "",
+      shed === 0
+        ? "_No notes have earned an index line yet._"
+        : `_${shed} note(s) earned a line but none fit the index budget._`,
+    );
   } else {
     for (const type of SECTION_ORDER) {
       const lines = bySection.get(type)!.filter((line) => selected.has(line));
@@ -293,9 +302,9 @@ export function renderMemoryIndex(
       parts.push("", `## ${SECTION_TITLE[type]}`);
       for (const line of lines) parts.push(line.text!);
     }
-  }
-  if (shed > 0) {
-    parts.push("", shedFooter(shed));
+    // The shed footer belongs to a non-empty render; the rendered===0 branch above
+    // already states the shed situation in its placeholder.
+    if (shed > 0) parts.push("", shedFooter(shed));
   }
 
   return {

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -46,8 +46,10 @@ const DEFAULT_HALFLIFE_DAYS = 90;
 // always-loaded line only after this many verified resurfacings.
 const RESURFACE_ADMIT = 2;
 
-// Governed weights (design §15). Quarantined is 0 on BOTH the admission filter
-// and the score, so it can never occupy an index line.
+// Governed weights (design §15). What actually keeps a quarantined note off the
+// index is the admission FILTER (isAdmitted rejects it before scoring); its 0
+// trust weight is a secondary backstop, not the guarantee — min-1-per-section can
+// offer a section's lone member regardless of score.
 const TRUST_WEIGHT: Record<SomaMemoryTrust, number> = { principal: 3, assistant: 1, quarantined: 0 };
 const TYPE_WEIGHT: Record<SomaMemoryNoteType, number> = { procedural: 3, semantic: 2, episodic: 1 };
 
@@ -161,8 +163,14 @@ function compareScored(a: ScoredLine, b: ScoredLine): number {
 
 function pointerLine(note: SomaMemoryNote, now: Date): string {
   // "verified Nd ago" is computed HERE, at rebuild time, from the injected now —
-  // never a wall clock at projection time (M4 invariant AC-4).
-  return `- ${note.id} — ${descriptorFor(note)} · ${note.trust}, verified ${ageDays(note.last_verified, now)}d ago`;
+  // never a wall clock at projection time (M4 invariant AC-4). The id is
+  // slug-validated by the parser (no control chars possible in a note that
+  // parsed), but run it through oneLine anyway so EVERY note-authored field on
+  // this always-loaded line stays on the sanitize path — no raw text can break
+  // the one-line pointer invariant or inject into projected memory. trust is an
+  // enum and the age is a number, so both are safe as-is.
+  const id = oneLine(note.id, DESCRIPTOR_MAX);
+  return `- ${id} — ${descriptorFor(note)} · ${note.trust}, verified ${ageDays(note.last_verified, now)}d ago`;
 }
 
 function byteLength(text: string): number {

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -22,7 +22,7 @@ import type { SomaMemoryIndexResult, SomaMemoryNote, SomaMemoryNoteType, SomaMem
  *    `resurface_count × 0.5^(daysSince(last_verified)/halflife)` with a future-
  *    timestamp clamp (adapted from recall's freshness-score concept — see
  *    Plans/2026-07-02-recall-adoption-analysis.md; this amends v1's linear recency
- *    term). When the ≤200-line / ≤25KB budget is hit the LOWEST score sheds first,
+ *    term). When the ≤200-pointer-line / ≤25KB budget is hit the LOWEST score sheds first,
  *    except that each non-empty section is first offered its single best line
  *    (min-1-per-section), subject to the hard ceiling. Quarantined weight is 0, so
  *    even if some future path admitted one it would sink to the bottom — defense in
@@ -48,8 +48,12 @@ const GRACE_DAYS = 7; // creation recency grace
 const TRUST_WEIGHT: Record<SomaMemoryTrust, number> = { principal: 3, assistant: 1, quarantined: 0 };
 const TYPE_WEIGHT: Record<SomaMemoryNoteType, number> = { procedural: 3, semantic: 2, episodic: 1 };
 
-// Budget (design §15 / plan §M3). 25KB matches the Claude auto-dream ceiling.
-const MAX_INDEX_LINES = 200;
+// Budget (design §15 / plan §M3). 25KB matches the Claude auto-dream ceiling and
+// is the HARD ceiling on the whole file. MAX_INDEX_POINTER_LINES caps the number
+// of note POINTER lines specifically — the title, per-section headings, blank
+// separators, and the optional shed footer are a small fixed overhead on top
+// (≤ ~7 lines given ≤3 sections), so the physical file is ≤ pointer-cap + overhead.
+const MAX_INDEX_POINTER_LINES = 200;
 const MAX_INDEX_BYTES = 25_000;
 
 // Sections render in this fixed order (highest type_weight first). Episodic has
@@ -130,7 +134,12 @@ interface ScoredLine {
   type: SomaMemoryNoteType;
   score: number;
   note: SomaMemoryNote;
-  /** The rendered `- …` pointer line, materialized lazily on admission (never for a shed note). */
+  /**
+   * The rendered `- …` pointer line, materialized during an admission ATTEMPT. A
+   * note shed by the line ceiling is never rendered (the attempt returns before
+   * rendering); one shed by the byte ceiling is rendered once (its size is needed
+   * to decide it doesn't fit) but then dropped.
+   */
   text?: string;
 }
 
@@ -167,19 +176,70 @@ export interface RenderedIndex {
   excluded: number;
 }
 
+const INDEX_HEADER = "# Soma Memory Index";
+
 /**
- * Render INDEX.md from a note set. Pure + deterministic given `notes` and `now`.
+ * The budgeted two-pass selection. Materializes pointer text on each admission
+ * attempt (a line shed by the line ceiling is never rendered; one shed by the byte
+ * ceiling is rendered once to measure it), and returns the admitted set.
  *
  * Budget policy (honest ordering): each non-empty section is OFFERED its top-scored
  * line first (min-1-per-section), then the remaining line/byte budget is filled in
  * global retention-score order. So the effective eviction rule is "lowest score
  * sheds first, EXCEPT a section's single best line is offered ahead of the global
- * fill" — a score-0 line that is its section's best can outrank a higher-scoring
- * line from a section that already has one. Both the min-1 offer and the global
- * fill are still subject to the hard line/byte ceiling: if even the top line does
- * not fit the byte budget it is shed too (the ceiling always wins). Shed notes are
- * counted and reported in a footer — never silently dropped. Pointer strings are
- * materialized lazily, only for admitted lines.
+ * fill". Both passes are subject to the hard ceiling: if even the top line does not
+ * fit the byte budget it is shed too (the ceiling always wins). Mutates `scored`
+ * (sorts it in place for pass 2) and the section buckets' order — both are the
+ * caller's throwaway working state.
+ */
+function selectIndexLines(
+  scored: ScoredLine[],
+  bySection: Map<SomaMemoryNoteType, ScoredLine[]>,
+  now: Date,
+  byteCeiling: number,
+): Set<ScoredLine> {
+  // usedBytes over-estimates the assembled bytes (header + a trailing doc newline;
+  // each section charged its full "\n\n## Title\n" prefix, each line its "…\n"), so
+  // header + sections ≤ byteCeiling and footer ≤ footerReserve ⇒ total ≤ MAX.
+  let usedBytes = byteLength(INDEX_HEADER) + 1;
+  let usedLines = 0;
+  const selected = new Set<ScoredLine>();
+  const chargedSectionHeader = new Set<SomaMemoryNoteType>();
+
+  function tryAdmit(line: ScoredLine): void {
+    if (usedLines >= MAX_INDEX_POINTER_LINES) return;
+    const text = line.text ?? pointerLine(line.note, now); // needed to measure the line
+    line.text = text;
+    let cost = byteLength(`${text}\n`);
+    if (!chargedSectionHeader.has(line.type)) {
+      cost += byteLength(`\n\n## ${SECTION_TITLE[line.type]}\n`);
+    }
+    if (usedBytes + cost > byteCeiling) return;
+    usedBytes += cost;
+    usedLines += 1;
+    chargedSectionHeader.add(line.type);
+    selected.add(line);
+  }
+
+  // Pass 1 — min-1-per-section: OFFER the top-scored line of each non-empty section
+  // (subject to the hard ceiling — an oversized top line is still shed).
+  for (const type of SECTION_ORDER) {
+    const top = bySection.get(type)!.at(0);
+    if (top) tryAdmit(top);
+  }
+  // Pass 2 — fill remaining budget in global score order (lowest sheds first).
+  scored.sort(compareScored);
+  for (const line of scored) {
+    if (!selected.has(line)) tryAdmit(line);
+  }
+  return selected;
+}
+
+/**
+ * Render INDEX.md from a note set. Pure + deterministic given `notes` and `now`.
+ * Orchestrates: admit → score → bucket → budgeted select ({@link selectIndexLines})
+ * → assemble markdown. Shed notes are counted and reported in a footer — never
+ * silently dropped.
  */
 export function renderMemoryIndex(
   notes: SomaMemoryNote[],
@@ -201,7 +261,6 @@ export function renderMemoryIndex(
   for (const line of scored) bySection.get(line.type)!.push(line);
   for (const lines of bySection.values()) lines.sort(compareScored);
 
-  const header = "# Soma Memory Index";
   // Reserve room for the shed footer up front so the final content — footer
   // included — can never exceed MAX_INDEX_BYTES. Reserve the worst case (all
   // admitted notes shed → largest count) whether or not a footer ends up rendered;
@@ -209,46 +268,12 @@ export function renderMemoryIndex(
   const footerReserve = byteLength(`\n\n${shedFooter(scored.length)}`);
   const byteCeiling = MAX_INDEX_BYTES - footerReserve;
 
-  // usedBytes over-estimates the assembled bytes (header + a trailing doc newline;
-  // each section charged its full "\n\n## Title\n" prefix, each line its "…\n"), so
-  // header + sections ≤ byteCeiling and footer ≤ footerReserve ⇒ total ≤ MAX.
-  let usedBytes = byteLength(header) + 1;
-  let usedLines = 0;
-  const selected = new Set<ScoredLine>();
-
-  const chargedSectionHeader = new Set<SomaMemoryNoteType>();
-  function tryAdmit(line: ScoredLine): boolean {
-    if (usedLines >= MAX_INDEX_LINES) return false;
-    const text = line.text ?? pointerLine(line.note, now); // materialize lazily
-    let cost = byteLength(`${text}\n`);
-    if (!chargedSectionHeader.has(line.type)) {
-      cost += byteLength(`\n\n## ${SECTION_TITLE[line.type]}\n`);
-    }
-    if (usedBytes + cost > byteCeiling) return false;
-    usedBytes += cost;
-    usedLines += 1;
-    line.text = text;
-    chargedSectionHeader.add(line.type);
-    selected.add(line);
-    return true;
-  }
-
-  // Pass 1 — min-1-per-section: OFFER the top-scored line of each non-empty section
-  // (subject to the hard ceiling — an oversized top line is still shed).
-  for (const type of SECTION_ORDER) {
-    const top = bySection.get(type)!.at(0);
-    if (top) tryAdmit(top);
-  }
-  // Pass 2 — fill remaining budget in global score order (lowest sheds first).
-  for (const line of [...scored].sort(compareScored)) {
-    if (!selected.has(line)) tryAdmit(line);
-  }
-
+  const selected = selectIndexLines(scored, bySection, now, byteCeiling);
   const rendered = selected.size;
   const shed = scored.length - rendered;
 
   // Assemble in fixed section order, only sections that have a selected line.
-  const parts: string[] = [header];
+  const parts: string[] = [INDEX_HEADER];
   if (rendered === 0) {
     parts.push("", "_No notes have earned an index line yet._");
   } else {

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -22,9 +22,11 @@ import type { SomaMemoryIndexResult, SomaMemoryNote, SomaMemoryNoteType, SomaMem
  *    `resurface_count × 0.5^(daysSince(last_verified)/halflife)` with a future-
  *    timestamp clamp (adapted from recall's freshness-score concept — see
  *    Plans/2026-07-02-recall-adoption-analysis.md; this amends v1's linear recency
- *    term). When the ≤200-line / ≤25KB budget is hit, the LOWEST score sheds
- *    first. Quarantined weight is 0, so even if some future path admitted one it
- *    would sink to the bottom — defense in depth behind the admission filter.
+ *    term). When the ≤200-line / ≤25KB budget is hit the LOWEST score sheds first,
+ *    except that each non-empty section is first offered its single best line
+ *    (min-1-per-section), subject to the hard ceiling. Quarantined weight is 0, so
+ *    even if some future path admitted one it would sink to the bottom — defense in
+ *    depth behind the admission filter.
  *
  * Determinism: every date derives from an injected `now`; ties break on a fixed
  * key (score → trust → last_verified → id), so the same tree + same `now` render
@@ -128,7 +130,8 @@ interface ScoredLine {
   type: SomaMemoryNoteType;
   score: number;
   note: SomaMemoryNote;
-  text: string; // the fully-rendered `- …` pointer line
+  /** The rendered `- …` pointer line, materialized lazily on admission (never for a shed note). */
+  text?: string;
 }
 
 /** Deterministic ordering: score desc → trust desc → last_verified desc → id asc. */
@@ -151,6 +154,11 @@ function byteLength(text: string): number {
   return Buffer.byteLength(text, "utf8");
 }
 
+/** The footer noting how many earned lines were shed to fit the budget. */
+function shedFooter(count: number): string {
+  return `_${count} more note(s) earned a line but were shed to fit the index budget._`;
+}
+
 export interface RenderedIndex {
   content: string;
   admitted: number;
@@ -161,10 +169,17 @@ export interface RenderedIndex {
 
 /**
  * Render INDEX.md from a note set. Pure + deterministic given `notes` and `now`.
- * Budget enforcement: every non-empty section is guaranteed its single
- * highest-scored line (min-1-per-section), then the remaining line/byte budget is
- * filled in global score order; whatever doesn't fit is shed (lowest score first)
- * and reported in the footer — never silently dropped.
+ *
+ * Budget policy (honest ordering): each non-empty section is OFFERED its top-scored
+ * line first (min-1-per-section), then the remaining line/byte budget is filled in
+ * global retention-score order. So the effective eviction rule is "lowest score
+ * sheds first, EXCEPT a section's single best line is offered ahead of the global
+ * fill" — a score-0 line that is its section's best can outrank a higher-scoring
+ * line from a section that already has one. Both the min-1 offer and the global
+ * fill are still subject to the hard line/byte ceiling: if even the top line does
+ * not fit the byte budget it is shed too (the ceiling always wins). Shed notes are
+ * counted and reported in a footer — never silently dropped. Pointer strings are
+ * materialized lazily, only for admitted lines.
  */
 export function renderMemoryIndex(
   notes: SomaMemoryNote[],
@@ -178,7 +193,6 @@ export function renderMemoryIndex(
     type: note.type,
     score: retentionScore(note, now, halflifeDays),
     note,
-    text: pointerLine(note, now),
   }));
 
   // Section buckets in fixed order, each internally score-sorted.
@@ -188,30 +202,39 @@ export function renderMemoryIndex(
   for (const lines of bySection.values()) lines.sort(compareScored);
 
   const header = "# Soma Memory Index";
-  // Running byte budget starts with the header; each selected line and section
-  // header is charged as it is admitted so the final string is within budget.
-  let usedBytes = byteLength(`${header}\n`);
+  // Reserve room for the shed footer up front so the final content — footer
+  // included — can never exceed MAX_INDEX_BYTES. Reserve the worst case (all
+  // admitted notes shed → largest count) whether or not a footer ends up rendered;
+  // an unused reserve just leaves the index below its ceiling (a ceiling, not a floor).
+  const footerReserve = byteLength(`\n\n${shedFooter(scored.length)}`);
+  const byteCeiling = MAX_INDEX_BYTES - footerReserve;
+
+  // usedBytes over-estimates the assembled bytes (header + a trailing doc newline;
+  // each section charged its full "\n\n## Title\n" prefix, each line its "…\n"), so
+  // header + sections ≤ byteCeiling and footer ≤ footerReserve ⇒ total ≤ MAX.
+  let usedBytes = byteLength(header) + 1;
   let usedLines = 0;
   const selected = new Set<ScoredLine>();
 
-  // Charge a candidate against the line/byte budget; on the first time a section
-  // contributes, also charge its "\n## Title\n" header. Returns false if it won't fit.
   const chargedSectionHeader = new Set<SomaMemoryNoteType>();
   function tryAdmit(line: ScoredLine): boolean {
     if (usedLines >= MAX_INDEX_LINES) return false;
-    let cost = byteLength(`${line.text}\n`);
+    const text = line.text ?? pointerLine(line.note, now); // materialize lazily
+    let cost = byteLength(`${text}\n`);
     if (!chargedSectionHeader.has(line.type)) {
-      cost += byteLength(`\n## ${SECTION_TITLE[line.type]}\n`);
+      cost += byteLength(`\n\n## ${SECTION_TITLE[line.type]}\n`);
     }
-    if (usedBytes + cost > MAX_INDEX_BYTES) return false;
+    if (usedBytes + cost > byteCeiling) return false;
     usedBytes += cost;
     usedLines += 1;
+    line.text = text;
     chargedSectionHeader.add(line.type);
     selected.add(line);
     return true;
   }
 
-  // Pass 1 — min-1-per-section: the top-scored line of each non-empty section.
+  // Pass 1 — min-1-per-section: OFFER the top-scored line of each non-empty section
+  // (subject to the hard ceiling — an oversized top line is still shed).
   for (const type of SECTION_ORDER) {
     const top = bySection.get(type)!.at(0);
     if (top) tryAdmit(top);
@@ -233,11 +256,11 @@ export function renderMemoryIndex(
       const lines = bySection.get(type)!.filter((line) => selected.has(line));
       if (lines.length === 0) continue;
       parts.push("", `## ${SECTION_TITLE[type]}`);
-      for (const line of lines) parts.push(line.text);
+      for (const line of lines) parts.push(line.text!);
     }
   }
   if (shed > 0) {
-    parts.push("", `_${shed} more note(s) earned a line but were shed to fit the index budget._`);
+    parts.push("", shedFooter(shed));
   }
 
   return {

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -163,12 +163,13 @@ function compareScored(a: ScoredLine, b: ScoredLine): number {
 
 function pointerLine(note: SomaMemoryNote, now: Date): string {
   // "verified Nd ago" is computed HERE, at rebuild time, from the injected now —
-  // never a wall clock at projection time (M4 invariant AC-4). The id is
-  // slug-validated by the parser (no control chars possible in a note that
-  // parsed), but run it through oneLine anyway so EVERY note-authored field on
-  // this always-loaded line stays on the sanitize path — no raw text can break
-  // the one-line pointer invariant or inject into projected memory. trust is an
-  // enum and the age is a number, so both are safe as-is.
+  // never a wall clock at projection time (M4 invariant AC-4). Both id and
+  // descriptor go through oneLine, which enforces the one-line pointer invariant
+  // and strips control chars — NOT a semantic prompt-injection defense: the
+  // descriptor deliberately projects note-authored hook/body text (that IS the
+  // index). What keeps untrusted text out is the admission ladder upstream
+  // (quarantined excluded, non-principal admitted only after verified resurfacing).
+  // trust is an enum and the age a number, so both are safe as-is.
   const id = oneLine(note.id, DESCRIPTOR_MAX);
   return `- ${id} — ${descriptorFor(note)} · ${note.trust}, verified ${ageDays(note.last_verified, now)}d ago`;
 }
@@ -333,7 +334,7 @@ export function memoryIndexPath(somaHome: string): string {
  * Collect every durable note (semantic + procedural) for indexing, plus the
  * unreadable-file blind spot. Episodic notes join here when M5 lands their dir.
  */
-export async function collectAllNotes(somaHome: string): Promise<{ notes: SomaMemoryNote[]; unreadable: string[] }> {
+async function collectAllNotes(somaHome: string): Promise<{ notes: SomaMemoryNote[]; unreadable: string[] }> {
   const { notes, unreadable } = await collectDurableNotes(somaHome);
   return { notes: notes.map((scanned) => scanned.note), unreadable };
 }

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -1,0 +1,290 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { createPaths } from "./paths";
+import { collectDurableNotes } from "./memory-write";
+import type { SomaMemoryIndexResult, SomaMemoryNote, SomaMemoryNoteType, SomaMemoryTrust } from "./types";
+
+/**
+ * Memory index renderer (subsystem M3). Plan v2 §M3 — the always-loaded, tiny
+ * pointer artifact (`memory/INDEX.md`) that makes session N+1 better-informed
+ * than N. Rebuilt deterministically from note frontmatter (never on the request
+ * path; no LLM), and projected verbatim to the substrate by M4.
+ *
+ * Two orthogonal decisions per note:
+ *
+ * 1. **Admission (earned inclusion).** A note earns a line only if it is active
+ *    (`valid_until === null`), NOT quarantined, and clears the ladder: resurfaced-
+ *    and-verified ≥2×, OR principal-marked (trust `principal`), OR still in the
+ *    <7-day creation grace window. Quarantined notes never appear (design §15 L3).
+ *
+ * 2. **Retention score (eviction order).** `trust_weight × type_weight ×
+ *    freshness`, where freshness is recall's decay curve applied to frontmatter:
+ *    `resurface_count × 0.5^(daysSince(last_verified)/halflife)` with a future-
+ *    timestamp clamp (adapted from recall's freshness-score concept — see
+ *    Plans/2026-07-02-recall-adoption-analysis.md; this amends v1's linear recency
+ *    term). When the ≤200-line / ≤25KB budget is hit, the LOWEST score sheds
+ *    first. Quarantined weight is 0, so even if some future path admitted one it
+ *    would sink to the bottom — defense in depth behind the admission filter.
+ *
+ * Determinism: every date derives from an injected `now`; ties break on a fixed
+ * key (score → trust → last_verified → id), so the same tree + same `now` render
+ * byte-identical output (golden-file tested).
+ */
+
+// Recency half-life for the freshness term, in days. A note verified within a
+// half-life keeps most of its resurface weight; the weight halves each half-life
+// it goes un-reverified. Named + tunable; 90d pairs with the design's "unverified
+// >180d → eviction" review rule (two half-lives ≈ a quarter of the original heat).
+const DEFAULT_HALFLIFE_DAYS = 90;
+
+// Admission-ladder thresholds (design §15 L3).
+const RESURFACE_ADMIT = 2; // resurfaced-and-verified ≥2×
+const GRACE_DAYS = 7; // creation recency grace
+
+// Governed weights (design §15). Quarantined is 0 on BOTH the admission filter
+// and the score, so it can never occupy an index line.
+const TRUST_WEIGHT: Record<SomaMemoryTrust, number> = { principal: 3, assistant: 1, quarantined: 0 };
+const TYPE_WEIGHT: Record<SomaMemoryNoteType, number> = { procedural: 3, semantic: 2, episodic: 1 };
+
+// Budget (design §15 / plan §M3). 25KB matches the Claude auto-dream ceiling.
+const MAX_INDEX_LINES = 200;
+const MAX_INDEX_BYTES = 25_000;
+
+// Sections render in this fixed order (highest type_weight first). Episodic has
+// no durable dir yet (M5); it joins here when it lands, hence the full type list.
+const SECTION_ORDER: SomaMemoryNoteType[] = ["procedural", "semantic", "episodic"];
+const SECTION_TITLE: Record<SomaMemoryNoteType, string> = {
+  procedural: "Procedural",
+  semantic: "Semantic",
+  episodic: "Episodic",
+};
+
+const MS_PER_DAY = 86_400_000;
+const DESCRIPTOR_MAX = 80;
+
+/** UTC-midnight ms for a `YYYY-MM-DD` date; the note schema guarantees the shape. */
+function dateMs(isoDate: string): number {
+  const [y, m, d] = isoDate.split("-").map(Number);
+  return Date.UTC(y, m - 1, d);
+}
+
+/** Whole days between `isoDate` and `now`, clamped at 0 for a future date. */
+function ageDays(isoDate: string, now: Date): number {
+  const delta = now.getTime() - dateMs(isoDate);
+  return delta <= 0 ? 0 : Math.floor(delta / MS_PER_DAY);
+}
+
+/**
+ * Freshness term — recall's decay curve on frontmatter. Never-resurfaced notes
+ * (`resurface_count === 0`) score 0 on this term; a future `last_verified`
+ * (clock skew) clamps to no decay rather than rewarding futureness.
+ */
+function freshness(note: SomaMemoryNote, now: Date, halflifeDays: number): number {
+  const count = note.resurface_count > 0 ? note.resurface_count : 0;
+  if (count === 0) return 0;
+  const dt = now.getTime() - dateMs(note.last_verified);
+  if (dt <= 0) return count; // future/equal timestamp → no decay
+  const days = dt / MS_PER_DAY;
+  const hl = halflifeDays > 0 ? halflifeDays : DEFAULT_HALFLIFE_DAYS;
+  return count * Math.pow(0.5, days / hl);
+}
+
+/** `trust_weight × type_weight × freshness` — the deterministic eviction score. */
+export function retentionScore(note: SomaMemoryNote, now: Date, halflifeDays = DEFAULT_HALFLIFE_DAYS): number {
+  return TRUST_WEIGHT[note.trust] * TYPE_WEIGHT[note.type] * freshness(note, now, halflifeDays);
+}
+
+/**
+ * The earned-inclusion admission ladder. Active + non-quarantined AND (resurfaced
+ * ≥2× OR principal-marked OR within the creation grace window). Superseded and
+ * quarantined notes never earn a line.
+ */
+function isAdmitted(note: SomaMemoryNote, now: Date): boolean {
+  if (note.trust === "quarantined") return false;
+  if (note.valid_until !== null) return false;
+  return (
+    note.resurface_count >= RESURFACE_ADMIT ||
+    note.trust === "principal" ||
+    ageDays(note.created, now) < GRACE_DAYS
+  );
+}
+
+/** Collapse to a single sanitized line and truncate — index descriptors are one line. */
+function oneLine(text: string, max: number): string {
+  const collapsed = text
+    .replace(/[\x00-\x1f\x7f-\x9f]+/g, " ") // control chars (incl. newlines/tabs) → space
+    .replace(/\s+/g, " ")
+    .trim();
+  return collapsed.length > max ? `${collapsed.slice(0, max - 1)}…` : collapsed;
+}
+
+/** The one-line pointer descriptor: the recall-trigger hook, else the first body line. */
+function descriptorFor(note: SomaMemoryNote): string {
+  const source = note.hook && note.hook.trim().length > 0 ? note.hook : note.body;
+  return oneLine(source, DESCRIPTOR_MAX);
+}
+
+interface ScoredLine {
+  type: SomaMemoryNoteType;
+  score: number;
+  note: SomaMemoryNote;
+  text: string; // the fully-rendered `- …` pointer line
+}
+
+/** Deterministic ordering: score desc → trust desc → last_verified desc → id asc. */
+function compareScored(a: ScoredLine, b: ScoredLine): number {
+  return (
+    b.score - a.score ||
+    TRUST_WEIGHT[b.note.trust] - TRUST_WEIGHT[a.note.trust] ||
+    dateMs(b.note.last_verified) - dateMs(a.note.last_verified) ||
+    a.note.id.localeCompare(b.note.id)
+  );
+}
+
+function pointerLine(note: SomaMemoryNote, now: Date): string {
+  // "verified Nd ago" is computed HERE, at rebuild time, from the injected now —
+  // never a wall clock at projection time (M4 invariant AC-4).
+  return `- ${note.id} — ${descriptorFor(note)} · ${note.trust}, verified ${ageDays(note.last_verified, now)}d ago`;
+}
+
+function byteLength(text: string): number {
+  return Buffer.byteLength(text, "utf8");
+}
+
+export interface RenderedIndex {
+  content: string;
+  admitted: number;
+  rendered: number;
+  shed: number;
+  excluded: number;
+}
+
+/**
+ * Render INDEX.md from a note set. Pure + deterministic given `notes` and `now`.
+ * Budget enforcement: every non-empty section is guaranteed its single
+ * highest-scored line (min-1-per-section), then the remaining line/byte budget is
+ * filled in global score order; whatever doesn't fit is shed (lowest score first)
+ * and reported in the footer — never silently dropped.
+ */
+export function renderMemoryIndex(
+  notes: SomaMemoryNote[],
+  now: Date,
+  halflifeDays = DEFAULT_HALFLIFE_DAYS,
+): RenderedIndex {
+  const admittedNotes = notes.filter((note) => isAdmitted(note, now));
+  const excluded = notes.length - admittedNotes.length;
+
+  const scored: ScoredLine[] = admittedNotes.map((note) => ({
+    type: note.type,
+    score: retentionScore(note, now, halflifeDays),
+    note,
+    text: pointerLine(note, now),
+  }));
+
+  // Section buckets in fixed order, each internally score-sorted.
+  const bySection = new Map<SomaMemoryNoteType, ScoredLine[]>();
+  for (const type of SECTION_ORDER) bySection.set(type, []);
+  for (const line of scored) bySection.get(line.type)!.push(line);
+  for (const lines of bySection.values()) lines.sort(compareScored);
+
+  const header = "# Soma Memory Index";
+  // Running byte budget starts with the header; each selected line and section
+  // header is charged as it is admitted so the final string is within budget.
+  let usedBytes = byteLength(`${header}\n`);
+  let usedLines = 0;
+  const selected = new Set<ScoredLine>();
+
+  // Charge a candidate against the line/byte budget; on the first time a section
+  // contributes, also charge its "\n## Title\n" header. Returns false if it won't fit.
+  const chargedSectionHeader = new Set<SomaMemoryNoteType>();
+  function tryAdmit(line: ScoredLine): boolean {
+    if (usedLines >= MAX_INDEX_LINES) return false;
+    let cost = byteLength(`${line.text}\n`);
+    if (!chargedSectionHeader.has(line.type)) {
+      cost += byteLength(`\n## ${SECTION_TITLE[line.type]}\n`);
+    }
+    if (usedBytes + cost > MAX_INDEX_BYTES) return false;
+    usedBytes += cost;
+    usedLines += 1;
+    chargedSectionHeader.add(line.type);
+    selected.add(line);
+    return true;
+  }
+
+  // Pass 1 — min-1-per-section: the top-scored line of each non-empty section.
+  for (const type of SECTION_ORDER) {
+    const top = bySection.get(type)!.at(0);
+    if (top) tryAdmit(top);
+  }
+  // Pass 2 — fill remaining budget in global score order (lowest sheds first).
+  for (const line of [...scored].sort(compareScored)) {
+    if (!selected.has(line)) tryAdmit(line);
+  }
+
+  const rendered = selected.size;
+  const shed = scored.length - rendered;
+
+  // Assemble in fixed section order, only sections that have a selected line.
+  const parts: string[] = [header];
+  if (rendered === 0) {
+    parts.push("", "_No notes have earned an index line yet._");
+  } else {
+    for (const type of SECTION_ORDER) {
+      const lines = bySection.get(type)!.filter((line) => selected.has(line));
+      if (lines.length === 0) continue;
+      parts.push("", `## ${SECTION_TITLE[type]}`);
+      for (const line of lines) parts.push(line.text);
+    }
+  }
+  if (shed > 0) {
+    parts.push("", `_${shed} more note(s) earned a line but were shed to fit the index budget._`);
+  }
+
+  return {
+    content: `${parts.join("\n")}\n`,
+    admitted: scored.length,
+    rendered,
+    shed,
+    excluded,
+  };
+}
+
+/** On-disk path of the rendered index. */
+export function memoryIndexPath(somaHome: string): string {
+  return createPaths(somaHome).resolve("memory", "INDEX.md");
+}
+
+/**
+ * Collect every durable note (semantic + procedural) for indexing, plus the
+ * unreadable-file blind spot. Episodic notes join here when M5 lands their dir.
+ */
+export async function collectAllNotes(somaHome: string): Promise<{ notes: SomaMemoryNote[]; unreadable: string[] }> {
+  const { notes, unreadable } = await collectDurableNotes(somaHome);
+  return { notes: notes.map((scanned) => scanned.note), unreadable };
+}
+
+export interface SomaMemoryIndexOptions {
+  homeDir?: string;
+  somaHome?: string;
+  /** Injected clock for deterministic ages/freshness. Defaults to now. */
+  now?: Date;
+  halflifeDays?: number;
+}
+
+/**
+ * Rebuild `memory/INDEX.md` from the current note corpus and write it. Returns the
+ * counts (admitted / rendered / shed / excluded) plus the unreadable blind spot.
+ * Deterministic given the tree and `now`.
+ */
+export async function rebuildMemoryIndex(options: SomaMemoryIndexOptions = {}): Promise<SomaMemoryIndexResult> {
+  const somaHome = createPaths(options).root();
+  const now = options.now ?? new Date();
+  const { notes, unreadable } = await collectAllNotes(somaHome);
+  const { content, admitted, rendered, shed, excluded } = renderMemoryIndex(notes, now, options.halflifeDays);
+
+  const path = memoryIndexPath(somaHome);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content, "utf8");
+
+  return { somaHome, path, content, admitted, rendered, shed, excluded, unreadable };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2528,8 +2528,11 @@ export interface SomaMemoryRecallResult {
 // — a tiny, always-loaded pointer list (≤200 lines / ≤25KB) rebuilt deterministically
 // from note frontmatter, never on the request path. A note earns a line via the
 // admission ladder (resurfaced-verified ≥2×, principal-marked, or <7d grace);
-// quarantined notes score 0 and never appear. When the budget is hit, the lowest
-// retention score sheds first. M4 projects this file → ~/.claude/rules/soma/MEMORY.md.
+// quarantined notes score 0 and never appear. When the budget is hit the lowest
+// retention score sheds first, EXCEPT that each non-empty section is offered its
+// single best line ahead of the global fill (min-1-per-section) — so a section's
+// top line can outrank a higher-scoring line from an already-represented section.
+// M4 projects this file → ~/.claude/rules/soma/MEMORY.md.
 export interface SomaMemoryIndexResult {
   somaHome: string;
   /** On-disk path of the rendered index (`memory/INDEX.md`). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -2525,11 +2525,11 @@ export interface SomaMemoryRecallResult {
 }
 
 // Memory subsystem M3 (index renderer). The result of rebuilding the tiny,
-// always-loaded INDEX (`memory/INDEX.md`, ≤200 pointer lines / ≤25KB). Admission,
-// scoring, and budget POLICY live with the renderer in `src/memory-index.ts` (the
-// single source of truth); this type carries only the rebuild's counts + path.
-// M4 projects the file through substrate adapters into each substrate's native
-// always-loaded surface.
+// always-loaded INDEX (`memory/INDEX.md`, ≤200 pointer lines / ≤25KB): its path,
+// rendered content, admit/render/shed/excluded counts, and the unreadable blind
+// spot. Admission, scoring, and budget POLICY live with the renderer in
+// `src/memory-index.ts` (the single source of truth). M4 projects the file through
+// substrate adapters into each substrate's native always-loaded surface.
 export interface SomaMemoryIndexResult {
   somaHome: string;
   /** On-disk path of the rendered index (`memory/INDEX.md`). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -2523,3 +2523,27 @@ export interface SomaMemoryRecallResult {
   /** Corpus files that exist but could not be read/parsed — recall's blind spot, never silent. */
   unreadable: string[];
 }
+
+// Memory subsystem M3 (index renderer). Plan v2 §M3: the earned-inclusion INDEX
+// — a tiny, always-loaded pointer list (≤200 lines / ≤25KB) rebuilt deterministically
+// from note frontmatter, never on the request path. A note earns a line via the
+// admission ladder (resurfaced-verified ≥2×, principal-marked, or <7d grace);
+// quarantined notes score 0 and never appear. When the budget is hit, the lowest
+// retention score sheds first. M4 projects this file → ~/.claude/rules/soma/MEMORY.md.
+export interface SomaMemoryIndexResult {
+  somaHome: string;
+  /** On-disk path of the rendered index (`memory/INDEX.md`). */
+  path: string;
+  /** The rendered INDEX.md content (also what M4 projects verbatim). */
+  content: string;
+  /** Notes that earned admission (before the budget was applied). */
+  admitted: number;
+  /** Index lines actually rendered after the budget. */
+  rendered: number;
+  /** admitted − rendered: lines shed to stay within the line/byte budget. */
+  shed: number;
+  /** Notes present but NOT admitted (quarantined, superseded, or not yet earned). */
+  excluded: number;
+  /** Corpus files that exist but could not be read/parsed — surfaced, never silent. */
+  unreadable: string[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2524,16 +2524,12 @@ export interface SomaMemoryRecallResult {
   unreadable: string[];
 }
 
-// Memory subsystem M3 (index renderer). Plan v2 §M3: the earned-inclusion INDEX
-// — a tiny, always-loaded pointer list (≤200 pointer lines / ≤25KB total) rebuilt deterministically
-// from note frontmatter, never on the request path. A note earns a line via the
-// admission ladder (principal-marked, or resurfaced-verified ≥2×; non-principal
-// notes get no pure recency grace — MINJA defense); quarantined notes never appear.
-// When the budget is hit the lowest retention score sheds first, EXCEPT that each
-// non-empty section is offered its single best line ahead of the global fill
-// (min-1-per-section) — so a section's top line can outrank a higher-scoring line
-// from an already-represented section. M4 projects this file through substrate
-// adapters into each substrate's native always-loaded surface.
+// Memory subsystem M3 (index renderer). The result of rebuilding the tiny,
+// always-loaded INDEX (`memory/INDEX.md`, ≤200 pointer lines / ≤25KB). Admission,
+// scoring, and budget POLICY live with the renderer in `src/memory-index.ts` (the
+// single source of truth); this type carries only the rebuild's counts + path.
+// M4 projects the file through substrate adapters into each substrate's native
+// always-loaded surface.
 export interface SomaMemoryIndexResult {
   somaHome: string;
   /** On-disk path of the rendered index (`memory/INDEX.md`). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -2527,12 +2527,13 @@ export interface SomaMemoryRecallResult {
 // Memory subsystem M3 (index renderer). Plan v2 §M3: the earned-inclusion INDEX
 // — a tiny, always-loaded pointer list (≤200 pointer lines / ≤25KB total) rebuilt deterministically
 // from note frontmatter, never on the request path. A note earns a line via the
-// admission ladder (resurfaced-verified ≥2×, principal-marked, or <7d grace);
-// quarantined notes score 0 and never appear. When the budget is hit the lowest
-// retention score sheds first, EXCEPT that each non-empty section is offered its
-// single best line ahead of the global fill (min-1-per-section) — so a section's
-// top line can outrank a higher-scoring line from an already-represented section.
-// M4 projects this file → ~/.claude/rules/soma/MEMORY.md.
+// admission ladder (principal-marked, or resurfaced-verified ≥2×; non-principal
+// notes get no pure recency grace — MINJA defense); quarantined notes never appear.
+// When the budget is hit the lowest retention score sheds first, EXCEPT that each
+// non-empty section is offered its single best line ahead of the global fill
+// (min-1-per-section) — so a section's top line can outrank a higher-scoring line
+// from an already-represented section. M4 projects this file through substrate
+// adapters into each substrate's native always-loaded surface.
 export interface SomaMemoryIndexResult {
   somaHome: string;
   /** On-disk path of the rendered index (`memory/INDEX.md`). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -2525,7 +2525,7 @@ export interface SomaMemoryRecallResult {
 }
 
 // Memory subsystem M3 (index renderer). Plan v2 §M3: the earned-inclusion INDEX
-// — a tiny, always-loaded pointer list (≤200 lines / ≤25KB) rebuilt deterministically
+// — a tiny, always-loaded pointer list (≤200 pointer lines / ≤25KB total) rebuilt deterministically
 // from note frontmatter, never on the request path. A note earns a line via the
 // admission ladder (resurfaced-verified ≥2×, principal-marked, or <7d grace);
 // quarantined notes score 0 and never appear. When the budget is hit the lowest

--- a/test/memory-index.test.ts
+++ b/test/memory-index.test.ts
@@ -214,6 +214,28 @@ test("min-1-per-section guarantees a low-scoring section keeps a line under budg
   expect(content).toContain("## Semantic");
 });
 
+test("byte budget holds with the shed footer included (never exceeds 25KB)", () => {
+  // Long ids + max-length descriptors so ~200 lines would blow past 25KB — the
+  // byte ceiling must bind before the line ceiling, and the appended shed footer
+  // must NOT push the final content over MAX_INDEX_BYTES.
+  const notes = Array.from({ length: 300 }, (_, i) =>
+    note({
+      id: `procedural-note-with-a-deliberately-long-slug-${String(i + 1).padStart(4, "0")}`,
+      type: "procedural",
+      body: "x".repeat(120), // truncated to the 80-char descriptor cap, still a long line
+      trust: "principal",
+      resurface_count: i + 2,
+      last_verified: "2026-07-10",
+    }),
+  );
+
+  const { content, rendered, shed } = renderMemoryIndex(notes, NOW);
+  expect(Buffer.byteLength(content, "utf8")).toBeLessThanOrEqual(25_000);
+  expect(shed).toBeGreaterThan(0); // budget bound → footer present
+  expect(content).toContain("earned a line but were shed");
+  expect(rendered).toBeLessThan(300);
+});
+
 test("empty corpus renders a placeholder, not a bare header", () => {
   const { content, admitted, rendered } = renderMemoryIndex([], NOW);
   expect(admitted).toBe(0);

--- a/test/memory-index.test.ts
+++ b/test/memory-index.test.ts
@@ -1,0 +1,260 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { expect, test } from "bun:test";
+import {
+  rebuildMemoryIndex,
+  renderMemoryIndex,
+  retentionScore,
+  memoryIndexPath,
+  serializeMemoryNote,
+  type SomaMemoryNote,
+} from "../src/index";
+import { memoryNotePath, type WritableType } from "../src/memory-write";
+import { parseMemoryArgs, runMemoryCli } from "../src/cli/memory";
+
+const NOW = new Date("2026-07-11T10:00:00.000Z");
+
+async function withTempSoma<T>(fn: (somaHome: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "soma-index-"));
+  const somaHome = join(dir, ".soma");
+  try {
+    return await fn(somaHome);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function note(overrides: Partial<SomaMemoryNote> & { id: string; body: string }): SomaMemoryNote {
+  return {
+    type: "semantic",
+    created: "2026-07-01",
+    last_verified: "2026-07-01",
+    valid_until: null,
+    provenance: "conversation",
+    trust: "principal",
+    source_of_truth: null,
+    project: null,
+    links: [],
+    resurface_count: 0,
+    ...overrides,
+  };
+}
+
+async function seed(somaHome: string, n: SomaMemoryNote): Promise<void> {
+  const path = memoryNotePath(somaHome, n.type as WritableType, n.id);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, serializeMemoryNote(n), "utf8");
+}
+
+// --- retentionScore ----------------------------------------------------------
+
+test("retentionScore is 0 for a quarantined note regardless of resurface/recency", () => {
+  const n = note({ id: "q", body: "x", trust: "quarantined", resurface_count: 9, last_verified: "2026-07-11" });
+  expect(retentionScore(n, NOW)).toBe(0);
+});
+
+test("retentionScore is 0 when a note has never been resurfaced (freshness term is 0)", () => {
+  const n = note({ id: "n", body: "x", trust: "principal", resurface_count: 0 });
+  expect(retentionScore(n, NOW)).toBe(0);
+});
+
+test("retentionScore applies trust × type × freshness, with the recall decay curve", () => {
+  // Use a midnight `now` so dt is exactly 10 days (the score uses the continuous
+  // fractional dt, not the floored display age). procedural(3) × principal(3) × [3 × 0.5^(10/90)]
+  const midnight = new Date("2026-07-11T00:00:00.000Z");
+  const n = note({ id: "p", body: "x", type: "procedural", trust: "principal", resurface_count: 3, last_verified: "2026-07-01" });
+  const expected = 3 * 3 * (3 * Math.pow(0.5, 10 / 90));
+  expect(retentionScore(n, midnight)).toBeCloseTo(expected, 10);
+});
+
+test("retentionScore clamps a future last_verified to no decay", () => {
+  const n = note({ id: "f", body: "x", type: "semantic", trust: "assistant", resurface_count: 4, last_verified: "2026-08-01" });
+  // assistant(1) × semantic(2) × 4 (no decay)
+  expect(retentionScore(n, NOW)).toBeCloseTo(1 * 2 * 4, 10);
+});
+
+// --- admission ladder --------------------------------------------------------
+
+test("quarantined and superseded notes never earn an index line", () => {
+  const notes = [
+    note({ id: "quar", body: "secret", trust: "quarantined", resurface_count: 9 }),
+    note({ id: "closed", body: "old", trust: "principal", resurface_count: 9, valid_until: "2026-07-05" }),
+  ];
+  const { content, admitted, excluded } = renderMemoryIndex(notes, NOW);
+  expect(admitted).toBe(0);
+  expect(excluded).toBe(2);
+  expect(content).not.toContain("quar");
+  expect(content).not.toContain("closed");
+});
+
+test("admission ladder: principal-marked OR resurfaced≥2 OR <7d grace earns a line; nothing else", () => {
+  const notes = [
+    note({ id: "principal-fresh", body: "b", trust: "principal", resurface_count: 0, created: "2026-01-01" }), // principal-marked
+    note({ id: "resurfaced", body: "b", trust: "assistant", resurface_count: 2, created: "2026-01-01" }), // resurfaced ≥2
+    note({ id: "grace", body: "b", trust: "assistant", resurface_count: 0, created: "2026-07-10" }), // <7d grace
+    note({ id: "not-earned", body: "b", trust: "assistant", resurface_count: 1, created: "2026-01-01" }), // none
+  ];
+  const { content, admitted } = renderMemoryIndex(notes, NOW);
+  expect(admitted).toBe(3);
+  expect(content).toContain("principal-fresh");
+  expect(content).toContain("resurfaced");
+  expect(content).toContain("grace");
+  expect(content).not.toContain("not-earned");
+});
+
+// --- golden file -------------------------------------------------------------
+
+test("renderMemoryIndex golden output for a fixed tree and now", () => {
+  const notes = [
+    note({
+      id: "restart-gateway",
+      type: "procedural",
+      trust: "principal",
+      resurface_count: 3,
+      last_verified: "2026-07-01",
+      created: "2026-06-01",
+      hook: "how to restart the gateway",
+      body: "Drain, stop, start, verify health.",
+    }),
+    note({
+      id: "old-assistant-fact",
+      type: "semantic",
+      trust: "assistant",
+      resurface_count: 5,
+      last_verified: "2026-05-01",
+      created: "2026-01-01",
+      body: "Gateway retries thrice before dead-lettering.",
+    }),
+    note({
+      id: "prefers-colon",
+      type: "semantic",
+      trust: "principal",
+      resurface_count: 0,
+      last_verified: "2026-07-10",
+      created: "2026-07-10",
+      body: "Use a colon instead of an em-dash.",
+    }),
+    note({ id: "quar", body: "untrusted", trust: "quarantined", resurface_count: 9 }),
+    note({ id: "stale", body: "cold", trust: "assistant", resurface_count: 0, created: "2026-01-01", last_verified: "2026-01-01" }),
+  ];
+
+  const { content, admitted, rendered, shed, excluded } = renderMemoryIndex(notes, NOW);
+
+  const expected = [
+    "# Soma Memory Index",
+    "",
+    "## Procedural",
+    "- restart-gateway — how to restart the gateway · principal, verified 10d ago",
+    "",
+    "## Semantic",
+    "- old-assistant-fact — Gateway retries thrice before dead-lettering. · assistant, verified 71d ago",
+    "- prefers-colon — Use a colon instead of an em-dash. · principal, verified 1d ago",
+    "",
+  ].join("\n");
+
+  expect(content).toBe(expected);
+  expect(admitted).toBe(3);
+  expect(rendered).toBe(3);
+  expect(shed).toBe(0);
+  expect(excluded).toBe(2);
+});
+
+// --- budget ------------------------------------------------------------------
+
+test("line budget sheds the lowest-score notes first", () => {
+  // 205 admitted semantic notes; resurface_count = rank so scores are strictly ordered.
+  const notes = Array.from({ length: 205 }, (_, i) =>
+    note({
+      id: `note-${String(i + 1).padStart(3, "0")}`,
+      body: `fact ${i + 1}`,
+      trust: "assistant",
+      resurface_count: i + 1, // 1..205 — all ≥2 except note-001; note-001 admitted via nothing? see below
+      last_verified: "2026-07-10",
+      created: "2026-07-10", // <7d grace so even note-001 (resurface 1) is admitted
+    }),
+  );
+
+  const { content, admitted, rendered, shed } = renderMemoryIndex(notes, NOW);
+  expect(admitted).toBe(205);
+  expect(rendered).toBe(200);
+  expect(shed).toBe(5);
+  // the five lowest resurface_count (=lowest score) are shed
+  for (const i of [1, 2, 3, 4, 5]) {
+    expect(content).not.toContain(`note-${String(i).padStart(3, "0")} `);
+  }
+  expect(content).toContain("note-006 ");
+  expect(content).toContain("note-205 ");
+});
+
+test("min-1-per-section guarantees a low-scoring section keeps a line under budget pressure", () => {
+  const procedurals = Array.from({ length: 205 }, (_, i) =>
+    note({
+      id: `proc-${String(i + 1).padStart(3, "0")}`,
+      type: "procedural",
+      body: `step ${i + 1}`,
+      trust: "principal",
+      resurface_count: i + 10, // all high-scoring
+      last_verified: "2026-07-10",
+    }),
+  );
+  const lowSemantic = note({
+    id: "lonely-semantic",
+    type: "semantic",
+    body: "the one semantic pointer",
+    trust: "principal",
+    resurface_count: 0, // score 0 — would lose to every procedural
+    created: "2026-07-10",
+  });
+
+  const { content, rendered } = renderMemoryIndex([...procedurals, lowSemantic], NOW);
+  expect(rendered).toBe(200);
+  // even though 205 procedurals outscore it, the semantic section keeps its one line
+  expect(content).toContain("lonely-semantic");
+  expect(content).toContain("## Semantic");
+});
+
+test("empty corpus renders a placeholder, not a bare header", () => {
+  const { content, admitted, rendered } = renderMemoryIndex([], NOW);
+  expect(admitted).toBe(0);
+  expect(rendered).toBe(0);
+  expect(content).toContain("_No notes have earned an index line yet._");
+});
+
+// --- rebuild + CLI -----------------------------------------------------------
+
+test("rebuildMemoryIndex writes memory/INDEX.md and returns counts", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, note({ id: "earned", body: "b", trust: "principal", resurface_count: 3, last_verified: "2026-07-10" }));
+    await seed(somaHome, note({ id: "quar", body: "x", trust: "quarantined", resurface_count: 9 }));
+
+    const result = await rebuildMemoryIndex({ somaHome, now: NOW });
+
+    expect(result.path).toBe(memoryIndexPath(somaHome));
+    expect(result.rendered).toBe(1);
+    expect(result.excluded).toBe(1);
+    const onDisk = await readFile(result.path, "utf8");
+    expect(onDisk).toBe(result.content);
+    expect(onDisk).toContain("- earned —");
+    expect(onDisk).not.toContain("quar");
+  });
+});
+
+test("rebuildMemoryIndex is deterministic — same tree + same now → identical bytes", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, note({ id: "a", body: "aa", trust: "principal", resurface_count: 4, last_verified: "2026-07-01" }));
+    await seed(somaHome, note({ id: "b", type: "procedural", body: "bb", trust: "principal", resurface_count: 2, last_verified: "2026-07-05" }));
+    const first = await rebuildMemoryIndex({ somaHome, now: NOW });
+    const second = await rebuildMemoryIndex({ somaHome, now: NOW });
+    expect(second.content).toBe(first.content);
+  });
+});
+
+test("runMemoryCli reindex reports the rebuild summary", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, note({ id: "earned", body: "b", trust: "principal", resurface_count: 3, last_verified: "2026-07-10" }));
+    const out = await runMemoryCli(parseMemoryArgs(["memory", "reindex", "--soma-home", somaHome]));
+    expect(out).toContain("Soma memory reindex");
+    expect(out).toContain("rendered: 1 line(s)");
+  });
+});

--- a/test/memory-index.test.ts
+++ b/test/memory-index.test.ts
@@ -83,19 +83,20 @@ test("quarantined and superseded notes never earn an index line", () => {
   expect(content).not.toContain("closed");
 });
 
-test("admission ladder: principal-marked OR resurfaced≥2 OR <7d grace earns a line; nothing else", () => {
+test("admission ladder: principal-marked OR resurfaced≥2 earns a line; non-principal recency does NOT", () => {
   const notes = [
     note({ id: "principal-fresh", body: "b", trust: "principal", resurface_count: 0, created: "2026-01-01" }), // principal-marked
     note({ id: "resurfaced", body: "b", trust: "assistant", resurface_count: 2, created: "2026-01-01" }), // resurfaced ≥2
-    note({ id: "grace", body: "b", trust: "assistant", resurface_count: 0, created: "2026-07-10" }), // <7d grace
-    note({ id: "not-earned", body: "b", trust: "assistant", resurface_count: 1, created: "2026-01-01" }), // none
+    // a fresh, unverified assistant note gets NO recency grace (MINJA defense, sage M3 r3)
+    note({ id: "fresh-assistant", body: "b", trust: "assistant", resurface_count: 0, created: "2026-07-10" }),
+    note({ id: "under-resurfaced", body: "b", trust: "assistant", resurface_count: 1, created: "2026-01-01" }),
   ];
   const { content, admitted } = renderMemoryIndex(notes, NOW);
-  expect(admitted).toBe(3);
+  expect(admitted).toBe(2);
   expect(content).toContain("principal-fresh");
   expect(content).toContain("resurfaced");
-  expect(content).toContain("grace");
-  expect(content).not.toContain("not-earned");
+  expect(content).not.toContain("fresh-assistant");
+  expect(content).not.toContain("under-resurfaced");
 });
 
 // --- golden file -------------------------------------------------------------
@@ -158,15 +159,15 @@ test("renderMemoryIndex golden output for a fixed tree and now", () => {
 // --- budget ------------------------------------------------------------------
 
 test("line budget sheds the lowest-score notes first", () => {
-  // 205 admitted semantic notes; resurface_count = rank so scores are strictly ordered.
+  // 205 admitted principal notes (principal → always admitted); resurface_count =
+  // rank so retention scores are strictly ordered and the lowest shed first.
   const notes = Array.from({ length: 205 }, (_, i) =>
     note({
       id: `note-${String(i + 1).padStart(3, "0")}`,
       body: `fact ${i + 1}`,
-      trust: "assistant",
-      resurface_count: i + 1, // 1..205 — all ≥2 except note-001; note-001 admitted via nothing? see below
+      trust: "principal",
+      resurface_count: i + 1, // 1..205 → strictly increasing score
       last_verified: "2026-07-10",
-      created: "2026-07-10", // <7d grace so even note-001 (resurface 1) is admitted
     }),
   );
 

--- a/test/memory-index.test.ts
+++ b/test/memory-index.test.ts
@@ -2,14 +2,9 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
-import {
-  rebuildMemoryIndex,
-  renderMemoryIndex,
-  retentionScore,
-  memoryIndexPath,
-  serializeMemoryNote,
-  type SomaMemoryNote,
-} from "../src/index";
+import { rebuildMemoryIndex, serializeMemoryNote, type SomaMemoryNote } from "../src/index";
+// Index internals are module-private (not public index API) — import direct.
+import { renderMemoryIndex, retentionScore, memoryIndexPath } from "../src/memory-index";
 import { memoryNotePath, type WritableType } from "../src/memory-write";
 import { parseMemoryArgs, runMemoryCli } from "../src/cli/memory";
 


### PR DESCRIPTION
## Memory subsystem M3 — index renderer (plan v2 §M3)

`soma memory reindex` rebuilds `memory/INDEX.md` from note frontmatter — the tiny, always-loaded pointer artifact that M4 will project through substrate adapters into each substrate's native always-loaded surface. Never on the request path; no LLM.

### Two orthogonal decisions per note
- **Admission (earned inclusion)** — a note earns a line only if active (`valid_until === null`), non-quarantined, and either **principal-marked** (trusted, same-turn) OR **resurfaced-and-verified ≥2×**. Non-principal notes get **no** pure recency grace — admitting unverified imported/tool-derived text into always-loaded memory would be a prompt-injection path (tightened per sage review). Quarantined notes never appear.
- **Retention score (eviction order)** — `trust_weight(principal 3 / assistant 1 / quarantined 0) × type_weight(procedural 3 / semantic 2 / episodic 1) × freshness`, where freshness is recall's decay curve on frontmatter: `resurface_count × 0.5^(daysSince(last_verified)/halflife)`, future-clamped. Adapted from the recall freshness-score concept (amends v1's linear recency term). When the budget is hit the lowest score sheds first, except each non-empty section is offered its single best line ahead of the global fill (min-1-per-section).

### Budget
≤200 **pointer** lines / ≤25KB total (the title, section headings, blank separators, and optional shed footer are a small fixed overhead on top). The shed footer is reserved up front, so the whole file never exceeds 25KB. Shed notes are counted and reported in a footer — never silently dropped.

### Invariants
- "verified Nd ago" is computed at rebuild time from an injected `now` — no wall clock in `renderMemoryIndex`. The `reindex` CLI uses the current date, so its output advances day to day (help text says so).
- Deterministic given the tree AND `now`: same inputs → byte-identical output (golden-file tested).

### Shape
- `src/memory-index.ts` — `retentionScore`, `collectAllNotes`, `renderMemoryIndex` (via extracted `selectIndexLines`), `rebuildMemoryIndex`, `memoryIndexPath`. Public API surface is the CLI-facing `rebuildMemoryIndex` only; the rest is module-private (scoring model / storage path not frozen — episodic joins at M5). Reuses M1's `collectDurableNotes`.
- `SomaMemoryIndexResult` in types.ts; `reindex` wired into the memory CLI.

### Verification evidence
`bunx tsc --noEmit` → clean. Memory suite → 98 pass (5 files).

`memory-index.test.ts` (14 tests): retentionScore (quarantined 0, resurface-0 → 0, trust×type×freshness, future-clamp); admission ladder (quarantined/superseded never; principal & resurfaced≥2 admitted; **fresh non-principal excluded**); **golden-file INDEX.md**; line-budget sheds lowest-score-first; **byte budget ≤25KB with shed footer**; min-1-per-section under pressure; empty-corpus placeholder; rebuild writes file + deterministic bytes; CLI reindex summary.

End-to-end smoke (write principal proc note + import quarantined web note → reindex):
```
## Procedural
- restart-gateway — how to restart the gateway · principal, verified 0d ago
```
(the quarantined web import is excluded).

### Sage review
4 rounds so far: r1 footer-byte-budget + honest eviction docs; r2 narrow public API + extract selection + honest line budget; r3 **drop non-principal recency grace (prompt-injection defense)** + honest CLI/type docs; r4 this description correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)