### PR TITLE
feat(memory): deterministic audit + Memory skill (M7)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -162,8 +162,10 @@ created-month digest, and the event/note ratio — and EXITS NON-ZERO on a
 schema-invalid note or a stale INDEX (so it can gate CI). A no-op pass writes no event. The write/event
 coupling is best-effort, not crash-atomic: an event-append *failure* rolls the file
 mutation back, but a hard process crash in the window between the two can still
-orphan a file from its event (a documented gap the M7 audit surfaces; soma has no
-WAL/2PC). This
+orphan a file from its event (soma has no WAL/2PC). The M7 audit does NOT reconcile
+note↔event linkage — its event-ratio probe is a COARSE count (event lines over
+notes), not per-note orphan detection; a missing event can be masked by unrelated
+lines. This
 taxonomy is intentionally distinct from the `MEMORY/*` stores: those stores hold
 curated free-form material; the note store holds single-fact, governed,
 decay-tracked notes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,11 +155,11 @@ reconciles the STATE (it re-does nothing already done — idempotent), but it do
 back-fill the missing journal record: a subsequent no-op run writes no event, so the
 gap persists. `soma memory audit` (M7) — a deterministic, read-only health check
 that reads the FILES directly, not the event stream — is the ground-truth check:
-it probes schema validity and INDEX freshness (the two health-gating probes), plus
-three informational drift signals — episodic note/digest COUNTS (a coverage
-indicator, not a verified note↔digest mapping), archived notes missing from their
-created-month digest, and the event/note ratio — and EXITS NON-ZERO on a
-schema-invalid note or a stale INDEX (so it can gate CI). A no-op pass writes no event. The write/event
+it has three health-gating probes — root-integrity (every note root is a real
+directory), schema validity, and INDEX freshness — plus three informational drift
+signals — episodic note/digest COUNTS (a coverage indicator, not a verified
+note↔digest mapping), archived notes missing from their created-month digest, and
+the event/note ratio — and EXITS NON-ZERO on any gating failure (so it can gate CI). A no-op pass writes no event. The write/event
 coupling is best-effort, not crash-atomic: an event-append *failure* rolls the file
 mutation back, but a hard process crash in the window between the two can still
 orphan a file from its event (soma has no WAL/2PC). The M7 audit does NOT reconcile

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -153,12 +153,15 @@ part-way, OR the event append itself fails, mutations may already be applied WIT
 the event — so an absent event does NOT prove no mutation happened. A re-run
 reconciles the STATE (it re-does nothing already done — idempotent), but it does NOT
 back-fill the missing journal record: a subsequent no-op run writes no event, so the
-gap persists. A memory audit (M7, forthcoming — not yet built) that reads the files
-directly, not the event stream, is the intended ground-truth check. A no-op pass
-writes no event. The write/event coupling is best-effort, not
-crash-atomic: an event-append *failure* rolls the file mutation back, but a hard
-process crash in the window between the two can still orphan a file from its
-event (a documented gap reconciled by the M7 audit; soma has no WAL/2PC). This
+gap persists. `soma memory audit` (M7) — a deterministic, read-only health check
+that reads the FILES directly, not the event stream — is the ground-truth check:
+it probes schema validity, INDEX freshness, digest coverage, orphaned archive
+notes, and the event/note ratio, and EXITS NON-ZERO on a schema-invalid note or a
+stale INDEX (so it can gate CI). A no-op pass writes no event. The write/event
+coupling is best-effort, not crash-atomic: an event-append *failure* rolls the file
+mutation back, but a hard process crash in the window between the two can still
+orphan a file from its event (a documented gap the M7 audit surfaces; soma has no
+WAL/2PC). This
 taxonomy is intentionally distinct from the `MEMORY/*` stores: those stores hold
 curated free-form material; the note store holds single-fact, governed,
 decay-tracked notes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,9 +155,11 @@ reconciles the STATE (it re-does nothing already done — idempotent), but it do
 back-fill the missing journal record: a subsequent no-op run writes no event, so the
 gap persists. `soma memory audit` (M7) — a deterministic, read-only health check
 that reads the FILES directly, not the event stream — is the ground-truth check:
-it probes schema validity, INDEX freshness, digest coverage, orphaned archive
-notes, and the event/note ratio, and EXITS NON-ZERO on a schema-invalid note or a
-stale INDEX (so it can gate CI). A no-op pass writes no event. The write/event
+it probes schema validity and INDEX freshness (the two health-gating probes), plus
+three informational drift signals — episodic note/digest COUNTS (a coverage
+indicator, not a verified note↔digest mapping), archived notes missing from their
+created-month digest, and the event/note ratio — and EXITS NON-ZERO on a
+schema-invalid note or a stale INDEX (so it can gate CI). A no-op pass writes no event. The write/event
 coupling is best-effort, not crash-atomic: an event-append *failure* rolls the file
 mutation back, but a hard process crash in the window between the two can still
 orphan a file from its event (a documented gap the M7 audit surfaces; soma has no

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1,4 +1,5 @@
 import {
+  auditMemory,
   consolidateMemory,
   promoteAlgorithmRunMemory,
   rebuildMemoryIndex,
@@ -15,6 +16,8 @@ import type {
   SomaMemoryActionApproval,
   SomaMemoryActionOptions,
   SomaMemoryActionResult,
+  SomaMemoryAuditOptions,
+  SomaMemoryAuditResult,
   SomaMemoryConsolidateOptions,
   SomaMemoryConsolidateResult,
   SomaMemoryDigestOptions,
@@ -43,6 +46,7 @@ interface MemoryReindexOptions {
 }
 import { readOption } from "./parse-utils";
 import { parseSubstrate } from "./substrate";
+import { SomaCliError } from "./errors";
 
 export interface ParsedMemorySearchArgs {
   command: "memory";
@@ -98,6 +102,12 @@ export interface ParsedMemoryConsolidateArgs {
   options: SomaMemoryConsolidateOptions;
 }
 
+export interface ParsedMemoryAuditArgs {
+  command: "memory";
+  action: "audit";
+  options: SomaMemoryAuditOptions;
+}
+
 export type ParsedMemoryArgs =
   | ParsedMemorySearchArgs
   | ParsedMemoryRecallArgs
@@ -107,9 +117,10 @@ export type ParsedMemoryArgs =
   | ParsedMemoryReindexArgs
   | ParsedMemoryDigestArgs
   | ParsedMemoryActionArgs
-  | ParsedMemoryConsolidateArgs;
+  | ParsedMemoryConsolidateArgs
+  | ParsedMemoryAuditArgs;
 
-const MEMORY_ACTIONS = ["search", "recall", "promote", "write", "verify", "reindex", "digest", "action", "consolidate"] as const;
+const MEMORY_ACTIONS = ["search", "recall", "promote", "write", "verify", "reindex", "digest", "action", "consolidate", "audit"] as const;
 type MemoryAction = (typeof MEMORY_ACTIONS)[number];
 
 export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAction, string> } = {
@@ -150,6 +161,10 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
       "Deterministic maintenance: prune aged episodic → digest+archive, mark aged-unverified semantic review:stale, " +
       "list lexically-similar note pairs (near-duplicates for review; no semantic check), rebuild INDEX. --gc-state additionally DELETES current-work state >7d (explicit override). " +
       "--dry-run prints the plan without touching anything.",
+    audit:
+      "Usage: soma memory audit [--home-dir <dir>] [--soma-home <dir>]. " +
+      "Deterministic, read-only health check of the memory tree (no LLM): schema validity, INDEX freshness, " +
+      "digest coverage, orphaned archive notes, event/note ratio. EXITS NON-ZERO on a schema-invalid note or a stale INDEX.",
   },
 };
 
@@ -183,7 +198,23 @@ export function parseMemoryArgs(args: string[]): ParsedMemoryArgs {
       return { command, action, options: parseMemoryActionArgs(rest) };
     case "consolidate":
       return { command, action, options: parseMemoryConsolidateArgs(rest) };
+    case "audit":
+      return { command, action, options: parseMemoryAuditArgs(rest) };
   }
+}
+
+function parseMemoryAuditArgs(args: string[]): SomaMemoryAuditOptions {
+  const options: SomaMemoryAuditOptions = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const consumed = consumeSharedMemoryOption(args, index, arg, options);
+    if (consumed > 0) {
+      index += consumed;
+      continue;
+    }
+    throw new Error(MEMORY_COMMAND_HELP.subcommands.audit);
+  }
+  return options;
 }
 
 function parseMemoryConsolidateArgs(args: string[]): SomaMemoryConsolidateOptions {
@@ -696,7 +727,32 @@ export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
       return formatMemoryActionResult(await writeMemoryAction(parsed.options));
     case "consolidate":
       return formatMemoryConsolidateResult(await consolidateMemory(parsed.options));
+    case "audit": {
+      const audit = await auditMemory(parsed.options);
+      const report = formatMemoryAuditResult(audit);
+      // A deterministic gate: an unhealthy tree (schema-invalid note or stale INDEX)
+      // exits NON-ZERO so the audit can fail CI / a pre-consolidation check. The full
+      // report is carried on the error so it is still shown.
+      if (!audit.healthy) throw new SomaCliError(report, 1);
+      return report;
+    }
   }
+}
+
+function formatMemoryAuditResult(result: SomaMemoryAuditResult): string {
+  const lines = [
+    result.healthy ? "Soma memory audit: HEALTHY" : "Soma memory audit: UNHEALTHY",
+    ...result.probes.map((p) => `  [${p.ok ? "ok" : "FAIL"}] ${p.name}: ${p.detail}`),
+  ];
+  if (result.invalidNotes.length > 0) {
+    lines.push("schema-invalid notes:");
+    for (const p of result.invalidNotes) lines.push(`  - ${p}`);
+  }
+  if (result.orphanedArchive.length > 0) {
+    lines.push("archived notes missing from a digest:");
+    for (const p of result.orphanedArchive) lines.push(`  - ${p}`);
+  }
+  return lines.join("\n");
 }
 
 function formatConsolidateIndexLine(result: SomaMemoryConsolidateResult, mutated: boolean): string {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -204,15 +204,20 @@ export function parseMemoryArgs(args: string[]): ParsedMemoryArgs {
 }
 
 function parseMemoryAuditArgs(args: string[]): SomaMemoryAuditOptions {
+  // Audit takes ONLY home overrides — no --substrate (it has no substrate behavior;
+  // accepting it as a no-op is confusing for a health gate).
   const options: SomaMemoryAuditOptions = {};
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    const consumed = consumeSharedMemoryOption(args, index, arg, options);
-    if (consumed > 0) {
-      index += consumed;
-      continue;
+    if (arg === "--home-dir") {
+      options.homeDir = readOption(args, index, arg);
+      index += 1;
+    } else if (arg === "--soma-home") {
+      options.somaHome = readOption(args, index, arg);
+      index += 1;
+    } else {
+      throw new Error(MEMORY_COMMAND_HELP.subcommands.audit);
     }
-    throw new Error(MEMORY_COMMAND_HELP.subcommands.audit);
   }
   return options;
 }

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -124,7 +124,7 @@ const MEMORY_ACTIONS = ["search", "recall", "promote", "write", "verify", "reind
 type MemoryAction = (typeof MEMORY_ACTIONS)[number];
 
 export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAction, string> } = {
-  usage: "Usage: soma memory <search|recall|promote|write|verify|reindex|digest|action|consolidate> ...",
+  usage: "Usage: soma memory <search|recall|promote|write|verify|reindex|digest|action|consolidate|audit> ...",
   subcommands: {
     search: "Usage: soma memory search [query] [--query <text>] [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
     recall:

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -164,7 +164,7 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
     audit:
       "Usage: soma memory audit [--home-dir <dir>] [--soma-home <dir>]. " +
       "Deterministic, read-only health check of the memory tree (no LLM): schema validity, INDEX freshness, " +
-      "digest coverage, orphaned archive notes, event/note ratio. EXITS NON-ZERO on a schema-invalid note or a stale INDEX.",
+      "digest coverage, orphaned archive notes, event/note ratio. EXITS NON-ZERO on any health-gating failure: an abnormal note root (root-integrity), a schema-invalid note, or a stale INDEX.",
   },
 };
 
@@ -735,7 +735,7 @@ export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
     case "audit": {
       const audit = await auditMemory(parsed.options);
       const report = formatMemoryAuditResult(audit);
-      // A deterministic gate: an unhealthy tree (schema-invalid note or stale INDEX)
+      // A deterministic gate: an unhealthy tree (abnormal root, schema-invalid note, or stale INDEX)
       // exits NON-ZERO so the audit can fail CI / a pre-consolidation check. The full
       // report is carried on the error so it is still shown.
       if (!audit.healthy) throw new SomaCliError(report, 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -470,6 +470,7 @@ export { recallMemory } from "./memory-recall";
 export { rebuildMemoryIndex } from "./memory-index";
 export { writeSessionDigest, writeMemoryAction } from "./memory-episodic";
 export { consolidateMemory } from "./memory-consolidate";
+export { auditMemory } from "./memory-audit";
 export { createSomaSnapshot, listSomaSnapshots, rollbackSomaSnapshot } from "./snapshots";
 export { querySomaTelemetryEvents, summarizeSomaTelemetry } from "./observability";
 export {

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -1,6 +1,6 @@
 import type { Dirent } from "node:fs";
 import { readFile, readdir, stat } from "node:fs/promises";
-import { join, relative } from "node:path";
+import { basename, join, relative, sep } from "node:path";
 import { createPaths } from "./paths";
 import { isEnoent } from "./fs-utils";
 import { runBoundedConcurrent } from "./internal-concurrency";
@@ -33,17 +33,18 @@ async function listRealMarkdownFilesRec(dir: string): Promise<string[]> {
     if (isEnoent(error)) return []; // a missing dir is genuinely empty
     throw error; // any other failure is a real blind spot — do not treat as empty
   }
-  const out: string[] = [];
+  const files: string[] = [];
+  const subdirs: string[] = [];
   for (const entry of entries) {
-    const full = join(dir, entry.name);
     if (entry.isSymbolicLink()) continue; // never follow a symlink out of the tree
-    if (entry.isDirectory()) {
-      out.push(...(await listRealMarkdownFilesRec(full)));
-    } else if (entry.isFile() && entry.name.endsWith(".md")) {
-      out.push(full);
-    }
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) subdirs.push(full);
+    else if (entry.isFile() && entry.name.endsWith(".md")) files.push(full);
   }
-  return out;
+  // Walk sibling subtrees concurrently rather than serially — a wide archive
+  // (many month/project dirs) would otherwise pay sequential walk latency.
+  const nested = await Promise.all(subdirs.map(listRealMarkdownFilesRec));
+  return [...files, ...nested.flat()];
 }
 
 /** Parse one note file → the note, or `undefined` if it cannot be read/parsed. */
@@ -80,110 +81,164 @@ export async function auditMemory(options: SomaMemoryAuditOptions = {}): Promise
     SCAN_CONCURRENCY,
   );
 
-  // --- probe: schema validity (GATES health) ---
-  const invalidNotes = parsed.filter((p) => p.note === undefined).map((p) => relative(somaHome, p.path)).sort();
-  const notesByType = { semantic: 0, procedural: 0, episodic: 0 };
-  for (const { note } of parsed) {
-    if (note && note.type in notesByType) notesByType[note.type] += 1;
-  }
-  probes.push({
-    name: "schema",
-    ok: invalidNotes.length === 0,
-    detail:
-      invalidNotes.length === 0
-        ? `${allFiles.length} note file(s) parse (semantic ${notesByType.semantic}, procedural ${notesByType.procedural}, episodic ${notesByType.episodic})`
-        : `${invalidNotes.length} schema-invalid note file(s): ${invalidNotes.join(", ")}`,
-  });
-
-  // --- probe: INDEX freshness (GATES health) ---
-  const indexPath = memoryIndexPath(somaHome);
-  const indexMtime = await mtimeMs(indexPath);
-  // The INDEX is built from the DURABLE corpus only (M3), so freshness is measured
-  // against durable-note mtimes — an episodic write does not stale the INDEX.
-  const durableMtimes = await Promise.all(durableFiles.map(mtimeMs));
-  const newestDurable = durableMtimes.reduce<number>((max, m) => (m !== undefined && m > max ? m : max), 0);
-  let indexStale: boolean;
-  let indexReason: string;
-  if (durableFiles.length === 0) {
-    indexStale = false;
-    indexReason = "no durable notes — nothing to index";
-  } else if (indexMtime === undefined) {
-    indexStale = true;
-    indexReason = `INDEX.md is absent but ${durableFiles.length} durable note(s) exist — run 'soma memory reindex'`;
-  } else if (newestDurable > indexMtime) {
-    indexStale = true;
-    indexReason = "a durable note is newer than INDEX.md — run 'soma memory reindex'";
-  } else {
-    indexStale = false;
-    indexReason = "INDEX.md is at least as new as every durable note";
-  }
-  probes.push({ name: "index-freshness", ok: !indexStale, detail: indexReason });
-
-  // --- probe: digest coverage (informational) ---
+  const schema = probeSchema(parsed, allFiles.length, somaHome);
+  const index = await probeIndexFreshness(somaHome, durableFiles);
   const digestFilesList = await listRealMarkdownFilesRec(paths.resolve("memory", "episodic", "digests"));
-  const digests = { sessionNotes: sessionFiles.length, actionNotes: actionFiles.length, digestFiles: digestFilesList.length };
-  probes.push({
-    name: "digest-coverage",
-    ok: true,
-    detail: `${digests.sessionNotes} session + ${digests.actionNotes} action note(s), ${digests.digestFiles} monthly digest file(s)`,
-  });
-
-  // --- probe: orphaned archive (informational) ---
-  // An archived episodic note whose id is not referenced in its created-month digest
-  // signals digest/archive drift (a lost or un-regenerated digest pointer).
-  const digestIds = await collectDigestIds(digestFilesList);
-  const orphanedArchive: string[] = [];
-  for (const { path, note } of parsed) {
-    if (note === undefined) continue;
-    if (!path.startsWith(archiveDir)) continue;
-    if (note.type !== "episodic") continue;
-    if (!digestIds.has(note.id)) orphanedArchive.push(relative(somaHome, path));
-  }
-  orphanedArchive.sort();
-  probes.push({
-    name: "orphaned-archive",
-    ok: true, // informational: a re-consolidation regenerates digests
-    detail:
-      orphanedArchive.length === 0
-        ? "every archived episodic note is referenced by a monthly digest"
-        : `${orphanedArchive.length} archived note(s) missing from a digest (run 'soma memory consolidate')`,
-  });
-
-  // --- probe: event/note ratio (informational) ---
+  const digestCov = probeDigestCoverage(sessionFiles.length, actionFiles.length, digestFilesList.length);
+  const archive = await probeOrphanedArchive(parsed, archiveDir, digestFilesList, somaHome);
   const eventLines = await countEventLines(somaMemoryEventsPath(somaHome));
-  const validNotes = parsed.length - invalidNotes.length;
-  const events = { lines: eventLines, notes: validNotes };
-  probes.push({ name: "event-ratio", ok: true, detail: `${eventLines} event line(s) over ${validNotes} valid note(s)` });
+  const validNotes = parsed.length - schema.invalidNotes.length;
+  const eventProbe = probeEventRatio(eventLines, validNotes);
 
-  const healthy = invalidNotes.length === 0 && !indexStale;
+  probes.push(schema.probe, index.probe, digestCov.probe, archive.probe, eventProbe.probe);
+
+  // Only schema + index-freshness GATE health; the rest are informational drift signals.
+  const healthy = schema.probe.ok && index.probe.ok;
   return {
     somaHome,
     healthy,
-    notesByType,
-    invalidNotes,
-    index: { path: indexPath, stale: indexStale, reason: indexReason },
-    digests,
-    orphanedArchive,
-    events,
+    notesByType: schema.notesByType,
+    invalidNotes: schema.invalidNotes,
+    index: { path: index.path, stale: !index.probe.ok, reason: index.probe.detail },
+    digests: digestCov.digests,
+    orphanedArchive: archive.orphanedArchive,
+    events: eventProbe.events,
     probes,
   };
 }
 
-/** Ids referenced by any monthly digest — each digest line is `- <id>: <text>`. */
-async function collectDigestIds(digestFiles: string[]): Promise<Set<string>> {
-  const ids = new Set<string>();
-  const contents = await runBoundedConcurrent(
+/** Probe: every note file parses against the schema (GATES health). */
+function probeSchema(
+  parsed: { path: string; note: SomaMemoryNote | undefined }[],
+  fileCount: number,
+  somaHome: string,
+): { probe: SomaMemoryAuditProbe; invalidNotes: string[]; notesByType: { semantic: number; procedural: number; episodic: number } } {
+  const invalidNotes = parsed.filter((p) => p.note === undefined).map((p) => relative(somaHome, p.path)).sort();
+  const notesByType = { semantic: 0, procedural: 0, episodic: 0 };
+  for (const { note } of parsed) if (note && note.type in notesByType) notesByType[note.type] += 1;
+  return {
+    invalidNotes,
+    notesByType,
+    probe: {
+      name: "schema",
+      ok: invalidNotes.length === 0,
+      detail:
+        invalidNotes.length === 0
+          ? `${fileCount} note file(s) parse (semantic ${notesByType.semantic}, procedural ${notesByType.procedural}, episodic ${notesByType.episodic})`
+          : `${invalidNotes.length} schema-invalid note file(s): ${invalidNotes.join(", ")}`,
+    },
+  };
+}
+
+/**
+ * Probe: INDEX.md is at least as new as every DURABLE note (GATES health). This is a
+ * FRESHNESS smoke check via mtime only — it does NOT read or validate INDEX contents,
+ * so a stale INDEX that was merely touched would still pass. `soma memory reindex`
+ * is the fix for a real staleness.
+ */
+async function probeIndexFreshness(
+  somaHome: string,
+  durableFiles: string[],
+): Promise<{ probe: SomaMemoryAuditProbe; path: string }> {
+  const path = memoryIndexPath(somaHome);
+  const indexMtime = await mtimeMs(path);
+  const durableMtimes = await Promise.all(durableFiles.map(mtimeMs));
+  const newestDurable = durableMtimes.reduce<number>((max, m) => (m !== undefined && m > max ? m : max), 0);
+  let ok: boolean;
+  let detail: string;
+  if (durableFiles.length === 0) {
+    ok = true;
+    detail = "no durable notes — nothing to index";
+  } else if (indexMtime === undefined) {
+    ok = false;
+    detail = `INDEX.md is absent but ${durableFiles.length} durable note(s) exist — run 'soma memory reindex'`;
+  } else if (newestDurable > indexMtime) {
+    ok = false;
+    detail = "a durable note is newer than INDEX.md (mtime check only, not contents) — run 'soma memory reindex'";
+  } else {
+    ok = true;
+    detail = "INDEX.md is at least as new as every durable note (mtime freshness only)";
+  }
+  return { path, probe: { name: "index-freshness", ok, detail } };
+}
+
+/** Probe: episodic coverage counts (informational). */
+function probeDigestCoverage(
+  sessionNotes: number,
+  actionNotes: number,
+  digestFiles: number,
+): { probe: SomaMemoryAuditProbe; digests: { sessionNotes: number; actionNotes: number; digestFiles: number } } {
+  const digests = { sessionNotes, actionNotes, digestFiles };
+  return {
+    digests,
+    probe: {
+      name: "digest-coverage",
+      ok: true,
+      detail: `${sessionNotes} session + ${actionNotes} action note(s), ${digestFiles} monthly digest file(s)`,
+    },
+  };
+}
+
+/**
+ * Probe: every archived episodic note is referenced by ITS created-month digest
+ * (informational). A reference in a DIFFERENT month is drift, not coverage — the
+ * check is scoped per month, not against all digests globally.
+ */
+async function probeOrphanedArchive(
+  parsed: { path: string; note: SomaMemoryNote | undefined }[],
+  archiveDir: string,
+  digestFilesList: string[],
+  somaHome: string,
+): Promise<{ probe: SomaMemoryAuditProbe; orphanedArchive: string[] }> {
+  const digestIdsByMonth = await collectDigestIdsByMonth(digestFilesList);
+  const orphanedArchive: string[] = [];
+  for (const { path, note } of parsed) {
+    if (note === undefined || note.type !== "episodic") continue;
+    if (!path.startsWith(archiveDir + sep)) continue;
+    const month = note.created.slice(0, 7);
+    if (!digestIdsByMonth.get(month)?.has(note.id)) orphanedArchive.push(relative(somaHome, path));
+  }
+  orphanedArchive.sort();
+  return {
+    orphanedArchive,
+    probe: {
+      name: "orphaned-archive",
+      ok: true, // informational: a re-consolidation regenerates the month's digest
+      detail:
+        orphanedArchive.length === 0
+          ? "every archived episodic note is referenced by its created-month digest"
+          : `${orphanedArchive.length} archived note(s) missing from their created-month digest (run 'soma memory consolidate')`,
+    },
+  };
+}
+
+/** Probe: event-stream lines over valid-note count (informational). */
+function probeEventRatio(lines: number, notes: number): { probe: SomaMemoryAuditProbe; events: { lines: number; notes: number } } {
+  return { events: { lines, notes }, probe: { name: "event-ratio", ok: true, detail: `${lines} event line(s) over ${notes} valid note(s)` } };
+}
+
+/**
+ * Digest-referenced ids keyed by MONTH (the digest's `YYYY-MM.md` basename). Keyed
+ * by month so the orphan check can require a note to appear in ITS created-month
+ * digest — a reference in the wrong month is drift, not coverage. Each digest line
+ * is `- <id>: <text>`.
+ */
+async function collectDigestIdsByMonth(digestFiles: string[]): Promise<Map<string, Set<string>>> {
+  const byMonth = new Map<string, Set<string>>();
+  const parsedFiles = await runBoundedConcurrent(
     digestFiles,
-    (path) => readFile(path, "utf8").catch(() => ""),
+    async (path) => ({ month: basename(path).replace(/\.md$/, ""), content: await readFile(path, "utf8").catch(() => "") }),
     SCAN_CONCURRENCY,
   );
-  for (const content of contents) {
+  for (const { month, content } of parsedFiles) {
+    const ids = byMonth.get(month) ?? new Set<string>();
     for (const line of content.split("\n")) {
       const match = /^-\s+([^:\s]+):/.exec(line.trim());
       if (match) ids.add(match[1]);
     }
+    byMonth.set(month, ids);
   }
-  return ids;
+  return byMonth;
 }
 
 /** Non-empty JSONL lines in the events file (0 if absent). */

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -1,6 +1,6 @@
 import { type Dirent, constants as fsConstants } from "node:fs";
 import { lstat, readFile, readdir } from "node:fs/promises";
-import { basename, isAbsolute, join, relative } from "node:path";
+import { basename, dirname, isAbsolute, join, relative } from "node:path";
 import { createPaths } from "./paths";
 import { isEnoent } from "./fs-utils";
 import { runBoundedConcurrent } from "./internal-concurrency";
@@ -133,7 +133,13 @@ export async function auditMemory(options: SomaMemoryAuditOptions = {}): Promise
 
   const schema = probeSchema(parsed, allFiles.length, somaHome);
   const index = await probeIndexFreshness(somaHome, durableFiles);
-  const digestFilesList = await listRealMarkdownFilesRec(paths.resolve("memory", "episodic", "digests"));
+  // CANONICAL digests only: a real `<YYYY-MM>.md` DIRECTLY under the digests root. A
+  // nested or oddly-named file (e.g. `digests/nested/2026-07.md`) must not satisfy
+  // month coverage.
+  const digestsDir = paths.resolve("memory", "episodic", "digests");
+  const digestFilesList = (await listRealMarkdownFilesRec(digestsDir)).filter(
+    (p) => dirname(p) === digestsDir && /^\d{4}-\d{2}\.md$/.test(basename(p)),
+  );
   const digestCov = probeDigestCoverage(sessionFiles.length, actionFiles.length, digestFilesList.length);
   const archive = await probeOrphanedArchive(parsed, archiveDir, digestFilesList, somaHome);
   const eventLines = await countEventLines(somaMemoryEventsPath(somaHome));

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -1,5 +1,5 @@
 import type { Dirent } from "node:fs";
-import { readFile, readdir, stat } from "node:fs/promises";
+import { lstat, readFile, readdir, stat } from "node:fs/promises";
 import { basename, join, relative, sep } from "node:path";
 import { createPaths } from "./paths";
 import { isEnoent } from "./fs-utils";
@@ -16,10 +16,12 @@ import type { SomaMemoryAuditOptions, SomaMemoryAuditProbe, SomaMemoryAuditResul
  * a probe that GATES health fails: a schema-invalid note, or a stale INDEX. The rest
  * (digest coverage, orphaned archive, event ratio) are informational drift signals.
  *
- * Every §15 design invariant of the memory subsystem maps to a probe here: notes
- * parse (schema), the INDEX reflects the corpus (freshness), episodic prune leaves a
- * digest (coverage), the archive stays consistent with its digests (orphans), and
- * the event stream tracks mutations (ratio).
+ * These are DETERMINISTIC SMOKE checks, not invariant ENFORCEMENT: they surface the
+ * cheap-to-detect drift each memory milestone can leave behind — an unparseable note
+ * (schema), an INDEX older by mtime than the corpus (freshness — NOT a content
+ * check), archived notes missing from their month's digest (coverage), and a coarse
+ * event/note ratio. A passing audit means no drift was DETECTED, not that every
+ * invariant is proven.
  */
 const SCAN_CONCURRENCY = 16;
 
@@ -41,9 +43,9 @@ async function listRealMarkdownFilesRec(dir: string): Promise<string[]> {
     if (entry.isDirectory()) subdirs.push(full);
     else if (entry.isFile() && entry.name.endsWith(".md")) files.push(full);
   }
-  // Walk sibling subtrees concurrently rather than serially — a wide archive
-  // (many month/project dirs) would otherwise pay sequential walk latency.
-  const nested = await Promise.all(subdirs.map(listRealMarkdownFilesRec));
+  // Walk sibling subtrees concurrently but BOUNDED — a wide archive (many
+  // month/project dirs) neither serializes nor spikes fds on an unbounded fan-out.
+  const nested = await runBoundedConcurrent(subdirs, listRealMarkdownFilesRec, SCAN_CONCURRENCY);
   return [...files, ...nested.flat()];
 }
 
@@ -58,6 +60,19 @@ async function mtimeMs(path: string): Promise<number | undefined> {
     if (isEnoent(error)) return undefined;
     throw error;
   });
+}
+
+/** lstat-based classification of INDEX.md — the audit trusts only a REAL file, so a
+ *  symlinked INDEX (which could point at a newer file to spoof freshness) is rejected. */
+async function classifyIndex(path: string): Promise<{ kind: "absent" | "symlink" | "irregular" | "file"; mtimeMs: number }> {
+  const info = await lstat(path).catch((error) => {
+    if (isEnoent(error)) return undefined;
+    throw error;
+  });
+  if (info === undefined) return { kind: "absent", mtimeMs: 0 };
+  if (info.isSymbolicLink()) return { kind: "symlink", mtimeMs: 0 };
+  if (!info.isFile()) return { kind: "irregular", mtimeMs: 0 };
+  return { kind: "file", mtimeMs: info.mtimeMs };
 }
 
 export async function auditMemory(options: SomaMemoryAuditOptions = {}): Promise<SomaMemoryAuditResult> {
@@ -141,18 +156,22 @@ async function probeIndexFreshness(
   durableFiles: string[],
 ): Promise<{ probe: SomaMemoryAuditProbe; path: string }> {
   const path = memoryIndexPath(somaHome);
-  const indexMtime = await mtimeMs(path);
+  const index = await classifyIndex(path);
   const durableMtimes = await Promise.all(durableFiles.map(mtimeMs));
   const newestDurable = durableMtimes.reduce<number>((max, m) => (m !== undefined && m > max ? m : max), 0);
   let ok: boolean;
   let detail: string;
-  if (durableFiles.length === 0) {
+  if (index.kind === "symlink" || index.kind === "irregular") {
+    // A non-regular INDEX can spoof mtime freshness — reject regardless of note count.
+    ok = false;
+    detail = `INDEX.md is a ${index.kind === "symlink" ? "symlink" : "non-regular file"} — refusing to trust it; run 'soma memory reindex' on a clean tree`;
+  } else if (durableFiles.length === 0) {
     ok = true;
     detail = "no durable notes — nothing to index";
-  } else if (indexMtime === undefined) {
+  } else if (index.kind === "absent") {
     ok = false;
     detail = `INDEX.md is absent but ${durableFiles.length} durable note(s) exist — run 'soma memory reindex'`;
-  } else if (newestDurable > indexMtime) {
+  } else if (newestDurable > index.mtimeMs) {
     ok = false;
     detail = "a durable note is newer than INDEX.md (mtime check only, not contents) — run 'soma memory reindex'";
   } else {
@@ -241,11 +260,24 @@ async function collectDigestIdsByMonth(digestFiles: string[]): Promise<Map<strin
   return byMonth;
 }
 
-/** Non-empty JSONL lines in the events file (0 if absent). */
+/** Non-empty JSONL lines in the events file (0 if absent). Single pass over the
+ *  content counting non-empty lines — no `split` allocation of the whole history. */
 async function countEventLines(eventsPath: string): Promise<number> {
   const content = await readFile(eventsPath, "utf8").catch((error) => {
     if (isEnoent(error)) return "";
     throw error;
   });
-  return content.trim() === "" ? 0 : content.trim().split("\n").length;
+  let count = 0;
+  let lineHasContent = false;
+  for (let i = 0; i < content.length; i += 1) {
+    const ch = content[i];
+    if (ch === "\n") {
+      if (lineHasContent) count += 1;
+      lineHasContent = false;
+    } else if (ch !== "\r" && ch !== " " && ch !== "\t") {
+      lineHasContent = true;
+    }
+  }
+  if (lineHasContent) count += 1; // a final line with no trailing newline
+  return count;
 }

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -124,8 +124,9 @@ export async function auditMemory(options: SomaMemoryAuditOptions = {}): Promise
 
   probes.push(schema.probe, index.probe, digestCov.probe, archive.probe, eventProbe.probe);
 
-  // Only schema + index-freshness GATE health; the rest are informational drift signals.
-  const healthy = schema.probe.ok && index.probe.ok;
+  // Single source of truth: healthy iff every HEALTH-GATING probe is ok. The
+  // informational probes carry gatesHealth:false and never affect this.
+  const healthy = probes.every((p) => !p.gatesHealth || p.ok);
   return {
     somaHome,
     healthy,
@@ -153,6 +154,7 @@ function probeSchema(
     notesByType,
     probe: {
       name: "schema",
+      gatesHealth: true,
       ok: invalidNotes.length === 0,
       detail:
         invalidNotes.length === 0
@@ -202,7 +204,7 @@ async function probeIndexFreshness(
     ok = true;
     detail = "INDEX.md is at least as new as every durable note (mtime freshness only)";
   }
-  return { path, probe: { name: "index-freshness", ok, detail } };
+  return { path, probe: { name: "index-freshness", gatesHealth: true, ok, detail } };
 }
 
 /** Probe: episodic coverage counts (informational). */
@@ -216,6 +218,7 @@ function probeDigestCoverage(
     digests,
     probe: {
       name: "digest-coverage",
+      gatesHealth: false,
       ok: true,
       detail: `${sessionNotes} session + ${actionNotes} action note(s), ${digestFiles} monthly digest file(s)`,
     },
@@ -233,8 +236,10 @@ async function probeOrphanedArchive(
   digestFilesList: string[],
   somaHome: string,
 ): Promise<{ probe: SomaMemoryAuditProbe; orphanedArchive: string[] }> {
-  const digestIdsByMonth = await collectDigestIdsByMonth(digestFilesList);
-  const orphanedArchive: string[] = [];
+  // Archived episodic notes and the months they need a digest for — computed FIRST so
+  // only the digests for those months are read (an empty archive reads no digest).
+  const archived: { relFromSoma: string; id: string; month: string }[] = [];
+  const neededMonths = new Set<string>();
   for (const { path, note } of parsed) {
     if (note === undefined || note.type !== "episodic") continue;
     // Path-segment containment (not a raw string prefix): `path` is under the archive
@@ -242,13 +247,21 @@ async function probeOrphanedArchive(
     const rel = relative(archiveDir, path);
     if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) continue;
     const month = note.created.slice(0, 7);
-    if (!digestIdsByMonth.get(month)?.has(note.id)) orphanedArchive.push(relative(somaHome, path));
+    archived.push({ relFromSoma: relative(somaHome, path), id: note.id, month });
+    neededMonths.add(month);
+  }
+  const relevantDigests = digestFilesList.filter((p) => neededMonths.has(basename(p).replace(/\.md$/, "")));
+  const digestIdsByMonth = await collectDigestIdsByMonth(relevantDigests);
+  const orphanedArchive: string[] = [];
+  for (const a of archived) {
+    if (!digestIdsByMonth.get(a.month)?.has(a.id)) orphanedArchive.push(a.relFromSoma);
   }
   orphanedArchive.sort();
   return {
     orphanedArchive,
     probe: {
       name: "orphaned-archive",
+      gatesHealth: false,
       ok: true, // informational: a re-consolidation regenerates the month's digest
       detail:
         orphanedArchive.length === 0
@@ -260,7 +273,7 @@ async function probeOrphanedArchive(
 
 /** Probe: event-stream lines over valid-note count (informational). */
 function probeEventRatio(lines: number, notes: number): { probe: SomaMemoryAuditProbe; events: { lines: number; notes: number } } {
-  return { events: { lines, notes }, probe: { name: "event-ratio", ok: true, detail: `${lines} event line(s) over ${notes} valid note(s)` } };
+  return { events: { lines, notes }, probe: { name: "event-ratio", gatesHealth: false, ok: true, detail: `${lines} event line(s) over ${notes} valid note(s)` } };
 }
 
 /**
@@ -273,7 +286,9 @@ async function collectDigestIdsByMonth(digestFiles: string[]): Promise<Map<strin
   const byMonth = new Map<string, Set<string>>();
   const parsedFiles = await runBoundedConcurrent(
     digestFiles,
-    async (path) => ({ month: basename(path).replace(/\.md$/, ""), content: await readFile(path, "utf8").catch(() => "") }),
+    // NOFOLLOW like every other audit read — a digest swapped to a symlink is not
+    // followed (reads empty), so it can't spoof archive coverage from an outside file.
+    async (path) => ({ month: basename(path).replace(/\.md$/, ""), content: await readFile(path, { encoding: "utf8", flag: NOFOLLOW_READ }).catch(() => "") }),
     SCAN_CONCURRENCY,
   );
   for (const { month, content } of parsedFiles) {

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -13,15 +13,17 @@ import type { SomaMemoryAuditOptions, SomaMemoryAuditProbe, SomaMemoryAuditResul
  * M7 — a DETERMINISTIC audit of the on-disk memory tree. No LLM, no sentiment: every
  * probe reads the filesystem and reports a ground-truth fact. Read-only — it mutates
  * nothing and appends no event. `healthy` is false (and the CLI exits non-zero) when
- * a probe that GATES health fails: a schema-invalid note, or a stale INDEX. The rest
- * (digest coverage, orphaned archive, event ratio) are informational drift signals.
+ * any HEALTH-GATING probe fails: an abnormal note root (root-integrity), a
+ * schema-invalid note, or a stale INDEX. The other three (digest coverage, orphaned
+ * archive, event ratio) are informational — they never affect `healthy`.
  *
  * These are DETERMINISTIC SMOKE checks, not invariant ENFORCEMENT: they surface the
- * cheap-to-detect drift each memory milestone can leave behind — an unparseable note
- * (schema), an INDEX older by mtime than the corpus (freshness — NOT a content
- * check), archived notes missing from their month's digest (coverage), and a coarse
- * event/note ratio. A passing audit means no drift was DETECTED, not that every
- * invariant is proven.
+ * cheap-to-detect drift each memory milestone can leave behind — a redirected note
+ * root (root-integrity), an unparseable note (schema), an INDEX older by mtime than
+ * the corpus (freshness — NOT a content check), archived notes missing from their
+ * month's digest (orphaned-archive), and a coarse event/note ratio. A HEALTHY exit
+ * means no health-GATING drift was detected — the informational probes may STILL
+ * report drift (e.g. orphaned archive) on a healthy tree; read each probe.
  */
 const SCAN_CONCURRENCY = 16;
 
@@ -282,7 +284,9 @@ function probeDigestCoverage(
 /**
  * Probe: every archived episodic note is referenced by ITS created-month digest
  * (informational). A reference in a DIFFERENT month is drift, not coverage — the
- * check is scoped per month, not against all digests globally.
+ * check is scoped per month, not against all digests globally. Covers only PARSEABLE
+ * episodic notes under `memory/archive/`; a malformed archived file is surfaced by
+ * the (health-gating) schema probe instead, not double-counted here.
  */
 async function probeOrphanedArchive(
   parsed: { path: string; note: SomaMemoryNote | undefined }[],

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -1,0 +1,196 @@
+import type { Dirent } from "node:fs";
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { createPaths } from "./paths";
+import { isEnoent } from "./fs-utils";
+import { runBoundedConcurrent } from "./internal-concurrency";
+import { memoryIndexPath } from "./memory-index";
+import { somaMemoryEventsPath } from "./memory";
+import { parseMemoryNote } from "./memory-note";
+import type { SomaMemoryAuditOptions, SomaMemoryAuditProbe, SomaMemoryAuditResult, SomaMemoryNote } from "./types";
+
+/**
+ * M7 — a DETERMINISTIC audit of the on-disk memory tree. No LLM, no sentiment: every
+ * probe reads the filesystem and reports a ground-truth fact. Read-only — it mutates
+ * nothing and appends no event. `healthy` is false (and the CLI exits non-zero) when
+ * a probe that GATES health fails: a schema-invalid note, or a stale INDEX. The rest
+ * (digest coverage, orphaned archive, event ratio) are informational drift signals.
+ *
+ * Every §15 design invariant of the memory subsystem maps to a probe here: notes
+ * parse (schema), the INDEX reflects the corpus (freshness), episodic prune leaves a
+ * digest (coverage), the archive stays consistent with its digests (orphans), and
+ * the event stream tracks mutations (ratio).
+ */
+const SCAN_CONCURRENCY = 16;
+
+/** All `.md` files under `dir`, recursively, REJECTING symlinked dirs/files (they
+ *  could point outside the memory root — the audit only trusts real entries). */
+async function listRealMarkdownFilesRec(dir: string): Promise<string[]> {
+  let entries: Dirent[];
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (error) {
+    if (isEnoent(error)) return []; // a missing dir is genuinely empty
+    throw error; // any other failure is a real blind spot — do not treat as empty
+  }
+  const out: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isSymbolicLink()) continue; // never follow a symlink out of the tree
+    if (entry.isDirectory()) {
+      out.push(...(await listRealMarkdownFilesRec(full)));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Parse one note file → the note, or `undefined` if it cannot be read/parsed. */
+async function parseFile(path: string): Promise<SomaMemoryNote | undefined> {
+  return readFile(path, "utf8").then(parseMemoryNote).catch(() => undefined);
+}
+
+/** mtime in ms, or `undefined` if the path is absent. */
+async function mtimeMs(path: string): Promise<number | undefined> {
+  return stat(path).then((s) => s.mtimeMs).catch((error) => {
+    if (isEnoent(error)) return undefined;
+    throw error;
+  });
+}
+
+export async function auditMemory(options: SomaMemoryAuditOptions = {}): Promise<SomaMemoryAuditResult> {
+  const paths = createPaths(options);
+  const somaHome = paths.root();
+  const probes: SomaMemoryAuditProbe[] = [];
+
+  // --- enumerate every note file in the tree (durable + episodic + archive) ---
+  const durableDirs = [paths.resolve("memory", "semantic"), paths.resolve("memory", "procedural")];
+  const episodicDirs = [paths.resolve("memory", "episodic", "sessions"), paths.resolve("memory", "episodic", "actions")];
+  const archiveDir = paths.resolve("memory", "archive");
+
+  const durableFiles = (await Promise.all(durableDirs.map(listRealMarkdownFilesRec))).flat();
+  const [sessionFiles, actionFiles] = await Promise.all(episodicDirs.map(listRealMarkdownFilesRec));
+  const archiveFiles = await listRealMarkdownFilesRec(archiveDir);
+  const allFiles = [...durableFiles, ...sessionFiles, ...actionFiles, ...archiveFiles];
+
+  const parsed = await runBoundedConcurrent(
+    allFiles,
+    async (path) => ({ path, note: await parseFile(path) }),
+    SCAN_CONCURRENCY,
+  );
+
+  // --- probe: schema validity (GATES health) ---
+  const invalidNotes = parsed.filter((p) => p.note === undefined).map((p) => relative(somaHome, p.path)).sort();
+  const notesByType = { semantic: 0, procedural: 0, episodic: 0 };
+  for (const { note } of parsed) {
+    if (note && note.type in notesByType) notesByType[note.type] += 1;
+  }
+  probes.push({
+    name: "schema",
+    ok: invalidNotes.length === 0,
+    detail:
+      invalidNotes.length === 0
+        ? `${allFiles.length} note file(s) parse (semantic ${notesByType.semantic}, procedural ${notesByType.procedural}, episodic ${notesByType.episodic})`
+        : `${invalidNotes.length} schema-invalid note file(s): ${invalidNotes.join(", ")}`,
+  });
+
+  // --- probe: INDEX freshness (GATES health) ---
+  const indexPath = memoryIndexPath(somaHome);
+  const indexMtime = await mtimeMs(indexPath);
+  // The INDEX is built from the DURABLE corpus only (M3), so freshness is measured
+  // against durable-note mtimes — an episodic write does not stale the INDEX.
+  const durableMtimes = await Promise.all(durableFiles.map(mtimeMs));
+  const newestDurable = durableMtimes.reduce<number>((max, m) => (m !== undefined && m > max ? m : max), 0);
+  let indexStale: boolean;
+  let indexReason: string;
+  if (durableFiles.length === 0) {
+    indexStale = false;
+    indexReason = "no durable notes — nothing to index";
+  } else if (indexMtime === undefined) {
+    indexStale = true;
+    indexReason = `INDEX.md is absent but ${durableFiles.length} durable note(s) exist — run 'soma memory reindex'`;
+  } else if (newestDurable > indexMtime) {
+    indexStale = true;
+    indexReason = "a durable note is newer than INDEX.md — run 'soma memory reindex'";
+  } else {
+    indexStale = false;
+    indexReason = "INDEX.md is at least as new as every durable note";
+  }
+  probes.push({ name: "index-freshness", ok: !indexStale, detail: indexReason });
+
+  // --- probe: digest coverage (informational) ---
+  const digestFilesList = await listRealMarkdownFilesRec(paths.resolve("memory", "episodic", "digests"));
+  const digests = { sessionNotes: sessionFiles.length, actionNotes: actionFiles.length, digestFiles: digestFilesList.length };
+  probes.push({
+    name: "digest-coverage",
+    ok: true,
+    detail: `${digests.sessionNotes} session + ${digests.actionNotes} action note(s), ${digests.digestFiles} monthly digest file(s)`,
+  });
+
+  // --- probe: orphaned archive (informational) ---
+  // An archived episodic note whose id is not referenced in its created-month digest
+  // signals digest/archive drift (a lost or un-regenerated digest pointer).
+  const digestIds = await collectDigestIds(digestFilesList);
+  const orphanedArchive: string[] = [];
+  for (const { path, note } of parsed) {
+    if (note === undefined) continue;
+    if (!path.startsWith(archiveDir)) continue;
+    if (note.type !== "episodic") continue;
+    if (!digestIds.has(note.id)) orphanedArchive.push(relative(somaHome, path));
+  }
+  orphanedArchive.sort();
+  probes.push({
+    name: "orphaned-archive",
+    ok: true, // informational: a re-consolidation regenerates digests
+    detail:
+      orphanedArchive.length === 0
+        ? "every archived episodic note is referenced by a monthly digest"
+        : `${orphanedArchive.length} archived note(s) missing from a digest (run 'soma memory consolidate')`,
+  });
+
+  // --- probe: event/note ratio (informational) ---
+  const eventLines = await countEventLines(somaMemoryEventsPath(somaHome));
+  const validNotes = parsed.length - invalidNotes.length;
+  const events = { lines: eventLines, notes: validNotes };
+  probes.push({ name: "event-ratio", ok: true, detail: `${eventLines} event line(s) over ${validNotes} valid note(s)` });
+
+  const healthy = invalidNotes.length === 0 && !indexStale;
+  return {
+    somaHome,
+    healthy,
+    notesByType,
+    invalidNotes,
+    index: { path: indexPath, stale: indexStale, reason: indexReason },
+    digests,
+    orphanedArchive,
+    events,
+    probes,
+  };
+}
+
+/** Ids referenced by any monthly digest — each digest line is `- <id>: <text>`. */
+async function collectDigestIds(digestFiles: string[]): Promise<Set<string>> {
+  const ids = new Set<string>();
+  const contents = await runBoundedConcurrent(
+    digestFiles,
+    (path) => readFile(path, "utf8").catch(() => ""),
+    SCAN_CONCURRENCY,
+  );
+  for (const content of contents) {
+    for (const line of content.split("\n")) {
+      const match = /^-\s+([^:\s]+):/.exec(line.trim());
+      if (match) ids.add(match[1]);
+    }
+  }
+  return ids;
+}
+
+/** Non-empty JSONL lines in the events file (0 if absent). */
+async function countEventLines(eventsPath: string): Promise<number> {
+  const content = await readFile(eventsPath, "utf8").catch((error) => {
+    if (isEnoent(error)) return "";
+    throw error;
+  });
+  return content.trim() === "" ? 0 : content.trim().split("\n").length;
+}

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -277,8 +277,15 @@ async function collectDigestIdsByMonth(digestFiles: string[]): Promise<Map<strin
 }
 
 /** Non-empty JSONL lines in the events file (0 if absent). Single pass over the
- *  content counting non-empty lines — no `split` allocation of the whole history. */
+ *  content counting non-empty lines — no `split` allocation of the whole history.
+ *  lstat-guarded: a symlinked/non-regular events file is not read through (the audit
+ *  follows NO symlink), so it counts as 0. */
 async function countEventLines(eventsPath: string): Promise<number> {
+  const info = await lstat(eventsPath).catch((error) => {
+    if (isEnoent(error)) return undefined;
+    throw error;
+  });
+  if (info === undefined || !info.isFile()) return 0; // absent, symlink, or non-regular → not followed
   const content = await readFile(eventsPath, "utf8").catch((error) => {
     if (isEnoent(error)) return "";
     throw error;

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -1,6 +1,6 @@
-import type { Dirent } from "node:fs";
-import { lstat, readFile, readdir, stat } from "node:fs/promises";
-import { basename, join, relative, sep } from "node:path";
+import { type Dirent, constants as fsConstants } from "node:fs";
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { basename, isAbsolute, join, relative } from "node:path";
 import { createPaths } from "./paths";
 import { isEnoent } from "./fs-utils";
 import { runBoundedConcurrent } from "./internal-concurrency";
@@ -58,14 +58,22 @@ async function listRealMarkdownFilesRec(dir: string): Promise<string[]> {
   return [...files, ...nested.flat()];
 }
 
-/** Parse one note file → the note, or `undefined` if it cannot be read/parsed. */
+// Read WITHOUT following a final-component symlink — closes the TOCTOU where a listed
+// regular file is swapped for a symlink between enumeration and read. O_NOFOLLOW makes
+// the open fail (ELOOP) on a symlink, so a swapped file reads as unreadable, never
+// through the link to an outside target.
+const NOFOLLOW_READ = fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW;
+
+/** Parse one note file → the note, or `undefined` if it cannot be read/parsed (incl.
+ *  a symlink swapped in after enumeration, which O_NOFOLLOW rejects). */
 async function parseFile(path: string): Promise<SomaMemoryNote | undefined> {
-  return readFile(path, "utf8").then(parseMemoryNote).catch(() => undefined);
+  return readFile(path, { encoding: "utf8", flag: NOFOLLOW_READ }).then(parseMemoryNote).catch(() => undefined);
 }
 
-/** mtime in ms, or `undefined` if the path is absent. */
+/** mtime in ms, or `undefined` if the path is absent. Uses `lstat` — a path swapped to
+ *  a symlink after enumeration is measured as the link itself, never followed. */
 async function mtimeMs(path: string): Promise<number | undefined> {
-  return stat(path).then((s) => s.mtimeMs).catch((error) => {
+  return lstat(path).then((s) => s.mtimeMs).catch((error) => {
     if (isEnoent(error)) return undefined;
     throw error;
   });
@@ -229,7 +237,10 @@ async function probeOrphanedArchive(
   const orphanedArchive: string[] = [];
   for (const { path, note } of parsed) {
     if (note === undefined || note.type !== "episodic") continue;
-    if (!path.startsWith(archiveDir + sep)) continue;
+    // Path-segment containment (not a raw string prefix): `path` is under the archive
+    // iff its relative path neither escapes (`..`) nor is absolute.
+    const rel = relative(archiveDir, path);
+    if (rel === "" || rel.startsWith("..") || isAbsolute(rel)) continue;
     const month = note.created.slice(0, 7);
     if (!digestIdsByMonth.get(month)?.has(note.id)) orphanedArchive.push(relative(somaHome, path));
   }

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -28,11 +28,20 @@ const SCAN_CONCURRENCY = 16;
 /** All `.md` files under `dir`, recursively, REJECTING symlinked dirs/files (they
  *  could point outside the memory root — the audit only trusts real entries). */
 async function listRealMarkdownFilesRec(dir: string): Promise<string[]> {
+  // lstat the dir ITSELF before reading it — `readdir` follows a symlinked directory,
+  // so a symlinked root (memory/semantic, archive, …) could otherwise redirect the
+  // whole walk outside the memory root and have the audit trust foreign files.
+  const dirInfo = await lstat(dir).catch((error) => {
+    if (isEnoent(error)) return undefined;
+    throw error;
+  });
+  if (dirInfo === undefined) return []; // a missing dir is genuinely empty
+  if (!dirInfo.isDirectory()) return []; // a symlink or non-directory — never follow it
   let entries: Dirent[];
   try {
     entries = await readdir(dir, { withFileTypes: true });
   } catch (error) {
-    if (isEnoent(error)) return []; // a missing dir is genuinely empty
+    if (isEnoent(error)) return []; // vanished between lstat and readdir
     throw error; // any other failure is a real blind spot — do not treat as empty
   }
   const files: string[] = [];
@@ -157,7 +166,11 @@ async function probeIndexFreshness(
 ): Promise<{ probe: SomaMemoryAuditProbe; path: string }> {
   const path = memoryIndexPath(somaHome);
   const index = await classifyIndex(path);
-  const durableMtimes = await Promise.all(durableFiles.map(mtimeMs));
+  // Bounded stats (not one-per-note unbounded), and every listed durable note MUST
+  // stat — a note that vanished/could-not-be-statted mid-audit means we can't confirm
+  // freshness against the full corpus, so the probe fails rather than passing blind.
+  const durableMtimes = await runBoundedConcurrent(durableFiles, mtimeMs, SCAN_CONCURRENCY);
+  const unstattable = durableFiles.filter((_, i) => durableMtimes[i] === undefined).length;
   const newestDurable = durableMtimes.reduce<number>((max, m) => (m !== undefined && m > max ? m : max), 0);
   let ok: boolean;
   let detail: string;
@@ -165,6 +178,9 @@ async function probeIndexFreshness(
     // A non-regular INDEX can spoof mtime freshness — reject regardless of note count.
     ok = false;
     detail = `INDEX.md is a ${index.kind === "symlink" ? "symlink" : "non-regular file"} — refusing to trust it; run 'soma memory reindex' on a clean tree`;
+  } else if (unstattable > 0) {
+    ok = false;
+    detail = `${unstattable} durable note(s) could not be statted (changed under the audit) — re-run the audit`;
   } else if (durableFiles.length === 0) {
     ok = true;
     detail = "no durable notes — nothing to index";

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -289,18 +289,11 @@ async function collectDigestIdsByMonth(digestFiles: string[]): Promise<Map<strin
 
 /** Non-empty JSONL lines in the events file (0 if absent). Single pass over the
  *  content counting non-empty lines — no `split` allocation of the whole history.
- *  lstat-guarded: a symlinked/non-regular events file is not read through (the audit
- *  follows NO symlink), so it counts as 0. */
+ *  Read with O_NOFOLLOW (same as notes), so a symlinked events file — even one
+ *  swapped in racily — makes the open fail and counts as 0; the audit follows NO
+ *  symlink, atomically, with no lstat/read TOCTOU gap. */
 async function countEventLines(eventsPath: string): Promise<number> {
-  const info = await lstat(eventsPath).catch((error) => {
-    if (isEnoent(error)) return undefined;
-    throw error;
-  });
-  if (info === undefined || !info.isFile()) return 0; // absent, symlink, or non-regular → not followed
-  const content = await readFile(eventsPath, "utf8").catch((error) => {
-    if (isEnoent(error)) return "";
-    throw error;
-  });
+  const content = await readFile(eventsPath, { encoding: "utf8", flag: NOFOLLOW_READ }).catch(() => "");
   let count = 0;
   let lineHasContent = false;
   for (let i = 0; i < content.length; i += 1) {

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -25,24 +25,35 @@ import type { SomaMemoryAuditOptions, SomaMemoryAuditProbe, SomaMemoryAuditResul
  */
 const SCAN_CONCURRENCY = 16;
 
+/** Raised when a directory is replaced (swapped for a symlink or another inode)
+ *  between the pre- and post-`readdir` lstat — the audit fails LOUDLY rather than
+ *  trusting a possibly-redirected read. */
+class AuditTreeError extends Error {}
+
 /** All `.md` files under `dir`, recursively, REJECTING symlinked dirs/files (they
  *  could point outside the memory root — the audit only trusts real entries). */
 async function listRealMarkdownFilesRec(dir: string): Promise<string[]> {
   // lstat the dir ITSELF before reading it — `readdir` follows a symlinked directory,
-  // so a symlinked root (memory/semantic, archive, …) could otherwise redirect the
-  // whole walk outside the memory root and have the audit trust foreign files.
-  const dirInfo = await lstat(dir).catch((error) => {
+  // so a symlinked dir could otherwise redirect the walk outside the memory root and
+  // have the audit trust foreign files.
+  const before = await lstat(dir).catch((error) => {
     if (isEnoent(error)) return undefined;
     throw error;
   });
-  if (dirInfo === undefined) return []; // a missing dir is genuinely empty
-  if (!dirInfo.isDirectory()) return []; // a symlink or non-directory — never follow it
+  if (before === undefined) return []; // a missing dir is genuinely empty
+  if (!before.isDirectory()) return []; // a symlink or non-directory — never follow it
   let entries: Dirent[];
   try {
     entries = await readdir(dir, { withFileTypes: true });
   } catch (error) {
     if (isEnoent(error)) return []; // vanished between lstat and readdir
     throw error; // any other failure is a real blind spot — do not treat as empty
+  }
+  // Close the lstat→readdir TOCTOU: re-lstat and require the SAME real directory
+  // (inode+device unchanged, still not a symlink). A mid-read swap → fail loudly.
+  const after = await lstat(dir).catch(() => undefined);
+  if (after === undefined || after.isSymbolicLink() || !after.isDirectory() || after.ino !== before.ino || after.dev !== before.dev) {
+    throw new AuditTreeError(`directory ${dir} was replaced during the audit walk — refusing to trust the read`);
   }
   const files: string[] = [];
   const subdirs: string[] = [];
@@ -102,6 +113,13 @@ export async function auditMemory(options: SomaMemoryAuditOptions = {}): Promise
   const episodicDirs = [paths.resolve("memory", "episodic", "sessions"), paths.resolve("memory", "episodic", "actions")];
   const archiveDir = paths.resolve("memory", "archive");
 
+  // Root integrity GATES health FIRST: a present-but-abnormal root (a symlink or
+  // non-directory where a real note dir belongs) makes the corpus inaccessible/
+  // untrusted — the walk skips it, so without this the tree would fail OPEN as
+  // "empty and healthy". A missing root is genuinely empty and fine.
+  const rootDirs = [...durableDirs, ...episodicDirs, archiveDir, paths.resolve("memory", "episodic", "digests")];
+  const treeIntegrity = await probeTreeIntegrity(rootDirs, somaHome);
+
   const durableFiles = (await Promise.all(durableDirs.map(listRealMarkdownFilesRec))).flat();
   const [sessionFiles, actionFiles] = await Promise.all(episodicDirs.map(listRealMarkdownFilesRec));
   const archiveFiles = await listRealMarkdownFilesRec(archiveDir);
@@ -122,7 +140,7 @@ export async function auditMemory(options: SomaMemoryAuditOptions = {}): Promise
   const validNotes = parsed.length - schema.invalidNotes.length;
   const eventProbe = probeEventRatio(eventLines, validNotes);
 
-  probes.push(schema.probe, index.probe, digestCov.probe, archive.probe, eventProbe.probe);
+  probes.push(treeIntegrity.probe, schema.probe, index.probe, digestCov.probe, archive.probe, eventProbe.probe);
 
   // Single source of truth: healthy iff every HEALTH-GATING probe is ok. The
   // informational probes carry gatesHealth:false and never affect this.
@@ -137,6 +155,36 @@ export async function auditMemory(options: SomaMemoryAuditOptions = {}): Promise
     orphanedArchive: archive.orphanedArchive,
     events: eventProbe.events,
     probes,
+  };
+}
+
+/**
+ * Probe: every expected note ROOT dir is either absent (empty, fine) or a REAL
+ * directory (GATES health). A root that exists but is a symlink or non-directory is
+ * abnormal — the walk skips it, so without this gate the corpus would fail OPEN as
+ * "empty and healthy" while durable notes are actually inaccessible/redirected.
+ */
+async function probeTreeIntegrity(rootDirs: string[], somaHome: string): Promise<{ probe: SomaMemoryAuditProbe }> {
+  const abnormal: string[] = [];
+  for (const dir of rootDirs) {
+    const info = await lstat(dir).catch((error) => {
+      if (isEnoent(error)) return undefined;
+      throw error;
+    });
+    if (info === undefined) continue; // absent → genuinely empty
+    if (info.isSymbolicLink() || !info.isDirectory()) abnormal.push(relative(somaHome, dir));
+  }
+  abnormal.sort();
+  return {
+    probe: {
+      name: "root-integrity",
+      gatesHealth: true,
+      ok: abnormal.length === 0,
+      detail:
+        abnormal.length === 0
+          ? "every note root is absent or a real directory"
+          : `${abnormal.length} note root(s) replaced by a symlink/non-directory: ${abnormal.join(", ")}`,
+    },
   };
 }
 

--- a/src/skills/Memory/SKILL.md
+++ b/src/skills/Memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Memory
-description: "Files-first assistant memory: durable notes (semantic/procedural), episodic session digests and action logs, a projected INDEX, deterministic consolidation, and a health audit. Use to remember a durable fact, recall what is known about a topic, log a session or action, run maintenance, or check memory-tree health. No LLM; every operation is a `soma memory` CLI call over markdown notes."
+description: "Files-first assistant memory: durable notes (semantic/procedural), episodic session digests and action logs, a generated INDEX, deterministic consolidation, and a health audit. Use to remember a durable fact, recall what is known about a topic, log a session or action, run maintenance, or check memory-tree health. No LLM; every operation is a `soma memory` CLI call over markdown notes."
 effort: low
 version: 1.0.0
 pack-id: soma-memory-v0.1.0
@@ -22,13 +22,14 @@ edits note files by hand.
 | semantic | `memory/semantic/` | durable facts | principal or assistant |
 | procedural | `memory/procedural/` | durable how-to / SOPs | principal or assistant |
 | episodic | `memory/episodic/sessions,actions/` | session digests + planned-action logs | assistant |
-| (projection) | `memory/INDEX.md` | the earned-inclusion index over durable notes | — |
+| (generated) | `memory/INDEX.md` | the earned-inclusion index over durable notes | — |
 | (archive) | `memory/archive/` | pruned episodic notes + monthly digests | — |
 
 Trust is DERIVED from how a note was written, never set by a flag. A
 `principal-correction` write needs `--principal-authority`; `import` writes are
-lower trust. Consolidation is the only path that mints `assistant` trust, and it
-is an internal SDK path, not a public flag.
+lower trust. Episodic notes (session digests, action logs) are written at
+`assistant` trust by the assistant itself. Consolidation NEVER mints or elevates
+trust — it only ages or relocates existing notes.
 
 ## Fast Path
 
@@ -64,5 +65,8 @@ recall (`soma algorithm`); or any non-memory Soma command.
 - A durable write updates the INDEX admission ladder (M1/M3).
 - Recall is READ-ONLY — it never verifies or mutates (M2).
 - Consolidation is idempotent, event-logged, and never auto-merges notes (M6).
-- `soma memory audit` is the deterministic check that these hold (M7); it exits
-  non-zero on a schema-invalid note or a stale INDEX, so it can gate CI.
+- `soma memory audit` (M7) is a smoke check, not a proof: it verifies notes PARSE
+  (schema) and that INDEX.md is at least as NEW as every durable note (mtime
+  freshness — NOT a check of INDEX contents), plus informational drift signals. It
+  exits non-zero on a schema-invalid note or a stale-by-mtime INDEX, so it can gate
+  CI. A content-correct INDEX is not proven; `soma memory reindex` rebuilds it.

--- a/src/skills/Memory/SKILL.md
+++ b/src/skills/Memory/SKILL.md
@@ -67,8 +67,9 @@ recall (`soma algorithm`); or any non-memory Soma command.
 - A durable write updates the INDEX admission ladder (M1/M3).
 - Recall is READ-ONLY — it never verifies or mutates (M2).
 - Consolidation is idempotent, event-logged, and never auto-merges notes (M6).
-- `soma memory audit` (M7) is a smoke check, not a proof: it verifies notes PARSE
-  (schema) and that INDEX.md is at least as NEW as every durable note (mtime
-  freshness — NOT a check of INDEX contents), plus informational drift signals. It
-  exits non-zero on a schema-invalid note or a stale-by-mtime INDEX, so it can gate
-  CI. A content-correct INDEX is not proven; `soma memory reindex` rebuilds it.
+- `soma memory audit` (M7) is a smoke check, not a proof. THREE probes gate health:
+  root-integrity (every note root is a real directory, not a symlink), schema (notes
+  PARSE), and index-freshness (INDEX.md is at least as NEW as every durable note by
+  mtime — NOT a check of INDEX contents). Three more are informational drift signals.
+  It exits non-zero on any gating failure, so it can gate CI; a content-correct INDEX
+  is not proven — `soma memory reindex` rebuilds it.

--- a/src/skills/Memory/SKILL.md
+++ b/src/skills/Memory/SKILL.md
@@ -37,7 +37,9 @@ trust — it only ages or relocates existing notes.
 2. Load ONLY that workflow file from `Workflows/`.
 3. Run the single `soma memory` command it specifies; report its output verbatim.
 4. Never hand-edit files under `memory/` — the CLI owns the schema, INDEX, and
-   event log. Hand edits desync the INDEX (the audit will flag them).
+   event log. A hand edit can desync the INDEX; the audit flags a note NEWER than
+   INDEX by mtime, but a mtime-preserving edit slips past — always run
+   `soma memory reindex` after any manual change.
 
 ## Routing
 

--- a/src/skills/Memory/SKILL.md
+++ b/src/skills/Memory/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: Memory
+description: "Files-first assistant memory: durable notes (semantic/procedural), episodic session digests and action logs, a projected INDEX, deterministic consolidation, and a health audit. Use to remember a durable fact, recall what is known about a topic, log a session or action, run maintenance, or check memory-tree health. No LLM; every operation is a `soma memory` CLI call over markdown notes."
+effort: low
+version: 1.0.0
+pack-id: soma-memory-v0.1.0
+---
+
+# Memory
+
+Soma memory is a files-first store of markdown notes under the `memory/` tree.
+Every note carries frontmatter (id, type, created, last_verified, provenance,
+trust, source_of_truth, links, resurface_count). There is NO model in the loop:
+each operation is a deterministic `soma memory` CLI subcommand. This skill routes
+a memory request to the right subcommand and reads back its result — it never
+edits note files by hand.
+
+## Note model (what lives where)
+
+| Type | Dir | What it holds | Trust |
+|------|-----|---------------|-------|
+| semantic | `memory/semantic/` | durable facts | principal or assistant |
+| procedural | `memory/procedural/` | durable how-to / SOPs | principal or assistant |
+| episodic | `memory/episodic/sessions,actions/` | session digests + planned-action logs | assistant |
+| (projection) | `memory/INDEX.md` | the earned-inclusion index over durable notes | — |
+| (archive) | `memory/archive/` | pruned episodic notes + monthly digests | — |
+
+Trust is DERIVED from how a note was written, never set by a flag. A
+`principal-correction` write needs `--principal-authority`; `import` writes are
+lower trust. Consolidation is the only path that mints `assistant` trust, and it
+is an internal SDK path, not a public flag.
+
+## Fast Path
+
+1. Identify the requested operation from the routing table.
+2. Load ONLY that workflow file from `Workflows/`.
+3. Run the single `soma memory` command it specifies; report its output verbatim.
+4. Never hand-edit files under `memory/` — the CLI owns the schema, INDEX, and
+   event log. Hand edits desync the INDEX (the audit will flag them).
+
+## Routing
+
+| Intent | Workflow | Command |
+|--------|----------|---------|
+| Save a durable fact / SOP | `Workflows/Remember.md` | `soma memory write …` |
+| Retrieve what is known about X | `Workflows/Recall.md` | `soma memory recall <query>` |
+| Log a session digest or a planned action | `Workflows/Remember.md` | `soma memory digest` / `soma memory action` |
+| Run maintenance (prune, digest, stale-mark, dedup) | `Workflows/Consolidate.md` | `soma memory consolidate` |
+| Check memory-tree health | `Workflows/Audit.md` | `soma memory audit` |
+
+## When To Use
+
+Use when the prompt is about REMEMBERING a durable fact, RECALLING what memory
+holds on a topic, LOGGING a session or an approved/executed action, running
+memory MAINTENANCE, or checking memory HEALTH.
+
+Do not use for: the pre-note line-grep `soma memory search` over the legacy
+`WORK/KNOWLEDGE` tree (that is a different, path-based tool); Algorithm run
+recall (`soma algorithm`); or any non-memory Soma command.
+
+## Invariants (why the audit exists)
+
+- Notes always parse against the schema (M0).
+- A durable write updates the INDEX admission ladder (M1/M3).
+- Recall is READ-ONLY — it never verifies or mutates (M2).
+- Consolidation is idempotent, event-logged, and never auto-merges notes (M6).
+- `soma memory audit` is the deterministic check that these hold (M7); it exits
+  non-zero on a schema-invalid note or a stale INDEX, so it can gate CI.

--- a/src/skills/Memory/Workflows/Audit.md
+++ b/src/skills/Memory/Workflows/Audit.md
@@ -2,11 +2,11 @@
 
 Run the deterministic, read-only health check over the memory tree. No LLM: each
 probe reports a deterministic filesystem observation (the event-ratio count is
-best-effort — an unreadable/symlinked events file counts 0). It is a SMOKE check
-that surfaces
-detectable drift — a passing audit means no drift was DETECTED, not that every
-invariant is proven. Use it to catch obvious breakage, or to gate CI / a
-pre-consolidation check.
+best-effort — an unreadable/symlinked events file counts 0). It is a SMOKE check: a
+HEALTHY exit means no health-GATING drift was detected, NOT that the tree is fully
+clean — the informational probes (e.g. orphaned-archive) can still report drift on a
+healthy exit, so read the whole report, not just the exit code. Use it to catch
+obvious breakage, or to gate CI / a pre-consolidation check.
 
 ## When to invoke
 

--- a/src/skills/Memory/Workflows/Audit.md
+++ b/src/skills/Memory/Workflows/Audit.md
@@ -1,7 +1,9 @@
 # Audit Workflow
 
-Run the deterministic, read-only health check over the memory tree. No LLM: every
-probe reports a filesystem ground-truth fact. It is a SMOKE check that surfaces
+Run the deterministic, read-only health check over the memory tree. No LLM: each
+probe reports a deterministic filesystem observation (the event-ratio count is
+best-effort — an unreadable/symlinked events file counts 0). It is a SMOKE check
+that surfaces
 detectable drift — a passing audit means no drift was DETECTED, not that every
 invariant is proven. Use it to catch obvious breakage, or to gate CI / a
 pre-consolidation check.

--- a/src/skills/Memory/Workflows/Audit.md
+++ b/src/skills/Memory/Workflows/Audit.md
@@ -1,0 +1,47 @@
+# Audit Workflow
+
+Run the deterministic, read-only health check over the memory tree. No LLM: every
+probe reports a filesystem ground-truth fact. Use it to verify the memory
+subsystem's invariants hold, or to gate CI / a pre-consolidation check.
+
+## When to invoke
+
+- Before trusting recall on a load-bearing question.
+- After a manual touch of the `memory/` tree, or a crashed consolidation.
+- As a CI gate — it EXITS NON-ZERO when the tree is unhealthy.
+- User: "audit memory", "is memory healthy", "check the memory tree".
+
+## Command
+
+```
+soma memory audit
+```
+
+## Probes
+
+| Probe | Gates health? | What it checks |
+|-------|---------------|----------------|
+| schema | YES | Every note file parses against the schema. |
+| index-freshness | YES | INDEX.md is at least as new as every durable note (else run `soma memory reindex`). |
+| digest-coverage | no (info) | Counts session/action notes and monthly digest files. |
+| orphaned-archive | no (info) | Archived episodic notes missing from a digest (run `soma memory consolidate`). |
+| event-ratio | no (info) | Event-stream lines over valid-note count. |
+
+## Exit code
+
+- HEALTHY → exit 0.
+- UNHEALTHY → exit NON-ZERO. Cause is always a schema-invalid note or a stale
+  INDEX (the two health-gating probes). The full report is still printed.
+
+## Acting on failures
+
+- schema FAIL: a listed note file does not parse. Inspect it; fix or remove it
+  (never leave a corrupt note — it is invisible to recall and dedup).
+- index-freshness FAIL: run `soma memory reindex` (a durable write landed after
+  the last index build, or INDEX.md is missing).
+- orphaned-archive (info): run `soma memory consolidate` to regenerate digests.
+
+## Report
+
+Return the report verbatim, then state the single next command to run for any
+failing gated probe. Do not claim "memory is healthy" unless the audit exited 0.

--- a/src/skills/Memory/Workflows/Audit.md
+++ b/src/skills/Memory/Workflows/Audit.md
@@ -1,8 +1,10 @@
 # Audit Workflow
 
 Run the deterministic, read-only health check over the memory tree. No LLM: every
-probe reports a filesystem ground-truth fact. Use it to verify the memory
-subsystem's invariants hold, or to gate CI / a pre-consolidation check.
+probe reports a filesystem ground-truth fact. It is a SMOKE check that surfaces
+detectable drift — a passing audit means no drift was DETECTED, not that every
+invariant is proven. Use it to catch obvious breakage, or to gate CI / a
+pre-consolidation check.
 
 ## When to invoke
 

--- a/src/skills/Memory/Workflows/Audit.md
+++ b/src/skills/Memory/Workflows/Audit.md
@@ -25,6 +25,7 @@ soma memory audit
 
 | Probe | Gates health? | What it checks |
 |-------|---------------|----------------|
+| root-integrity | YES | Every expected note root is absent or a REAL directory (not a symlink/non-dir). |
 | schema | YES | Every note file parses against the schema. |
 | index-freshness | YES | INDEX.md is at least as new as every durable note (else run `soma memory reindex`). |
 | digest-coverage | no (info) | Counts session/action notes and monthly digest files. |
@@ -34,15 +35,19 @@ soma memory audit
 ## Exit code
 
 - HEALTHY → exit 0.
-- UNHEALTHY → exit NON-ZERO. Cause is always a schema-invalid note or a stale
-  INDEX (the two health-gating probes). The full report is still printed.
+- UNHEALTHY → exit NON-ZERO. Cause is one of the THREE health-gating probes:
+  root-integrity, schema, or index-freshness. The full report is still printed;
+  read each probe's `gatesHealth`/`ok` rather than assuming the cause.
 
 ## Acting on failures
 
+- root-integrity FAIL: a note root (e.g. `memory/semantic`) exists but is a symlink
+  or non-directory — the corpus is inaccessible/redirected. Restore it to a real
+  directory before trusting recall.
 - schema FAIL: a listed note file does not parse. Inspect it; fix or remove it
   (never leave a corrupt note — it is invisible to recall and dedup).
 - index-freshness FAIL: run `soma memory reindex` (a durable write landed after
-  the last index build, or INDEX.md is missing).
+  the last index build, or INDEX.md is missing/abnormal).
 - orphaned-archive (info): run `soma memory consolidate` to regenerate digests.
 
 ## Report

--- a/src/skills/Memory/Workflows/Audit.md
+++ b/src/skills/Memory/Workflows/Audit.md
@@ -9,7 +9,7 @@ subsystem's invariants hold, or to gate CI / a pre-consolidation check.
 - Before trusting recall on a load-bearing question.
 - After a manual touch of the `memory/` tree, or a crashed consolidation.
 - As a CI gate — it EXITS NON-ZERO when the tree is unhealthy.
-- User: "audit memory", "is memory healthy", "check the memory tree".
+- Principal says: "audit memory", "is memory healthy", "check the memory tree".
 
 ## Command
 

--- a/src/skills/Memory/Workflows/Consolidate.md
+++ b/src/skills/Memory/Workflows/Consolidate.md
@@ -1,0 +1,53 @@
+# Consolidate Workflow
+
+Run deterministic memory maintenance: prune aged episodic notes into the archive
+(regenerating monthly digests), mark aged-unverified semantic notes `review:stale`,
+list lexical near-duplicate pairs for review, and rebuild the INDEX. No LLM;
+nothing is auto-merged.
+
+## When to invoke
+
+- Periodic housekeeping (the memory tree has grown; digests/INDEX may lag).
+- The audit reported orphaned-archive drift or a stale INDEX.
+- User: "consolidate memory", "tidy up memory", "run memory maintenance".
+
+## Preview first (always)
+
+```
+soma memory consolidate --dry-run
+```
+
+`--dry-run` prints the exact file OPERATIONS the real run would apply (archive
+moves, stale marks, digest regenerations, similar pairs) and touches nothing.
+Read it before running for real.
+
+## Apply
+
+```
+soma memory consolidate
+```
+
+Operations, in order:
+1. Prune aged episodic — sessions >90d, actions >180d (by `created`) → regenerate
+   the month's digest from the archive, then move the note under `memory/archive/`.
+2. Mark aged-unverified semantic notes (>180d, never resurfaced) `review:stale` —
+   the principal reviews them; nothing is auto-archived.
+3. List the top lexical near-duplicate pairs (Jaccard ≥ 0.6) for review. This is a
+   LISTING only — no semantic contradiction check, and nothing is merged.
+4. Rebuild `INDEX.md` and append one `memory.consolidate` event — ONLY when the
+   pass actually changed something.
+
+## Destructive state GC (opt-in)
+
+```
+soma memory consolidate --gc-state
+```
+
+Additionally DELETES `current-work-*.json` state older than 7 days. This is the
+pass's only deletion and needs the explicit flag — omit it unless you intend to
+GC protected state.
+
+## Report
+
+Return the CLI summary verbatim. If it lists `unreadable` note files, surface
+them — they were skipped, and the audit should be run to investigate.

--- a/src/skills/Memory/Workflows/Consolidate.md
+++ b/src/skills/Memory/Workflows/Consolidate.md
@@ -9,7 +9,7 @@ nothing is auto-merged.
 
 - Periodic housekeeping (the memory tree has grown; digests/INDEX may lag).
 - The audit reported orphaned-archive drift or a stale INDEX.
-- User: "consolidate memory", "tidy up memory", "run memory maintenance".
+- Principal says: "consolidate memory", "tidy up memory", "run memory maintenance".
 
 ## Preview first (always)
 

--- a/src/skills/Memory/Workflows/Recall.md
+++ b/src/skills/Memory/Workflows/Recall.md
@@ -1,0 +1,38 @@
+# Recall Workflow
+
+Retrieve what durable memory holds about a topic BEFORE answering from your own
+recollection or writing a new note. Recall is READ-ONLY.
+
+## When to invoke
+
+- Before asserting a remembered fact ("we decided X", "the stack is Y").
+- Before a durable write, to avoid creating a near-duplicate.
+- User: "what do we know about …", "have we noted …", "recall …".
+
+## Command
+
+```
+soma memory recall "<query>" [--limit <n>]
+```
+
+What it does (deterministic, no LLM):
+- Term-scores whole durable notes (semantic + procedural) against the query.
+- Returns the top matches (default limit 3) plus their 1-hop linked notes.
+- EXCLUDES superseded notes (those with a `valid_until`).
+- Attaches a verification banner to each hit: age since `last_verified`, trust,
+  provenance, and the `source_of_truth` to check against.
+
+## Reading the result
+
+- Treat a note as a POINTER, not gospel. The banner says how stale it is and
+  what the ground-truth source is — verify against that source before relying on
+  a load-bearing fact.
+- A `QUARANTINED` note is untrusted; surface it as such, never as fact.
+- Nothing returned ≠ nothing true. Say memory has no note on it, then proceed.
+
+## Do not
+
+- Do not verify or edit as part of recall — verifying is a separate,
+  authority-gated act (`soma memory verify`).
+- Do not paraphrase a note as your own knowledge without the banner's caveat when
+  it is stale.

--- a/src/skills/Memory/Workflows/Recall.md
+++ b/src/skills/Memory/Workflows/Recall.md
@@ -7,7 +7,7 @@ recollection or writing a new note. Recall is READ-ONLY.
 
 - Before asserting a remembered fact ("we decided X", "the stack is Y").
 - Before a durable write, to avoid creating a near-duplicate.
-- User: "what do we know about …", "have we noted …", "recall …".
+- Principal says: "what do we know about …", "have we noted …", "recall …".
 
 ## Command
 

--- a/src/skills/Memory/Workflows/Remember.md
+++ b/src/skills/Memory/Workflows/Remember.md
@@ -1,0 +1,66 @@
+# Remember Workflow
+
+Persist something worth keeping: a durable fact/SOP (a note), a session digest,
+or a planned-action log. Pick the sub-path by DURABILITY and KIND.
+
+## When to invoke
+
+- User: "remember that …", "note that …", "log this decision", "record the outcome".
+- End of a work session: write the one session digest.
+- After an approved/executed action worth an audit trail.
+
+## Decision
+
+| What you're keeping | Command |
+|---------------------|---------|
+| A durable FACT | `soma memory write --type semantic …` |
+| A durable HOW-TO / procedure | `soma memory write --type procedural …` |
+| The ONE digest for this session | `soma memory digest --session <id> --body <text>` |
+| A planned-action → approval → outcome entry | `soma memory action --slug <slug> …` |
+
+## Durable write
+
+```
+soma memory write \
+  --trigger <principal-correction|import> \
+  --id <slug> --type <semantic|procedural> \
+  --body "<the fact, one idea per note>" \
+  [--principal-authority] [--source-of-truth <ref>] [--links a,b] \
+  [--recall-trigger "<when this should resurface>"] [--provenance <import|tool:name>]
+```
+
+Rules:
+- Trust is DERIVED from `--trigger`. `principal-correction` (a fact the principal
+  asserts) REQUIRES `--principal-authority`. `import` is for lower-trust intake.
+- One idea per note. Do not restate what the repo/code already records — capture
+  what was non-obvious.
+- To revise an existing note, use `--merge <id>` or `--supersede <id>`; never
+  hand-edit the file.
+- If a near-duplicate exists, the write is refused — recall first, then merge.
+
+## Session digest
+
+```
+soma memory digest --session <session-id> --body "<8–15 non-empty lines>"
+```
+
+- Exactly ONE digest per session. A second call for the same session no-ops
+  (and logs an event) — it never overwrites the first.
+- The body must be 8–15 non-empty lines; anything outside that is rejected.
+
+## Action log
+
+```
+soma memory action --slug <slug> \
+  --planned-action "<what was planned>" \
+  --approval <proposed|approved|rejected|auto> \
+  [--outcome "<what happened>"] [--session <id>]
+```
+
+- The id is `YYYYMMDD-<slug>`; a same-day collision is refused (never overwrites).
+- The session id goes in the body, not the `project` field.
+
+## Report
+
+Return the CLI's confirmation verbatim (id + path, or the no-op/refusal line).
+Do not claim a write that the CLI did not confirm.

--- a/src/skills/Memory/Workflows/Remember.md
+++ b/src/skills/Memory/Workflows/Remember.md
@@ -5,7 +5,7 @@ or a planned-action log. Pick the sub-path by DURABILITY and KIND.
 
 ## When to invoke
 
-- User: "remember that …", "note that …", "log this decision", "record the outcome".
+- Principal says: "remember that …", "note that …", "log this decision", "record the outcome".
 - End of a work session: write the one session digest.
 - After an approved/executed action worth an audit trail.
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2661,7 +2661,8 @@ export interface SomaMemoryAuditProbe {
 
 export interface SomaMemoryAuditResult {
   somaHome: string;
-  /** false ⇒ the CLI exits non-zero. Gated by: no schema-invalid notes AND a fresh INDEX. */
+  /** false ⇒ the CLI exits non-zero. Gated by ALL three: real note roots (root-integrity),
+   *  no schema-invalid notes, AND a fresh INDEX. */
   healthy: boolean;
   /** Valid-note counts by type across the whole tree (durable + episodic + archive). */
   notesByType: { semantic: number; procedural: number; episodic: number };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2635,10 +2635,24 @@ export interface SomaMemoryAuditOptions {
   somaHome?: string;
 }
 
-/** One deterministic probe's outcome. `ok: false` on any that gates health. */
+/** The fixed set of audit probes (stable public names; `auditMemory` is exported). */
+export type SomaMemoryAuditProbeName =
+  | "schema"
+  | "index-freshness"
+  | "digest-coverage"
+  | "orphaned-archive"
+  | "event-ratio";
+
+/**
+ * One deterministic probe's outcome. `gatesHealth` is machine-readable: when it is
+ * true, `ok: false` forces `result.healthy` false (only `schema` and
+ * `index-freshness` gate). Informational probes have `gatesHealth: false` and always
+ * report `ok: true`.
+ */
 export interface SomaMemoryAuditProbe {
-  name: string;
+  name: SomaMemoryAuditProbeName;
   ok: boolean;
+  gatesHealth: boolean;
   detail: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2628,7 +2628,8 @@ export interface SomaMemoryConsolidateResult {
 // Memory subsystem M7 (audit). Plan v2 §M7: a DETERMINISTIC health check over the
 // on-disk memory tree — no LLM, no sentiment, only filesystem ground-truth probes.
 // Read-only: it mutates nothing and appends no event. The CLI exits NON-ZERO when
-// `healthy` is false (a schema-invalid note or a stale INDEX), so it can gate CI /
+// `healthy` is false — any health-gating probe failing: an abnormal note root
+// (root-integrity), a schema-invalid note, or a stale INDEX — so it can gate CI /
 // a pre-consolidation check.
 export interface SomaMemoryAuditOptions {
   homeDir?: string;
@@ -2646,9 +2647,10 @@ export type SomaMemoryAuditProbeName =
 
 /**
  * One deterministic probe's outcome. `gatesHealth` is machine-readable: when it is
- * true, `ok: false` forces `result.healthy` false (only `schema` and
- * `index-freshness` gate). Informational probes have `gatesHealth: false` and always
- * report `ok: true`.
+ * true, `ok: false` forces `result.healthy` false. Three probes gate:
+ * `root-integrity`, `schema`, and `index-freshness`. Informational probes
+ * (`digest-coverage`, `orphaned-archive`, `event-ratio`) have `gatesHealth: false`
+ * and always report `ok: true`.
  */
 export interface SomaMemoryAuditProbe {
   name: SomaMemoryAuditProbeName;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2637,6 +2637,7 @@ export interface SomaMemoryAuditOptions {
 
 /** The fixed set of audit probes (stable public names; `auditMemory` is exported). */
 export type SomaMemoryAuditProbeName =
+  | "root-integrity"
   | "schema"
   | "index-freshness"
   | "digest-coverage"
@@ -2673,9 +2674,10 @@ export interface SomaMemoryAuditResult {
   /** Event-stream vs corpus size — a coarse write-amplification signal (informational). */
   events: { lines: number; notes: number };
   /**
-   * Every probe run, in report order. Exactly TWO gate `healthy`: `schema` and
-   * `index-freshness`. The other three (`digest-coverage`, `orphaned-archive`,
-   * `event-ratio`) are informational drift signals whose `ok` is always true.
+   * Every probe run, in report order. THREE gate `healthy` (`root-integrity`,
+   * `schema`, `index-freshness`); the other three (`digest-coverage`,
+   * `orphaned-archive`, `event-ratio`) are informational drift signals whose `ok` is
+   * always true. Read `probe.gatesHealth` rather than hardcoding this list.
    */
   probes: SomaMemoryAuditProbe[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2625,6 +2625,43 @@ export interface SomaMemoryConsolidateResult {
   indexPath: string;
 }
 
+// Memory subsystem M7 (audit). Plan v2 §M7: a DETERMINISTIC health check over the
+// on-disk memory tree — no LLM, no sentiment, only filesystem ground-truth probes.
+// Read-only: it mutates nothing and appends no event. The CLI exits NON-ZERO when
+// `healthy` is false (a schema-invalid note or a stale INDEX), so it can gate CI /
+// a pre-consolidation check.
+export interface SomaMemoryAuditOptions {
+  homeDir?: string;
+  somaHome?: string;
+}
+
+/** One deterministic probe's outcome. `ok: false` on any that gates health. */
+export interface SomaMemoryAuditProbe {
+  name: string;
+  ok: boolean;
+  detail: string;
+}
+
+export interface SomaMemoryAuditResult {
+  somaHome: string;
+  /** false ⇒ the CLI exits non-zero. Gated by: no schema-invalid notes AND a fresh INDEX. */
+  healthy: boolean;
+  /** Valid-note counts by type across the whole tree (durable + episodic + archive). */
+  notesByType: { semantic: number; procedural: number; episodic: number };
+  /** Note files that exist but fail to parse (schema-invalid) — a health failure. */
+  invalidNotes: string[];
+  /** INDEX freshness: stale when a durable note is newer than INDEX.md, or INDEX is absent while durable notes exist. */
+  index: { path: string; stale: boolean; reason: string };
+  /** Episodic coverage counts — session/action notes vs monthly digest files present. */
+  digests: { sessionNotes: number; actionNotes: number; digestFiles: number };
+  /** Archived episodic notes whose id is absent from their month's digest (informational drift signal). */
+  orphanedArchive: string[];
+  /** Event-stream vs corpus size — a coarse write-amplification signal (informational). */
+  events: { lines: number; notes: number };
+  /** Every probe run, in report order (most gate `healthy`; some are informational). */
+  probes: SomaMemoryAuditProbe[];
+}
+
 // Memory subsystem M2 (recall). Plan v2 §M2: note-aware retrieval over the
 // durable corpus (semantic + procedural) — term scoring, whole-file retrieval
 // (limit 3), 1-hop link expansion, superseded-exclusion via `valid_until`, and a

--- a/src/types.ts
+++ b/src/types.ts
@@ -2658,7 +2658,11 @@ export interface SomaMemoryAuditResult {
   orphanedArchive: string[];
   /** Event-stream vs corpus size — a coarse write-amplification signal (informational). */
   events: { lines: number; notes: number };
-  /** Every probe run, in report order (most gate `healthy`; some are informational). */
+  /**
+   * Every probe run, in report order. Exactly TWO gate `healthy`: `schema` and
+   * `index-freshness`. The other three (`digest-coverage`, `orphaned-archive`,
+   * `event-ratio`) are informational drift signals whose `ok` is always true.
+   */
   probes: SomaMemoryAuditProbe[];
 }
 

--- a/test/memory-audit.test.ts
+++ b/test/memory-audit.test.ts
@@ -202,6 +202,23 @@ test("a symlinked note DIRECTORY is not followed (no reading outside the root)",
   });
 });
 
+test("a durable ROOT replaced by a symlink is UNHEALTHY, not silently empty", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(somaHome, "real", "A real note.");
+    await rebuildMemoryIndex({ somaHome, now: NOW });
+    // Replace memory/semantic ROOT with a symlink to an outside dir of notes.
+    const outsideDir = join(somaHome, "..", "swapped-root");
+    await mkdir(outsideDir, { recursive: true });
+    await rm(join(somaHome, "memory/semantic"), { recursive: true, force: true });
+    await symlink(outsideDir, join(somaHome, "memory/semantic"));
+
+    const result = await auditMemory({ somaHome });
+    // Must NOT fail open as healthy-empty — the root-integrity gate fails.
+    expect(result.healthy).toBe(false);
+    expect(result.probes.find((p) => p.name === "root-integrity")?.ok).toBe(false);
+  });
+});
+
 // --- CLI gate -----------------------------------------------------------------
 
 test("the CLI exits non-zero (throws) on an unhealthy tree, with the report", async () => {

--- a/test/memory-audit.test.ts
+++ b/test/memory-audit.test.ts
@@ -29,6 +29,19 @@ async function setMtime(path: string, when: Date): Promise<void> {
   await utimes(path, when, when);
 }
 
+/** Write an archived episodic note under `archive/episodic/sessions/<month>/`. */
+async function writeArchivedEpisodicNote(somaHome: string, id: string, created: string, body: string): Promise<void> {
+  const month = created.slice(0, 7);
+  const dir = join(somaHome, "memory/archive/episodic/sessions", month);
+  await mkdir(dir, { recursive: true });
+  const note = [
+    "---", `id: ${id}`, "type: episodic", `created: ${created}`, `last_verified: ${created}`,
+    "valid_until: null", "provenance: tool:test", "trust: assistant", "source_of_truth: null",
+    "project: null", "links: []", "resurface_count: 0", "---", body, "",
+  ].join("\n");
+  await writeFile(join(dir, `${id}.md`), note, "utf8");
+}
+
 // --- healthy baseline ---------------------------------------------------------
 
 test("a valid note + fresh INDEX audits HEALTHY with a type count", async () => {
@@ -113,27 +126,8 @@ test("session digests are counted and do not stale the durable INDEX", async () 
 
 test("an archived episodic note absent from any digest is reported as orphaned", async () => {
   await withTempSoma(async (somaHome) => {
-    // Place an archived episodic note with no corresponding digest.
-    const archiveDir = join(somaHome, "memory/archive/episodic/sessions/2026-07");
-    await mkdir(archiveDir, { recursive: true });
-    const note = [
-      "---",
-      "id: 20260704-orphan",
-      "type: episodic",
-      "created: 2026-07-04",
-      "last_verified: 2026-07-04",
-      "valid_until: null",
-      "provenance: tool:test",
-      "trust: assistant",
-      "source_of_truth: null",
-      "project: null",
-      "links: []",
-      "resurface_count: 0",
-      "---",
-      "An archived session with no digest pointer.",
-      "",
-    ].join("\n");
-    await writeFile(join(archiveDir, "20260704-orphan.md"), note, "utf8");
+    // An archived episodic note with no corresponding digest.
+    await writeArchivedEpisodicNote(somaHome, "20260704-orphan", "2026-07-04", "An archived session with no digest pointer.");
 
     const result = await auditMemory({ somaHome });
     expect(result.orphanedArchive.some((p) => p.includes("20260704-orphan.md"))).toBe(true);
@@ -145,22 +139,31 @@ test("an archived episodic note absent from any digest is reported as orphaned",
 test("an archived note referenced only in the WRONG month's digest is still orphaned", async () => {
   await withTempSoma(async (somaHome) => {
     // Archived note created 2026-07, but the only digest listing its id is 2026-06.
-    const archiveDir = join(somaHome, "memory/archive/episodic/sessions/2026-07");
+    await writeArchivedEpisodicNote(somaHome, "20260704-misfiled", "2026-07-04", "A misfiled archived session.");
     const digestsDir = join(somaHome, "memory/episodic/digests");
-    await mkdir(archiveDir, { recursive: true });
     await mkdir(digestsDir, { recursive: true });
-    const note = [
-      "---", "id: 20260704-misfiled", "type: episodic", "created: 2026-07-04",
-      "last_verified: 2026-07-04", "valid_until: null", "provenance: tool:test",
-      "trust: assistant", "source_of_truth: null", "project: null", "links: []",
-      "resurface_count: 0", "---", "A misfiled archived session.", "",
-    ].join("\n");
-    await writeFile(join(archiveDir, "20260704-misfiled.md"), note, "utf8");
-    // Wrong-month digest references the id — must NOT count as coverage.
     await writeFile(join(digestsDir, "2026-06.md"), "# Episodic digest 2026-06\n\n- 20260704-misfiled: a misfiled session\n", "utf8");
 
     const result = await auditMemory({ somaHome });
     expect(result.orphanedArchive.some((p) => p.includes("20260704-misfiled.md"))).toBe(true);
+  });
+});
+
+test("a symlinked INDEX.md is refused — it cannot spoof freshness past the gate", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(somaHome, "durable", "A durable note.");
+    await rebuildMemoryIndex({ somaHome, now: NOW });
+    // Replace the real INDEX with a symlink to a newer file outside the tree.
+    const realIndex = join(somaHome, "memory/INDEX.md");
+    const decoy = join(somaHome, "..", "newer-decoy.md");
+    await writeFile(decoy, "not a real index", "utf8");
+    await rm(realIndex);
+    await symlink(decoy, realIndex);
+
+    const result = await auditMemory({ somaHome });
+    expect(result.index.stale).toBe(true);
+    expect(result.healthy).toBe(false);
+    expect(result.index.reason).toContain("symlink");
   });
 });
 

--- a/test/memory-audit.test.ts
+++ b/test/memory-audit.test.ts
@@ -1,0 +1,181 @@
+import { mkdir, mkdtemp, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { expect, test } from "bun:test";
+import { auditMemory, rebuildMemoryIndex, writeMemoryNote, writeSessionDigest } from "../src/index";
+import { parseMemoryArgs, runMemoryCli } from "../src/cli/memory";
+
+const NOW = new Date("2026-07-04T10:00:00.000Z");
+const SESSION = "0afea4e4-967d-4a38-a855-0d12ac63c2f3";
+const DIGEST_BODY = Array.from({ length: 10 }, (_, i) => `- line ${i + 1} of the digest`).join("\n");
+
+async function withTempSoma<T>(fn: (somaHome: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "soma-audit-"));
+  const somaHome = join(dir, ".soma");
+  try {
+    return await fn(somaHome);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/** Write a valid semantic note directly (bypassing the write path's clock). */
+async function writeNote(somaHome: string, id: string, body: string): Promise<string> {
+  const r = await writeMemoryNote({ somaHome, now: NOW, mode: "create", trigger: "import", id, type: "semantic", body, provenance: "import" });
+  return r.path;
+}
+
+async function setMtime(path: string, when: Date): Promise<void> {
+  await utimes(path, when, when);
+}
+
+// --- healthy baseline ---------------------------------------------------------
+
+test("a valid note + fresh INDEX audits HEALTHY with a type count", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(somaHome, "reporter-stack", "Reporter uses Bun and SQLite.");
+    await rebuildMemoryIndex({ somaHome, now: NOW });
+
+    const result = await auditMemory({ somaHome });
+    expect(result.healthy).toBe(true);
+    expect(result.notesByType.semantic).toBe(1);
+    expect(result.invalidNotes).toEqual([]);
+    expect(result.index.stale).toBe(false);
+  });
+});
+
+test("an empty tree (no durable notes) is HEALTHY — nothing to index", async () => {
+  await withTempSoma(async (somaHome) => {
+    const result = await auditMemory({ somaHome });
+    expect(result.healthy).toBe(true);
+    expect(result.index.stale).toBe(false);
+  });
+});
+
+// --- schema validity (gates health) ------------------------------------------
+
+test("a schema-invalid note file makes the audit UNHEALTHY and is listed", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(somaHome, "good", "A perfectly good note body.");
+    await rebuildMemoryIndex({ somaHome, now: NOW });
+    await writeFile(join(somaHome, "memory/semantic/broken.md"), "not a note at all", "utf8");
+
+    const result = await auditMemory({ somaHome });
+    expect(result.healthy).toBe(false);
+    expect(result.invalidNotes.some((p) => p.includes("broken.md"))).toBe(true);
+    expect(result.probes.find((p) => p.name === "schema")?.ok).toBe(false);
+  });
+});
+
+// --- INDEX freshness (gates health) ------------------------------------------
+
+test("a durable note newer than INDEX.md is a stale-INDEX failure", async () => {
+  await withTempSoma(async (somaHome) => {
+    const notePath = await writeNote(somaHome, "fresh", "This note changed after the index build.");
+    await rebuildMemoryIndex({ somaHome, now: NOW });
+    // Force the note's mtime strictly after the INDEX's.
+    await setMtime(join(somaHome, "memory/INDEX.md"), new Date("2026-07-04T10:00:00.000Z"));
+    await setMtime(notePath, new Date("2026-07-04T11:00:00.000Z"));
+
+    const result = await auditMemory({ somaHome });
+    expect(result.index.stale).toBe(true);
+    expect(result.healthy).toBe(false);
+    expect(result.index.reason).toContain("newer than INDEX");
+  });
+});
+
+test("durable notes present but INDEX.md absent is stale", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(somaHome, "unindexed", "No index was ever built for this corpus.");
+    const result = await auditMemory({ somaHome });
+    expect(result.index.stale).toBe(true);
+    expect(result.index.reason).toContain("absent");
+    expect(result.healthy).toBe(false);
+  });
+});
+
+// --- episodic coverage + orphaned archive (informational) --------------------
+
+test("session digests are counted and do not stale the durable INDEX", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(somaHome, "durable", "A durable note.");
+    await rebuildMemoryIndex({ somaHome, now: NOW });
+    // An episodic write lands AFTER the index build but must NOT stale it.
+    await setMtime(join(somaHome, "memory/INDEX.md"), new Date("2026-07-04T10:00:00.000Z"));
+    await writeSessionDigest({ somaHome, now: new Date("2026-07-04T12:00:00.000Z"), sessionId: SESSION, body: DIGEST_BODY });
+
+    const result = await auditMemory({ somaHome });
+    expect(result.digests.sessionNotes).toBe(1);
+    expect(result.index.stale).toBe(false); // episodic write does not stale the durable INDEX
+    expect(result.healthy).toBe(true);
+  });
+});
+
+test("an archived episodic note absent from any digest is reported as orphaned", async () => {
+  await withTempSoma(async (somaHome) => {
+    // Place an archived episodic note with no corresponding digest.
+    const archiveDir = join(somaHome, "memory/archive/episodic/sessions/2026-07");
+    await mkdir(archiveDir, { recursive: true });
+    const note = [
+      "---",
+      "id: 20260704-orphan",
+      "type: episodic",
+      "created: 2026-07-04",
+      "last_verified: 2026-07-04",
+      "valid_until: null",
+      "provenance: tool:test",
+      "trust: assistant",
+      "source_of_truth: null",
+      "project: null",
+      "links: []",
+      "resurface_count: 0",
+      "---",
+      "An archived session with no digest pointer.",
+      "",
+    ].join("\n");
+    await writeFile(join(archiveDir, "20260704-orphan.md"), note, "utf8");
+
+    const result = await auditMemory({ somaHome });
+    expect(result.orphanedArchive.some((p) => p.includes("20260704-orphan.md"))).toBe(true);
+    // orphaned archive is informational — it does NOT by itself fail health
+    expect(result.notesByType.episodic).toBe(1);
+  });
+});
+
+// --- symlink safety -----------------------------------------------------------
+
+test("a symlinked note is NOT followed (only real entries are audited)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(somaHome, "real", "A real note.");
+    await rebuildMemoryIndex({ somaHome, now: NOW });
+    // A symlink pointing outside the tree must be ignored, not parsed/failed.
+    const outside = join(somaHome, "..", "outside.md");
+    await writeFile(outside, "not a note", "utf8");
+    await symlink(outside, join(somaHome, "memory/semantic/link.md"));
+
+    const result = await auditMemory({ somaHome });
+    expect(result.notesByType.semantic).toBe(1); // only the real note
+    expect(result.invalidNotes).toEqual([]); // the symlink was skipped, not flagged
+  });
+});
+
+// --- CLI gate -----------------------------------------------------------------
+
+test("the CLI exits non-zero (throws) on an unhealthy tree, with the report", async () => {
+  await withTempSoma(async (somaHome) => {
+    await mkdir(join(somaHome, "memory/semantic"), { recursive: true });
+    await writeFile(join(somaHome, "memory/semantic/broken.md"), "invalid", "utf8");
+
+    await expect(runMemoryCli(parseMemoryArgs(["memory", "audit", "--soma-home", somaHome]))).rejects.toThrow(/UNHEALTHY/);
+  });
+});
+
+test("the CLI returns a HEALTHY report string on a clean tree", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(somaHome, "clean", "A clean, indexed note.");
+    await rebuildMemoryIndex({ somaHome, now: NOW });
+    const out = await runMemoryCli(parseMemoryArgs(["memory", "audit", "--soma-home", somaHome]));
+    expect(out).toContain("Soma memory audit: HEALTHY");
+    expect(out).toContain("[ok] schema:");
+  });
+});

--- a/test/memory-audit.test.ts
+++ b/test/memory-audit.test.ts
@@ -222,3 +222,21 @@ test("the CLI returns a HEALTHY report string on a clean tree", async () => {
     expect(out).toContain("[ok] schema:");
   });
 });
+
+// Real spawned-process exit codes (not just a thrown SomaCliError) — the audit is a
+// CI gate, so the actual process exit is what matters.
+test("the spawned CLI exits 0 on a healthy tree and non-zero on an unhealthy one", async () => {
+  await withTempSoma(async (somaHome) => {
+    const cli = join(import.meta.dirname, "..", "src", "cli.ts");
+    await writeNote(somaHome, "clean", "A clean, indexed note.");
+    await rebuildMemoryIndex({ somaHome, now: NOW });
+
+    const healthy = Bun.spawnSync(["bun", "run", cli, "memory", "audit", "--soma-home", somaHome]);
+    expect(healthy.exitCode).toBe(0);
+
+    // Corrupt a note → the process must exit non-zero.
+    await writeFile(join(somaHome, "memory/semantic/broken.md"), "invalid", "utf8");
+    const unhealthy = Bun.spawnSync(["bun", "run", cli, "memory", "audit", "--soma-home", somaHome]);
+    expect(unhealthy.exitCode).not.toBe(0);
+  });
+});

--- a/test/memory-audit.test.ts
+++ b/test/memory-audit.test.ts
@@ -184,6 +184,24 @@ test("a symlinked note is NOT followed (only real entries are audited)", async (
   });
 });
 
+test("a symlinked note DIRECTORY is not followed (no reading outside the root)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(somaHome, "real", "A real note.");
+    await rebuildMemoryIndex({ somaHome, now: NOW });
+    // Replace memory/procedural with a symlink to an outside dir holding a note.
+    const outsideDir = join(somaHome, "..", "outside-notes");
+    await mkdir(outsideDir, { recursive: true });
+    await writeFile(join(outsideDir, "foreign.md"), "would-be note", "utf8");
+    await rm(join(somaHome, "memory/procedural"), { recursive: true, force: true });
+    await symlink(outsideDir, join(somaHome, "memory/procedural"));
+
+    const result = await auditMemory({ somaHome });
+    // The symlinked dir is not walked → only the one real semantic note is seen.
+    expect(result.notesByType.semantic).toBe(1);
+    expect(result.notesByType.procedural).toBe(0);
+  });
+});
+
 // --- CLI gate -----------------------------------------------------------------
 
 test("the CLI exits non-zero (throws) on an unhealthy tree, with the report", async () => {

--- a/test/memory-audit.test.ts
+++ b/test/memory-audit.test.ts
@@ -142,6 +142,28 @@ test("an archived episodic note absent from any digest is reported as orphaned",
   });
 });
 
+test("an archived note referenced only in the WRONG month's digest is still orphaned", async () => {
+  await withTempSoma(async (somaHome) => {
+    // Archived note created 2026-07, but the only digest listing its id is 2026-06.
+    const archiveDir = join(somaHome, "memory/archive/episodic/sessions/2026-07");
+    const digestsDir = join(somaHome, "memory/episodic/digests");
+    await mkdir(archiveDir, { recursive: true });
+    await mkdir(digestsDir, { recursive: true });
+    const note = [
+      "---", "id: 20260704-misfiled", "type: episodic", "created: 2026-07-04",
+      "last_verified: 2026-07-04", "valid_until: null", "provenance: tool:test",
+      "trust: assistant", "source_of_truth: null", "project: null", "links: []",
+      "resurface_count: 0", "---", "A misfiled archived session.", "",
+    ].join("\n");
+    await writeFile(join(archiveDir, "20260704-misfiled.md"), note, "utf8");
+    // Wrong-month digest references the id — must NOT count as coverage.
+    await writeFile(join(digestsDir, "2026-06.md"), "# Episodic digest 2026-06\n\n- 20260704-misfiled: a misfiled session\n", "utf8");
+
+    const result = await auditMemory({ somaHome });
+    expect(result.orphanedArchive.some((p) => p.includes("20260704-misfiled.md"))).toBe(true);
+  });
+});
+
 // --- symlink safety -----------------------------------------------------------
 
 test("a symlinked note is NOT followed (only real entries are audited)", async () => {

--- a/test/memory-audit.test.ts
+++ b/test/memory-audit.test.ts
@@ -149,6 +149,19 @@ test("an archived note referenced only in the WRONG month's digest is still orph
   });
 });
 
+test("a NON-canonical digest file cannot satisfy archive coverage", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeArchivedEpisodicNote(somaHome, "20260704-real", "2026-07-04", "An archived session.");
+    // A nested, non-canonical file named like the month must NOT count as its digest.
+    const nested = join(somaHome, "memory/episodic/digests/nested");
+    await mkdir(nested, { recursive: true });
+    await writeFile(join(nested, "2026-07.md"), "- 20260704-real: sneaky non-canonical digest\n", "utf8");
+
+    const result = await auditMemory({ somaHome });
+    expect(result.orphanedArchive.some((p) => p.includes("20260704-real.md"))).toBe(true);
+  });
+});
+
 test("a symlinked INDEX.md is refused — it cannot spoof freshness past the gate", async () => {
   await withTempSoma(async (somaHome) => {
     await writeNote(somaHome, "durable", "A durable note.");


### PR DESCRIPTION
M7 — final memory milestone. (1) `soma memory audit`: deterministic, read-only, no-LLM SMOKE check with SIX filesystem-ground-truth probes. THREE gate health (CLI exits non-zero on any): root-integrity (every note root is a real directory, not a symlink/non-dir — no fail-open), schema validity, INDEX freshness (mtime). Three informational: digest-coverage counts, orphaned-archive (per canonical created-month digest), event-ratio. Every audit input is O_NOFOLLOW/lstat-guarded — no symlink followed (walk roots+subdirs with a lstat→readdir TOCTOU re-check, INDEX, events, digests); a symlinked INDEX/root can't spoof the gate. (2) `src/skills/Memory/` skill (SKILL.md + Remember/Recall/Consolidate/Audit workflows, pack-id soma-memory-v0.1.0). architecture.md: audit is the shipped ground-truth check (event-ratio is a coarse count, NOT per-note crash-orphan detection). Verification (local): bunx tsc --noEmit clean; 16 audit tests incl. spawned exit-code e2e + skill-entrypoint/frontmatter green.