### PR TITLE
feat(memory): project INDEX.md → Claude Code MEMORY.md (M4)

### DIFF
--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -180,10 +180,19 @@ export const CLAUDE_CODE_RULES_FILES = [
   "rules/soma/SKILLS.md",
   "rules/soma/POLICY.md",
   "rules/soma/ACTIVE_VSA.md",
+  // Memory index (M4). Conditional like ACTIVE_VSA — omitted when memory is
+  // disabled or no index exists — so it is declared here (for the planner /
+  // doctor / owned-subtree reconcile) but excluded from the always-on builders
+  // map below and appended by memoryIndexBundleFile.
+  "rules/soma/MEMORY.md",
 ] as const;
 
+// The conditionally-projected rules files (ACTIVE_VSA + MEMORY): both are omitted
+// when their source is absent, so neither has an always-on content builder.
+type ConditionalRulesFile = "rules/soma/ACTIVE_VSA.md" | "rules/soma/MEMORY.md";
+
 const CLAUDE_RULES_CONTENT_BUILDERS: Record<
-  Exclude<(typeof CLAUDE_CODE_RULES_FILES)[number], "rules/soma/ACTIVE_VSA.md">,
+  Exclude<(typeof CLAUDE_CODE_RULES_FILES)[number], ConditionalRulesFile>,
   (input: ProjectionInput) => string
 > = {
   "rules/soma/README.md": () => renderClaudeRulesReadme(),
@@ -194,6 +203,19 @@ const CLAUDE_RULES_CONTENT_BUILDERS: Record<
   "rules/soma/SKILLS.md": (input) => renderSkills(input),
   "rules/soma/POLICY.md": () => renderClaudePolicy(),
 };
+
+/**
+ * The always-loaded memory index file (M4), or `[]` when no memory index is set.
+ * Content is the VERBATIM rendered `memory/INDEX.md` — no provenance header (like
+ * ACTIVE_VSA, it is derived content, and wrapping it would diverge from the stored
+ * bytes) and no wall clock (ages were baked at index rebuild time, AC-4). The file
+ * is `rules/soma/MEMORY.md`; `MEMORY_LAYOUT.md` is a separate, untouched file.
+ */
+export function memoryIndexBundleFile(input: ProjectionInput): { path: string; content: string }[] {
+  const indexContent = input.memory?.indexContent;
+  if (indexContent === undefined || indexContent.trim().length === 0) return [];
+  return [{ path: "rules/soma/MEMORY.md", content: indexContent }];
+}
 
 /**
  * Claude Code home projection (#29). Writes the Soma context under
@@ -227,6 +249,8 @@ export function projectClaudeCodeHome(input: ProjectionInput): Projection {
       ...skeleton.map((file) => ({ ...file, content: withProvenance("claude-code", file.content) })),
       // Active VSA — omitted when no active VSA set (preserves #37 AC-2).
       ...activeVsaBundleFile("claude-code", input.activeVsa),
+      // Memory index (M4) — omitted when memory disabled / no index. Verbatim bytes.
+      ...memoryIndexBundleFile(input),
     ],
   };
 }

--- a/src/adapters/claude-code/doctor.ts
+++ b/src/adapters/claude-code/doctor.ts
@@ -9,12 +9,13 @@ import {
   SOMA_CLAUDE_HOOK_RELATIVE_PATH,
 } from "./hooks";
 
-// The provenance-wrapped skeleton files (soma#370). ACTIVE_VSA.md is excluded
-// because the projection deliberately does not wrap it (it is a byte-portable
-// cross-substrate artifact with its own leading frontmatter), so it must not be
-// checked for a header.
+// The provenance-wrapped skeleton files (soma#370). ACTIVE_VSA.md and MEMORY.md
+// are excluded because the projection deliberately does not wrap them: ACTIVE_VSA
+// is a byte-portable cross-substrate artifact with its own frontmatter, and
+// MEMORY.md (M4) is the verbatim rendered memory index — a provenance header would
+// diverge both from their stored bytes. Neither is checked for a header.
 const PROVENANCE_MANAGED_RULES_FILES = CLAUDE_CODE_RULES_FILES.filter(
-  (path) => path !== "rules/soma/ACTIVE_VSA.md",
+  (path) => path !== "rules/soma/ACTIVE_VSA.md" && path !== "rules/soma/MEMORY.md",
 );
 
 // The hook file's basename (e.g. `soma-claude-code-hook.mjs`) appears in the

--- a/src/install.ts
+++ b/src/install.ts
@@ -17,6 +17,7 @@ import { createPaths } from "./paths";
 import { pruneLegacyVsaSkill } from "./legacy-skill-prune";
 import { installVsaSkillProjection } from "./vsa-skill-installer";
 import { loadActiveVsaForBundle } from "./adapter-active-vsa";
+import { loadMemoryIndexForProjection } from "./memory-index";
 import { isUnderOrEqual, reconcileOwnedDir } from "./projection-reconcile";
 import { isEnoent } from "./fs-errors";
 import {
@@ -173,11 +174,15 @@ async function installSomaForSubstrate(
     skillNameOverride: spec.vsaSkillProjection.skillNameOverride,
     projectionSubstrate: substrate,
   });
-  // Populate the projection input with the active VSA so each
-  // substrate writes its `active-vsa.md` file (#37 AC-1/AC-2).
+  // Populate the projection input with the active VSA so each substrate writes its
+  // `active-vsa.md` file (#37 AC-1/AC-2), and with the memory index (M4) so
+  // memory-aware substrates project their always-loaded memory file. Both are
+  // soft: absent source → the file is simply omitted.
+  const memoryIndexContent = await loadMemoryIndexForProjection({ somaHome: somaHome.somaHome });
   const contextWithActiveVsa: ProjectionInput = {
     ...projectionContext,
     activeVsa: (await loadActiveVsaForBundle({ somaHome: somaHome.somaHome })) ?? undefined,
+    memory: memoryIndexContent !== undefined ? { indexContent: memoryIndexContent } : undefined,
   };
   const substrateHome = await installHomeProjectionFor(substrate, contextWithActiveVsa, projectionOptions);
   await removeObsoleteHomeFiles(spec, substrateHome.rootDir);

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { createPaths } from "./paths";
+import { isEnoent } from "./fs-utils";
 import { collectDurableNotes } from "./memory-write";
 import type { SomaMemoryIndexResult, SomaMemoryNote, SomaMemoryNoteType, SomaMemoryTrust } from "./types";
 
@@ -342,18 +343,36 @@ function memoryProjectionDisabled(): boolean {
 /**
  * Read the rendered `memory/INDEX.md` for substrate projection (M4). Returns the
  * verbatim stored bytes so the projected memory file has NO wall clock — ages were
- * baked at index rebuild time (AC-4). Soft-fails to `undefined` (never throws) when
- * memory/projection is disabled, the index is absent, or it is empty/whitespace —
- * in which case the substrate simply projects no memory file. The projection reads,
- * it does NOT rebuild: rebuilding here would stamp install-time ages into the output.
+ * baked at index rebuild time (AC-4). The projection reads, it does NOT rebuild:
+ * rebuilding here would stamp install-time ages into the output.
+ *
+ * Returns `undefined` (project no memory file) when memory/projection is disabled,
+ * the index is absent (ENOENT — the normal pre-first-reindex case, silent), or it
+ * is empty/whitespace. Any OTHER read failure (permissions, a directory at the
+ * path, I/O) is ALSO soft-failed to `undefined` — the projection must never block
+ * an install — but it is WARNED to stderr rather than hidden, so a genuine
+ * misconfiguration is not silently mistaken for "no memory".
  */
 export async function loadMemoryIndexForProjection(
   options: { homeDir?: string; somaHome?: string } = {},
 ): Promise<string | undefined> {
   if (memoryProjectionDisabled()) return undefined;
   const somaHome = createPaths(options).root();
-  const content = await readFile(memoryIndexPath(somaHome), "utf8").catch(() => undefined);
-  return content !== undefined && content.trim().length > 0 ? content : undefined;
+  const path = memoryIndexPath(somaHome);
+  let content: string;
+  try {
+    content = await readFile(path, "utf8");
+  } catch (error) {
+    if (!isEnoent(error)) {
+      // Unexpected read failure: degrade (don't block install) but surface it.
+      console.warn(
+        `soma: could not read the memory index at ${path} for projection — skipping the memory file. ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    return undefined;
+  }
+  return content.trim().length > 0 ? content : undefined;
 }
 
 /**

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { createPaths } from "./paths";
 import { collectDurableNotes } from "./memory-write";
@@ -330,6 +330,30 @@ export function renderMemoryIndex(
 /** On-disk path of the rendered index. */
 export function memoryIndexPath(somaHome: string): string {
   return createPaths(somaHome).resolve("memory", "INDEX.md");
+}
+
+/** Env kill-switches (M4, adapted from recall's tiered disable pattern — pattern only, no code). */
+function memoryProjectionDisabled(): boolean {
+  // SOMA_MEMORY_DISABLE turns off ALL memory behavior; SOMA_MEMORY_DISABLE_PROJECT
+  // turns off only the substrate projection (recall/reindex still work).
+  return process.env.SOMA_MEMORY_DISABLE === "1" || process.env.SOMA_MEMORY_DISABLE_PROJECT === "1";
+}
+
+/**
+ * Read the rendered `memory/INDEX.md` for substrate projection (M4). Returns the
+ * verbatim stored bytes so the projected memory file has NO wall clock — ages were
+ * baked at index rebuild time (AC-4). Soft-fails to `undefined` (never throws) when
+ * memory/projection is disabled, the index is absent, or it is empty/whitespace —
+ * in which case the substrate simply projects no memory file. The projection reads,
+ * it does NOT rebuild: rebuilding here would stamp install-time ages into the output.
+ */
+export async function loadMemoryIndexForProjection(
+  options: { homeDir?: string; somaHome?: string } = {},
+): Promise<string | undefined> {
+  if (memoryProjectionDisabled()) return undefined;
+  const somaHome = createPaths(options).root();
+  const content = await readFile(memoryIndexPath(somaHome), "utf8").catch(() => undefined);
+  return content !== undefined && content.trim().length > 0 ? content : undefined;
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -559,6 +559,15 @@ export interface ProjectionInput {
   profile: SomaProfile;
   activeVsa?: VerificationStateArtifact;
   prompt?: string;
+  /**
+   * Memory subsystem M4 — the projected always-loaded memory index. A SIBLING
+   * surface to `profile`, deliberately NOT under it: Memory is a peer compartment
+   * to Identity/Purpose, not a sub-field of the profile. `indexContent` is the
+   * verbatim rendered `memory/INDEX.md` (no wall clock — ages are baked at index
+   * rebuild time, AC-4). Omitted when memory is disabled or no index exists, in
+   * which case the substrate simply does not project a memory file.
+   */
+  memory?: { indexContent: string };
 }
 
 export interface Projection {

--- a/test/claude-code-install.test.ts
+++ b/test/claude-code-install.test.ts
@@ -151,6 +151,7 @@ test("AC-2: planSomaForClaudeCodeInstall lists every file written", () => {
     "/tmp/test-home/.claude/rules/soma/SKILLS.md",
     "/tmp/test-home/.claude/rules/soma/POLICY.md",
     "/tmp/test-home/.claude/rules/soma/ACTIVE_VSA.md",
+    "/tmp/test-home/.claude/rules/soma/MEMORY.md",
     "/tmp/test-home/.claude/hooks/soma/soma-claude-code-hook.mjs",
     "/tmp/test-home/.claude/hooks/soma/soma-claude-code-hook.config.json",
     "/tmp/test-home/.claude/settings.json",

--- a/test/memory-projection.test.ts
+++ b/test/memory-projection.test.ts
@@ -96,6 +96,24 @@ test("loadMemoryIndexForProjection soft-fails to undefined when the index is abs
   });
 });
 
+test("loadMemoryIndexForProjection soft-fails (warns, no throw) on an unexpected read error", async () => {
+  await withTempSoma(async (somaHome) => {
+    // A directory at the index path makes readFile throw EISDIR (not ENOENT).
+    const path = memoryIndexPath(somaHome);
+    await mkdir(path, { recursive: true });
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (msg: unknown) => warnings.push(String(msg));
+    try {
+      expect(await loadMemoryIndexForProjection({ somaHome })).toBeUndefined();
+    } finally {
+      console.warn = original;
+    }
+    // the failure is surfaced, not hidden
+    expect(warnings.some((w) => w.includes("could not read the memory index"))).toBe(true);
+  });
+});
+
 test("SOMA_MEMORY_DISABLE and SOMA_MEMORY_DISABLE_PROJECT both suppress the projection", async () => {
   await withTempSoma(async (somaHome) => {
     const path = memoryIndexPath(somaHome);

--- a/test/memory-projection.test.ts
+++ b/test/memory-projection.test.ts
@@ -1,0 +1,112 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, expect, test } from "bun:test";
+import {
+  CLAUDE_CODE_RULES_FILES,
+  memoryIndexBundleFile,
+  projectClaudeCodeHome,
+} from "../src/adapters/claude-code";
+import { loadMemoryIndexForProjection, memoryIndexPath } from "../src/memory-index";
+import type { ProjectionInput } from "../src/index";
+import { portableProjectionInput } from "./fixtures";
+
+const INDEX_SAMPLE = "# Soma Memory Index\n\n## Procedural\n- restart-gateway — how to restart · principal, verified 3d ago\n";
+
+function withMemory(indexContent?: string): ProjectionInput {
+  return indexContent === undefined
+    ? portableProjectionInput
+    : { ...portableProjectionInput, memory: { indexContent } };
+}
+
+async function withTempSoma<T>(fn: (somaHome: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "soma-proj-"));
+  const somaHome = join(dir, ".soma");
+  try {
+    return await fn(somaHome);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+// Restore env after any test that toggles the kill-switches.
+afterEach(() => {
+  delete process.env.SOMA_MEMORY_DISABLE;
+  delete process.env.SOMA_MEMORY_DISABLE_PROJECT;
+});
+
+// --- bundle helper -----------------------------------------------------------
+
+test("memoryIndexBundleFile projects MEMORY.md verbatim when an index is present", () => {
+  const files = memoryIndexBundleFile(withMemory(INDEX_SAMPLE));
+  expect(files).toEqual([{ path: "rules/soma/MEMORY.md", content: INDEX_SAMPLE }]);
+});
+
+test("memoryIndexBundleFile omits the file when there is no index (or it is blank)", () => {
+  expect(memoryIndexBundleFile(withMemory(undefined))).toEqual([]);
+  expect(memoryIndexBundleFile(withMemory("   \n  "))).toEqual([]);
+});
+
+// --- home projection ---------------------------------------------------------
+
+test("projectClaudeCodeHome includes rules/soma/MEMORY.md (verbatim) when memory is set", () => {
+  const projection = projectClaudeCodeHome(withMemory(INDEX_SAMPLE));
+  const memoryFile = projection.files.find((f) => f.path === "rules/soma/MEMORY.md");
+  expect(memoryFile).toBeDefined();
+  // verbatim stored bytes — no provenance header, no wall clock
+  expect(memoryFile!.content).toBe(INDEX_SAMPLE);
+  expect(memoryFile!.content).not.toContain("Provenance");
+});
+
+test("projectClaudeCodeHome omits MEMORY.md when no memory index is set", () => {
+  const projection = projectClaudeCodeHome(withMemory(undefined));
+  expect(projection.files.some((f) => f.path === "rules/soma/MEMORY.md")).toBe(false);
+});
+
+test("MEMORY.md projection is idempotent — same input renders byte-identical content", () => {
+  const first = projectClaudeCodeHome(withMemory(INDEX_SAMPLE));
+  const second = projectClaudeCodeHome(withMemory(INDEX_SAMPLE));
+  const pick = (p: ReturnType<typeof projectClaudeCodeHome>) =>
+    p.files.find((f) => f.path === "rules/soma/MEMORY.md")!.content;
+  expect(pick(second)).toBe(pick(first));
+});
+
+test("MEMORY.md is a declared rules file (planner / doctor / uninstall awareness)", () => {
+  expect(CLAUDE_CODE_RULES_FILES).toContain("rules/soma/MEMORY.md");
+});
+
+// --- loader ------------------------------------------------------------------
+
+test("loadMemoryIndexForProjection returns the verbatim INDEX.md bytes", async () => {
+  await withTempSoma(async (somaHome) => {
+    const path = memoryIndexPath(somaHome);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, INDEX_SAMPLE, "utf8");
+    expect(await loadMemoryIndexForProjection({ somaHome })).toBe(INDEX_SAMPLE);
+  });
+});
+
+test("loadMemoryIndexForProjection soft-fails to undefined when the index is absent or blank", async () => {
+  await withTempSoma(async (somaHome) => {
+    expect(await loadMemoryIndexForProjection({ somaHome })).toBeUndefined();
+    const path = memoryIndexPath(somaHome);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, "   \n", "utf8");
+    expect(await loadMemoryIndexForProjection({ somaHome })).toBeUndefined();
+  });
+});
+
+test("SOMA_MEMORY_DISABLE and SOMA_MEMORY_DISABLE_PROJECT both suppress the projection", async () => {
+  await withTempSoma(async (somaHome) => {
+    const path = memoryIndexPath(somaHome);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, INDEX_SAMPLE, "utf8");
+
+    process.env.SOMA_MEMORY_DISABLE = "1";
+    expect(await loadMemoryIndexForProjection({ somaHome })).toBeUndefined();
+    delete process.env.SOMA_MEMORY_DISABLE;
+
+    process.env.SOMA_MEMORY_DISABLE_PROJECT = "1";
+    expect(await loadMemoryIndexForProjection({ somaHome })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Memory subsystem M4 — Claude Code projection (plan v2 §M4)

The always-loaded memory index (M3) reaches Claude Code as `~/.claude/rules/soma/MEMORY.md`.

### What it does
- **`ProjectionInput.memory`** — a `{ indexContent }` SIBLING surface, deliberately NOT under `profile` (Memory is a peer compartment to Identity/Purpose).
- **`loadMemoryIndexForProjection()`** — reads the **verbatim** `memory/INDEX.md` bytes (no wall clock; ages baked at index rebuild time, AC-4). ENOENT (no index yet) is silent; any other read error is warned to stderr but still soft-failed to `undefined` (the projection never blocks an install). Honors **`SOMA_MEMORY_DISABLE`** / **`SOMA_MEMORY_DISABLE_PROJECT`**.
- **claude-code adapter** projects `rules/soma/MEMORY.md` via `memoryIndexBundleFile`, conditional like ACTIVE_VSA: declared in `CLAUDE_CODE_RULES_FILES` (planner / doctor / owned-subtree reconcile) but omitted when there is no index. Verbatim content, no provenance header. `MEMORY_LAYOUT.md` untouched.
- **install.ts** populates `input.memory` from the loader (reads, does NOT rebuild). **doctor** excludes MEMORY.md from the provenance check. Uninstall removal is handled by the existing `ownedSubtrees: ["rules/soma"]` (MEMORY.md lives under it).

### Verification
`bunx tsc --noEmit` clean; 66 pass across memory-projection (10) / memory-index / claude-code-install / home-projection. Projection tests cover: verbatim bundle / omit-when-blank, home-projection include+omit, idempotent bytes, MEMORY.md declared in rules files, loader verbatim read / ENOENT+blank soft-fail / EISDIR warns-not-hidden / both kill-switches suppress.

End-to-end CLI (seed principal note → `reindex` → install/uninstall), actual output:
```
$ diff memory/INDEX.md .claude/rules/soma/MEMORY.md
  → IDENTICAL to INDEX.md (verbatim)
$ install claude-code again; diff MEMORY.md
  → IDEMPOTENT (identical bytes)
$ uninstall claude-code --home-dir <h> --soma-home <s>
  → rules/soma REMOVED (incl MEMORY.md)
$ SOMA_MEMORY_DISABLE_PROJECT=1 install claude-code
  → MEMORY.md SUPPRESSED; other 7 rules/soma .md files present
```

### Sage
r1 (important, HonestOracle): loader no longer swallows unexpected read errors — ENOENT silent, others warned. r2: commented (converged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)