### PR TITLE
feat(memory): episodic session digests + action log (M5 core)

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -9,6 +9,7 @@ import {
   writeSessionDigest,
 } from "../index";
 import { WRITABLE_NOTE_TYPES, isWritableNoteType } from "../memory-write";
+import { SOMA_MEMORY_ACTION_APPROVALS } from "../types";
 import type {
   SomaMemoryActionApproval,
   SomaMemoryActionOptions,
@@ -131,9 +132,9 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
       "Usage: soma memory digest --session <id> --body <text> [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
       "Write the ONE session digest (8–15 non-empty lines). A second digest for the same session no-ops with an event.",
     action:
-      "Usage: soma memory action --slug <slug> --intent <text> --approval <proposed|approved|rejected|auto> " +
+      "Usage: soma memory action --slug <slug> --planned-action <text> --approval <proposed|approved|rejected|auto> " +
       "[--outcome <text>] [--session <id>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
-      "Log one intent→approval→outcome action entry (id YYYYMMDD-<slug>; collision refused).",
+      "Log one planned-action→approval→outcome entry (id YYYYMMDD-<slug>; collision refused).",
   },
 };
 
@@ -226,10 +227,10 @@ function parseMemoryDigestArgs(args: string[]): SomaMemoryDigestOptions {
 }
 
 function parseActionApproval(value: string): SomaMemoryActionApproval {
-  if (value === "proposed" || value === "approved" || value === "rejected" || value === "auto") {
-    return value;
+  if ((SOMA_MEMORY_ACTION_APPROVALS as readonly string[]).includes(value)) {
+    return value as SomaMemoryActionApproval;
   }
-  throw new Error("--approval must be one of proposed, approved, rejected, auto.");
+  throw new Error(`--approval must be one of ${SOMA_MEMORY_ACTION_APPROVALS.join(", ")}.`);
 }
 
 function parseMemoryActionArgs(args: string[]): SomaMemoryActionOptions {
@@ -249,8 +250,8 @@ function parseMemoryActionArgs(args: string[]): SomaMemoryActionOptions {
         options.sessionId = readOption(args, index, arg);
         index += 1;
         break;
-      case "--intent":
-        options.intent = readOption(args, index, arg);
+      case "--planned-action":
+        options.plannedAction = readOption(args, index, arg);
         index += 1;
         break;
       case "--approval":
@@ -267,7 +268,7 @@ function parseMemoryActionArgs(args: string[]): SomaMemoryActionOptions {
   }
   const missing: string[] = [];
   if (!options.slug) missing.push("--slug");
-  if (!options.intent) missing.push("--intent");
+  if (!options.plannedAction) missing.push("--planned-action");
   if (!options.approval) missing.push("--approval");
   if (missing.length > 0) {
     throw new Error(`soma memory action is missing required option(s): ${missing.join(", ")}.`);

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -4,7 +4,7 @@ import {
   recallMemory,
   searchSomaMemory,
   verifyMemoryNote,
-  writeAction,
+  writeMemoryAction,
   writeMemoryNote,
   writeSessionDigest,
 } from "../index";
@@ -29,6 +29,7 @@ import type {
   SomaMemoryWriteOptions,
   SomaMemoryWriteResult,
   SomaMemoryWriteTrigger,
+  SubstrateId,
 } from "../types";
 
 /** Parsed `soma memory reindex` — home overrides only; rebuild uses the real clock. */
@@ -167,23 +168,42 @@ export function parseMemoryArgs(args: string[]): ParsedMemoryArgs {
   }
 }
 
+/**
+ * Consume a shared episodic/home option (`--home-dir`, `--soma-home`,
+ * `--substrate`) into `options`. Returns true if `arg` was one of them (the value
+ * was read from args[index+1], so the caller advances the index). One place for the
+ * options both `digest` and `action` share, so they can't drift.
+ */
+function consumeSharedMemoryOption(
+  args: string[],
+  index: number,
+  arg: string,
+  options: { homeDir?: string; somaHome?: string; substrate?: SubstrateId },
+): boolean {
+  switch (arg) {
+    case "--home-dir":
+      options.homeDir = readOption(args, index, arg);
+      return true;
+    case "--soma-home":
+      options.somaHome = readOption(args, index, arg);
+      return true;
+    case "--substrate":
+      options.substrate = parseSubstrate(readOption(args, index, arg));
+      return true;
+    default:
+      return false;
+  }
+}
+
 function parseMemoryDigestArgs(args: string[]): SomaMemoryDigestOptions {
   const options: Partial<SomaMemoryDigestOptions> = {};
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    if (consumeSharedMemoryOption(args, index, arg, options)) {
+      index += 1;
+      continue;
+    }
     switch (arg) {
-      case "--home-dir":
-        options.homeDir = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--soma-home":
-        options.somaHome = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--substrate":
-        options.substrate = parseSubstrate(readOption(args, index, arg));
-        index += 1;
-        break;
       case "--session":
         options.sessionId = readOption(args, index, arg);
         index += 1;
@@ -216,19 +236,11 @@ function parseMemoryActionArgs(args: string[]): SomaMemoryActionOptions {
   const options: Partial<SomaMemoryActionOptions> = {};
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
+    if (consumeSharedMemoryOption(args, index, arg, options)) {
+      index += 1;
+      continue;
+    }
     switch (arg) {
-      case "--home-dir":
-        options.homeDir = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--soma-home":
-        options.somaHome = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--substrate":
-        options.substrate = parseSubstrate(readOption(args, index, arg));
-        index += 1;
-        break;
       case "--slug":
         options.slug = readOption(args, index, arg);
         index += 1;
@@ -637,7 +649,7 @@ export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
     case "digest":
       return formatMemoryDigestResult(await writeSessionDigest(parsed.options));
     case "action":
-      return formatMemoryActionResult(await writeAction(parsed.options));
+      return formatMemoryActionResult(await writeMemoryAction(parsed.options));
   }
 }
 

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -4,10 +4,17 @@ import {
   recallMemory,
   searchSomaMemory,
   verifyMemoryNote,
+  writeAction,
   writeMemoryNote,
+  writeSessionDigest,
 } from "../index";
 import { WRITABLE_NOTE_TYPES, isWritableNoteType } from "../memory-write";
 import type {
+  SomaMemoryActionApproval,
+  SomaMemoryActionOptions,
+  SomaMemoryActionResult,
+  SomaMemoryDigestOptions,
+  SomaMemoryDigestResult,
   SomaMemoryIndexResult,
   SomaMemoryNoteType,
   SomaMemoryPromotionOptions,
@@ -68,19 +75,33 @@ export interface ParsedMemoryReindexArgs {
   options: MemoryReindexOptions;
 }
 
+export interface ParsedMemoryDigestArgs {
+  command: "memory";
+  action: "digest";
+  options: SomaMemoryDigestOptions;
+}
+
+export interface ParsedMemoryActionArgs {
+  command: "memory";
+  action: "action";
+  options: SomaMemoryActionOptions;
+}
+
 export type ParsedMemoryArgs =
   | ParsedMemorySearchArgs
   | ParsedMemoryRecallArgs
   | ParsedMemoryPromoteArgs
   | ParsedMemoryWriteArgs
   | ParsedMemoryVerifyArgs
-  | ParsedMemoryReindexArgs;
+  | ParsedMemoryReindexArgs
+  | ParsedMemoryDigestArgs
+  | ParsedMemoryActionArgs;
 
-const MEMORY_ACTIONS = ["search", "recall", "promote", "write", "verify", "reindex"] as const;
+const MEMORY_ACTIONS = ["search", "recall", "promote", "write", "verify", "reindex", "digest", "action"] as const;
 type MemoryAction = (typeof MEMORY_ACTIONS)[number];
 
 export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAction, string> } = {
-  usage: "Usage: soma memory <search|recall|promote|write|verify|reindex> ...",
+  usage: "Usage: soma memory <search|recall|promote|write|verify|reindex|digest|action> ...",
   subcommands: {
     search: "Usage: soma memory search [query] [--query <text>] [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
     recall:
@@ -105,6 +126,13 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
       "Usage: soma memory reindex [--home-dir <dir>] [--soma-home <dir>]. " +
       "Rebuild memory/INDEX.md from note frontmatter (earned-inclusion ladder, retention-score budget); " +
       "ages are computed against the current date, so 'verified Nd ago' advances day to day. Quarantined notes never appear.",
+    digest:
+      "Usage: soma memory digest --session <id> --body <text> [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
+      "Write the ONE session digest (8–15 non-empty lines). A second digest for the same session no-ops with an event.",
+    action:
+      "Usage: soma memory action --slug <slug> --intent <text> --approval <proposed|approved|rejected|auto> " +
+      "[--outcome <text>] [--session <id>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
+      "Log one intent→approval→outcome action entry (id YYYYMMDD-<slug>; collision refused).",
   },
 };
 
@@ -132,7 +160,107 @@ export function parseMemoryArgs(args: string[]): ParsedMemoryArgs {
       return { command, action, options: parseMemoryVerifyArgs(rest) };
     case "reindex":
       return { command, action, options: parseMemoryReindexArgs(rest) };
+    case "digest":
+      return { command, action, options: parseMemoryDigestArgs(rest) };
+    case "action":
+      return { command, action, options: parseMemoryActionArgs(rest) };
   }
+}
+
+function parseMemoryDigestArgs(args: string[]): SomaMemoryDigestOptions {
+  const options: Partial<SomaMemoryDigestOptions> = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--substrate":
+        options.substrate = parseSubstrate(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--session":
+        options.sessionId = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--body":
+        options.body = readOption(args, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  const missing: string[] = [];
+  if (!options.sessionId) missing.push("--session");
+  if (options.body === undefined) missing.push("--body");
+  if (missing.length > 0) {
+    throw new Error(`soma memory digest is missing required option(s): ${missing.join(", ")}.`);
+  }
+  return options as SomaMemoryDigestOptions;
+}
+
+function parseActionApproval(value: string): SomaMemoryActionApproval {
+  if (value === "proposed" || value === "approved" || value === "rejected" || value === "auto") {
+    return value;
+  }
+  throw new Error("--approval must be one of proposed, approved, rejected, auto.");
+}
+
+function parseMemoryActionArgs(args: string[]): SomaMemoryActionOptions {
+  const options: Partial<SomaMemoryActionOptions> = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--substrate":
+        options.substrate = parseSubstrate(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--slug":
+        options.slug = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--session":
+        options.sessionId = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--intent":
+        options.intent = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--approval":
+        options.approval = parseActionApproval(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--outcome":
+        options.outcome = readOption(args, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  const missing: string[] = [];
+  if (!options.slug) missing.push("--slug");
+  if (!options.intent) missing.push("--intent");
+  if (!options.approval) missing.push("--approval");
+  if (missing.length > 0) {
+    throw new Error(`soma memory action is missing required option(s): ${missing.join(", ")}.`);
+  }
+  return options as SomaMemoryActionOptions;
 }
 
 function parseMemoryReindexArgs(args: string[]): MemoryReindexOptions {
@@ -506,7 +634,30 @@ export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
       return formatMemoryRecallResult(await recallMemory(parsed.options));
     case "reindex":
       return formatMemoryReindexResult(await rebuildMemoryIndex(parsed.options));
+    case "digest":
+      return formatMemoryDigestResult(await writeSessionDigest(parsed.options));
+    case "action":
+      return formatMemoryActionResult(await writeAction(parsed.options));
   }
+}
+
+function formatMemoryDigestResult(result: SomaMemoryDigestResult): string {
+  return [
+    result.created ? "Soma memory digest written" : "Soma memory digest already exists (no-op)",
+    `id: ${result.note.id}`,
+    `path: ${result.path}`,
+    `event: ${result.event.id}`,
+  ].join("\n");
+}
+
+function formatMemoryActionResult(result: SomaMemoryActionResult): string {
+  return [
+    "Soma memory action logged",
+    `id: ${result.note.id}`,
+    `trust: ${result.note.trust}`,
+    `path: ${result.path}`,
+    `event: ${result.event.id}`,
+  ].join("\n");
 }
 
 function formatMemoryReindexResult(result: SomaMemoryIndexResult): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,11 @@ export type {
   SomaMemoryRecallResult,
   SomaMemoryRecalledNote,
   SomaMemoryIndexResult,
+  SomaMemoryDigestOptions,
+  SomaMemoryDigestResult,
+  SomaMemoryActionOptions,
+  SomaMemoryActionResult,
+  SomaMemoryActionApproval,
   SomaMemorySearchMatch,
   SomaMemorySearchOptions,
   SomaMemorySearchResult,
@@ -459,6 +464,7 @@ export { recallMemory } from "./memory-recall";
 // storage path are not frozen as stable API — episodic joins at M5); internal soma
 // modules and tests import them from "./memory-index" directly.
 export { rebuildMemoryIndex } from "./memory-index";
+export { writeSessionDigest, writeAction } from "./memory-episodic";
 export { createSomaSnapshot, listSomaSnapshots, rollbackSomaSnapshot } from "./snapshots";
 export { querySomaTelemetryEvents, summarizeSomaTelemetry } from "./observability";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -464,7 +464,7 @@ export { recallMemory } from "./memory-recall";
 // storage path are not frozen as stable API — episodic joins at M5); internal soma
 // modules and tests import them from "./memory-index" directly.
 export { rebuildMemoryIndex } from "./memory-index";
-export { writeSessionDigest, writeAction } from "./memory-episodic";
+export { writeSessionDigest, writeMemoryAction } from "./memory-episodic";
 export { createSomaSnapshot, listSomaSnapshots, rollbackSomaSnapshot } from "./snapshots";
 export { querySomaTelemetryEvents, summarizeSomaTelemetry } from "./observability";
 export {

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -147,7 +147,7 @@ async function findExistingSessionDigestPath(somaHome: string, slug: string): Pr
   return undefined;
 }
 
-/** Build an episodic note (assistant trust, agent-authored account). */
+/** Build an episodic note (assistant trust, assistant-authored account). */
 function buildEpisodicNote(id: string, now: Date, body: string): SomaMemoryNote {
   const today = isoDate(now);
   return {

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdir, writeFile, unlink, readdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { createPaths } from "./paths";
+import { isEnoent } from "./fs-utils";
 import { appendSomaMemoryEvent } from "./memory";
 import { serializeMemoryNote, parseMemoryNote, MemoryNoteError } from "./memory-note";
 import { SOMA_MEMORY_ACTION_APPROVALS } from "./types";
@@ -34,9 +35,13 @@ import type {
  *   consolidator to mine. Actions are many-per-session, keyed by a caller slug; an
  *   id collision is refused via the same O_EXCL create (never overwrites a record).
  *
- * Episodic notes are `assistant` trust (the agent's own account of a session), so
- * they never enter the always-loaded INDEX by admission (M3) until consolidation
- * promotes a recurring pattern. Each write appends exactly one journal event; if
+ * Episodic notes are written at `assistant` trust (the assistant's own account of
+ * a session). Whether they reach the always-loaded INDEX is decided by M3's
+ * admission ladder, NOT here — under that rule an unresurfaced assistant note is
+ * not admitted, so digests stay out of the projected index until consolidation
+ * promotes a recurring pattern; that enforcement (and its tests) live in
+ * `memory-index.ts`, this module only sets the trust. Each write appends exactly
+ * one journal event; if
  * that append fails, the just-written file is removed — and if THAT removal also
  * fails, the inconsistency is surfaced (never silently swallowed). Not crash-atomic:
  * a hard kill between the file write and the event append can still orphan a file,
@@ -120,18 +125,24 @@ async function findExistingSessionDigestPath(somaHome: string, slug: string): Pr
   let months: string[];
   try {
     months = await readdir(base);
-  } catch {
-    return undefined; // sessions dir absent → no digests yet
+  } catch (error) {
+    if (isEnoent(error)) return undefined; // sessions dir absent → genuinely no digests yet
+    // Any OTHER failure (permissions, ENOTDIR, I/O) must NOT fail open — a scan we
+    // can't complete can't prove "no existing digest", and swallowing it would let
+    // a duplicate slip past the one-per-session gate.
+    throw new Error(`Soma memory: could not scan session digests at ${base} — dedup cannot proceed.`, { cause: error });
   }
   for (const month of months.sort()) {
+    const monthDirPath = join(base, month);
     let entries: string[];
     try {
-      entries = await readdir(join(base, month));
-    } catch {
-      continue;
+      entries = await readdir(monthDirPath);
+    } catch (error) {
+      if (isEnoent(error)) continue; // a month dir vanished mid-scan — nothing there
+      throw new Error(`Soma memory: could not scan session digests in ${monthDirPath} — dedup cannot proceed.`, { cause: error });
     }
     const match = entries.sort().find((entry) => idPattern.test(entry));
-    if (match) return join(base, month, match);
+    if (match) return join(monthDirPath, match);
   }
   return undefined;
 }

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -1,0 +1,249 @@
+import { mkdir, writeFile, unlink, access } from "node:fs/promises";
+import { dirname } from "node:path";
+import { createPaths } from "./paths";
+import { appendSomaMemoryEvent } from "./memory";
+import { serializeMemoryNote, MemoryNoteError } from "./memory-note";
+import { SOMA_MEMORY_ACTION_APPROVALS } from "./types";
+import type {
+  SomaMemoryActionOptions,
+  SomaMemoryActionResult,
+  SomaMemoryDigestOptions,
+  SomaMemoryDigestResult,
+  SomaMemoryNote,
+} from "./types";
+
+/**
+ * Episodic capture (subsystem M5). Session digests + a first-class action log,
+ * written as `episodic` notes under
+ * `memory/episodic/{sessions,actions}/YYYY-MM/YYYYMMDD-<slug>.md`. Deterministic
+ * (dates from an injected `now`, no LLM). Two capture paths:
+ *
+ * - **digest** — one 8–15-line "what happened / what changed / open loops" per
+ *   session. The write is GATED to exactly one per session: a second `digest` for
+ *   the same session no-ops and records a `memory.digest.duplicate` event, so the
+ *   design's one-digest-per-session invariant holds even if the CLI and a hook both
+ *   fire (the exactly-one write gate).
+ * - **action** — an intent → approval → outcome entry for the M6 consolidator to
+ *   mine. Actions are many-per-session, keyed by a caller-supplied slug; an id
+ *   collision is refused (never silently overwrite an existing action record).
+ *
+ * Episodic notes are `assistant` trust (the agent's own account of a session), so
+ * they never enter the always-loaded INDEX by admission (M3) until consolidation
+ * promotes a recurring pattern. Each write appends exactly one journal event, with
+ * the same write-then-event-with-rollback discipline as M1: if the event append
+ * fails, the just-written file is removed so no episodic file is orphaned.
+ */
+
+// Same slug grammar as the M0 note id / M1 write boundary.
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+// Digest body bounds (plan §M5): a digest is 8–15 non-empty lines.
+const DIGEST_MIN_LINES = 8;
+const DIGEST_MAX_LINES = 15;
+
+function assertNonEmpty(value: string | undefined, field: string): asserts value is string {
+  if (value === undefined || value.trim().length === 0) {
+    throw new MemoryNoteError(`Soma memory episodic ${field} must not be empty.`, field);
+  }
+}
+
+function assertSlug(slug: string, field: string): void {
+  if (!SLUG.test(slug) || slug.length > 64) {
+    throw new MemoryNoteError(`${field} "${slug}" is not a valid slug (lowercase [a-z0-9-], <=64 chars).`, field);
+  }
+}
+
+/** YYYY-MM-DD (UTC) — the note schema's calendar-date grammar. */
+function isoDate(now: Date): string {
+  return now.toISOString().slice(0, 10);
+}
+
+/** YYYYMMDD (UTC) — the id date prefix. */
+function idDate(now: Date): string {
+  return now.toISOString().slice(0, 10).replace(/-/g, "");
+}
+
+/** YYYY-MM (UTC) — the month directory. */
+function monthDir(now: Date): string {
+  return now.toISOString().slice(0, 7);
+}
+
+/**
+ * Turn an opaque session id into a bounded kebab slug so it is filesystem-safe and
+ * a valid note id fragment. Lowercase, non-alphanumerics → single dashes, trimmed,
+ * capped. A session id that reduces to nothing (all punctuation) is rejected —
+ * better to fail loud than write an ambiguous `YYYYMMDD-.md`.
+ */
+function sessionSlug(sessionId: string): string {
+  const slug = sessionId
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40)
+    .replace(/-+$/g, "");
+  if (slug.length === 0) {
+    throw new MemoryNoteError(`session id "${sessionId}" has no slug-able characters.`, "sessionId");
+  }
+  return slug;
+}
+
+function episodicPath(somaHome: string, kind: "sessions" | "actions", now: Date, id: string): string {
+  return createPaths(somaHome).resolve("memory", "episodic", kind, monthDir(now), `${id}.md`);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  return access(path)
+    .then(() => true)
+    .catch(() => false);
+}
+
+/** Build an episodic note (assistant trust, agent-authored account). */
+function buildEpisodicNote(id: string, now: Date, body: string, project: string | null): SomaMemoryNote {
+  const today = isoDate(now);
+  return {
+    id,
+    type: "episodic",
+    created: today,
+    last_verified: today,
+    valid_until: null,
+    provenance: "conversation",
+    trust: "assistant",
+    source_of_truth: null,
+    project,
+    links: [],
+    resurface_count: 0,
+    body: body.trim(),
+  };
+}
+
+/**
+ * Write a note file (fail if it already exists) then append its event; if the
+ * event append fails, remove the just-written file so no episodic file is orphaned
+ * from its journal entry. Mirrors M1's write-then-event-with-rollback (not
+ * crash-atomic — a hard kill between the two can still orphan a file, reconciled by
+ * the M7 audit).
+ */
+async function writeEpisodicNoteWithEvent(
+  somaHome: string,
+  path: string,
+  note: SomaMemoryNote,
+  substrate: SomaMemoryDigestOptions["substrate"],
+  eventFields: { kind: string; summary: string; metadata: Record<string, unknown> },
+  now: Date,
+): Promise<SomaMemoryDigestResult["event"]> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, serializeMemoryNote(note), { encoding: "utf8", flag: "wx" });
+  try {
+    return await appendSomaMemoryEvent(somaHome, {
+      timestamp: now.toISOString(),
+      substrate: substrate ?? "custom",
+      kind: eventFields.kind,
+      summary: eventFields.summary,
+      artifactPaths: [path],
+      metadata: eventFields.metadata,
+    });
+  } catch (appendError) {
+    await unlink(path).catch(() => undefined);
+    throw new Error(`Soma memory ${eventFields.kind} event append failed; rolled back the file.`, { cause: appendError });
+  }
+}
+
+/**
+ * Write the one session digest (M5). Gated to exactly one per session: if a digest
+ * for `sessionId` already exists (same id, `YYYYMMDD-<sessionSlug>`), this no-ops,
+ * records a `memory.digest.duplicate` event, and returns `created: false` with the
+ * existing note re-read from disk NOT re-parsed here (the caller only needs the
+ * decision + path). The body must be 8–15 non-empty lines.
+ */
+export async function writeSessionDigest(options: SomaMemoryDigestOptions): Promise<SomaMemoryDigestResult> {
+  const somaHome = createPaths(options).root();
+  const now = options.now ?? new Date();
+  assertNonEmpty(options.sessionId, "sessionId");
+  assertNonEmpty(options.body, "body");
+
+  const lines = options.body.trim().split("\n").filter((line) => line.trim().length > 0);
+  if (lines.length < DIGEST_MIN_LINES || lines.length > DIGEST_MAX_LINES) {
+    throw new MemoryNoteError(
+      `a session digest must be ${DIGEST_MIN_LINES}–${DIGEST_MAX_LINES} non-empty lines (got ${lines.length}).`,
+      "body",
+    );
+  }
+
+  const id = `${idDate(now)}-${sessionSlug(options.sessionId)}`;
+  assertSlug(id, "digest id");
+  const path = episodicPath(somaHome, "sessions", now, id);
+  const note = buildEpisodicNote(id, now, options.body, null);
+
+  // One-per-session gate: an existing digest for this session is NOT overwritten.
+  if (await pathExists(path)) {
+    const event = await appendSomaMemoryEvent(somaHome, {
+      timestamp: now.toISOString(),
+      substrate: options.substrate ?? "custom",
+      kind: "memory.digest.duplicate",
+      summary: `Digest already exists for session ${options.sessionId} (${id}); no-op.`,
+      artifactPaths: [path],
+      metadata: { id, sessionId: options.sessionId },
+    });
+    return { somaHome, path, created: false, note, event };
+  }
+
+  const event = await writeEpisodicNoteWithEvent(
+    somaHome,
+    path,
+    note,
+    options.substrate,
+    {
+      kind: "memory.digest",
+      summary: `Session digest ${id} for session ${options.sessionId} (${lines.length} lines).`,
+      metadata: { id, sessionId: options.sessionId, lines: lines.length },
+    },
+    now,
+  );
+  return { somaHome, path, created: true, note, event };
+}
+
+/**
+ * Log one action (M5): intent → approval → outcome, as an episodic note under
+ * `actions/`. Keyed by a caller slug (`YYYYMMDD-<slug>`); an id collision is
+ * refused rather than overwriting an existing action record.
+ */
+export async function writeAction(options: SomaMemoryActionOptions): Promise<SomaMemoryActionResult> {
+  const somaHome = createPaths(options).root();
+  const now = options.now ?? new Date();
+  assertNonEmpty(options.slug, "slug");
+  assertSlug(options.slug, "slug");
+  assertNonEmpty(options.intent, "intent");
+  if (!(SOMA_MEMORY_ACTION_APPROVALS as readonly string[]).includes(options.approval)) {
+    throw new MemoryNoteError(`approval must be one of ${SOMA_MEMORY_ACTION_APPROVALS.join(", ")}.`, "approval");
+  }
+
+  const id = `${idDate(now)}-${options.slug}`;
+  assertSlug(id, "action id");
+  const path = episodicPath(somaHome, "actions", now, id);
+  if (await pathExists(path)) {
+    throw new MemoryNoteError(`Soma memory action id already exists: ${id}`, "slug");
+  }
+
+  // The action's structured record — intent/approval/outcome, one per line so the
+  // consolidator can parse it mechanically.
+  const body = [
+    `**Intent:** ${options.intent.trim()}`,
+    `**Approval:** ${options.approval}`,
+    `**Outcome:** ${options.outcome && options.outcome.trim().length > 0 ? options.outcome.trim() : "(not yet recorded)"}`,
+  ].join("\n");
+  const note = buildEpisodicNote(id, now, body, options.sessionId ?? null);
+
+  const event = await writeEpisodicNoteWithEvent(
+    somaHome,
+    path,
+    note,
+    options.substrate,
+    {
+      kind: "memory.action",
+      summary: `Action ${id} (${options.approval}): ${options.intent.trim().slice(0, 80)}`,
+      metadata: { id, sessionId: options.sessionId ?? null, approval: options.approval },
+    },
+    now,
+  );
+  return { somaHome, path, note, event };
+}

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -61,11 +61,17 @@ function assertNonEmpty(value: string | undefined, field: string): asserts value
   }
 }
 
-function assertSlug(slug: string, field: string): void {
-  if (!SLUG.test(slug) || slug.length > 64) {
-    throw new MemoryNoteError(`${field} "${slug}" is not a valid slug (lowercase [a-z0-9-], <=64 chars).`, field);
+function assertSlug(slug: string, field: string, maxLen = 64): void {
+  if (!SLUG.test(slug) || slug.length > maxLen) {
+    throw new MemoryNoteError(`${field} "${slug}" is not a valid slug (lowercase [a-z0-9-], <=${maxLen} chars).`, field);
   }
 }
+
+// The `YYYYMMDD-` date prefix (9 chars) eats into the 64-char id budget, so a
+// caller-supplied action slug is capped so `${date}-${slug}` stays a valid id —
+// caught at the `slug` field (clear error) rather than surfacing later as a
+// confusing `action id` failure.
+const MAX_ID_SLUG = 64 - "YYYYMMDD-".length;
 
 function isEexist(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "EEXIST";
@@ -116,8 +122,9 @@ function episodicPath(somaHome: string, kind: "sessions" | "actions", now: Date,
  * later UTC date must still be recognized). A digest id is always `YYYYMMDD-<slug>`,
  * so a file matching `^\d{8}-<slug>\.md$` in any month dir is the session's digest.
  * Exact-match on the full id avoids a slug being a false suffix of another. The scan
- * cost grows with retained digests but is bounded by M6's 90-day archival; the
- * O_EXCL write below is the atomic gate, this is the cross-date fast-path.
+ * is an unbounded directory walk today; M6 (episodic archival, not yet implemented)
+ * is expected to bound it by pruning old digests. The O_EXCL write below is the
+ * atomic gate — this is only the cross-date fast-path.
  */
 async function findExistingSessionDigestPath(somaHome: string, slug: string): Promise<string | undefined> {
   const base = createPaths(somaHome).resolve("memory", "episodic", "sessions");
@@ -312,7 +319,7 @@ export async function writeMemoryAction(options: SomaMemoryActionOptions): Promi
   const somaHome = createPaths(options).root();
   const now = options.now ?? new Date();
   assertNonEmpty(options.slug, "slug");
-  assertSlug(options.slug, "slug");
+  assertSlug(options.slug, "slug", MAX_ID_SLUG);
   assertNonEmpty(options.plannedAction, "plannedAction");
   if (!(SOMA_MEMORY_ACTION_APPROVALS as readonly string[]).includes(options.approval)) {
     throw new MemoryNoteError(`approval must be one of ${SOMA_MEMORY_ACTION_APPROVALS.join(", ")}.`, "approval");

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -1,8 +1,8 @@
-import { mkdir, writeFile, unlink, access } from "node:fs/promises";
-import { dirname } from "node:path";
+import { mkdir, writeFile, unlink, access, readdir, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { createPaths } from "./paths";
 import { appendSomaMemoryEvent } from "./memory";
-import { serializeMemoryNote, MemoryNoteError } from "./memory-note";
+import { serializeMemoryNote, parseMemoryNote, MemoryNoteError } from "./memory-note";
 import { SOMA_MEMORY_ACTION_APPROVALS } from "./types";
 import type {
   SomaMemoryActionOptions,
@@ -97,6 +97,36 @@ async function pathExists(path: string): Promise<boolean> {
     .catch(() => false);
 }
 
+/**
+ * Find an EXISTING session digest for `slug`, across ALL month directories — the
+ * one-per-session gate must be date-INDEPENDENT (a multi-day session digested on a
+ * later UTC date must still be recognized as a duplicate). A digest id is always
+ * `YYYYMMDD-<slug>`, so a file matching `^\d{8}-<slug>\.md$` in any month dir is the
+ * session's digest. Exact-match on the full id avoids a slug being a false suffix
+ * of a different session's slug. Returns the existing path, or undefined.
+ */
+async function findExistingSessionDigestPath(somaHome: string, slug: string): Promise<string | undefined> {
+  const base = createPaths(somaHome).resolve("memory", "episodic", "sessions");
+  const idPattern = new RegExp(`^\\d{8}-${slug}\\.md$`); // slug is [a-z0-9-] only — no regex metachars
+  let months: string[];
+  try {
+    months = await readdir(base);
+  } catch {
+    return undefined; // sessions dir absent → no digests yet
+  }
+  for (const month of months.sort()) {
+    let entries: string[];
+    try {
+      entries = await readdir(join(base, month));
+    } catch {
+      continue;
+    }
+    const match = entries.sort().find((entry) => idPattern.test(entry));
+    if (match) return join(base, month, match);
+  }
+  return undefined;
+}
+
 /** Build an episodic note (assistant trust, agent-authored account). */
 function buildEpisodicNote(id: string, now: Date, body: string, project: string | null): SomaMemoryNote {
   const today = isoDate(now);
@@ -149,11 +179,11 @@ async function writeEpisodicNoteWithEvent(
 }
 
 /**
- * Write the one session digest (M5). Gated to exactly one per session: if a digest
- * for `sessionId` already exists (same id, `YYYYMMDD-<sessionSlug>`), this no-ops,
+ * Write the one session digest (M5). Gated to exactly one per session, ACROSS
+ * DATES: if a digest for `sessionId` already exists in any month dir, this no-ops,
  * records a `memory.digest.duplicate` event, and returns `created: false` with the
- * existing note re-read from disk NOT re-parsed here (the caller only needs the
- * decision + path). The body must be 8–15 non-empty lines.
+ * EXISTING on-disk note (re-parsed) and its actual path — so the returned `note`
+ * always matches `path`. The body must be 8–15 non-empty lines.
  */
 export async function writeSessionDigest(options: SomaMemoryDigestOptions): Promise<SomaMemoryDigestResult> {
   const somaHome = createPaths(options).root();
@@ -169,24 +199,28 @@ export async function writeSessionDigest(options: SomaMemoryDigestOptions): Prom
     );
   }
 
-  const id = `${idDate(now)}-${sessionSlug(options.sessionId)}`;
+  const slug = sessionSlug(options.sessionId);
+  const id = `${idDate(now)}-${slug}`;
   assertSlug(id, "digest id");
-  const path = episodicPath(somaHome, "sessions", now, id);
-  const note = buildEpisodicNote(id, now, options.body, null);
 
-  // One-per-session gate: an existing digest for this session is NOT overwritten.
-  if (await pathExists(path)) {
+  // One-per-session gate: date-INDEPENDENT. An existing digest for this session
+  // (any month) is NOT overwritten — the returned note/path are the existing ones.
+  const existingPath = await findExistingSessionDigestPath(somaHome, slug);
+  if (existingPath !== undefined) {
+    const existingNote = parseMemoryNote(await readFile(existingPath, "utf8"));
     const event = await appendSomaMemoryEvent(somaHome, {
       timestamp: now.toISOString(),
       substrate: options.substrate ?? "custom",
       kind: "memory.digest.duplicate",
-      summary: `Digest already exists for session ${options.sessionId} (${id}); no-op.`,
-      artifactPaths: [path],
-      metadata: { id, sessionId: options.sessionId },
+      summary: `Digest already exists for session ${options.sessionId} (${existingNote.id}); no-op.`,
+      artifactPaths: [existingPath],
+      metadata: { id: existingNote.id, sessionId: options.sessionId },
     });
-    return { somaHome, path, created: false, note, event };
+    return { somaHome, path: existingPath, created: false, note: existingNote, event };
   }
 
+  const path = episodicPath(somaHome, "sessions", now, id);
+  const note = buildEpisodicNote(id, now, options.body, null);
   const event = await writeEpisodicNoteWithEvent(
     somaHome,
     path,
@@ -207,7 +241,7 @@ export async function writeSessionDigest(options: SomaMemoryDigestOptions): Prom
  * `actions/`. Keyed by a caller slug (`YYYYMMDD-<slug>`); an id collision is
  * refused rather than overwriting an existing action record.
  */
-export async function writeAction(options: SomaMemoryActionOptions): Promise<SomaMemoryActionResult> {
+export async function writeMemoryAction(options: SomaMemoryActionOptions): Promise<SomaMemoryActionResult> {
   const somaHome = createPaths(options).root();
   const now = options.now ?? new Date();
   assertNonEmpty(options.slug, "slug");

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -84,8 +84,10 @@ function monthDir(now: Date): string {
 /**
  * A collision-RESISTANT slug for a session. A human-readable prefix (normalized,
  * truncated) is combined with an 8-hex digest of the FULL session id, so two
- * distinct session ids can never map to the same slug (which would make one
- * session's digest no-op against the other's). If the id has no slug-able
+ * distinct session ids are overwhelmingly unlikely to map to the same slug — an
+ * 8-hex (32-bit) digest is collision-resistant, not collision-proof, but it closes
+ * the systematic truncation collisions (distinct ids sharing a 32-char prefix) that
+ * a plain truncated slug would alias into one digest. If the id has no slug-able
  * characters, the hash alone identifies it.
  */
 function sessionSlug(sessionId: string): string {
@@ -194,6 +196,25 @@ async function writeEpisodicNoteWithEvent(input: EpisodicWrite): Promise<SomaMem
   }
 }
 
+/**
+ * Read + parse the existing digest, retrying briefly. The cross-date SCAN path
+ * hits a fully-written file (first attempt succeeds), but the EEXIST path can race
+ * a concurrent winner whose O_EXCL-created file is not yet fully written — a bounded
+ * retry rides out that in-flight window rather than throwing a confusing parse error.
+ */
+async function readNoteWithRetry(path: string, attempts = 5): Promise<SomaMemoryNote> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    try {
+      return parseMemoryNote(await readFile(path, "utf8"));
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 5)); // let the winner finish its write
+    }
+  }
+  throw new Error(`Soma memory: existing digest at ${path} could not be read/parsed after ${attempts} attempts.`, { cause: lastError });
+}
+
 /** Record a duplicate-digest no-op against an existing on-disk digest. */
 async function recordDuplicateDigest(
   somaHome: string,
@@ -202,7 +223,7 @@ async function recordDuplicateDigest(
   substrate: SubstrateId | undefined,
   now: Date,
 ): Promise<SomaMemoryDigestResult> {
-  const existingNote = parseMemoryNote(await readFile(existingPath, "utf8"));
+  const existingNote = await readNoteWithRetry(existingPath);
   const event = await appendSomaMemoryEvent(somaHome, {
     timestamp: now.toISOString(),
     substrate: substrate ?? "custom",

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -1,4 +1,5 @@
-import { mkdir, writeFile, unlink, access, readdir, readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, writeFile, unlink, readdir, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { createPaths } from "./paths";
 import { appendSomaMemoryEvent } from "./memory";
@@ -9,7 +10,9 @@ import type {
   SomaMemoryActionResult,
   SomaMemoryDigestOptions,
   SomaMemoryDigestResult,
+  SomaMemoryEvent,
   SomaMemoryNote,
+  SubstrateId,
 } from "./types";
 
 /**
@@ -19,19 +22,25 @@ import type {
  * (dates from an injected `now`, no LLM). Two capture paths:
  *
  * - **digest** — one 8–15-line "what happened / what changed / open loops" per
- *   session. The write is GATED to exactly one per session: a second `digest` for
- *   the same session no-ops and records a `memory.digest.duplicate` event, so the
- *   design's one-digest-per-session invariant holds even if the CLI and a hook both
- *   fire (the exactly-one write gate).
- * - **action** — an intent → approval → outcome entry for the M6 consolidator to
- *   mine. Actions are many-per-session, keyed by a caller-supplied slug; an id
- *   collision is refused (never silently overwrite an existing action record).
+ *   session. The write is gated to one-per-session: a cross-date scan finds any
+ *   existing digest for the session, and the actual write uses an O_EXCL create so
+ *   two same-date writers can't both win — the loser observes EEXIST and records a
+ *   `memory.digest.duplicate` event instead of erroring. HONEST LIMIT: soma has no
+ *   cross-process lock, so a genuine concurrent race between two writers on
+ *   DIFFERENT UTC dates (e.g. a multi-day session) could still produce two digests
+ *   before either scan sees the other — reconciled by the M7 audit, not prevented
+ *   here.
+ * - **action** — a plannedAction → approval → outcome entry for the M6
+ *   consolidator to mine. Actions are many-per-session, keyed by a caller slug; an
+ *   id collision is refused via the same O_EXCL create (never overwrites a record).
  *
  * Episodic notes are `assistant` trust (the agent's own account of a session), so
  * they never enter the always-loaded INDEX by admission (M3) until consolidation
- * promotes a recurring pattern. Each write appends exactly one journal event, with
- * the same write-then-event-with-rollback discipline as M1: if the event append
- * fails, the just-written file is removed so no episodic file is orphaned.
+ * promotes a recurring pattern. Each write appends exactly one journal event; if
+ * that append fails, the just-written file is removed — and if THAT removal also
+ * fails, the inconsistency is surfaced (never silently swallowed). Not crash-atomic:
+ * a hard kill between the file write and the event append can still orphan a file,
+ * reconciled by the M7 audit.
  */
 
 // Same slug grammar as the M0 note id / M1 write boundary.
@@ -53,6 +62,10 @@ function assertSlug(slug: string, field: string): void {
   }
 }
 
+function isEexist(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "EEXIST";
+}
+
 /** YYYY-MM-DD (UTC) — the note schema's calendar-date grammar. */
 function isoDate(now: Date): string {
   return now.toISOString().slice(0, 10);
@@ -69,41 +82,35 @@ function monthDir(now: Date): string {
 }
 
 /**
- * Turn an opaque session id into a bounded kebab slug so it is filesystem-safe and
- * a valid note id fragment. Lowercase, non-alphanumerics → single dashes, trimmed,
- * capped. A session id that reduces to nothing (all punctuation) is rejected —
- * better to fail loud than write an ambiguous `YYYYMMDD-.md`.
+ * A collision-RESISTANT slug for a session. A human-readable prefix (normalized,
+ * truncated) is combined with an 8-hex digest of the FULL session id, so two
+ * distinct session ids can never map to the same slug (which would make one
+ * session's digest no-op against the other's). If the id has no slug-able
+ * characters, the hash alone identifies it.
  */
 function sessionSlug(sessionId: string): string {
-  const slug = sessionId
+  const readable = sessionId
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
-    .slice(0, 40)
+    .slice(0, 32)
     .replace(/-+$/g, "");
-  if (slug.length === 0) {
-    throw new MemoryNoteError(`session id "${sessionId}" has no slug-able characters.`, "sessionId");
-  }
-  return slug;
+  const hash = createHash("sha256").update(sessionId).digest("hex").slice(0, 8);
+  return readable.length > 0 ? `${readable}-${hash}` : hash;
 }
 
 function episodicPath(somaHome: string, kind: "sessions" | "actions", now: Date, id: string): string {
   return createPaths(somaHome).resolve("memory", "episodic", kind, monthDir(now), `${id}.md`);
 }
 
-async function pathExists(path: string): Promise<boolean> {
-  return access(path)
-    .then(() => true)
-    .catch(() => false);
-}
-
 /**
  * Find an EXISTING session digest for `slug`, across ALL month directories — the
- * one-per-session gate must be date-INDEPENDENT (a multi-day session digested on a
- * later UTC date must still be recognized as a duplicate). A digest id is always
- * `YYYYMMDD-<slug>`, so a file matching `^\d{8}-<slug>\.md$` in any month dir is the
- * session's digest. Exact-match on the full id avoids a slug being a false suffix
- * of a different session's slug. Returns the existing path, or undefined.
+ * one-per-session scan must be date-INDEPENDENT (a multi-day session digested on a
+ * later UTC date must still be recognized). A digest id is always `YYYYMMDD-<slug>`,
+ * so a file matching `^\d{8}-<slug>\.md$` in any month dir is the session's digest.
+ * Exact-match on the full id avoids a slug being a false suffix of another. The scan
+ * cost grows with retained digests but is bounded by M6's 90-day archival; the
+ * O_EXCL write below is the atomic gate, this is the cross-date fast-path.
  */
 async function findExistingSessionDigestPath(somaHome: string, slug: string): Promise<string | undefined> {
   const base = createPaths(somaHome).resolve("memory", "episodic", "sessions");
@@ -128,7 +135,7 @@ async function findExistingSessionDigestPath(somaHome: string, slug: string): Pr
 }
 
 /** Build an episodic note (assistant trust, agent-authored account). */
-function buildEpisodicNote(id: string, now: Date, body: string, project: string | null): SomaMemoryNote {
+function buildEpisodicNote(id: string, now: Date, body: string): SomaMemoryNote {
   const today = isoDate(now);
   return {
     id,
@@ -139,51 +146,79 @@ function buildEpisodicNote(id: string, now: Date, body: string, project: string 
     provenance: "conversation",
     trust: "assistant",
     source_of_truth: null,
-    project,
+    project: null,
     links: [],
     resurface_count: 0,
     body: body.trim(),
   };
 }
 
-/**
- * Write a note file (fail if it already exists) then append its event; if the
- * event append fails, remove the just-written file so no episodic file is orphaned
- * from its journal entry. Mirrors M1's write-then-event-with-rollback (not
- * crash-atomic — a hard kill between the two can still orphan a file, reconciled by
- * the M7 audit).
- */
-async function writeEpisodicNoteWithEvent(
-  somaHome: string,
-  path: string,
-  note: SomaMemoryNote,
-  substrate: SomaMemoryDigestOptions["substrate"],
-  eventFields: { kind: string; summary: string; metadata: Record<string, unknown> },
-  now: Date,
-): Promise<SomaMemoryDigestResult["event"]> {
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, serializeMemoryNote(note), { encoding: "utf8", flag: "wx" });
-  try {
-    return await appendSomaMemoryEvent(somaHome, {
-      timestamp: now.toISOString(),
-      substrate: substrate ?? "custom",
-      kind: eventFields.kind,
-      summary: eventFields.summary,
-      artifactPaths: [path],
-      metadata: eventFields.metadata,
-    });
-  } catch (appendError) {
-    await unlink(path).catch(() => undefined);
-    throw new Error(`Soma memory ${eventFields.kind} event append failed; rolled back the file.`, { cause: appendError });
-  }
+interface EpisodicWrite {
+  somaHome: string;
+  path: string;
+  note: SomaMemoryNote;
+  substrate: SubstrateId | undefined;
+  now: Date;
+  event: { kind: string; summary: string; metadata: Record<string, unknown> };
 }
 
 /**
- * Write the one session digest (M5). Gated to exactly one per session, ACROSS
- * DATES: if a digest for `sessionId` already exists in any month dir, this no-ops,
- * records a `memory.digest.duplicate` event, and returns `created: false` with the
- * EXISTING on-disk note (re-parsed) and its actual path — so the returned `note`
- * always matches `path`. The body must be 8–15 non-empty lines.
+ * O_EXCL-create the note file (throws EEXIST if it already exists — the callers
+ * turn that into duplicate/collision handling), then append its event. If the
+ * event append fails, remove the just-written file; if that removal ALSO fails, the
+ * inconsistency is surfaced rather than swallowed (mirrors M1's honest rollback).
+ */
+async function writeEpisodicNoteWithEvent(input: EpisodicWrite): Promise<SomaMemoryEvent> {
+  await mkdir(dirname(input.path), { recursive: true });
+  await writeFile(input.path, serializeMemoryNote(input.note), { encoding: "utf8", flag: "wx" });
+  try {
+    return await appendSomaMemoryEvent(input.somaHome, {
+      timestamp: input.now.toISOString(),
+      substrate: input.substrate ?? "custom",
+      kind: input.event.kind,
+      summary: input.event.summary,
+      artifactPaths: [input.path],
+      metadata: input.event.metadata,
+    });
+  } catch (appendError) {
+    try {
+      await unlink(input.path);
+    } catch (unlinkError) {
+      throw new Error(
+        `Soma memory ${input.event.kind} event append failed AND the rollback unlink failed — ` +
+          `orphaned file ${input.path}; reconcile manually.`,
+        { cause: unlinkError },
+      );
+    }
+    throw new Error(`Soma memory ${input.event.kind} event append failed; rolled back the file.`, { cause: appendError });
+  }
+}
+
+/** Record a duplicate-digest no-op against an existing on-disk digest. */
+async function recordDuplicateDigest(
+  somaHome: string,
+  existingPath: string,
+  sessionId: string,
+  substrate: SubstrateId | undefined,
+  now: Date,
+): Promise<SomaMemoryDigestResult> {
+  const existingNote = parseMemoryNote(await readFile(existingPath, "utf8"));
+  const event = await appendSomaMemoryEvent(somaHome, {
+    timestamp: now.toISOString(),
+    substrate: substrate ?? "custom",
+    kind: "memory.digest.duplicate",
+    summary: `Digest already exists for session ${sessionId} (${existingNote.id}); no-op.`,
+    artifactPaths: [existingPath],
+    metadata: { id: existingNote.id, sessionId },
+  });
+  return { somaHome, path: existingPath, created: false, note: existingNote, event };
+}
+
+/**
+ * Write the one session digest (M5). One-per-session: a cross-date scan short-
+ * circuits to a duplicate no-op, and the O_EXCL write makes the same-date path
+ * atomic — a concurrent same-date writer that loses observes EEXIST and records a
+ * duplicate event too. The body must be 8–15 non-empty lines.
  */
 export async function writeSessionDigest(options: SomaMemoryDigestOptions): Promise<SomaMemoryDigestResult> {
   const somaHome = createPaths(options).root();
@@ -203,50 +238,50 @@ export async function writeSessionDigest(options: SomaMemoryDigestOptions): Prom
   const id = `${idDate(now)}-${slug}`;
   assertSlug(id, "digest id");
 
-  // One-per-session gate: date-INDEPENDENT. An existing digest for this session
-  // (any month) is NOT overwritten — the returned note/path are the existing ones.
+  // Cross-date fast-path: an existing digest for this session (any month) no-ops.
   const existingPath = await findExistingSessionDigestPath(somaHome, slug);
   if (existingPath !== undefined) {
-    const existingNote = parseMemoryNote(await readFile(existingPath, "utf8"));
-    const event = await appendSomaMemoryEvent(somaHome, {
-      timestamp: now.toISOString(),
-      substrate: options.substrate ?? "custom",
-      kind: "memory.digest.duplicate",
-      summary: `Digest already exists for session ${options.sessionId} (${existingNote.id}); no-op.`,
-      artifactPaths: [existingPath],
-      metadata: { id: existingNote.id, sessionId: options.sessionId },
-    });
-    return { somaHome, path: existingPath, created: false, note: existingNote, event };
+    return recordDuplicateDigest(somaHome, existingPath, options.sessionId, options.substrate, now);
   }
 
   const path = episodicPath(somaHome, "sessions", now, id);
-  const note = buildEpisodicNote(id, now, options.body, null);
-  const event = await writeEpisodicNoteWithEvent(
-    somaHome,
-    path,
-    note,
-    options.substrate,
-    {
-      kind: "memory.digest",
-      summary: `Session digest ${id} for session ${options.sessionId} (${lines.length} lines).`,
-      metadata: { id, sessionId: options.sessionId, lines: lines.length },
-    },
-    now,
-  );
-  return { somaHome, path, created: true, note, event };
+  const note = buildEpisodicNote(id, now, options.body);
+  try {
+    const event = await writeEpisodicNoteWithEvent({
+      somaHome,
+      path,
+      note,
+      substrate: options.substrate,
+      now,
+      event: {
+        kind: "memory.digest",
+        summary: `Session digest ${id} for session ${options.sessionId} (${lines.length} lines).`,
+        metadata: { id, sessionId: options.sessionId, lines: lines.length },
+      },
+    });
+    return { somaHome, path, created: true, note, event };
+  } catch (error) {
+    // A concurrent same-date writer created the file first (O_EXCL) — treat as duplicate.
+    if (isEexist(error)) {
+      return recordDuplicateDigest(somaHome, path, options.sessionId, options.substrate, now);
+    }
+    throw error;
+  }
 }
 
 /**
- * Log one action (M5): intent → approval → outcome, as an episodic note under
- * `actions/`. Keyed by a caller slug (`YYYYMMDD-<slug>`); an id collision is
- * refused rather than overwriting an existing action record.
+ * Log one action (M5): plannedAction → approval → outcome, as an episodic note
+ * under `actions/`. Keyed by a caller slug (`YYYYMMDD-<slug>`); an id collision is
+ * refused via the O_EXCL create (never overwrites an existing action record). The
+ * session id is recorded in the body (NOT `project`, which is reserved for actual
+ * project scope).
  */
 export async function writeMemoryAction(options: SomaMemoryActionOptions): Promise<SomaMemoryActionResult> {
   const somaHome = createPaths(options).root();
   const now = options.now ?? new Date();
   assertNonEmpty(options.slug, "slug");
   assertSlug(options.slug, "slug");
-  assertNonEmpty(options.intent, "intent");
+  assertNonEmpty(options.plannedAction, "plannedAction");
   if (!(SOMA_MEMORY_ACTION_APPROVALS as readonly string[]).includes(options.approval)) {
     throw new MemoryNoteError(`approval must be one of ${SOMA_MEMORY_ACTION_APPROVALS.join(", ")}.`, "approval");
   }
@@ -254,30 +289,37 @@ export async function writeMemoryAction(options: SomaMemoryActionOptions): Promi
   const id = `${idDate(now)}-${options.slug}`;
   assertSlug(id, "action id");
   const path = episodicPath(somaHome, "actions", now, id);
-  if (await pathExists(path)) {
-    throw new MemoryNoteError(`Soma memory action id already exists: ${id}`, "slug");
-  }
 
-  // The action's structured record — intent/approval/outcome, one per line so the
-  // consolidator can parse it mechanically.
-  const body = [
-    `**Intent:** ${options.intent.trim()}`,
+  // The action's structured record — one field per line so the consolidator can
+  // parse it mechanically. Session id lives here, not in `project`.
+  const bodyLines = [
+    `**Planned action:** ${options.plannedAction.trim()}`,
     `**Approval:** ${options.approval}`,
     `**Outcome:** ${options.outcome && options.outcome.trim().length > 0 ? options.outcome.trim() : "(not yet recorded)"}`,
-  ].join("\n");
-  const note = buildEpisodicNote(id, now, body, options.sessionId ?? null);
+  ];
+  if (options.sessionId && options.sessionId.trim().length > 0) {
+    bodyLines.push(`**Session:** ${options.sessionId.trim()}`);
+  }
+  const note = buildEpisodicNote(id, now, bodyLines.join("\n"));
 
-  const event = await writeEpisodicNoteWithEvent(
-    somaHome,
-    path,
-    note,
-    options.substrate,
-    {
-      kind: "memory.action",
-      summary: `Action ${id} (${options.approval}): ${options.intent.trim().slice(0, 80)}`,
-      metadata: { id, sessionId: options.sessionId ?? null, approval: options.approval },
-    },
-    now,
-  );
-  return { somaHome, path, note, event };
+  try {
+    const event = await writeEpisodicNoteWithEvent({
+      somaHome,
+      path,
+      note,
+      substrate: options.substrate,
+      now,
+      event: {
+        kind: "memory.action",
+        summary: `Action ${id} (${options.approval}): ${options.plannedAction.trim().slice(0, 80)}`,
+        metadata: { id, sessionId: options.sessionId ?? null, approval: options.approval },
+      },
+    });
+    return { somaHome, path, note, event };
+  } catch (error) {
+    if (isEexist(error)) {
+      throw new MemoryNoteError(`Soma memory action id already exists: ${id}`, "slug");
+    }
+    throw error;
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2526,9 +2526,9 @@ export interface SomaMemoryActionOptions {
   /** The session this action belongs to (recorded in the note body for consolidation scope). */
   sessionId?: string;
   /**
-   * What the agent planned to do. Named `plannedAction` (not `intent`) because
+   * What the assistant planned to do. Named `plannedAction` (not `intent`) because
    * CONTEXT.md reserves `intent` for the principal's checkable directional anchor
-   * sourced from Purpose — a different concept from an agent's logged action.
+   * sourced from Purpose — a different concept from the assistant's logged action.
    */
   plannedAction: string;
   /** Approval state at record time. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -2485,8 +2485,11 @@ export interface SomaMemoryVerifyResult {
 // Memory subsystem M5 (episodic capture). Plan v2 §M5: session digests + a
 // first-class action log, stored as `episodic` notes under
 // `memory/episodic/{sessions,actions}/YYYY-MM/YYYYMMDD-<slug>.md`. Deterministic,
-// no LLM. The digest write is gated to EXACTLY ONE per session (a second call for
-// the same session no-ops with an event). Action entries record plannedAction →
+// no LLM. The digest write is gated to one-per-session — atomic (O_EXCL) within a
+// UTC date, and a cross-date scan catches later re-digests — but it is best-effort,
+// NOT an absolute guarantee: with no cross-process lock, a genuine concurrent race
+// across different UTC dates can still produce two digests (reconciled by the M7
+// audit). A second same-session call no-ops with an event. Action entries record plannedAction →
 // approval → outcome for the consolidator (M6) to mine. Episodic notes are written
 // at `assistant` trust (the assistant's own account); whether they reach the
 // always-loaded INDEX is decided by M3's admission ladder, where an unresurfaced

--- a/src/types.ts
+++ b/src/types.ts
@@ -2523,10 +2523,14 @@ export interface SomaMemoryActionOptions {
   now?: Date;
   /** kebab slug for the action's id (`YYYYMMDD-<slug>`). */
   slug: string;
-  /** The session this action belongs to (recorded for consolidation scope). */
+  /** The session this action belongs to (recorded in the note body for consolidation scope). */
   sessionId?: string;
-  /** What the agent intended to do. */
-  intent: string;
+  /**
+   * What the agent planned to do. Named `plannedAction` (not `intent`) because
+   * CONTEXT.md reserves `intent` for the principal's checkable directional anchor
+   * sourced from Purpose — a different concept from an agent's logged action.
+   */
+  plannedAction: string;
   /** Approval state at record time. */
   approval: SomaMemoryActionApproval;
   /** What actually happened (may be recorded later; empty = not-yet-known). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -2482,6 +2482,64 @@ export interface SomaMemoryVerifyResult {
   event: SomaMemoryEvent;
 }
 
+// Memory subsystem M5 (episodic capture). Plan v2 §M5: session digests + a
+// first-class action log, stored as `episodic` notes under
+// `memory/episodic/{sessions,actions}/YYYY-MM/YYYYMMDD-<slug>.md`. Deterministic,
+// no LLM. The digest write is gated to EXACTLY ONE per session (a second call for
+// the same session no-ops with an event). Action entries record intent → approval
+// → outcome for the consolidator (M6) to mine. Episodic notes are `assistant`
+// trust (agent-authored account), so they never enter the always-loaded INDEX by
+// admission (M3) unless later promoted.
+
+/** Approval state of a logged action (design §: intent → approval → outcome). */
+export const SOMA_MEMORY_ACTION_APPROVALS = ["proposed", "approved", "rejected", "auto"] as const;
+export type SomaMemoryActionApproval = (typeof SOMA_MEMORY_ACTION_APPROVALS)[number];
+
+export interface SomaMemoryDigestOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate?: SubstrateId;
+  /** Injected clock for deterministic `created`/id date. Defaults to now. */
+  now?: Date;
+  /** The session this digest summarizes — the one-per-session gate key. */
+  sessionId: string;
+  /** The digest text: 8–15 non-empty lines of what happened / changed / open loops. */
+  body: string;
+}
+
+export interface SomaMemoryDigestResult {
+  somaHome: string;
+  path: string;
+  /** False when a digest already existed for the session (the write no-op'd). */
+  created: boolean;
+  note: SomaMemoryNote;
+  event: SomaMemoryEvent;
+}
+
+export interface SomaMemoryActionOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate?: SubstrateId;
+  now?: Date;
+  /** kebab slug for the action's id (`YYYYMMDD-<slug>`). */
+  slug: string;
+  /** The session this action belongs to (recorded for consolidation scope). */
+  sessionId?: string;
+  /** What the agent intended to do. */
+  intent: string;
+  /** Approval state at record time. */
+  approval: SomaMemoryActionApproval;
+  /** What actually happened (may be recorded later; empty = not-yet-known). */
+  outcome?: string;
+}
+
+export interface SomaMemoryActionResult {
+  somaHome: string;
+  path: string;
+  note: SomaMemoryNote;
+  event: SomaMemoryEvent;
+}
+
 // Memory subsystem M2 (recall). Plan v2 §M2: note-aware retrieval over the
 // durable corpus (semantic + procedural) — term scoring, whole-file retrieval
 // (limit 3), 1-hop link expansion, superseded-exclusion via `valid_until`, and a

--- a/src/types.ts
+++ b/src/types.ts
@@ -2486,12 +2486,13 @@ export interface SomaMemoryVerifyResult {
 // first-class action log, stored as `episodic` notes under
 // `memory/episodic/{sessions,actions}/YYYY-MM/YYYYMMDD-<slug>.md`. Deterministic,
 // no LLM. The digest write is gated to EXACTLY ONE per session (a second call for
-// the same session no-ops with an event). Action entries record intent → approval
-// → outcome for the consolidator (M6) to mine. Episodic notes are `assistant`
-// trust (agent-authored account), so they never enter the always-loaded INDEX by
-// admission (M3) unless later promoted.
+// the same session no-ops with an event). Action entries record plannedAction →
+// approval → outcome for the consolidator (M6) to mine. Episodic notes are written
+// at `assistant` trust (the assistant's own account); whether they reach the
+// always-loaded INDEX is decided by M3's admission ladder, where an unresurfaced
+// assistant note is not admitted until consolidation promotes it.
 
-/** Approval state of a logged action (design §: intent → approval → outcome). */
+/** Approval state of a logged action (plannedAction → approval → outcome). */
 export const SOMA_MEMORY_ACTION_APPROVALS = ["proposed", "approved", "rejected", "auto"] as const;
 export type SomaMemoryActionApproval = (typeof SOMA_MEMORY_ACTION_APPROVALS)[number];
 

--- a/test/memory-episodic.test.ts
+++ b/test/memory-episodic.test.ts
@@ -5,7 +5,7 @@ import { expect, test } from "bun:test";
 import {
   parseMemoryNote,
   somaMemoryEventsPath,
-  writeAction,
+  writeMemoryAction,
   writeSessionDigest,
 } from "../src/index";
 import { parseMemoryArgs, runMemoryCli } from "../src/cli/memory";
@@ -85,9 +85,9 @@ test("a session id with no slug-able characters is rejected", async () => {
 
 // --- action ------------------------------------------------------------------
 
-test("writeAction logs an intent→approval→outcome episodic note under actions/", async () => {
+test("writeMemoryAction logs an intent→approval→outcome episodic note under actions/", async () => {
   await withTempSoma(async (somaHome) => {
-    const result = await writeAction({
+    const result = await writeMemoryAction({
       somaHome,
       now: NOW,
       slug: "deploy-reporter",
@@ -109,15 +109,15 @@ test("writeAction logs an intent→approval→outcome episodic note under action
 
 test("an action with no outcome records a not-yet placeholder", async () => {
   await withTempSoma(async (somaHome) => {
-    const result = await writeAction({ somaHome, now: NOW, slug: "pending-thing", intent: "do a thing", approval: "proposed" });
+    const result = await writeMemoryAction({ somaHome, now: NOW, slug: "pending-thing", intent: "do a thing", approval: "proposed" });
     expect(result.note.body).toContain("**Outcome:** (not yet recorded)");
   });
 });
 
 test("a duplicate action id is refused (never overwrites)", async () => {
   await withTempSoma(async (somaHome) => {
-    await writeAction({ somaHome, now: NOW, slug: "dup", intent: "first", approval: "auto" });
-    await expect(writeAction({ somaHome, now: NOW, slug: "dup", intent: "second", approval: "auto" })).rejects.toThrow(
+    await writeMemoryAction({ somaHome, now: NOW, slug: "dup", intent: "first", approval: "auto" });
+    await expect(writeMemoryAction({ somaHome, now: NOW, slug: "dup", intent: "second", approval: "auto" })).rejects.toThrow(
       /already exists/,
     );
   });
@@ -127,7 +127,7 @@ test("an invalid approval is rejected", async () => {
   await withTempSoma(async (somaHome) => {
     await expect(
       // @ts-expect-error — exercising the runtime guard with a bad approval
-      writeAction({ somaHome, now: NOW, slug: "x", intent: "y", approval: "maybe" }),
+      writeMemoryAction({ somaHome, now: NOW, slug: "x", intent: "y", approval: "maybe" }),
     ).rejects.toThrow(/approval must be/);
   });
 });

--- a/test/memory-episodic.test.ts
+++ b/test/memory-episodic.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
@@ -105,6 +105,19 @@ test("two distinct session ids that share a truncation prefix get separate diges
     expect(first.created).toBe(true);
     expect(second.created).toBe(true); // NOT a false duplicate
     expect(second.path).not.toBe(first.path);
+  });
+});
+
+test("the duplicate scan fails CLOSED on an unreadable sessions path (no silent duplicate)", async () => {
+  await withTempSoma(async (somaHome) => {
+    // Put a FILE where the sessions directory should be → readdir throws ENOTDIR
+    // (not ENOENT). The gate must refuse rather than treat it as "no digest yet".
+    const sessions = join(somaHome, "memory", "episodic", "sessions");
+    await mkdir(join(somaHome, "memory", "episodic"), { recursive: true });
+    await writeFile(sessions, "not a directory", "utf8");
+    await expect(writeSessionDigest({ somaHome, now: NOW, sessionId: SESSION, body: DIGEST_BODY })).rejects.toThrow(
+      /could not scan session digests/,
+    );
   });
 });
 

--- a/test/memory-episodic.test.ts
+++ b/test/memory-episodic.test.ts
@@ -1,0 +1,173 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { expect, test } from "bun:test";
+import {
+  parseMemoryNote,
+  somaMemoryEventsPath,
+  writeAction,
+  writeSessionDigest,
+} from "../src/index";
+import { parseMemoryArgs, runMemoryCli } from "../src/cli/memory";
+
+const NOW = new Date("2026-07-04T10:00:00.000Z");
+const SESSION = "0afea4e4-967d-4a38-a855-0d12ac63c2f3";
+const DIGEST_BODY = Array.from({ length: 10 }, (_, i) => `- line ${i + 1} of the session digest`).join("\n");
+
+async function withTempSoma<T>(fn: (somaHome: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "soma-episodic-"));
+  const somaHome = join(dir, ".soma");
+  try {
+    return await fn(somaHome);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function countEvents(somaHome: string): Promise<number> {
+  const content = await readFile(somaMemoryEventsPath(somaHome), "utf8").catch(() => "");
+  return content.trim() === "" ? 0 : content.trim().split("\n").length;
+}
+
+// --- digest ------------------------------------------------------------------
+
+test("writeSessionDigest writes an episodic assistant note under sessions/YYYY-MM", async () => {
+  await withTempSoma(async (somaHome) => {
+    const result = await writeSessionDigest({ somaHome, now: NOW, sessionId: SESSION, body: DIGEST_BODY });
+
+    expect(result.created).toBe(true);
+    expect(result.note.type).toBe("episodic");
+    expect(result.note.trust).toBe("assistant");
+    expect(result.note.id.startsWith("20260704-")).toBe(true);
+    expect(result.path).toContain(join("memory", "episodic", "sessions", "2026-07"));
+
+    const onDisk = parseMemoryNote(await readFile(result.path, "utf8"));
+    expect(onDisk.id).toBe(result.note.id);
+    expect(onDisk.body).toBe(DIGEST_BODY);
+    expect(await countEvents(somaHome)).toBe(1);
+  });
+});
+
+test("a digest body outside 8–15 non-empty lines is rejected", async () => {
+  await withTempSoma(async (somaHome) => {
+    const seven = Array.from({ length: 7 }, (_, i) => `line ${i}`).join("\n");
+    const sixteen = Array.from({ length: 16 }, (_, i) => `line ${i}`).join("\n");
+    await expect(writeSessionDigest({ somaHome, now: NOW, sessionId: SESSION, body: seven })).rejects.toThrow(/8–15/);
+    await expect(writeSessionDigest({ somaHome, now: NOW, sessionId: SESSION, body: sixteen })).rejects.toThrow(/8–15/);
+  });
+});
+
+test("a second digest for the same session no-ops with an event (exactly-one gate)", async () => {
+  await withTempSoma(async (somaHome) => {
+    const first = await writeSessionDigest({ somaHome, now: NOW, sessionId: SESSION, body: DIGEST_BODY });
+    expect(first.created).toBe(true);
+
+    const otherBody = Array.from({ length: 9 }, (_, i) => `- different line ${i}`).join("\n");
+    const second = await writeSessionDigest({ somaHome, now: NOW, sessionId: SESSION, body: otherBody });
+    expect(second.created).toBe(false);
+    expect(second.path).toBe(first.path);
+
+    // the on-disk digest is unchanged (the first body survives)
+    const onDisk = parseMemoryNote(await readFile(first.path, "utf8"));
+    expect(onDisk.body).toBe(DIGEST_BODY);
+    // one write event + one duplicate event
+    expect(await countEvents(somaHome)).toBe(2);
+  });
+});
+
+test("a session id with no slug-able characters is rejected", async () => {
+  await withTempSoma(async (somaHome) => {
+    await expect(writeSessionDigest({ somaHome, now: NOW, sessionId: "!!!", body: DIGEST_BODY })).rejects.toThrow(
+      /no slug-able/,
+    );
+  });
+});
+
+// --- action ------------------------------------------------------------------
+
+test("writeAction logs an intent→approval→outcome episodic note under actions/", async () => {
+  await withTempSoma(async (somaHome) => {
+    const result = await writeAction({
+      somaHome,
+      now: NOW,
+      slug: "deploy-reporter",
+      sessionId: SESSION,
+      intent: "Deploy the reporter service to production",
+      approval: "approved",
+      outcome: "Deployed; smoke test green",
+    });
+
+    expect(result.note.type).toBe("episodic");
+    expect(result.note.id).toBe("20260704-deploy-reporter");
+    expect(result.note.project).toBe(SESSION);
+    expect(result.path).toContain(join("memory", "episodic", "actions", "2026-07"));
+    expect(result.note.body).toContain("**Intent:** Deploy the reporter service to production");
+    expect(result.note.body).toContain("**Approval:** approved");
+    expect(result.note.body).toContain("**Outcome:** Deployed; smoke test green");
+  });
+});
+
+test("an action with no outcome records a not-yet placeholder", async () => {
+  await withTempSoma(async (somaHome) => {
+    const result = await writeAction({ somaHome, now: NOW, slug: "pending-thing", intent: "do a thing", approval: "proposed" });
+    expect(result.note.body).toContain("**Outcome:** (not yet recorded)");
+  });
+});
+
+test("a duplicate action id is refused (never overwrites)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeAction({ somaHome, now: NOW, slug: "dup", intent: "first", approval: "auto" });
+    await expect(writeAction({ somaHome, now: NOW, slug: "dup", intent: "second", approval: "auto" })).rejects.toThrow(
+      /already exists/,
+    );
+  });
+});
+
+test("an invalid approval is rejected", async () => {
+  await withTempSoma(async (somaHome) => {
+    await expect(
+      // @ts-expect-error — exercising the runtime guard with a bad approval
+      writeAction({ somaHome, now: NOW, slug: "x", intent: "y", approval: "maybe" }),
+    ).rejects.toThrow(/approval must be/);
+  });
+});
+
+// --- CLI ---------------------------------------------------------------------
+
+test("parseMemoryArgs digest requires --session and --body", () => {
+  expect(() => parseMemoryArgs(["memory", "digest", "--session", "s"])).toThrow(/--body/);
+  expect(() => parseMemoryArgs(["memory", "digest", "--body", "b"])).toThrow(/--session/);
+});
+
+test("parseMemoryArgs action requires slug/intent/approval and validates approval", () => {
+  expect(() => parseMemoryArgs(["memory", "action", "--slug", "s", "--intent", "i"])).toThrow(/--approval/);
+  expect(() => parseMemoryArgs(["memory", "action", "--slug", "s", "--intent", "i", "--approval", "nope"])).toThrow(
+    /--approval must be/,
+  );
+});
+
+test("runMemoryCli digest reports written then no-op on a repeat", async () => {
+  await withTempSoma(async (somaHome) => {
+    const first = await runMemoryCli(
+      parseMemoryArgs(["memory", "digest", "--session", SESSION, "--body", DIGEST_BODY, "--soma-home", somaHome]),
+    );
+    expect(first).toContain("Soma memory digest written");
+    const second = await runMemoryCli(
+      parseMemoryArgs(["memory", "digest", "--session", SESSION, "--body", DIGEST_BODY, "--soma-home", somaHome]),
+    );
+    expect(second).toContain("already exists (no-op)");
+  });
+});
+
+test("runMemoryCli action logs an entry", async () => {
+  await withTempSoma(async (somaHome) => {
+    const out = await runMemoryCli(
+      parseMemoryArgs([
+        "memory", "action", "--slug", "ship-it", "--intent", "ship the feature", "--approval", "approved", "--soma-home", somaHome,
+      ]),
+    );
+    expect(out).toContain("Soma memory action logged");
+    // the CLI uses the real clock, so assert on the date-independent slug
+    expect(out).toMatch(/id: \d{8}-ship-it/);
+  });
+});

--- a/test/memory-episodic.test.ts
+++ b/test/memory-episodic.test.ts
@@ -75,49 +75,76 @@ test("a second digest for the same session no-ops with an event (exactly-one gat
   });
 });
 
-test("a session id with no slug-able characters is rejected", async () => {
+test("a session id with no slug-able characters still gets a hash-based id", async () => {
   await withTempSoma(async (somaHome) => {
-    await expect(writeSessionDigest({ somaHome, now: NOW, sessionId: "!!!", body: DIGEST_BODY })).rejects.toThrow(
-      /no slug-able/,
-    );
+    const result = await writeSessionDigest({ somaHome, now: NOW, sessionId: "!!!", body: DIGEST_BODY });
+    expect(result.created).toBe(true);
+    expect(result.note.id).toMatch(/^20260704-[0-9a-f]{8}$/); // date + hash only
+  });
+});
+
+test("the same session digested on a LATER date is still recognized as a duplicate", async () => {
+  await withTempSoma(async (somaHome) => {
+    const first = await writeSessionDigest({ somaHome, now: NOW, sessionId: SESSION, body: DIGEST_BODY });
+    expect(first.created).toBe(true);
+    // a different UTC date — the gate must be date-independent
+    const later = new Date("2026-09-15T10:00:00.000Z");
+    const second = await writeSessionDigest({ somaHome, now: later, sessionId: SESSION, body: DIGEST_BODY });
+    expect(second.created).toBe(false);
+    expect(second.path).toBe(first.path);
+  });
+});
+
+test("two distinct session ids that share a truncation prefix get separate digests (hash guard)", async () => {
+  await withTempSoma(async (somaHome) => {
+    // 32+ char prefixes identical; the appended full-id hash keeps them distinct
+    const a = "session-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-1";
+    const b = "session-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-2";
+    const first = await writeSessionDigest({ somaHome, now: NOW, sessionId: a, body: DIGEST_BODY });
+    const second = await writeSessionDigest({ somaHome, now: NOW, sessionId: b, body: DIGEST_BODY });
+    expect(first.created).toBe(true);
+    expect(second.created).toBe(true); // NOT a false duplicate
+    expect(second.path).not.toBe(first.path);
   });
 });
 
 // --- action ------------------------------------------------------------------
 
-test("writeMemoryAction logs an intent→approval→outcome episodic note under actions/", async () => {
+test("writeMemoryAction logs a plannedAction→approval→outcome note; session goes in the body, not project", async () => {
   await withTempSoma(async (somaHome) => {
     const result = await writeMemoryAction({
       somaHome,
       now: NOW,
       slug: "deploy-reporter",
       sessionId: SESSION,
-      intent: "Deploy the reporter service to production",
+      plannedAction: "Deploy the reporter service to production",
       approval: "approved",
       outcome: "Deployed; smoke test green",
     });
 
     expect(result.note.type).toBe("episodic");
     expect(result.note.id).toBe("20260704-deploy-reporter");
-    expect(result.note.project).toBe(SESSION);
+    // sessionId is recorded in the body, NOT project (project stays for real scope)
+    expect(result.note.project).toBeNull();
     expect(result.path).toContain(join("memory", "episodic", "actions", "2026-07"));
-    expect(result.note.body).toContain("**Intent:** Deploy the reporter service to production");
+    expect(result.note.body).toContain("**Planned action:** Deploy the reporter service to production");
     expect(result.note.body).toContain("**Approval:** approved");
     expect(result.note.body).toContain("**Outcome:** Deployed; smoke test green");
+    expect(result.note.body).toContain(`**Session:** ${SESSION}`);
   });
 });
 
 test("an action with no outcome records a not-yet placeholder", async () => {
   await withTempSoma(async (somaHome) => {
-    const result = await writeMemoryAction({ somaHome, now: NOW, slug: "pending-thing", intent: "do a thing", approval: "proposed" });
+    const result = await writeMemoryAction({ somaHome, now: NOW, slug: "pending-thing", plannedAction: "do a thing", approval: "proposed" });
     expect(result.note.body).toContain("**Outcome:** (not yet recorded)");
   });
 });
 
 test("a duplicate action id is refused (never overwrites)", async () => {
   await withTempSoma(async (somaHome) => {
-    await writeMemoryAction({ somaHome, now: NOW, slug: "dup", intent: "first", approval: "auto" });
-    await expect(writeMemoryAction({ somaHome, now: NOW, slug: "dup", intent: "second", approval: "auto" })).rejects.toThrow(
+    await writeMemoryAction({ somaHome, now: NOW, slug: "dup", plannedAction: "first", approval: "auto" });
+    await expect(writeMemoryAction({ somaHome, now: NOW, slug: "dup", plannedAction: "second", approval: "auto" })).rejects.toThrow(
       /already exists/,
     );
   });
@@ -127,7 +154,7 @@ test("an invalid approval is rejected", async () => {
   await withTempSoma(async (somaHome) => {
     await expect(
       // @ts-expect-error — exercising the runtime guard with a bad approval
-      writeMemoryAction({ somaHome, now: NOW, slug: "x", intent: "y", approval: "maybe" }),
+      writeMemoryAction({ somaHome, now: NOW, slug: "x", plannedAction: "y", approval: "maybe" }),
     ).rejects.toThrow(/approval must be/);
   });
 });
@@ -139,9 +166,9 @@ test("parseMemoryArgs digest requires --session and --body", () => {
   expect(() => parseMemoryArgs(["memory", "digest", "--body", "b"])).toThrow(/--session/);
 });
 
-test("parseMemoryArgs action requires slug/intent/approval and validates approval", () => {
-  expect(() => parseMemoryArgs(["memory", "action", "--slug", "s", "--intent", "i"])).toThrow(/--approval/);
-  expect(() => parseMemoryArgs(["memory", "action", "--slug", "s", "--intent", "i", "--approval", "nope"])).toThrow(
+test("parseMemoryArgs action requires slug/planned-action/approval and validates approval", () => {
+  expect(() => parseMemoryArgs(["memory", "action", "--slug", "s", "--planned-action", "i"])).toThrow(/--approval/);
+  expect(() => parseMemoryArgs(["memory", "action", "--slug", "s", "--planned-action", "i", "--approval", "nope"])).toThrow(
     /--approval must be/,
   );
 });
@@ -163,7 +190,7 @@ test("runMemoryCli action logs an entry", async () => {
   await withTempSoma(async (somaHome) => {
     const out = await runMemoryCli(
       parseMemoryArgs([
-        "memory", "action", "--slug", "ship-it", "--intent", "ship the feature", "--approval", "approved", "--soma-home", somaHome,
+        "memory", "action", "--slug", "ship-it", "--planned-action", "ship the feature", "--approval", "approved", "--soma-home", somaHome,
       ]),
     );
     expect(out).toContain("Soma memory action logged");


### PR DESCRIPTION
## Memory subsystem M5 — episodic capture (core) (plan v2 §M5)

Deterministic capture write paths (no LLM). Episodic notes under `memory/episodic/{sessions,actions}/YYYY-MM/YYYYMMDD-<slug>.md`.

### What it does
- **`soma memory digest --session <id> --body <8–15 lines>`** — writes THE one session digest. One-per-session: a date-independent cross-date scan short-circuits to a duplicate no-op, and the actual write uses an **O_EXCL create** so a concurrent same-date loser observes EEXIST and records a `memory.digest.duplicate` event (with a bounded retry to ride out an in-flight winner's write). Honest limit: no cross-process lock, so a genuine concurrent race across DIFFERENT UTC dates could still produce two digests (M7-audit reconciled). Body validated to 8–15 non-empty lines.
- **`soma memory action --slug <s> --planned-action <t> --approval <proposed|approved|rejected|auto> [--outcome <t>] [--session <id>]`** — logs one plannedAction → approval → outcome entry for the M6 consolidator. Id collision refused via O_EXCL. The session id is recorded in a `**Session:**` body line (not `project`, which stays for real scope). `plannedAction` (not `intent`) because CONTEXT.md reserves `intent` for the principal's Purpose-sourced anchor.
- Session slugs append an 8-hex digest of the full session id — collision-resistant, closing systematic truncation-prefix collisions.
- Episodic notes are **`assistant`** trust, so they don't enter the always-loaded INDEX by admission (M3) until consolidation promotes a pattern.
- Each write appends one journal event with honest write-then-event-rollback (an unlink failure during rollback is surfaced, not swallowed).

### Deferred — the SessionEnd hook
Its ADR-0014 transplant is the sub-agent suppression logic, but recall authored digests via an LLM, which soma forbids. **How the hook obtains the digest text at SessionEnd is a design call for the principal** (agent pre-stages it vs. deterministic event-derived summary), so the hook is not in this PR. The exactly-one write gate holds regardless of whether the CLI or a hook writes.

### Verification
`bunx tsc --noEmit` clean; 14 episodic tests (gate no-op + cross-date dedup + hash collision-guard, 8–15 bound, action structured body / not-yet-outcome / collision refusal / approval validation, CLI parse+run) + full memory suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)