### PR TITLE
feat(memory): SessionEnd deterministic digest fallback (M5b)

### DIFF
--- a/src/adapters/claude-code/hook-runner.mjs
+++ b/src/adapters/claude-code/hook-runner.mjs
@@ -92,8 +92,10 @@ function lifecycle(config, event, input) {
     const transcriptPath =
       typeof input.transcript_path === "string" && input.transcript_path.trim().length > 0 ? input.transcript_path : undefined;
     if (transcriptPath) args.push("--transcript", transcriptPath);
-    if (typeof input.agent_id === "string" && input.agent_id.trim().length > 0) args.push("--agent-id", input.agent_id);
-    if (typeof input.agent_type === "string" && input.agent_type.trim().length > 0) args.push("--agent-type", input.agent_type);
+    // Claude Code's payload keys are `agent_id`/`agent_type`; Soma's flags are the
+    // qualified `--subagent-*` (bare `agent` is banned in Soma surfaces).
+    if (typeof input.agent_id === "string" && input.agent_id.trim().length > 0) args.push("--subagent-id", input.agent_id);
+    if (typeof input.agent_type === "string" && input.agent_type.trim().length > 0) args.push("--subagent-type", input.agent_type);
   }
   runSomaDetached(config, args);
 }

--- a/src/adapters/claude-code/hook-runner.mjs
+++ b/src/adapters/claude-code/hook-runner.mjs
@@ -85,6 +85,26 @@ function lifecycle(config, event, input) {
   const cwd = typeof input.cwd === "string" && input.cwd.trim().length > 0 ? input.cwd : undefined;
   if (cwd) args.push("--cwd", cwd);
   runSomaDetached(config, args);
+  // M5b: on SessionEnd, also fire the deterministic digest FALLBACK (assistant-authored
+  // digests come from the wrap-up rule, not here). Sub-agent suppression + one-per-session
+  // dedup live in the CLI/SDK; this only forwards the payload. Detached, never blocks.
+  if (event === "session-end") sessionEndDigest(config, input, id);
+}
+
+function sessionEndDigest(config, input, id) {
+  const transcriptPath =
+    typeof input.transcript_path === "string" && input.transcript_path.trim().length > 0 ? input.transcript_path : undefined;
+  if (!id || !transcriptPath) return; // nothing to summarize without a session id + transcript
+  const args = [
+    "src/cli.ts", "memory", "digest",
+    "--session", id,
+    "--transcript", transcriptPath,
+    "--soma-home", config.somaHome,
+    "--substrate", "claude-code",
+  ];
+  if (typeof input.agent_id === "string" && input.agent_id.trim().length > 0) args.push("--agent-id", input.agent_id);
+  if (typeof input.agent_type === "string" && input.agent_type.trim().length > 0) args.push("--agent-type", input.agent_type);
+  runSomaDetached(config, args);
 }
 
 function metadata(input, source) {

--- a/src/adapters/claude-code/hook-runner.mjs
+++ b/src/adapters/claude-code/hook-runner.mjs
@@ -84,26 +84,17 @@ function lifecycle(config, event, input) {
   if (id) args.push("--session-id", id);
   const cwd = typeof input.cwd === "string" && input.cwd.trim().length > 0 ? input.cwd : undefined;
   if (cwd) args.push("--cwd", cwd);
-  runSomaDetached(config, args);
-  // M5b: on SessionEnd, also fire the deterministic digest FALLBACK (assistant-authored
-  // digests come from the wrap-up rule, not here). Sub-agent suppression + one-per-session
-  // dedup live in the CLI/SDK; this only forwards the payload. Detached, never blocks.
-  if (event === "session-end") sessionEndDigest(config, input, id);
-}
-
-function sessionEndDigest(config, input, id) {
-  const transcriptPath =
-    typeof input.transcript_path === "string" && input.transcript_path.trim().length > 0 ? input.transcript_path : undefined;
-  if (!id || !transcriptPath) return; // nothing to summarize without a session id + transcript
-  const args = [
-    "src/cli.ts", "memory", "digest",
-    "--session", id,
-    "--transcript", transcriptPath,
-    "--soma-home", config.somaHome,
-    "--substrate", "claude-code",
-  ];
-  if (typeof input.agent_id === "string" && input.agent_id.trim().length > 0) args.push("--agent-id", input.agent_id);
-  if (typeof input.agent_type === "string" && input.agent_type.trim().length > 0) args.push("--agent-type", input.agent_type);
+  // M5b: on SessionEnd, forward the transcript path + sub-agent markers so the
+  // lifecycle handler can attempt the deterministic digest FALLBACK (dispatched to the
+  // Claude Code transcript adapter — `soma memory digest` itself stays neutral/body-only).
+  // Assistant-authored digests come from the wrap-up rule, not here.
+  if (event === "session-end") {
+    const transcriptPath =
+      typeof input.transcript_path === "string" && input.transcript_path.trim().length > 0 ? input.transcript_path : undefined;
+    if (transcriptPath) args.push("--transcript", transcriptPath);
+    if (typeof input.agent_id === "string" && input.agent_id.trim().length > 0) args.push("--agent-id", input.agent_id);
+    if (typeof input.agent_type === "string" && input.agent_type.trim().length > 0) args.push("--agent-type", input.agent_type);
+  }
   runSomaDetached(config, args);
 }
 

--- a/src/adapters/claude-code/session-digest.ts
+++ b/src/adapters/claude-code/session-digest.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { hasSessionDigest, writeSessionDigest } from "../../memory-episodic";
+import { registerSessionEndTranscriptHandler } from "../../lifecycle";
 import type { SomaMemoryDigestResult, SubstrateId } from "../../types";
 
 /**
@@ -143,11 +144,12 @@ export function extractDigestBodyFromTranscript(transcript: string): string | un
     .map(([name, n]) => `${name}×${n}`)
     .join(", ");
 
-  // Prompt lines are VERBATIM principal input. Quote + label them (JSON.stringify
-  // escapes quotes/controls) so they read as DATA — what was asked — rather than as
-  // assistant instructions. This REDUCES the prompt-injection risk (paired with the
-  // tool:<name> provenance below); it does not PROVE every downstream recall consumer
-  // treats embedded instructions as inert.
+  // Prompt lines are principal input, control-collapsed + truncated by cleanLine (a
+  // lossy pointer, NOT an exact excerpt). Quote + label them (JSON.stringify escapes
+  // quotes/controls) so they read as DATA — what was asked — rather than as assistant
+  // instructions. This REDUCES the prompt-injection risk (paired with the tool:<name>
+  // provenance below); it does not PROVE every downstream recall consumer treats
+  // embedded instructions as inert.
   const lines = [
     `- session: ${prompts.length} principal prompts, ${assistantTurns} assistant turns, ${totalTools} tool calls`,
     ...shown.map((p) => `- principal prompt: ${JSON.stringify(p)}`),
@@ -244,3 +246,8 @@ export async function writeSessionDigestFromTranscript(options: ClaudeSessionDig
     reason: digest.created ? "wrote a deterministic session-end fallback digest" : "a digest already exists for this session — no-op",
   };
 }
+
+// Dependency inversion: register this adapter's transcript fallback with core
+// lifecycle at module load. Core never imports this adapter — it looks the handler up
+// by substrate. Importing this module (CLI side-effect / tests) triggers registration.
+registerSessionEndTranscriptHandler("claude-code", (input) => writeSessionDigestFromTranscript(input));

--- a/src/adapters/claude-code/session-digest.ts
+++ b/src/adapters/claude-code/session-digest.ts
@@ -14,7 +14,9 @@ import type { SomaMemoryDigestResult, SubstrateId } from "../../types";
  */
 
 // A deterministic fallback needs enough genuine prompts to make a useful 8–15-line
-// digest — below this it skips (the assistant self-authors small sessions instead).
+// digest — below this it returns undefined and the session is simply DROPPED (no
+// fallback digest). A small session is only captured if the assistant self-authored
+// one; the fallback neither checks nor guarantees that.
 const FALLBACK_MIN_PROMPTS = 6;
 const FALLBACK_MAX_PROMPT_LINES = 13; // + 2 structural (header + tools) = 15 max
 const PROMPT_LINE_MAX_CHARS = 120;
@@ -249,7 +251,7 @@ export async function writeSessionDigestFromTranscript(options: ClaudeSessionDig
     now: options.now,
     sessionId: options.sessionId,
     body,
-    hook: "session-end",
+    lifecycleEvent: "session-end", // → the note's M0 `hook:` field
     // Distinct provenance: recall's trust banner shows this body was machine-extracted
     // from principal input, NOT assistant-authored.
     provenance: "tool:claude-session-end",

--- a/src/adapters/claude-code/session-digest.ts
+++ b/src/adapters/claude-code/session-digest.ts
@@ -1,4 +1,7 @@
+import { constants as fsConstants } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { hasSessionDigest, writeSessionDigest } from "../../memory-episodic";
 import { registerSessionEndTranscriptHandler } from "../../lifecycle";
 import type { SomaMemoryDigestResult, SubstrateId } from "../../types";
@@ -183,8 +186,15 @@ export interface ClaudeSessionDigestOptions {
   now?: Date;
   /** The session this digest summarizes. */
   sessionId: string;
-  /** Path to the Claude Code session transcript (JSONL). */
+  /** Path to the Claude Code session transcript (JSONL). VALIDATED against transcriptRoot. */
   transcriptPath: string;
+  /**
+   * The directory the transcript MUST live under — a hook-controlled path is only read
+   * if it resolves inside this root and ends in `.jsonl`. Defaults to
+   * `$SOMA_CLAUDE_TRANSCRIPT_ROOT` or `~/.claude/projects` (Claude Code's transcript
+   * store). Injected by tests to point at a fixture dir.
+   */
+  transcriptRoot?: string;
   /** Claude Code sub-agent markers from the hook payload — when set, the digest is suppressed. */
   subagentId?: string;
   subagentType?: string;
@@ -196,7 +206,7 @@ export interface ClaudeSessionDigestOptions {
 
 /** Outcome of the transcript-fallback digest. Each cause is distinguished. */
 export interface ClaudeSessionDigestResult {
-  outcome: "written" | "duplicate" | "suppressed" | "skipped" | "unreadable";
+  outcome: "written" | "duplicate" | "suppressed" | "skipped" | "unreadable" | "refused";
   /** The core digest result when a write/dedup happened; absent otherwise. */
   digest?: SomaMemoryDigestResult;
   /** Human-readable reason (always set). */
@@ -229,13 +239,25 @@ export async function writeSessionDigestFromTranscript(options: ClaudeSessionDig
     return { outcome: "suppressed", reason: "sub-agent session (ADR 0014) — no fallback digest written" };
   }
 
+  // Path containment: transcriptPath is HOOK-CONTROLLED, so validate it before reading —
+  // a forged/confused payload must not read an arbitrary local file into recall. Require
+  // an absolute `.jsonl` path resolving inside the Claude transcript root.
+  const root = resolve(options.transcriptRoot ?? process.env.SOMA_CLAUDE_TRANSCRIPT_ROOT ?? join(homedir(), ".claude", "projects"));
+  const target = resolve(options.transcriptPath);
+  const rel = relative(root, target);
+  if (!isAbsolute(options.transcriptPath) || !target.endsWith(".jsonl") || rel === "" || rel.startsWith("..") || isAbsolute(rel)) {
+    return { outcome: "refused", reason: `transcript path is outside the allowed transcript root or not a .jsonl file: ${options.transcriptPath}` };
+  }
+
   // Dedup BEFORE reading the transcript — an assistant-authored digest (the primary
   // path) makes the whole transcript read/parse unnecessary.
   if (await hasSessionDigest({ homeDir: options.homeDir, somaHome: options.somaHome, sessionId: options.sessionId })) {
     return { outcome: "duplicate", reason: "a digest already exists for this session — no-op (no transcript read)" };
   }
 
-  const transcript = await readFile(options.transcriptPath, "utf8").catch(() => undefined);
+  // Read WITHOUT following a final-component symlink (a symlinked transcript could point
+  // outside the validated root).
+  const transcript = await readFile(options.transcriptPath, { encoding: "utf8", flag: fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW }).catch(() => undefined);
   if (transcript === undefined) {
     return { outcome: "unreadable", reason: `transcript could not be read at ${options.transcriptPath}` };
   }

--- a/src/adapters/claude-code/session-digest.ts
+++ b/src/adapters/claude-code/session-digest.ts
@@ -74,12 +74,15 @@ type ClassifiedEntry = { kind: "prompt"; text: string } | { kind: "assistant"; t
 function parseTranscriptLine(raw: string): ClassifiedEntry | undefined {
   const line = raw.trim();
   if (line.length === 0) return undefined;
-  let entry: Record<string, unknown>;
+  let parsed: unknown;
   try {
-    entry = JSON.parse(line) as Record<string, unknown>;
+    parsed = JSON.parse(line);
   } catch {
     return undefined; // a non-JSON line — skip, never fail the whole extraction
   }
+  // A valid JSONL line can be `null`, a number, or an array — none is a usable entry.
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
+  const entry = parsed as Record<string, unknown>;
   if (entry.isSidechain === true || entry.isMeta === true) return undefined; // sub-agent / meta noise
   const message = entry.message as { role?: unknown; content?: unknown } | undefined;
 
@@ -181,14 +184,18 @@ export interface ClaudeSessionDigestResult {
   reason: string;
 }
 
-/** A sub-agent invocation carries a non-empty agent id or type in the hook payload. */
+/** True when the hook payload CARRIES a sub-agent marker (agent id or type). NOTE:
+ *  suppression depends on the payload actually supplying these — an unmarked sub-agent
+ *  invocation is NOT detected here and falls through to the write path. Detection is
+ *  only as complete as the substrate's markers. */
 function hasAgentMarker(options: ClaudeSessionDigestOptions): boolean {
   return (options.agentId ?? "").trim().length > 0 || (options.agentType ?? "").trim().length > 0;
 }
 
 /**
  * SessionEnd fallback (M5b): write a deterministic digest from a Claude transcript.
- * Suppresses sub-agent sessions (ADR 0014); no-ops when a digest already exists (the
+ * Suppresses MARKED sub-agent sessions (ADR 0014 — via agentId/agentType in the hook
+ * payload; an unmarked sub-agent is not detected); no-ops when a digest already exists (the
  * one-per-session gate — checked BEFORE reading the transcript, so the common primary
  * path does no wasted work); skips a too-thin session; reports an unreadable transcript
  * distinctly. NEVER throws for an absent/unreadable transcript — a hook must not block

--- a/src/adapters/claude-code/session-digest.ts
+++ b/src/adapters/claude-code/session-digest.ts
@@ -63,8 +63,9 @@ function samplePrompts(prompts: string[], max: number): string[] {
 
 /**
  * Deterministically extract an 8–15-line digest body from a Claude Code transcript
- * (JSONL). No LLM: it lists the genuine principal prompts (noise/tool/command lines
- * filtered, sidechain/sub-agent lines skipped) plus a header and a tool-use rollup.
+ * (JSONL). No LLM: it lists the genuine principal prompts — command/system/tool-RESULT
+ * lines and sidechain/sub-agent lines are excluded — while assistant `tool_use`
+ * activity is SUMMARIZED into a rollup line (counts by tool), not listed as prompts.
  * Returns `undefined` when the session has too few real prompts to summarize.
  */
 export function extractDigestBodyFromTranscript(transcript: string): string | undefined {
@@ -115,9 +116,12 @@ export function extractDigestBodyFromTranscript(transcript: string): string | un
     .map(([name, n]) => `${name}×${n}`)
     .join(", ");
 
+  // Prompt lines are VERBATIM principal input — quote + label them so a trusted-recall
+  // reader treats them as DATA (what was asked), never as assistant instructions to
+  // follow. JSON.stringify escapes quotes/controls, closing the injection vector.
   const lines = [
     `- session: ${prompts.length} principal prompts, ${assistantTurns} assistant turns, ${totalTools} tool calls`,
-    ...shown.map((p) => `- ${p}`),
+    ...shown.map((p) => `- principal prompt: ${JSON.stringify(p)}`),
     `- tools: ${topTools.length > 0 ? topTools : "none"}`,
   ];
   return lines.join("\n");
@@ -196,6 +200,9 @@ export async function writeSessionDigestFromTranscript(options: ClaudeSessionDig
     sessionId: options.sessionId,
     body,
     hook: "session-end",
+    // Distinct provenance: recall's trust banner shows this body was machine-extracted
+    // from principal input, NOT assistant-authored.
+    provenance: "tool:claude-session-end",
   });
   // A race could still have another writer win between the dedup check and here.
   return {

--- a/src/adapters/claude-code/session-digest.ts
+++ b/src/adapters/claude-code/session-digest.ts
@@ -92,7 +92,8 @@ function parseTranscriptLine(raw: string): ClassifiedEntry | undefined {
     if (typeof message.content !== "string" && !isTextOnlyContent(message.content)) return undefined;
     const text = cleanLine(messageText(message.content));
     if (text.length === 0) return undefined;
-    if (PROMPT_NOISE_PREFIXES.some((p) => text.toLowerCase().startsWith(p))) return undefined;
+    const lowerText = text.toLowerCase(); // lowercase ONCE, not per prefix
+    if (PROMPT_NOISE_PREFIXES.some((p) => lowerText.startsWith(p))) return undefined;
     return { kind: "prompt", text };
   }
 
@@ -102,7 +103,12 @@ function parseTranscriptLine(raw: string): ClassifiedEntry | undefined {
       for (const part of message.content) {
         if (part && typeof part === "object" && (part as { type?: unknown }).type === "tool_use") {
           const name = (part as { name?: unknown }).name;
-          if (typeof name === "string") tools.push(name);
+          // A transcript-derived tool name is untrusted — control-collapse it (same as
+          // prompts) so it can't inject directive text into the `- tools:` rollup line.
+          if (typeof name === "string") {
+            const clean = cleanLine(name);
+            if (clean.length > 0) tools.push(clean);
+          }
         }
       }
     }
@@ -168,9 +174,9 @@ export interface ClaudeSessionDigestOptions {
   sessionId: string;
   /** Path to the Claude Code session transcript (JSONL). */
   transcriptPath: string;
-  /** Sub-agent markers from the hook payload — when set, the digest is suppressed. */
-  agentId?: string;
-  agentType?: string;
+  /** Claude Code sub-agent markers from the hook payload — when set, the digest is suppressed. */
+  subagentId?: string;
+  subagentType?: string;
   /** Force the primary (write) path even for a sub-agent-marked invocation. */
   forcePrimary?: boolean;
   /** Force treating the invocation as a sub-agent (suppress) — takes precedence over forcePrimary. */
@@ -190,13 +196,13 @@ export interface ClaudeSessionDigestResult {
  *  suppression depends on the payload actually supplying these — an unmarked sub-agent
  *  invocation is NOT detected here and falls through to the write path. Detection is
  *  only as complete as the substrate's markers. */
-function hasAgentMarker(options: ClaudeSessionDigestOptions): boolean {
-  return (options.agentId ?? "").trim().length > 0 || (options.agentType ?? "").trim().length > 0;
+function hasSubagentMarker(options: ClaudeSessionDigestOptions): boolean {
+  return (options.subagentId ?? "").trim().length > 0 || (options.subagentType ?? "").trim().length > 0;
 }
 
 /**
  * SessionEnd fallback (M5b): write a deterministic digest from a Claude transcript.
- * Suppresses MARKED sub-agent sessions (ADR 0014 — via agentId/agentType in the hook
+ * Suppresses MARKED sub-agent sessions (ADR 0014 — via subagentId/subagentType in the hook
  * payload; an unmarked sub-agent is not detected); no-ops when a digest already exists (the
  * one-per-session gate — checked BEFORE reading the transcript, so the common primary
  * path does no wasted work); skips a too-thin session; reports an unreadable transcript
@@ -208,7 +214,7 @@ export async function writeSessionDigestFromTranscript(options: ClaudeSessionDig
   if (options.forceSubagent === true) {
     return { outcome: "suppressed", reason: "forced sub-agent (ADR 0014) — no fallback digest written" };
   }
-  if (options.forcePrimary !== true && hasAgentMarker(options)) {
+  if (options.forcePrimary !== true && hasSubagentMarker(options)) {
     return { outcome: "suppressed", reason: "sub-agent session (ADR 0014) — no fallback digest written" };
   }
 

--- a/src/adapters/claude-code/session-digest.ts
+++ b/src/adapters/claude-code/session-digest.ts
@@ -257,8 +257,10 @@ export async function writeSessionDigestFromTranscript(options: ClaudeSessionDig
     sessionId: options.sessionId,
     body,
     lifecycleEvent: "session-end", // → the note's M0 `hook:` field
-    // Distinct provenance: recall's trust banner shows this body was machine-extracted
-    // from principal input, NOT assistant-authored.
+    // Distinct provenance: recall surfaces the raw provenance TOKEN
+    // (`tool:claude-session-end`) in its banner rather than the default `conversation`,
+    // so a reader CAN tell this body is machine-extracted — the banner shows the token,
+    // not a rendered "machine-authored" label.
     provenance: "tool:claude-session-end",
   });
   // A race could still have another writer win between the dedup check and here.

--- a/src/adapters/claude-code/session-digest.ts
+++ b/src/adapters/claude-code/session-digest.ts
@@ -1,0 +1,206 @@
+import { readFile } from "node:fs/promises";
+import { hasSessionDigest, writeSessionDigest } from "../../memory-episodic";
+import type { SomaMemoryDigestResult, SubstrateId } from "../../types";
+
+/**
+ * Claude Code SessionEnd digest FALLBACK (M5b) — adapter-owned.
+ *
+ * The transcript FORMAT (Claude Code session JSONL) is a substrate concept, so its
+ * extraction lives here, NOT in the substrate-neutral core (docs/architecture.md#Core).
+ * Core exposes only `writeSessionDigest` (takes a ready body + `hook:` marker) and the
+ * neutral `hasSessionDigest` dedup check; this module turns a Claude transcript into a
+ * body deterministically (no LLM) and writes it via core.
+ */
+
+// A deterministic fallback needs enough genuine prompts to make a useful 8–15-line
+// digest — below this it skips (the assistant self-authors small sessions instead).
+const FALLBACK_MIN_PROMPTS = 6;
+const FALLBACK_MAX_PROMPT_LINES = 13; // + 2 structural (header + tools) = 15 max
+const PROMPT_LINE_MAX_CHARS = 120;
+
+/** Wrapper/noise prefixes that mark a "user" line as NOT a genuine principal prompt. */
+const PROMPT_NOISE_PREFIXES = [
+  "<command-name>",
+  "<command-message>",
+  "<local-command-",
+  "<system-reminder>",
+  "caveat:",
+  "<user-prompt-submit-hook>",
+];
+
+/** Collapse control chars + whitespace and truncate — one clean digest pointer line. */
+function cleanLine(text: string): string {
+  const collapsed = text.replace(/[\u0000-\u001F\u007F-\u009F]+/g, " ").replace(/\s+/g, " ").trim();
+  return collapsed.length > PROMPT_LINE_MAX_CHARS ? `${collapsed.slice(0, PROMPT_LINE_MAX_CHARS - 1)}…` : collapsed;
+}
+
+/** The text of a transcript message's `content` (string, or joined `text` parts). */
+function messageText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((part): part is { type?: unknown; text?: unknown } => part !== null && typeof part === "object")
+      .filter((part) => part.type === "text" && typeof part.text === "string")
+      .map((part) => part.text as string)
+      .join(" ");
+  }
+  return "";
+}
+
+/** True only for array content that is purely text parts (never a tool_result). */
+function isTextOnlyContent(content: unknown): boolean {
+  if (!Array.isArray(content) || content.length === 0) return false;
+  return content.every((part) => part !== null && typeof part === "object" && (part as { type?: unknown }).type === "text");
+}
+
+/** Head+tail sample to `max` lines, inserting an elision marker when trimmed. */
+function samplePrompts(prompts: string[], max: number): string[] {
+  if (prompts.length <= max) return prompts;
+  const head = Math.ceil((max - 1) / 2);
+  const tail = max - 1 - head;
+  return [...prompts.slice(0, head), `… (${prompts.length - head - tail} more prompts) …`, ...prompts.slice(prompts.length - tail)];
+}
+
+/**
+ * Deterministically extract an 8–15-line digest body from a Claude Code transcript
+ * (JSONL). No LLM: it lists the genuine principal prompts (noise/tool/command lines
+ * filtered, sidechain/sub-agent lines skipped) plus a header and a tool-use rollup.
+ * Returns `undefined` when the session has too few real prompts to summarize.
+ */
+export function extractDigestBodyFromTranscript(transcript: string): string | undefined {
+  const prompts: string[] = [];
+  const toolCounts = new Map<string, number>();
+  let assistantTurns = 0;
+
+  for (const raw of transcript.split("\n")) {
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue; // a non-JSON line — skip, never fail the whole extraction
+    }
+    if (entry.isSidechain === true || entry.isMeta === true) continue; // sub-agent / meta noise
+    const message = entry.message as { role?: unknown; content?: unknown } | undefined;
+    if (entry.type === "user" && message?.role === "user") {
+      // A real prompt is string content; a tool_result array is not principal text.
+      if (typeof message.content !== "string" && !isTextOnlyContent(message.content)) continue;
+      const text = cleanLine(messageText(message.content));
+      if (text.length === 0) continue;
+      const lower = text.toLowerCase();
+      if (PROMPT_NOISE_PREFIXES.some((p) => lower.startsWith(p))) continue;
+      prompts.push(text);
+    } else if (entry.type === "assistant" && message?.role === "assistant") {
+      assistantTurns += 1;
+      if (Array.isArray(message.content)) {
+        for (const part of message.content) {
+          if (part && typeof part === "object" && (part as { type?: unknown }).type === "tool_use") {
+            const name = (part as { name?: unknown }).name;
+            if (typeof name === "string") toolCounts.set(name, (toolCounts.get(name) ?? 0) + 1);
+          }
+        }
+      }
+    }
+  }
+
+  if (prompts.length < FALLBACK_MIN_PROMPTS) return undefined;
+
+  // Sample head + tail when there are many prompts, so the digest captures the arc.
+  const shown = samplePrompts(prompts, FALLBACK_MAX_PROMPT_LINES);
+  const totalTools = [...toolCounts.values()].reduce((sum, n) => sum + n, 0);
+  const topTools = [...toolCounts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 5)
+    .map(([name, n]) => `${name}×${n}`)
+    .join(", ");
+
+  const lines = [
+    `- session: ${prompts.length} principal prompts, ${assistantTurns} assistant turns, ${totalTools} tool calls`,
+    ...shown.map((p) => `- ${p}`),
+    `- tools: ${topTools.length > 0 ? topTools : "none"}`,
+  ];
+  return lines.join("\n");
+}
+
+/** Options for the Claude Code SessionEnd digest fallback. */
+export interface ClaudeSessionDigestOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate?: SubstrateId;
+  now?: Date;
+  /** The session this digest summarizes. */
+  sessionId: string;
+  /** Path to the Claude Code session transcript (JSONL). */
+  transcriptPath: string;
+  /** Sub-agent markers from the hook payload — when set, the digest is suppressed. */
+  agentId?: string;
+  agentType?: string;
+  /** Force the primary (write) path even for a sub-agent-marked invocation. */
+  forcePrimary?: boolean;
+  /** Force treating the invocation as a sub-agent (suppress) — takes precedence over forcePrimary. */
+  forceSubagent?: boolean;
+}
+
+/** Outcome of the transcript-fallback digest. Each cause is distinguished. */
+export interface ClaudeSessionDigestResult {
+  outcome: "written" | "duplicate" | "suppressed" | "skipped" | "unreadable";
+  /** The core digest result when a write/dedup happened; absent otherwise. */
+  digest?: SomaMemoryDigestResult;
+  /** Human-readable reason (always set). */
+  reason: string;
+}
+
+/** A sub-agent invocation carries a non-empty agent id or type in the hook payload. */
+function hasAgentMarker(options: ClaudeSessionDigestOptions): boolean {
+  return (options.agentId ?? "").trim().length > 0 || (options.agentType ?? "").trim().length > 0;
+}
+
+/**
+ * SessionEnd fallback (M5b): write a deterministic digest from a Claude transcript.
+ * Suppresses sub-agent sessions (ADR 0014); no-ops when a digest already exists (the
+ * one-per-session gate — checked BEFORE reading the transcript, so the common primary
+ * path does no wasted work); skips a too-thin session; reports an unreadable transcript
+ * distinctly. NEVER throws for an absent/unreadable transcript — a hook must not block
+ * a session. Best-effort, not a guarantee.
+ */
+export async function writeSessionDigestFromTranscript(options: ClaudeSessionDigestOptions): Promise<ClaudeSessionDigestResult> {
+  // forceSubagent has precedence over forcePrimary (the type promises "regardless").
+  if (options.forceSubagent === true) {
+    return { outcome: "suppressed", reason: "forced sub-agent (ADR 0014) — no fallback digest written" };
+  }
+  if (options.forcePrimary !== true && hasAgentMarker(options)) {
+    return { outcome: "suppressed", reason: "sub-agent session (ADR 0014) — no fallback digest written" };
+  }
+
+  // Dedup BEFORE reading the transcript — an assistant-authored digest (the primary
+  // path) makes the whole transcript read/parse unnecessary.
+  if (await hasSessionDigest({ homeDir: options.homeDir, somaHome: options.somaHome, sessionId: options.sessionId })) {
+    return { outcome: "duplicate", reason: "a digest already exists for this session — no-op (no transcript read)" };
+  }
+
+  const transcript = await readFile(options.transcriptPath, "utf8").catch(() => undefined);
+  if (transcript === undefined) {
+    return { outcome: "unreadable", reason: `transcript could not be read at ${options.transcriptPath}` };
+  }
+  const body = extractDigestBodyFromTranscript(transcript);
+  if (body === undefined) {
+    return { outcome: "skipped", reason: "transcript has too few principal prompts for a fallback digest" };
+  }
+
+  const digest = await writeSessionDigest({
+    homeDir: options.homeDir,
+    somaHome: options.somaHome,
+    substrate: options.substrate,
+    now: options.now,
+    sessionId: options.sessionId,
+    body,
+    hook: "session-end",
+  });
+  // A race could still have another writer win between the dedup check and here.
+  return {
+    outcome: digest.created ? "written" : "duplicate",
+    digest,
+    reason: digest.created ? "wrote a deterministic session-end fallback digest" : "a digest already exists for this session — no-op",
+  };
+}

--- a/src/adapters/claude-code/session-digest.ts
+++ b/src/adapters/claude-code/session-digest.ts
@@ -244,6 +244,11 @@ export async function writeSessionDigestFromTranscript(options: ClaudeSessionDig
     return { outcome: "skipped", reason: "transcript has too few principal prompts for a fallback digest" };
   }
 
+  // Governance: this is the GOVERNED M5 memory-write path — schema validation, the
+  // one-per-session gate, provenance validation, and a memory.digest event. That is the
+  // write governance for memory CONTENT. It is NOT the PostToolUse tool-activity
+  // writeback QUEUE (substrate telemetry); a session digest is memory content, so it is
+  // authored through the memory API, not the telemetry writeback pipeline.
   const digest = await writeSessionDigest({
     homeDir: options.homeDir,
     somaHome: options.somaHome,
@@ -267,4 +272,6 @@ export async function writeSessionDigestFromTranscript(options: ClaudeSessionDig
 // Dependency inversion: register this adapter's transcript fallback with core
 // lifecycle at module load. Core never imports this adapter — it looks the handler up
 // by substrate. Importing this module (CLI side-effect / tests) triggers registration.
-registerSessionEndTranscriptHandler("claude-code", (input) => writeSessionDigestFromTranscript(input));
+registerSessionEndTranscriptHandler("claude-code", (input) =>
+  writeSessionDigestFromTranscript(input).then((r) => ({ outcome: r.outcome, path: r.digest?.path })),
+);

--- a/src/adapters/claude-code/session-digest.ts
+++ b/src/adapters/claude-code/session-digest.ts
@@ -79,7 +79,11 @@ function parseTranscriptLine(raw: string): ClassifiedEntry | undefined {
   try {
     parsed = JSON.parse(line);
   } catch {
-    return undefined; // a non-JSON line — skip, never fail the whole extraction
+    // Best-effort: a malformed line is SKIPPED so one bad line can't fail the whole
+    // extraction. A corrupt transcript therefore yields a digest from its readable
+    // subset with no error — acceptable for a best-effort fallback record (the M7 audit,
+    // not this, is the integrity check), NOT a guarantee the digest saw every line.
+    return undefined;
   }
   // A valid JSONL line can be `null`, a number, or an array — none is a usable entry.
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return undefined;
@@ -103,8 +107,11 @@ function parseTranscriptLine(raw: string): ClassifiedEntry | undefined {
       for (const part of message.content) {
         if (part && typeof part === "object" && (part as { type?: unknown }).type === "tool_use") {
           const name = (part as { name?: unknown }).name;
-          // A transcript-derived tool name is untrusted — control-collapse it (same as
-          // prompts) so it can't inject directive text into the `- tools:` rollup line.
+          // Tool names come from the ASSISTANT's own tool_use (not principal input), so
+          // the injection surface is small; still control-collapse them (strips control
+          // chars/newlines) before the `- tools:` rollup. This does NOT escape ordinary
+          // directive PROSE — a tool literally named "ignore prior memory" would still
+          // read as prose; real tool names are short identifiers, so it is left readable.
           if (typeof name === "string") {
             const clean = cleanLine(name);
             if (clean.length > 0) tools.push(clean);
@@ -123,6 +130,8 @@ function parseTranscriptLine(raw: string): ClassifiedEntry | undefined {
  * lines and sidechain/sub-agent lines are excluded — while assistant `tool_use`
  * activity is SUMMARIZED into a rollup line (counts by tool), not listed as prompts.
  * Returns `undefined` when the session has too few real prompts to summarize.
+ * DETERMINISTIC but best-effort: malformed/non-JSON lines are silently skipped, so a
+ * corrupt transcript yields a digest of its readable subset (not a complete record).
  */
 export function extractDigestBodyFromTranscript(transcript: string): string | undefined {
   const prompts: string[] = [];

--- a/src/adapters/claude-code/session-digest.ts
+++ b/src/adapters/claude-code/session-digest.ts
@@ -61,6 +61,52 @@ function samplePrompts(prompts: string[], max: number): string[] {
   return [...prompts.slice(0, head), `… (${prompts.length - head - tail} more prompts) …`, ...prompts.slice(prompts.length - tail)];
 }
 
+/** A classified transcript line: a genuine principal prompt, an assistant turn (with
+ *  the tools it used), or nothing worth counting. */
+type ClassifiedEntry = { kind: "prompt"; text: string } | { kind: "assistant"; tools: string[] };
+
+/**
+ * Classify ONE raw JSONL line. Returns `undefined` for a blank/non-JSON line, a
+ * sidechain/meta entry, or a "user" line that isn't a genuine principal prompt
+ * (tool_result content or a command/system wrapper). Keeps line-parsing, filtering,
+ * and tool-collection out of the extraction loop.
+ */
+function parseTranscriptLine(raw: string): ClassifiedEntry | undefined {
+  const line = raw.trim();
+  if (line.length === 0) return undefined;
+  let entry: Record<string, unknown>;
+  try {
+    entry = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    return undefined; // a non-JSON line — skip, never fail the whole extraction
+  }
+  if (entry.isSidechain === true || entry.isMeta === true) return undefined; // sub-agent / meta noise
+  const message = entry.message as { role?: unknown; content?: unknown } | undefined;
+
+  if (entry.type === "user" && message?.role === "user") {
+    // A real prompt is string content; a tool_result array is not principal text.
+    if (typeof message.content !== "string" && !isTextOnlyContent(message.content)) return undefined;
+    const text = cleanLine(messageText(message.content));
+    if (text.length === 0) return undefined;
+    if (PROMPT_NOISE_PREFIXES.some((p) => text.toLowerCase().startsWith(p))) return undefined;
+    return { kind: "prompt", text };
+  }
+
+  if (entry.type === "assistant" && message?.role === "assistant") {
+    const tools: string[] = [];
+    if (Array.isArray(message.content)) {
+      for (const part of message.content) {
+        if (part && typeof part === "object" && (part as { type?: unknown }).type === "tool_use") {
+          const name = (part as { name?: unknown }).name;
+          if (typeof name === "string") tools.push(name);
+        }
+      }
+    }
+    return { kind: "assistant", tools };
+  }
+  return undefined;
+}
+
 /**
  * Deterministically extract an 8–15-line digest body from a Claude Code transcript
  * (JSONL). No LLM: it lists the genuine principal prompts — command/system/tool-RESULT
@@ -74,34 +120,12 @@ export function extractDigestBodyFromTranscript(transcript: string): string | un
   let assistantTurns = 0;
 
   for (const raw of transcript.split("\n")) {
-    const line = raw.trim();
-    if (line.length === 0) continue;
-    let entry: Record<string, unknown>;
-    try {
-      entry = JSON.parse(line) as Record<string, unknown>;
-    } catch {
-      continue; // a non-JSON line — skip, never fail the whole extraction
-    }
-    if (entry.isSidechain === true || entry.isMeta === true) continue; // sub-agent / meta noise
-    const message = entry.message as { role?: unknown; content?: unknown } | undefined;
-    if (entry.type === "user" && message?.role === "user") {
-      // A real prompt is string content; a tool_result array is not principal text.
-      if (typeof message.content !== "string" && !isTextOnlyContent(message.content)) continue;
-      const text = cleanLine(messageText(message.content));
-      if (text.length === 0) continue;
-      const lower = text.toLowerCase();
-      if (PROMPT_NOISE_PREFIXES.some((p) => lower.startsWith(p))) continue;
-      prompts.push(text);
-    } else if (entry.type === "assistant" && message?.role === "assistant") {
+    const entry = parseTranscriptLine(raw);
+    if (entry === undefined) continue; // blank / non-JSON / sidechain / meta
+    if (entry.kind === "prompt") prompts.push(entry.text);
+    else {
       assistantTurns += 1;
-      if (Array.isArray(message.content)) {
-        for (const part of message.content) {
-          if (part && typeof part === "object" && (part as { type?: unknown }).type === "tool_use") {
-            const name = (part as { name?: unknown }).name;
-            if (typeof name === "string") toolCounts.set(name, (toolCounts.get(name) ?? 0) + 1);
-          }
-        }
-      }
+      for (const name of entry.tools) toolCounts.set(name, (toolCounts.get(name) ?? 0) + 1);
     }
   }
 
@@ -116,9 +140,11 @@ export function extractDigestBodyFromTranscript(transcript: string): string | un
     .map(([name, n]) => `${name}×${n}`)
     .join(", ");
 
-  // Prompt lines are VERBATIM principal input — quote + label them so a trusted-recall
-  // reader treats them as DATA (what was asked), never as assistant instructions to
-  // follow. JSON.stringify escapes quotes/controls, closing the injection vector.
+  // Prompt lines are VERBATIM principal input. Quote + label them (JSON.stringify
+  // escapes quotes/controls) so they read as DATA — what was asked — rather than as
+  // assistant instructions. This REDUCES the prompt-injection risk (paired with the
+  // tool:<name> provenance below); it does not PROVE every downstream recall consumer
+  // treats embedded instructions as inert.
   const lines = [
     `- session: ${prompts.length} principal prompts, ${assistantTurns} assistant turns, ${totalTools} tool calls`,
     ...shown.map((p) => `- principal prompt: ${JSON.stringify(p)}`),

--- a/src/cli/lifecycle.ts
+++ b/src/cli/lifecycle.ts
@@ -7,6 +7,10 @@ import {
 import type { SomaLifecycleOptions, SomaLifecycleResult } from "../types";
 import { readOption } from "./parse-utils";
 import { parseSubstrate } from "./substrate";
+// Composition layer: importing the Claude Code adapter registers its SessionEnd
+// transcript-digest handler with core lifecycle (dependency inversion — core never
+// imports the adapter). Side-effect import; the symbol itself is not used here.
+import "../adapters/claude-code/session-digest";
 
 export interface ParsedLifecycleArgs {
   command: "lifecycle";

--- a/src/cli/lifecycle.ts
+++ b/src/cli/lifecycle.ts
@@ -72,12 +72,12 @@ export function parseLifecycleArgs(args: string[]): ParsedLifecycleArgs {
         options.transcriptPath = readOption(rest, index, arg);
         index += 1;
         break;
-      case "--agent-id":
-        options.agentId = readOption(rest, index, arg);
+      case "--subagent-id":
+        options.subagentId = readOption(rest, index, arg);
         index += 1;
         break;
-      case "--agent-type":
-        options.agentType = readOption(rest, index, arg);
+      case "--subagent-type":
+        options.subagentType = readOption(rest, index, arg);
         index += 1;
         break;
       default:

--- a/src/cli/lifecycle.ts
+++ b/src/cli/lifecycle.ts
@@ -64,6 +64,18 @@ export function parseLifecycleArgs(args: string[]): ParsedLifecycleArgs {
         options.gitBranch = readOption(rest, index, arg);
         index += 1;
         break;
+      case "--transcript":
+        options.transcriptPath = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--agent-id":
+        options.agentId = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--agent-type":
+        options.agentType = readOption(rest, index, arg);
+        index += 1;
+        break;
       default:
         throw new Error(`Unknown option: ${arg}`);
     }

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -12,11 +12,6 @@ import {
 } from "../index";
 import { WRITABLE_NOTE_TYPES, isWritableNoteType } from "../memory-write";
 import { SOMA_MEMORY_ACTION_APPROVALS } from "../types";
-import {
-  writeSessionDigestFromTranscript,
-  type ClaudeSessionDigestOptions,
-  type ClaudeSessionDigestResult,
-} from "../adapters/claude-code/session-digest";
 import type {
   SomaMemoryActionApproval,
   SomaMemoryActionOptions,
@@ -89,16 +84,10 @@ export interface ParsedMemoryReindexArgs {
   options: MemoryReindexOptions;
 }
 
-/** A digest is authored EITHER by the assistant (`--body`) OR deterministically from
- *  a transcript by the SessionEnd fallback (`--transcript`). */
-export type ParsedMemoryDigest =
-  | { mode: "body"; options: SomaMemoryDigestOptions }
-  | { mode: "transcript"; options: ClaudeSessionDigestOptions };
-
 export interface ParsedMemoryDigestArgs {
   command: "memory";
   action: "digest";
-  options: ParsedMemoryDigest;
+  options: SomaMemoryDigestOptions;
 }
 
 export interface ParsedMemoryActionArgs {
@@ -161,8 +150,9 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
       "Rebuild memory/INDEX.md from note frontmatter (earned-inclusion ladder, retention-score budget); " +
       "ages are computed against the current date, so 'verified Nd ago' advances day to day. Quarantined notes never appear.",
     digest:
-      "Usage: soma memory digest --session <id> (--body <text> | --transcript <path>) [--agent-id <id>] [--agent-type <t>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
-      "Write the ONE session digest (8–15 non-empty lines). --body is assistant-authored; --transcript is the deterministic SessionEnd fallback (extracts the body, marks hook: session-end, suppresses sub-agent sessions per ADR 0014 unless SOMA_MEMORY_FORCE_PRIMARY=1). A second digest for the same session no-ops with an event.",
+      "Usage: soma memory digest --session <id> --body <text> [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
+      "Write the ONE assistant-authored session digest (8–15 non-empty lines). A second digest for the same session no-ops with an event. " +
+      "(The deterministic SessionEnd fallback is a Claude Code adapter concern — see `soma lifecycle session-end`.)",
     action:
       "Usage: soma memory action --slug <slug> --planned-action <text> --approval <proposed|approved|rejected|auto> " +
       "[--outcome <text>] [--session <id>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
@@ -284,67 +274,35 @@ function consumeSharedMemoryOption(
   }
 }
 
-function parseMemoryDigestArgs(args: string[]): ParsedMemoryDigest {
-  const shared: { homeDir?: string; somaHome?: string; substrate?: SubstrateId } = {};
-  let sessionId: string | undefined;
-  let body: string | undefined;
-  let transcript: string | undefined;
-  let agentId: string | undefined;
-  let agentType: string | undefined;
+function parseMemoryDigestArgs(args: string[]): SomaMemoryDigestOptions {
+  const options: Partial<SomaMemoryDigestOptions> = {};
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    const consumed = consumeSharedMemoryOption(args, index, arg, shared);
+    const consumed = consumeSharedMemoryOption(args, index, arg, options);
     if (consumed > 0) {
       index += consumed;
       continue;
     }
     switch (arg) {
       case "--session":
-        sessionId = readOption(args, index, arg);
+        options.sessionId = readOption(args, index, arg);
         index += 1;
         break;
       case "--body":
-        body = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--transcript":
-        transcript = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--agent-id":
-        agentId = readOption(args, index, arg);
-        index += 1;
-        break;
-      case "--agent-type":
-        agentType = readOption(args, index, arg);
+        options.body = readOption(args, index, arg);
         index += 1;
         break;
       default:
         throw new Error(`Unknown option: ${arg}`);
     }
   }
-  if (!sessionId) throw new Error("soma memory digest is missing required option: --session.");
-  if (body !== undefined && transcript !== undefined) {
-    throw new Error("soma memory digest takes exactly one of --body (assistant-authored) or --transcript (SessionEnd fallback), not both.");
+  const missing: string[] = [];
+  if (!options.sessionId) missing.push("--session");
+  if (options.body === undefined) missing.push("--body");
+  if (missing.length > 0) {
+    throw new Error(`soma memory digest is missing required option(s): ${missing.join(", ")}.`);
   }
-  if (transcript !== undefined) {
-    // Sub-agent suppression (ADR 0014) and its overrides are read from the env here —
-    // the SDK stays pure and takes explicit booleans.
-    return {
-      mode: "transcript",
-      options: {
-        ...shared,
-        sessionId,
-        transcriptPath: transcript,
-        agentId,
-        agentType,
-        forcePrimary: process.env.SOMA_MEMORY_FORCE_PRIMARY === "1",
-        forceSubagent: process.env.SOMA_MEMORY_FORCE_SUBAGENT === "1",
-      },
-    };
-  }
-  if (body === undefined) throw new Error("soma memory digest is missing required option: --body (or --transcript).");
-  return { mode: "body", options: { ...shared, sessionId, body } };
+  return options as SomaMemoryDigestOptions;
 }
 
 function parseActionApproval(value: string): SomaMemoryActionApproval {
@@ -770,9 +728,7 @@ export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
     case "reindex":
       return formatMemoryReindexResult(await rebuildMemoryIndex(parsed.options));
     case "digest":
-      return parsed.options.mode === "transcript"
-        ? formatMemoryDigestFromTranscriptResult(await writeSessionDigestFromTranscript(parsed.options.options))
-        : formatMemoryDigestResult(await writeSessionDigest(parsed.options.options));
+      return formatMemoryDigestResult(await writeSessionDigest(parsed.options));
     case "action":
       return formatMemoryActionResult(await writeMemoryAction(parsed.options));
     case "consolidate":
@@ -840,12 +796,6 @@ function formatMemoryDigestResult(result: SomaMemoryDigestResult): string {
     `path: ${result.path}`,
     `event: ${result.event.id}`,
   ].join("\n");
-}
-
-function formatMemoryDigestFromTranscriptResult(result: ClaudeSessionDigestResult): string {
-  const header = `Soma memory digest (SessionEnd fallback): ${result.outcome} — ${result.reason}`;
-  if (result.digest === undefined) return header; // suppressed / skipped
-  return [header, `id: ${result.digest.note.id}`, `path: ${result.digest.path}`].join("\n");
 }
 
 function formatMemoryActionResult(result: SomaMemoryActionResult): string {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -2,7 +2,6 @@ import {
   auditMemory,
   consolidateMemory,
   promoteAlgorithmRunMemory,
-  writeSessionDigestFromTranscript,
   rebuildMemoryIndex,
   recallMemory,
   searchSomaMemory,
@@ -13,7 +12,11 @@ import {
 } from "../index";
 import { WRITABLE_NOTE_TYPES, isWritableNoteType } from "../memory-write";
 import { SOMA_MEMORY_ACTION_APPROVALS } from "../types";
-import type { ClaudeSessionDigestOptions, ClaudeSessionDigestResult } from "../adapters/claude-code/session-digest";
+import {
+  writeSessionDigestFromTranscript,
+  type ClaudeSessionDigestOptions,
+  type ClaudeSessionDigestResult,
+} from "../adapters/claude-code/session-digest";
 import type {
   SomaMemoryActionApproval,
   SomaMemoryActionOptions,

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -2,6 +2,7 @@ import {
   auditMemory,
   consolidateMemory,
   promoteAlgorithmRunMemory,
+  writeSessionDigestFromTranscript,
   rebuildMemoryIndex,
   recallMemory,
   searchSomaMemory,
@@ -18,6 +19,8 @@ import type {
   SomaMemoryActionResult,
   SomaMemoryAuditOptions,
   SomaMemoryAuditResult,
+  SomaMemoryDigestFromTranscriptOptions,
+  SomaMemoryDigestFromTranscriptResult,
   SomaMemoryConsolidateOptions,
   SomaMemoryConsolidateResult,
   SomaMemoryDigestOptions,
@@ -84,10 +87,16 @@ export interface ParsedMemoryReindexArgs {
   options: MemoryReindexOptions;
 }
 
+/** A digest is authored EITHER by the assistant (`--body`) OR deterministically from
+ *  a transcript by the SessionEnd fallback (`--transcript`). */
+export type ParsedMemoryDigest =
+  | { mode: "body"; options: SomaMemoryDigestOptions }
+  | { mode: "transcript"; options: SomaMemoryDigestFromTranscriptOptions };
+
 export interface ParsedMemoryDigestArgs {
   command: "memory";
   action: "digest";
-  options: SomaMemoryDigestOptions;
+  options: ParsedMemoryDigest;
 }
 
 export interface ParsedMemoryActionArgs {
@@ -150,8 +159,8 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
       "Rebuild memory/INDEX.md from note frontmatter (earned-inclusion ladder, retention-score budget); " +
       "ages are computed against the current date, so 'verified Nd ago' advances day to day. Quarantined notes never appear.",
     digest:
-      "Usage: soma memory digest --session <id> --body <text> [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
-      "Write the ONE session digest (8–15 non-empty lines). A second digest for the same session no-ops with an event.",
+      "Usage: soma memory digest --session <id> (--body <text> | --transcript <path>) [--agent-id <id>] [--agent-type <t>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
+      "Write the ONE session digest (8–15 non-empty lines). --body is assistant-authored; --transcript is the deterministic SessionEnd fallback (extracts the body, marks hook: session-end, suppresses sub-agent sessions per ADR 0014 unless SOMA_MEMORY_FORCE_PRIMARY=1). A second digest for the same session no-ops with an event.",
     action:
       "Usage: soma memory action --slug <slug> --planned-action <text> --approval <proposed|approved|rejected|auto> " +
       "[--outcome <text>] [--session <id>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
@@ -273,35 +282,67 @@ function consumeSharedMemoryOption(
   }
 }
 
-function parseMemoryDigestArgs(args: string[]): SomaMemoryDigestOptions {
-  const options: Partial<SomaMemoryDigestOptions> = {};
+function parseMemoryDigestArgs(args: string[]): ParsedMemoryDigest {
+  const shared: { homeDir?: string; somaHome?: string; substrate?: SubstrateId } = {};
+  let sessionId: string | undefined;
+  let body: string | undefined;
+  let transcript: string | undefined;
+  let agentId: string | undefined;
+  let agentType: string | undefined;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
-    const consumed = consumeSharedMemoryOption(args, index, arg, options);
+    const consumed = consumeSharedMemoryOption(args, index, arg, shared);
     if (consumed > 0) {
       index += consumed;
       continue;
     }
     switch (arg) {
       case "--session":
-        options.sessionId = readOption(args, index, arg);
+        sessionId = readOption(args, index, arg);
         index += 1;
         break;
       case "--body":
-        options.body = readOption(args, index, arg);
+        body = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--transcript":
+        transcript = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--agent-id":
+        agentId = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--agent-type":
+        agentType = readOption(args, index, arg);
         index += 1;
         break;
       default:
         throw new Error(`Unknown option: ${arg}`);
     }
   }
-  const missing: string[] = [];
-  if (!options.sessionId) missing.push("--session");
-  if (options.body === undefined) missing.push("--body");
-  if (missing.length > 0) {
-    throw new Error(`soma memory digest is missing required option(s): ${missing.join(", ")}.`);
+  if (!sessionId) throw new Error("soma memory digest is missing required option: --session.");
+  if (body !== undefined && transcript !== undefined) {
+    throw new Error("soma memory digest takes exactly one of --body (assistant-authored) or --transcript (SessionEnd fallback), not both.");
   }
-  return options as SomaMemoryDigestOptions;
+  if (transcript !== undefined) {
+    // Sub-agent suppression (ADR 0014) and its overrides are read from the env here —
+    // the SDK stays pure and takes explicit booleans.
+    return {
+      mode: "transcript",
+      options: {
+        ...shared,
+        sessionId,
+        transcriptPath: transcript,
+        agentId,
+        agentType,
+        forcePrimary: process.env.SOMA_MEMORY_FORCE_PRIMARY === "1",
+        forceSubagent: process.env.SOMA_MEMORY_FORCE_SUBAGENT === "1",
+      },
+    };
+  }
+  if (body === undefined) throw new Error("soma memory digest is missing required option: --body (or --transcript).");
+  return { mode: "body", options: { ...shared, sessionId, body } };
 }
 
 function parseActionApproval(value: string): SomaMemoryActionApproval {
@@ -727,7 +768,9 @@ export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
     case "reindex":
       return formatMemoryReindexResult(await rebuildMemoryIndex(parsed.options));
     case "digest":
-      return formatMemoryDigestResult(await writeSessionDigest(parsed.options));
+      return parsed.options.mode === "transcript"
+        ? formatMemoryDigestFromTranscriptResult(await writeSessionDigestFromTranscript(parsed.options.options))
+        : formatMemoryDigestResult(await writeSessionDigest(parsed.options.options));
     case "action":
       return formatMemoryActionResult(await writeMemoryAction(parsed.options));
     case "consolidate":
@@ -795,6 +838,12 @@ function formatMemoryDigestResult(result: SomaMemoryDigestResult): string {
     `path: ${result.path}`,
     `event: ${result.event.id}`,
   ].join("\n");
+}
+
+function formatMemoryDigestFromTranscriptResult(result: SomaMemoryDigestFromTranscriptResult): string {
+  const header = `Soma memory digest (SessionEnd fallback): ${result.outcome} — ${result.reason}`;
+  if (result.digest === undefined) return header; // suppressed / skipped
+  return [header, `id: ${result.digest.note.id}`, `path: ${result.digest.path}`].join("\n");
 }
 
 function formatMemoryActionResult(result: SomaMemoryActionResult): string {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -13,14 +13,13 @@ import {
 } from "../index";
 import { WRITABLE_NOTE_TYPES, isWritableNoteType } from "../memory-write";
 import { SOMA_MEMORY_ACTION_APPROVALS } from "../types";
+import type { ClaudeSessionDigestOptions, ClaudeSessionDigestResult } from "../adapters/claude-code/session-digest";
 import type {
   SomaMemoryActionApproval,
   SomaMemoryActionOptions,
   SomaMemoryActionResult,
   SomaMemoryAuditOptions,
   SomaMemoryAuditResult,
-  SomaMemoryDigestFromTranscriptOptions,
-  SomaMemoryDigestFromTranscriptResult,
   SomaMemoryConsolidateOptions,
   SomaMemoryConsolidateResult,
   SomaMemoryDigestOptions,
@@ -91,7 +90,7 @@ export interface ParsedMemoryReindexArgs {
  *  a transcript by the SessionEnd fallback (`--transcript`). */
 export type ParsedMemoryDigest =
   | { mode: "body"; options: SomaMemoryDigestOptions }
-  | { mode: "transcript"; options: SomaMemoryDigestFromTranscriptOptions };
+  | { mode: "transcript"; options: ClaudeSessionDigestOptions };
 
 export interface ParsedMemoryDigestArgs {
   command: "memory";
@@ -840,7 +839,7 @@ function formatMemoryDigestResult(result: SomaMemoryDigestResult): string {
   ].join("\n");
 }
 
-function formatMemoryDigestFromTranscriptResult(result: SomaMemoryDigestFromTranscriptResult): string {
+function formatMemoryDigestFromTranscriptResult(result: ClaudeSessionDigestResult): string {
   const header = `Soma memory digest (SessionEnd fallback): ${result.outcome} — ${result.reason}`;
   if (result.digest === undefined) return header; // suppressed / skipped
   return [header, `id: ${result.digest.note.id}`, `path: ${result.digest.path}`].join("\n");

--- a/src/index.ts
+++ b/src/index.ts
@@ -468,7 +468,13 @@ export { recallMemory } from "./memory-recall";
 // storage path are not frozen as stable API — episodic joins at M5); internal soma
 // modules and tests import them from "./memory-index" directly.
 export { rebuildMemoryIndex } from "./memory-index";
-export { writeSessionDigest, writeMemoryAction, writeSessionDigestFromTranscript, extractDigestBodyFromTranscript } from "./memory-episodic";
+export { writeSessionDigest, writeMemoryAction, hasSessionDigest } from "./memory-episodic";
+export {
+  extractDigestBodyFromTranscript,
+  writeSessionDigestFromTranscript,
+  type ClaudeSessionDigestOptions,
+  type ClaudeSessionDigestResult,
+} from "./adapters/claude-code/session-digest";
 export { consolidateMemory } from "./memory-consolidate";
 export { auditMemory } from "./memory-audit";
 export { createSomaSnapshot, listSomaSnapshots, rollbackSomaSnapshot } from "./snapshots";

--- a/src/index.ts
+++ b/src/index.ts
@@ -469,12 +469,11 @@ export { recallMemory } from "./memory-recall";
 // modules and tests import them from "./memory-index" directly.
 export { rebuildMemoryIndex } from "./memory-index";
 export { writeSessionDigest, writeMemoryAction, hasSessionDigest } from "./memory-episodic";
-export {
-  extractDigestBodyFromTranscript,
-  writeSessionDigestFromTranscript,
-  type ClaudeSessionDigestOptions,
-  type ClaudeSessionDigestResult,
-} from "./adapters/claude-code/session-digest";
+// The Claude Code SessionEnd transcript fallback (extractDigestBodyFromTranscript /
+// writeSessionDigestFromTranscript / ClaudeSessionDigest*) is adapter-specific and is
+// NOT re-exported from the package root — the CLI and tests import it directly from
+// `./adapters/claude-code/session-digest`, keeping the root substrate-neutral
+// (docs/architecture.md#Core; sage m5b r2).
 export { consolidateMemory } from "./memory-consolidate";
 export { auditMemory } from "./memory-audit";
 export { createSomaSnapshot, listSomaSnapshots, rollbackSomaSnapshot } from "./snapshots";

--- a/src/index.ts
+++ b/src/index.ts
@@ -468,7 +468,7 @@ export { recallMemory } from "./memory-recall";
 // storage path are not frozen as stable API — episodic joins at M5); internal soma
 // modules and tests import them from "./memory-index" directly.
 export { rebuildMemoryIndex } from "./memory-index";
-export { writeSessionDigest, writeMemoryAction } from "./memory-episodic";
+export { writeSessionDigest, writeMemoryAction, writeSessionDigestFromTranscript, extractDigestBodyFromTranscript } from "./memory-episodic";
 export { consolidateMemory } from "./memory-consolidate";
 export { auditMemory } from "./memory-audit";
 export { createSomaSnapshot, listSomaSnapshots, rollbackSomaSnapshot } from "./snapshots";

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -722,7 +722,7 @@ export type SessionEndTranscriptHandler = (input: {
   subagentType?: string;
   forcePrimary?: boolean;
   forceSubagent?: boolean;
-}) => Promise<{ outcome: string }>;
+}) => Promise<{ outcome: string; path?: string }>;
 
 const sessionEndTranscriptHandlers = new Map<SubstrateId, SessionEndTranscriptHandler>();
 
@@ -780,6 +780,7 @@ export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions =
   // registerSessionEndTranscriptHandler) which core looks up by substrate here.
   // Best-effort: never blocks session end.
   let digestNote = "";
+  let digestPath: string | undefined;
   const transcriptHandler = sessionEndTranscriptHandlers.get(substrate(options));
   if (options.transcriptPath && options.sessionId && transcriptHandler) {
     try {
@@ -795,6 +796,7 @@ export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions =
         forceSubagent: process.env.SOMA_MEMORY_FORCE_SUBAGENT === "1",
       });
       digestNote = ` | digest: ${fallback.outcome}`;
+      digestPath = fallback.path; // so lifecycle reports the written digest file below
     } catch {
       // A fallback failure must never block session end.
     }
@@ -813,6 +815,7 @@ export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions =
   });
 
   const files = [index.path, index.activePath, ...learningFiles, ...registryFiles, join(somaHome, "memory/STATE/events.jsonl")];
+  if (digestPath) files.push(digestPath); // the SessionEnd fallback digest, when written
   return {
     event: "session_end",
     somaHome,

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -6,9 +6,6 @@ import { promisify } from "node:util";
 import { listAlgorithmRunSummaries, listAlgorithmRuns, readAlgorithmRunById, writeAlgorithmRun } from "./algorithm-store";
 import { appendAlgorithmProvenance } from "./algorithm-provenance";
 import { appendSomaMemoryEvent } from "./memory";
-// Substrate-integration boundary: lifecycle dispatches the substrate-specific digest
-// fallback to the Claude Code transcript adapter (keeps `soma memory digest` neutral).
-import { writeSessionDigestFromTranscript } from "./adapters/claude-code/session-digest";
 import { loadSomaProfile } from "./soma-home";
 import { normalizeSomaWorkRegistryArtifacts, upsertSomaCurrentWorkPointer } from "./work-registry";
 import { SECTION_NAME_MAP, getCriteria, getGoal } from "./vsa-accessors";
@@ -709,6 +706,31 @@ function normalizeLifecycleArtifactPaths(somaHome: string, artifactPaths: string
   return Object.values(normalizeSomaWorkRegistryArtifacts({ somaHome }, artifacts));
 }
 
+/**
+ * A substrate-registered SessionEnd transcript-digest handler. Dependency INVERSION:
+ * core lifecycle owns this neutral hook point; a substrate adapter (e.g. claude-code)
+ * registers its transcript→digest fallback, so core never imports an adapter. The
+ * transcript FORMAT stays entirely inside the adapter.
+ */
+export type SessionEndTranscriptHandler = (input: {
+  somaHome: string;
+  now: Date;
+  substrate: SubstrateId;
+  sessionId: string;
+  transcriptPath: string;
+  agentId?: string;
+  agentType?: string;
+  forcePrimary?: boolean;
+  forceSubagent?: boolean;
+}) => Promise<{ outcome: string }>;
+
+const sessionEndTranscriptHandlers = new Map<SubstrateId, SessionEndTranscriptHandler>();
+
+/** Register a substrate's SessionEnd transcript-digest fallback (see the type doc). */
+export function registerSessionEndTranscriptHandler(substrate: SubstrateId, handler: SessionEndTranscriptHandler): void {
+  sessionEndTranscriptHandlers.set(substrate, handler);
+}
+
 export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions = {}): Promise<SomaLifecycleResult> {
   const somaHome = resolveSomaHome(options);
   const timestamp = options.timestamp ?? new Date().toISOString();
@@ -752,14 +774,16 @@ export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions =
     }
   }
 
-  // M5b deterministic digest FALLBACK. The transcript FORMAT is substrate-specific,
-  // so lifecycle (the substrate-integration boundary) dispatches to the substrate's
-  // transcript adapter — currently only claude-code. The neutral `soma memory digest`
-  // stays body-only. Best-effort: never blocks session end.
+  // M5b deterministic digest FALLBACK — dependency-INVERTED so core stays
+  // substrate-neutral. The transcript FORMAT is substrate-specific, so core does not
+  // import any adapter; instead a substrate REGISTERS a handler (see
+  // registerSessionEndTranscriptHandler) which core looks up by substrate here.
+  // Best-effort: never blocks session end.
   let digestNote = "";
-  if (options.transcriptPath && options.sessionId && substrate(options) === "claude-code") {
+  const transcriptHandler = sessionEndTranscriptHandlers.get(substrate(options));
+  if (options.transcriptPath && options.sessionId && transcriptHandler) {
     try {
-      const fallback = await writeSessionDigestFromTranscript({
+      const fallback = await transcriptHandler({
         somaHome,
         now: new Date(timestamp),
         substrate: substrate(options),

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -778,7 +778,9 @@ export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions =
   // substrate-neutral. The transcript FORMAT is substrate-specific, so core does not
   // import any adapter; instead a substrate REGISTERS a handler (see
   // registerSessionEndTranscriptHandler) which core looks up by substrate here.
-  // Best-effort: never blocks session end.
+  // Best-effort: a thrown handler failure is swallowed so it never FAILS session end —
+  // but the handler IS awaited, so its transcript read/parse/write latency is on the
+  // session-end path (the dedup-before-read keeps the common no-op path cheap).
   let digestNote = "";
   let digestPath: string | undefined;
   const transcriptHandler = sessionEndTranscriptHandlers.get(substrate(options));

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -6,6 +6,9 @@ import { promisify } from "node:util";
 import { listAlgorithmRunSummaries, listAlgorithmRuns, readAlgorithmRunById, writeAlgorithmRun } from "./algorithm-store";
 import { appendAlgorithmProvenance } from "./algorithm-provenance";
 import { appendSomaMemoryEvent } from "./memory";
+// Substrate-integration boundary: lifecycle dispatches the substrate-specific digest
+// fallback to the Claude Code transcript adapter (keeps `soma memory digest` neutral).
+import { writeSessionDigestFromTranscript } from "./adapters/claude-code/session-digest";
 import { loadSomaProfile } from "./soma-home";
 import { normalizeSomaWorkRegistryArtifacts, upsertSomaCurrentWorkPointer } from "./work-registry";
 import { SECTION_NAME_MAP, getCriteria, getGoal } from "./vsa-accessors";
@@ -749,10 +752,34 @@ export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions =
     }
   }
 
+  // M5b deterministic digest FALLBACK. The transcript FORMAT is substrate-specific,
+  // so lifecycle (the substrate-integration boundary) dispatches to the substrate's
+  // transcript adapter — currently only claude-code. The neutral `soma memory digest`
+  // stays body-only. Best-effort: never blocks session end.
+  let digestNote = "";
+  if (options.transcriptPath && options.sessionId && substrate(options) === "claude-code") {
+    try {
+      const fallback = await writeSessionDigestFromTranscript({
+        somaHome,
+        now: new Date(timestamp),
+        substrate: substrate(options),
+        sessionId: options.sessionId,
+        transcriptPath: options.transcriptPath,
+        agentId: options.agentId,
+        agentType: options.agentType,
+        forcePrimary: process.env.SOMA_MEMORY_FORCE_PRIMARY === "1",
+        forceSubagent: process.env.SOMA_MEMORY_FORCE_SUBAGENT === "1",
+      });
+      digestNote = ` | digest: ${fallback.outcome}`;
+    } catch {
+      // A fallback failure must never block session end.
+    }
+  }
+
   await appendSomaMemoryEvent(somaHome, {
     substrate: substrate(options),
     kind: "lifecycle.session_end",
-    summary: `Session ended; captured ${learningFiles.length} Algorithm learning artifact(s).${tierGateNote}`,
+    summary: `Session ended; captured ${learningFiles.length} Algorithm learning artifact(s).${tierGateNote}${digestNote}`,
     timestamp,
     artifactPaths: normalizeLifecycleArtifactPaths(somaHome, [index.path, index.activePath, ...learningFiles, ...registryFiles]),
     metadata: {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -718,8 +718,8 @@ export type SessionEndTranscriptHandler = (input: {
   substrate: SubstrateId;
   sessionId: string;
   transcriptPath: string;
-  agentId?: string;
-  agentType?: string;
+  subagentId?: string;
+  subagentType?: string;
   forcePrimary?: boolean;
   forceSubagent?: boolean;
 }) => Promise<{ outcome: string }>;
@@ -789,8 +789,8 @@ export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions =
         substrate: substrate(options),
         sessionId: options.sessionId,
         transcriptPath: options.transcriptPath,
-        agentId: options.agentId,
-        agentType: options.agentType,
+        subagentId: options.subagentId,
+        subagentType: options.subagentType,
         forcePrimary: process.env.SOMA_MEMORY_FORCE_PRIMARY === "1",
         forceSubagent: process.env.SOMA_MEMORY_FORCE_SUBAGENT === "1",
       });

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -9,8 +9,6 @@ import { SOMA_MEMORY_ACTION_APPROVALS } from "./types";
 import type {
   SomaMemoryActionOptions,
   SomaMemoryActionResult,
-  SomaMemoryDigestFromTranscriptOptions,
-  SomaMemoryDigestFromTranscriptResult,
   SomaMemoryDigestOptions,
   SomaMemoryDigestResult,
   SomaMemoryEvent,
@@ -154,6 +152,17 @@ async function findExistingSessionDigestPath(somaHome: string, slug: string): Pr
     if (match) return join(monthDirPath, match);
   }
   return undefined;
+}
+
+/**
+ * Cheap, substrate-neutral check: does a session already have a digest? Reuses the
+ * date-independent one-per-session scan. Lets a caller (e.g. a SessionEnd fallback)
+ * skip expensive body preparation when an assistant-authored digest already exists.
+ */
+export async function hasSessionDigest(options: { homeDir?: string; somaHome?: string; sessionId: string }): Promise<boolean> {
+  const somaHome = createPaths(options).root();
+  assertNonEmpty(options.sessionId, "sessionId");
+  return (await findExistingSessionDigestPath(somaHome, sessionSlug(options.sessionId))) !== undefined;
 }
 
 /** Build an episodic note (assistant trust, assistant-authored account). */
@@ -310,165 +319,6 @@ export async function writeSessionDigest(options: SomaMemoryDigestOptions): Prom
     }
     throw error;
   }
-}
-
-// --- SessionEnd deterministic fallback (M5b) ---------------------------------
-
-// A deterministic fallback needs enough genuine prompts to make a useful 8–15-line
-// digest — below this it skips (the assistant self-authors small sessions instead).
-const FALLBACK_MIN_PROMPTS = 6;
-const FALLBACK_MAX_PROMPT_LINES = 13; // + 2 structural (header + tools) = 15 max
-const PROMPT_LINE_MAX_CHARS = 120;
-
-/** Wrapper/noise prefixes that mark a "user" line as NOT a genuine principal prompt. */
-const PROMPT_NOISE_PREFIXES = [
-  "<command-name>",
-  "<command-message>",
-  "<local-command-",
-  "<system-reminder>",
-  "caveat:",
-  "<user-prompt-submit-hook>",
-];
-
-/** Collapse control chars + whitespace and truncate — one clean digest pointer line. */
-function cleanLine(text: string): string {
-  const collapsed = text.replace(/[\u0000-\u001F\u007F-\u009F]+/g, " ").replace(/\s+/g, " ").trim();
-  return collapsed.length > PROMPT_LINE_MAX_CHARS ? `${collapsed.slice(0, PROMPT_LINE_MAX_CHARS - 1)}…` : collapsed;
-}
-
-/** The text of a transcript message's `content` (string, or joined `text` parts). */
-function messageText(content: unknown): string {
-  if (typeof content === "string") return content;
-  if (Array.isArray(content)) {
-    return content
-      .filter((part): part is { type?: unknown; text?: unknown } => part !== null && typeof part === "object")
-      .filter((part) => part.type === "text" && typeof part.text === "string")
-      .map((part) => part.text as string)
-      .join(" ");
-  }
-  return "";
-}
-
-/**
- * Deterministically extract an 8–15-line digest body from a Claude Code transcript
- * (JSONL). No LLM: it lists the genuine principal prompts (noise/tool/command lines
- * filtered, sidechain/sub-agent lines skipped) plus a header and a tool-use rollup.
- * Returns `undefined` when the session has too few real prompts to summarize.
- */
-export function extractDigestBodyFromTranscript(transcript: string): string | undefined {
-  const prompts: string[] = [];
-  const toolCounts = new Map<string, number>();
-  let assistantTurns = 0;
-
-  for (const raw of transcript.split("\n")) {
-    const line = raw.trim();
-    if (line.length === 0) continue;
-    let entry: Record<string, unknown>;
-    try {
-      entry = JSON.parse(line) as Record<string, unknown>;
-    } catch {
-      continue; // a non-JSON line — skip, never fail the whole extraction
-    }
-    if (entry.isSidechain === true || entry.isMeta === true) continue; // sub-agent / meta noise
-    const message = entry.message as { role?: unknown; content?: unknown } | undefined;
-    if (entry.type === "user" && message?.role === "user") {
-      // A real prompt is string content; a tool_result array is not principal text.
-      if (typeof message.content !== "string" && !isTextOnlyContent(message.content)) continue;
-      const text = cleanLine(messageText(message.content));
-      if (text.length === 0) continue;
-      const lower = text.toLowerCase();
-      if (PROMPT_NOISE_PREFIXES.some((p) => lower.startsWith(p))) continue;
-      prompts.push(text);
-    } else if (entry.type === "assistant" && message?.role === "assistant") {
-      assistantTurns += 1;
-      if (Array.isArray(message.content)) {
-        for (const part of message.content) {
-          if (part && typeof part === "object" && (part as { type?: unknown }).type === "tool_use") {
-            const name = (part as { name?: unknown }).name;
-            if (typeof name === "string") toolCounts.set(name, (toolCounts.get(name) ?? 0) + 1);
-          }
-        }
-      }
-    }
-  }
-
-  if (prompts.length < FALLBACK_MIN_PROMPTS) return undefined;
-
-  // Sample head + tail when there are many prompts, so the digest captures the arc.
-  const shown = samplePrompts(prompts, FALLBACK_MAX_PROMPT_LINES);
-  const totalTools = [...toolCounts.values()].reduce((sum, n) => sum + n, 0);
-  const topTools = [...toolCounts.entries()]
-    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-    .slice(0, 5)
-    .map(([name, n]) => `${name}×${n}`)
-    .join(", ");
-
-  const lines = [
-    `- session: ${prompts.length} principal prompts, ${assistantTurns} assistant turns, ${totalTools} tool calls`,
-    ...shown.map((p) => `- ${p}`),
-    `- tools: ${topTools.length > 0 ? topTools : "none"}`,
-  ];
-  return lines.join("\n");
-}
-
-/** True only for array content that is purely text parts (never a tool_result). */
-function isTextOnlyContent(content: unknown): boolean {
-  if (!Array.isArray(content) || content.length === 0) return false;
-  return content.every((part) => part !== null && typeof part === "object" && (part as { type?: unknown }).type === "text");
-}
-
-/** Head+tail sample to `max` lines, inserting an elision marker when trimmed. */
-function samplePrompts(prompts: string[], max: number): string[] {
-  if (prompts.length <= max) return prompts;
-  const head = Math.ceil((max - 1) / 2);
-  const tail = max - 1 - head;
-  return [...prompts.slice(0, head), `… (${prompts.length - head - tail} more prompts) …`, ...prompts.slice(prompts.length - tail)];
-}
-
-/**
- * SessionEnd fallback (M5b): write a deterministic digest from a transcript. Suppresses
- * sub-agent sessions (ADR 0014) unless `forcePrimary`; no-ops when an assistant digest
- * already exists (the one-per-session gate); skips when the transcript is too thin.
- * NEVER throws for an absent/unreadable transcript — the hook must not block a session.
- */
-export async function writeSessionDigestFromTranscript(
-  options: SomaMemoryDigestFromTranscriptOptions,
-): Promise<SomaMemoryDigestFromTranscriptResult> {
-  const isSubagent = options.forceSubagent === true || (options.forcePrimary !== true && hasAgentMarker(options));
-  if (isSubagent && options.forcePrimary !== true) {
-    return { outcome: "suppressed", reason: "sub-agent session (ADR 0014) — no fallback digest written" };
-  }
-
-  const transcript = await readFile(options.transcriptPath, "utf8").catch(() => undefined);
-  if (transcript === undefined) {
-    return { outcome: "skipped", reason: `transcript not readable at ${options.transcriptPath}` };
-  }
-  const body = extractDigestBodyFromTranscript(transcript);
-  if (body === undefined) {
-    return { outcome: "skipped", reason: "transcript has too few principal prompts for a fallback digest" };
-  }
-
-  const digest = await writeSessionDigest({
-    homeDir: options.homeDir,
-    somaHome: options.somaHome,
-    substrate: options.substrate,
-    now: options.now,
-    sessionId: options.sessionId,
-    body,
-    hook: "session-end",
-  });
-  return {
-    outcome: digest.created ? "written" : "duplicate",
-    digest,
-    reason: digest.created
-      ? "wrote a deterministic session-end fallback digest"
-      : "a digest already exists for this session — no-op",
-  };
-}
-
-/** A sub-agent invocation carries a non-empty agent id or type in the hook payload. */
-function hasAgentMarker(options: SomaMemoryDigestFromTranscriptOptions): boolean {
-  return (options.agentId ?? "").trim().length > 0 || (options.agentType ?? "").trim().length > 0;
 }
 
 /**

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -9,6 +9,8 @@ import { SOMA_MEMORY_ACTION_APPROVALS } from "./types";
 import type {
   SomaMemoryActionOptions,
   SomaMemoryActionResult,
+  SomaMemoryDigestFromTranscriptOptions,
+  SomaMemoryDigestFromTranscriptResult,
   SomaMemoryDigestOptions,
   SomaMemoryDigestResult,
   SomaMemoryEvent,
@@ -155,9 +157,9 @@ async function findExistingSessionDigestPath(somaHome: string, slug: string): Pr
 }
 
 /** Build an episodic note (assistant trust, assistant-authored account). */
-function buildEpisodicNote(id: string, now: Date, body: string): SomaMemoryNote {
+function buildEpisodicNote(id: string, now: Date, body: string, hook?: string): SomaMemoryNote {
   const today = isoDate(now);
-  return {
+  const note: SomaMemoryNote = {
     id,
     type: "episodic",
     created: today,
@@ -171,6 +173,8 @@ function buildEpisodicNote(id: string, now: Date, body: string): SomaMemoryNote 
     resurface_count: 0,
     body: body.trim(),
   };
+  if (hook !== undefined && hook.trim().length > 0) note.hook = hook.trim();
+  return note;
 }
 
 interface EpisodicWrite {
@@ -284,7 +288,7 @@ export async function writeSessionDigest(options: SomaMemoryDigestOptions): Prom
   }
 
   const path = episodicPath(somaHome, "sessions", now, id);
-  const note = buildEpisodicNote(id, now, options.body);
+  const note = buildEpisodicNote(id, now, options.body, options.hook);
   try {
     const event = await writeEpisodicNoteWithEvent({
       somaHome,
@@ -306,6 +310,165 @@ export async function writeSessionDigest(options: SomaMemoryDigestOptions): Prom
     }
     throw error;
   }
+}
+
+// --- SessionEnd deterministic fallback (M5b) ---------------------------------
+
+// A deterministic fallback needs enough genuine prompts to make a useful 8–15-line
+// digest — below this it skips (the assistant self-authors small sessions instead).
+const FALLBACK_MIN_PROMPTS = 6;
+const FALLBACK_MAX_PROMPT_LINES = 13; // + 2 structural (header + tools) = 15 max
+const PROMPT_LINE_MAX_CHARS = 120;
+
+/** Wrapper/noise prefixes that mark a "user" line as NOT a genuine principal prompt. */
+const PROMPT_NOISE_PREFIXES = [
+  "<command-name>",
+  "<command-message>",
+  "<local-command-",
+  "<system-reminder>",
+  "caveat:",
+  "<user-prompt-submit-hook>",
+];
+
+/** Collapse control chars + whitespace and truncate — one clean digest pointer line. */
+function cleanLine(text: string): string {
+  const collapsed = text.replace(/[\u0000-\u001F\u007F-\u009F]+/g, " ").replace(/\s+/g, " ").trim();
+  return collapsed.length > PROMPT_LINE_MAX_CHARS ? `${collapsed.slice(0, PROMPT_LINE_MAX_CHARS - 1)}…` : collapsed;
+}
+
+/** The text of a transcript message's `content` (string, or joined `text` parts). */
+function messageText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((part): part is { type?: unknown; text?: unknown } => part !== null && typeof part === "object")
+      .filter((part) => part.type === "text" && typeof part.text === "string")
+      .map((part) => part.text as string)
+      .join(" ");
+  }
+  return "";
+}
+
+/**
+ * Deterministically extract an 8–15-line digest body from a Claude Code transcript
+ * (JSONL). No LLM: it lists the genuine principal prompts (noise/tool/command lines
+ * filtered, sidechain/sub-agent lines skipped) plus a header and a tool-use rollup.
+ * Returns `undefined` when the session has too few real prompts to summarize.
+ */
+export function extractDigestBodyFromTranscript(transcript: string): string | undefined {
+  const prompts: string[] = [];
+  const toolCounts = new Map<string, number>();
+  let assistantTurns = 0;
+
+  for (const raw of transcript.split("\n")) {
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      continue; // a non-JSON line — skip, never fail the whole extraction
+    }
+    if (entry.isSidechain === true || entry.isMeta === true) continue; // sub-agent / meta noise
+    const message = entry.message as { role?: unknown; content?: unknown } | undefined;
+    if (entry.type === "user" && message?.role === "user") {
+      // A real prompt is string content; a tool_result array is not principal text.
+      if (typeof message.content !== "string" && !isTextOnlyContent(message.content)) continue;
+      const text = cleanLine(messageText(message.content));
+      if (text.length === 0) continue;
+      const lower = text.toLowerCase();
+      if (PROMPT_NOISE_PREFIXES.some((p) => lower.startsWith(p))) continue;
+      prompts.push(text);
+    } else if (entry.type === "assistant" && message?.role === "assistant") {
+      assistantTurns += 1;
+      if (Array.isArray(message.content)) {
+        for (const part of message.content) {
+          if (part && typeof part === "object" && (part as { type?: unknown }).type === "tool_use") {
+            const name = (part as { name?: unknown }).name;
+            if (typeof name === "string") toolCounts.set(name, (toolCounts.get(name) ?? 0) + 1);
+          }
+        }
+      }
+    }
+  }
+
+  if (prompts.length < FALLBACK_MIN_PROMPTS) return undefined;
+
+  // Sample head + tail when there are many prompts, so the digest captures the arc.
+  const shown = samplePrompts(prompts, FALLBACK_MAX_PROMPT_LINES);
+  const totalTools = [...toolCounts.values()].reduce((sum, n) => sum + n, 0);
+  const topTools = [...toolCounts.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 5)
+    .map(([name, n]) => `${name}×${n}`)
+    .join(", ");
+
+  const lines = [
+    `- session: ${prompts.length} principal prompts, ${assistantTurns} assistant turns, ${totalTools} tool calls`,
+    ...shown.map((p) => `- ${p}`),
+    `- tools: ${topTools.length > 0 ? topTools : "none"}`,
+  ];
+  return lines.join("\n");
+}
+
+/** True only for array content that is purely text parts (never a tool_result). */
+function isTextOnlyContent(content: unknown): boolean {
+  if (!Array.isArray(content) || content.length === 0) return false;
+  return content.every((part) => part !== null && typeof part === "object" && (part as { type?: unknown }).type === "text");
+}
+
+/** Head+tail sample to `max` lines, inserting an elision marker when trimmed. */
+function samplePrompts(prompts: string[], max: number): string[] {
+  if (prompts.length <= max) return prompts;
+  const head = Math.ceil((max - 1) / 2);
+  const tail = max - 1 - head;
+  return [...prompts.slice(0, head), `… (${prompts.length - head - tail} more prompts) …`, ...prompts.slice(prompts.length - tail)];
+}
+
+/**
+ * SessionEnd fallback (M5b): write a deterministic digest from a transcript. Suppresses
+ * sub-agent sessions (ADR 0014) unless `forcePrimary`; no-ops when an assistant digest
+ * already exists (the one-per-session gate); skips when the transcript is too thin.
+ * NEVER throws for an absent/unreadable transcript — the hook must not block a session.
+ */
+export async function writeSessionDigestFromTranscript(
+  options: SomaMemoryDigestFromTranscriptOptions,
+): Promise<SomaMemoryDigestFromTranscriptResult> {
+  const isSubagent = options.forceSubagent === true || (options.forcePrimary !== true && hasAgentMarker(options));
+  if (isSubagent && options.forcePrimary !== true) {
+    return { outcome: "suppressed", reason: "sub-agent session (ADR 0014) — no fallback digest written" };
+  }
+
+  const transcript = await readFile(options.transcriptPath, "utf8").catch(() => undefined);
+  if (transcript === undefined) {
+    return { outcome: "skipped", reason: `transcript not readable at ${options.transcriptPath}` };
+  }
+  const body = extractDigestBodyFromTranscript(transcript);
+  if (body === undefined) {
+    return { outcome: "skipped", reason: "transcript has too few principal prompts for a fallback digest" };
+  }
+
+  const digest = await writeSessionDigest({
+    homeDir: options.homeDir,
+    somaHome: options.somaHome,
+    substrate: options.substrate,
+    now: options.now,
+    sessionId: options.sessionId,
+    body,
+    hook: "session-end",
+  });
+  return {
+    outcome: digest.created ? "written" : "duplicate",
+    digest,
+    reason: digest.created
+      ? "wrote a deterministic session-end fallback digest"
+      : "a digest already exists for this session — no-op",
+  };
+}
+
+/** A sub-agent invocation carries a non-empty agent id or type in the hook payload. */
+function hasAgentMarker(options: SomaMemoryDigestFromTranscriptOptions): boolean {
+  return (options.agentId ?? "").trim().length > 0 || (options.agentType ?? "").trim().length > 0;
 }
 
 /**

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -170,7 +170,20 @@ export async function hasSessionDigest(options: { homeDir?: string; somaHome?: s
  * account); a machine-extracted digest passes a distinct `tool:<name>` provenance so
  * recall's trust banner shows the body was NOT assistant-authored.
  */
+// Provenance grammar (mirrors the M0 note schema): a closed set plus the open
+// `tool:<name>` family. Validated HERE so a caller-supplied override can't persist a
+// forged/malformed provenance into trusted recall metadata.
+const PROVENANCE_LITERALS = new Set(["conversation", "consolidation", "import"]);
+const TOOL_PROVENANCE = /^tool:[a-z0-9][a-z0-9._-]{0,63}$/i;
+
+function assertProvenance(provenance: string): void {
+  if (!PROVENANCE_LITERALS.has(provenance) && !TOOL_PROVENANCE.test(provenance)) {
+    throw new MemoryNoteError(`provenance "${provenance}" must be conversation, consolidation, import, or tool:<name>.`, "provenance");
+  }
+}
+
 function buildEpisodicNote(id: string, now: Date, body: string, hook?: string, provenance?: string): SomaMemoryNote {
+  if (provenance !== undefined) assertProvenance(provenance);
   const today = isoDate(now);
   const note: SomaMemoryNote = {
     id,

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -314,7 +314,7 @@ export async function writeSessionDigest(options: SomaMemoryDigestOptions): Prom
   }
 
   const path = episodicPath(somaHome, "sessions", now, id);
-  const note = buildEpisodicNote(id, now, options.body, options.hook, options.provenance);
+  const note = buildEpisodicNote(id, now, options.body, options.lifecycleEvent, options.provenance);
   try {
     const event = await writeEpisodicNoteWithEvent({
       somaHome,

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -165,8 +165,12 @@ export async function hasSessionDigest(options: { homeDir?: string; somaHome?: s
   return (await findExistingSessionDigestPath(somaHome, sessionSlug(options.sessionId))) !== undefined;
 }
 
-/** Build an episodic note (assistant trust, assistant-authored account). */
-function buildEpisodicNote(id: string, now: Date, body: string, hook?: string): SomaMemoryNote {
+/**
+ * Build an episodic note. `provenance` defaults to `conversation` (an assistant's own
+ * account); a machine-extracted digest passes a distinct `tool:<name>` provenance so
+ * recall's trust banner shows the body was NOT assistant-authored.
+ */
+function buildEpisodicNote(id: string, now: Date, body: string, hook?: string, provenance?: string): SomaMemoryNote {
   const today = isoDate(now);
   const note: SomaMemoryNote = {
     id,
@@ -174,7 +178,7 @@ function buildEpisodicNote(id: string, now: Date, body: string, hook?: string): 
     created: today,
     last_verified: today,
     valid_until: null,
-    provenance: "conversation",
+    provenance: provenance ?? "conversation",
     trust: "assistant",
     source_of_truth: null,
     project: null,
@@ -297,7 +301,7 @@ export async function writeSessionDigest(options: SomaMemoryDigestOptions): Prom
   }
 
   const path = episodicPath(somaHome, "sessions", now, id);
-  const note = buildEpisodicNote(id, now, options.body, options.hook);
+  const note = buildEpisodicNote(id, now, options.body, options.hook, options.provenance);
   try {
     const event = await writeEpisodicNoteWithEvent({
       somaHome,

--- a/src/skills/Memory/Workflows/Remember.md
+++ b/src/skills/Memory/Workflows/Remember.md
@@ -53,10 +53,11 @@ soma memory digest --session <session-id> --body "<8–15 non-empty lines>"
 - **Do this before the session ends.** If you don't, the SessionEnd hook attempts a
   DETERMINISTIC fallback digest (`--transcript`, marked `hook: session-end`) — legible
   but mechanical, not a real summary. Prefer self-authoring for a genuine summary; the
-  fallback is only a BEST-EFFORT floor — it skips silently if the transcript is unreadable or
-  too thin, and writes nothing for a MARKED sub-agent session (ADR 0014; an unmarked
-  sub-agent is not detected), so it is not a guarantee. The fallback is a hook concern
-  — you invoke `--body`, never `--transcript`.
+  fallback is only a BEST-EFFORT floor — it writes nothing if the transcript is unreadable,
+  too thin, or refused (path outside the allowed root), and nothing for a MARKED sub-agent
+  session (ADR 0014; an unmarked sub-agent is not detected), so it is not a guarantee. Its
+  outcome is recorded on the `lifecycle.session_end` event (`digest: <outcome>`) — not
+  silent. The fallback is a hook concern — you invoke `--body`, never `--transcript`.
 
 ## Action log
 

--- a/src/skills/Memory/Workflows/Remember.md
+++ b/src/skills/Memory/Workflows/Remember.md
@@ -52,8 +52,8 @@ soma memory digest --session <session-id> --body "<8–15 non-empty lines>"
 - The body must be 8–15 non-empty lines; anything outside that is rejected.
 - **Do this before the session ends.** If you don't, the SessionEnd hook attempts a
   DETERMINISTIC fallback digest (`--transcript`, marked `hook: session-end`) — legible
-  but mechanical, not a real summary. Self-authoring is strictly better; the fallback
-  is only a BEST-EFFORT floor — it skips silently if the transcript is unreadable or
+  but mechanical, not a real summary. Prefer self-authoring for a genuine summary; the
+  fallback is only a BEST-EFFORT floor — it skips silently if the transcript is unreadable or
   too thin, and writes nothing for a sub-agent session (ADR 0014), so it is not a
   guarantee. The fallback is a hook concern — you invoke `--body`, never `--transcript`.
 

--- a/src/skills/Memory/Workflows/Remember.md
+++ b/src/skills/Memory/Workflows/Remember.md
@@ -40,6 +40,9 @@ Rules:
 
 ## Session digest
 
+At session WRAP-UP, self-author the digest — this is the primary, high-quality path
+(a real "what happened / what changed / open loops" summary at `trust: assistant`):
+
 ```
 soma memory digest --session <session-id> --body "<8–15 non-empty lines>"
 ```
@@ -47,6 +50,12 @@ soma memory digest --session <session-id> --body "<8–15 non-empty lines>"
 - Exactly ONE digest per session. A second call for the same session no-ops
   (and logs an event) — it never overwrites the first.
 - The body must be 8–15 non-empty lines; anything outside that is rejected.
+- **Do this before the session ends.** If you don't, the SessionEnd hook writes a
+  DETERMINISTIC fallback digest (`--transcript`, marked `hook: session-end`) — legible
+  but mechanical, not a real summary. Self-authoring is strictly better; the fallback
+  is only a floor so substantial sessions are never lost. A sub-agent session writes
+  no fallback (ADR 0014). The fallback is a hook concern — you invoke `--body`, never
+  `--transcript`.
 
 ## Action log
 

--- a/src/skills/Memory/Workflows/Remember.md
+++ b/src/skills/Memory/Workflows/Remember.md
@@ -54,8 +54,9 @@ soma memory digest --session <session-id> --body "<8–15 non-empty lines>"
   DETERMINISTIC fallback digest (`--transcript`, marked `hook: session-end`) — legible
   but mechanical, not a real summary. Prefer self-authoring for a genuine summary; the
   fallback is only a BEST-EFFORT floor — it skips silently if the transcript is unreadable or
-  too thin, and writes nothing for a sub-agent session (ADR 0014), so it is not a
-  guarantee. The fallback is a hook concern — you invoke `--body`, never `--transcript`.
+  too thin, and writes nothing for a MARKED sub-agent session (ADR 0014; an unmarked
+  sub-agent is not detected), so it is not a guarantee. The fallback is a hook concern
+  — you invoke `--body`, never `--transcript`.
 
 ## Action log
 

--- a/src/skills/Memory/Workflows/Remember.md
+++ b/src/skills/Memory/Workflows/Remember.md
@@ -50,12 +50,12 @@ soma memory digest --session <session-id> --body "<8–15 non-empty lines>"
 - Exactly ONE digest per session. A second call for the same session no-ops
   (and logs an event) — it never overwrites the first.
 - The body must be 8–15 non-empty lines; anything outside that is rejected.
-- **Do this before the session ends.** If you don't, the SessionEnd hook writes a
+- **Do this before the session ends.** If you don't, the SessionEnd hook attempts a
   DETERMINISTIC fallback digest (`--transcript`, marked `hook: session-end`) — legible
   but mechanical, not a real summary. Self-authoring is strictly better; the fallback
-  is only a floor so substantial sessions are never lost. A sub-agent session writes
-  no fallback (ADR 0014). The fallback is a hook concern — you invoke `--body`, never
-  `--transcript`.
+  is only a BEST-EFFORT floor — it skips silently if the transcript is unreadable or
+  too thin, and writes nothing for a sub-agent session (ADR 0014), so it is not a
+  guarantee. The fallback is a hook concern — you invoke `--body`, never `--transcript`.
 
 ## Action log
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2515,6 +2515,12 @@ export interface SomaMemoryDigestOptions {
    * assistant-authored one (which omits it). Absent ⇒ assistant-authored.
    */
   hook?: string;
+  /**
+   * Optional provenance override (`conversation` | `import` | `tool:<name>`). Defaults
+   * to `conversation`. A machine-extracted fallback passes a `tool:<name>` value so
+   * recall surfaces that the body was not assistant-authored.
+   */
+  provenance?: string;
 }
 
 // The Claude Code SessionEnd transcript-fallback types (ClaudeSessionDigestOptions/

--- a/src/types.ts
+++ b/src/types.ts
@@ -2259,6 +2259,15 @@ export interface SomaLifecycleOptions {
   cwd?: string;
   /** Git branch of `cwd`, when known. Detected from `cwd` when omitted. */
   gitBranch?: string;
+  /**
+   * On `session-end`: path to the substrate session transcript. When set (and the
+   * substrate has a transcript adapter, e.g. claude-code), the handler attempts the
+   * deterministic digest FALLBACK. Substrate-owned — core does not parse it.
+   */
+  transcriptPath?: string;
+  /** Sub-agent markers from the hook payload (suppress the fallback per ADR 0014). */
+  agentId?: string;
+  agentType?: string;
 }
 
 export interface SomaStartupContext {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2520,11 +2520,12 @@ export interface SomaMemoryDigestOptions {
   body: string;
   /**
    * Optional lifecycle-event label (e.g. `session-end`) recorded into the note's M0
-   * `hook:` frontmatter field. Marks a digest as lifecycle-triggered rather than
-   * assistant-authored (absent ⇒ assistant-authored). The VALUE is an opaque string
-   * the adapter supplies; the field carries lifecycle-event semantics (not
-   * SUBSTRATE-specific hook names), so core stays substrate-neutral without being
-   * semantics-free.
+   * `hook:` frontmatter field, marking the digest as lifecycle-triggered. Its ABSENCE
+   * means only "not lifecycle-triggered" — it does NOT by itself prove assistant
+   * authorship; `provenance` is the independent source signal (e.g. a `tool:<name>`
+   * digest is machine-authored with no lifecycleEvent). Read both. The VALUE is an
+   * opaque adapter-supplied string carrying lifecycle-event (not substrate-hook)
+   * semantics, so core stays substrate-neutral without being semantics-free.
    */
   lifecycleEvent?: string;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -2519,12 +2519,12 @@ export interface SomaMemoryDigestOptions {
   /** The digest text: 8–15 non-empty lines of what happened / changed / open loops. */
   body: string;
   /**
-   * Optional `hook:` frontmatter marker (the neutral M0 note field). A lifecycle
-   * capture on ANY substrate may set it (e.g. `session-end`) to mark a digest as
-   * lifecycle-triggered rather than assistant-authored; absent ⇒ assistant-authored.
-   * The value is an opaque string — no substrate vocabulary is baked into core.
+   * Optional lifecycle-event label (e.g. `session-end`) recorded into the note's M0
+   * `hook:` frontmatter field. Marks a digest as lifecycle-triggered rather than
+   * assistant-authored (absent ⇒ assistant-authored). Neutral opaque string — no
+   * substrate hook vocabulary enters this core API; adapters supply the value.
    */
-  hook?: string;
+  lifecycleEvent?: string;
   /**
    * Optional provenance override (`conversation` | `consolidation` | `import` |
    * `tool:<name>`). Defaults to `conversation`. A machine-extracted fallback passes a

--- a/src/types.ts
+++ b/src/types.ts
@@ -2521,8 +2521,10 @@ export interface SomaMemoryDigestOptions {
   /**
    * Optional lifecycle-event label (e.g. `session-end`) recorded into the note's M0
    * `hook:` frontmatter field. Marks a digest as lifecycle-triggered rather than
-   * assistant-authored (absent ⇒ assistant-authored). Neutral opaque string — no
-   * substrate hook vocabulary enters this core API; adapters supply the value.
+   * assistant-authored (absent ⇒ assistant-authored). The VALUE is an opaque string
+   * the adapter supplies; the field carries lifecycle-event semantics (not
+   * SUBSTRATE-specific hook names), so core stays substrate-neutral without being
+   * semantics-free.
    */
   lifecycleEvent?: string;
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -2526,9 +2526,10 @@ export interface SomaMemoryDigestOptions {
    */
   hook?: string;
   /**
-   * Optional provenance override (`conversation` | `import` | `tool:<name>`). Defaults
-   * to `conversation`. A machine-extracted fallback passes a `tool:<name>` value so
-   * recall surfaces that the body was not assistant-authored.
+   * Optional provenance override (`conversation` | `consolidation` | `import` |
+   * `tool:<name>`). Defaults to `conversation`. A machine-extracted fallback passes a
+   * `tool:<name>` value so recall surfaces that the body was not assistant-authored.
+   * Rejected if outside this grammar.
    */
   provenance?: string;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2265,9 +2265,9 @@ export interface SomaLifecycleOptions {
    * deterministic digest FALLBACK. Substrate-owned — core does not parse it.
    */
   transcriptPath?: string;
-  /** Sub-agent markers from the hook payload (suppress the fallback per ADR 0014). */
-  agentId?: string;
-  agentType?: string;
+  /** Claude Code sub-agent markers from the hook payload (suppress the fallback per ADR 0014). */
+  subagentId?: string;
+  subagentType?: string;
 }
 
 export interface SomaStartupContext {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2517,40 +2517,10 @@ export interface SomaMemoryDigestOptions {
   hook?: string;
 }
 
-/**
- * Write a session digest whose body is DETERMINISTICALLY extracted from a Claude Code
- * transcript (the SessionEnd hook fallback). No LLM. Sub-agent sessions are suppressed
- * (ADR 0014) unless `forcePrimary`. Reuses the one-per-session gate, so it no-ops when
- * an assistant-authored digest already exists.
- */
-export interface SomaMemoryDigestFromTranscriptOptions {
-  homeDir?: string;
-  somaHome?: string;
-  substrate?: SubstrateId;
-  now?: Date;
-  /** The session this digest summarizes. */
-  sessionId: string;
-  /** Path to the Claude Code session transcript (JSONL). */
-  transcriptPath: string;
-  /** Sub-agent markers from the hook payload — when set, the digest is suppressed. */
-  agentId?: string;
-  agentType?: string;
-  /** Force the primary (write) path even for a sub-agent-marked invocation. */
-  forcePrimary?: boolean;
-  /** Force treating the invocation as a sub-agent (suppress) regardless of markers. */
-  forceSubagent?: boolean;
-}
-
-/** Outcome of the transcript-fallback digest. */
-export interface SomaMemoryDigestFromTranscriptResult {
-  /** "written" (a new fallback digest), "duplicate" (a digest already existed),
-   *  "suppressed" (sub-agent), or "skipped" (too little transcript content). */
-  outcome: "written" | "duplicate" | "suppressed" | "skipped";
-  /** The digest result when a write/dedup happened; absent for suppressed/skipped. */
-  digest?: SomaMemoryDigestResult;
-  /** Human-readable reason (always set). */
-  reason: string;
-}
+// The Claude Code SessionEnd transcript-fallback types (ClaudeSessionDigestOptions/
+// Result) are adapter-owned — see src/adapters/claude-code/session-digest.ts. Core
+// stays substrate-neutral: it exposes only `writeSessionDigest` (ready body + hook
+// marker) and `hasSessionDigest`; the Claude JSONL format never enters core.
 
 export interface SomaMemoryDigestResult {
   somaHome: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2509,6 +2509,47 @@ export interface SomaMemoryDigestOptions {
   sessionId: string;
   /** The digest text: 8–15 non-empty lines of what happened / changed / open loops. */
   body: string;
+  /**
+   * Optional `hook:` frontmatter marker. Set to `session-end` by the deterministic
+   * SessionEnd fallback so a machine-extracted digest is distinguishable from an
+   * assistant-authored one (which omits it). Absent ⇒ assistant-authored.
+   */
+  hook?: string;
+}
+
+/**
+ * Write a session digest whose body is DETERMINISTICALLY extracted from a Claude Code
+ * transcript (the SessionEnd hook fallback). No LLM. Sub-agent sessions are suppressed
+ * (ADR 0014) unless `forcePrimary`. Reuses the one-per-session gate, so it no-ops when
+ * an assistant-authored digest already exists.
+ */
+export interface SomaMemoryDigestFromTranscriptOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate?: SubstrateId;
+  now?: Date;
+  /** The session this digest summarizes. */
+  sessionId: string;
+  /** Path to the Claude Code session transcript (JSONL). */
+  transcriptPath: string;
+  /** Sub-agent markers from the hook payload — when set, the digest is suppressed. */
+  agentId?: string;
+  agentType?: string;
+  /** Force the primary (write) path even for a sub-agent-marked invocation. */
+  forcePrimary?: boolean;
+  /** Force treating the invocation as a sub-agent (suppress) regardless of markers. */
+  forceSubagent?: boolean;
+}
+
+/** Outcome of the transcript-fallback digest. */
+export interface SomaMemoryDigestFromTranscriptResult {
+  /** "written" (a new fallback digest), "duplicate" (a digest already existed),
+   *  "suppressed" (sub-agent), or "skipped" (too little transcript content). */
+  outcome: "written" | "duplicate" | "suppressed" | "skipped";
+  /** The digest result when a write/dedup happened; absent for suppressed/skipped. */
+  digest?: SomaMemoryDigestResult;
+  /** Human-readable reason (always set). */
+  reason: string;
 }
 
 export interface SomaMemoryDigestResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2510,9 +2510,10 @@ export interface SomaMemoryDigestOptions {
   /** The digest text: 8–15 non-empty lines of what happened / changed / open loops. */
   body: string;
   /**
-   * Optional `hook:` frontmatter marker. Set to `session-end` by the deterministic
-   * SessionEnd fallback so a machine-extracted digest is distinguishable from an
-   * assistant-authored one (which omits it). Absent ⇒ assistant-authored.
+   * Optional `hook:` frontmatter marker (the neutral M0 note field). A lifecycle
+   * capture on ANY substrate may set it (e.g. `session-end`) to mark a digest as
+   * lifecycle-triggered rather than assistant-authored; absent ⇒ assistant-authored.
+   * The value is an opaque string — no substrate vocabulary is baked into core.
    */
   hook?: string;
   /**

--- a/test/memory-episodic.test.ts
+++ b/test/memory-episodic.test.ts
@@ -347,9 +347,10 @@ test("an unreadable transcript reports 'unreadable' (distinct from a thin sessio
 });
 
 test("the SPAWNED `soma lifecycle session-end` CLI writes the fallback for claude-code", async () => {
-  // Spawn the real CLI (fresh process) so registration happens ONLY through the
-  // composition-layer side-effect import — NOT primed by this test file importing the
-  // adapter. This proves the exported CLI path writes the fallback end to end.
+  // Spawn the SOURCE CLI entrypoint (`bun run src/cli.ts`, not an installed binary) in
+  // a fresh process, so registration happens ONLY through the composition-layer
+  // side-effect import — NOT primed by this test file importing the adapter. This
+  // proves the source CLI path writes the fallback end to end.
   await withTempSoma((somaHome) =>
     withTranscriptFile(SEVEN_PROMPTS, async (tp) => {
       const cli = join(import.meta.dirname, "..", "src", "cli.ts");

--- a/test/memory-episodic.test.ts
+++ b/test/memory-episodic.test.ts
@@ -3,13 +3,15 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import {
-  extractDigestBodyFromTranscript,
   parseMemoryNote,
   somaMemoryEventsPath,
   writeMemoryAction,
   writeSessionDigest,
-  writeSessionDigestFromTranscript,
 } from "../src/index";
+import {
+  extractDigestBodyFromTranscript,
+  writeSessionDigestFromTranscript,
+} from "../src/adapters/claude-code/session-digest";
 import { parseMemoryArgs, runMemoryCli } from "../src/cli/memory";
 
 /** Build a JSONL transcript from a list of {user}/{assistant tool} lines. */
@@ -247,10 +249,20 @@ test("extractDigestBodyFromTranscript builds 8–15 lines from genuine prompts, 
   expect(lines.length).toBeGreaterThanOrEqual(8);
   expect(lines.length).toBeLessThanOrEqual(15);
   expect(lines[0]).toContain("6 principal prompts"); // sidechain + command + tool_result excluded
-  expect(body).toContain("- add a login endpoint");
+  // prompt text is quoted + labeled (injection-safe), not a bare instruction line
+  expect(body).toContain(`- principal prompt: "add a login endpoint"`);
   expect(body).toContain("- tools: "); // rollup line
   expect(body).not.toContain("/clear"); // command noise filtered
   expect(body).not.toContain("fix the bug"); // sidechain skipped
+});
+
+test("a fallback digest carries tool:claude-session-end provenance (not assistant conversation)", async () => {
+  await withTempSoma((somaHome) =>
+    withTranscriptFile(SEVEN_PROMPTS, async (tp) => {
+      const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp });
+      expect(result.digest!.note.provenance).toBe("tool:claude-session-end");
+    }),
+  );
 });
 
 test("extractDigestBodyFromTranscript returns undefined when too few genuine prompts", () => {

--- a/test/memory-episodic.test.ts
+++ b/test/memory-episodic.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import {
   parseMemoryNote,
+  runSomaLifecycleSessionEnd,
   somaMemoryEventsPath,
   writeMemoryAction,
   writeSessionDigest,
@@ -249,7 +250,7 @@ test("extractDigestBodyFromTranscript builds 8–15 lines from genuine prompts, 
   expect(lines.length).toBeGreaterThanOrEqual(8);
   expect(lines.length).toBeLessThanOrEqual(15);
   expect(lines[0]).toContain("6 principal prompts"); // sidechain + command + tool_result excluded
-  // prompt text is quoted + labeled (injection-safe), not a bare instruction line
+  // prompt text is quoted + labeled (REDUCES injection risk; not a bare instruction line)
   expect(body).toContain(`- principal prompt: "add a login endpoint"`);
   expect(body).toContain("- tools: "); // rollup line
   expect(body).not.toContain("/clear"); // command noise filtered
@@ -346,8 +347,20 @@ test("an unreadable transcript reports 'unreadable' (distinct from a thin sessio
   });
 });
 
-test("parseMemoryArgs digest accepts --transcript and rejects --body + --transcript together", () => {
-  const parsed = parseMemoryArgs(["memory", "digest", "--session", "s", "--transcript", "/t.jsonl"]);
-  expect(parsed.options).toMatchObject({ mode: "transcript" });
-  expect(() => parseMemoryArgs(["memory", "digest", "--session", "s", "--body", "b", "--transcript", "/t.jsonl"])).toThrow(/exactly one/);
+test("lifecycle session-end writes the deterministic fallback digest for claude-code", async () => {
+  await withTempSoma((somaHome) =>
+    withTranscriptFile(SEVEN_PROMPTS, async (tp) => {
+      await runSomaLifecycleSessionEnd({ somaHome, substrate: "claude-code", sessionId: SESSION, transcriptPath: tp });
+      // The lifecycle-dispatched fallback wrote the session digest — a fresh fallback
+      // now no-ops (date-independent one-per-session gate), proving it was written.
+      const again = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp });
+      expect(again.outcome).toBe("duplicate");
+    }),
+  );
+});
+
+test("the neutral `soma memory digest` is body-only — it rejects the Claude --transcript flag", () => {
+  // The transcript FALLBACK is a Claude Code adapter concern routed through
+  // `soma lifecycle session-end`, NOT the substrate-neutral memory command.
+  expect(() => parseMemoryArgs(["memory", "digest", "--session", "s", "--transcript", "/t.jsonl"])).toThrow(/Unknown option/);
 });

--- a/test/memory-episodic.test.ts
+++ b/test/memory-episodic.test.ts
@@ -3,12 +3,38 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import {
+  extractDigestBodyFromTranscript,
   parseMemoryNote,
   somaMemoryEventsPath,
   writeMemoryAction,
   writeSessionDigest,
+  writeSessionDigestFromTranscript,
 } from "../src/index";
 import { parseMemoryArgs, runMemoryCli } from "../src/cli/memory";
+
+/** Build a JSONL transcript from a list of {user}/{assistant tool} lines. */
+function transcript(lines: object[]): string {
+  return lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+}
+function userLine(content: unknown, extra: object = {}): object {
+  return { type: "user", message: { role: "user", content }, ...extra };
+}
+function assistantTool(name: string): object {
+  return { type: "assistant", message: { role: "assistant", content: [{ type: "tool_use", name }] } };
+}
+const SEVEN_PROMPTS = transcript([
+  userLine("add a login endpoint"),
+  assistantTool("Edit"),
+  userLine("<command-name>/clear</command-name>"), // noise — filtered
+  userLine([{ type: "tool_result", content: "x" }]), // tool result — filtered
+  userLine("now add tests"),
+  userLine("fix the bug", { isSidechain: true }), // sub-agent line — skipped
+  userLine("handle the null case"),
+  assistantTool("Bash"),
+  userLine("run the linter"),
+  userLine("commit and push"),
+  userLine("update the changelog"),
+]);
 
 const NOW = new Date("2026-07-04T10:00:00.000Z");
 const SESSION = "0afea4e4-967d-4a38-a855-0d12ac63c2f3";
@@ -210,4 +236,93 @@ test("runMemoryCli action logs an entry", async () => {
     // the CLI uses the real clock, so assert on the date-independent slug
     expect(out).toMatch(/id: \d{8}-ship-it/);
   });
+});
+
+// --- SessionEnd deterministic fallback (M5b) ---------------------------------
+
+test("extractDigestBodyFromTranscript builds 8–15 lines from genuine prompts, filtering noise", () => {
+  const body = extractDigestBodyFromTranscript(SEVEN_PROMPTS);
+  expect(body).toBeDefined();
+  const lines = body!.split("\n");
+  expect(lines.length).toBeGreaterThanOrEqual(8);
+  expect(lines.length).toBeLessThanOrEqual(15);
+  expect(lines[0]).toContain("6 principal prompts"); // sidechain + command + tool_result excluded
+  expect(body).toContain("- add a login endpoint");
+  expect(body).toContain("- tools: "); // rollup line
+  expect(body).not.toContain("/clear"); // command noise filtered
+  expect(body).not.toContain("fix the bug"); // sidechain skipped
+});
+
+test("extractDigestBodyFromTranscript returns undefined when too few genuine prompts", () => {
+  const thin = transcript([userLine("only one real prompt"), assistantTool("Read")]);
+  expect(extractDigestBodyFromTranscript(thin)).toBeUndefined();
+});
+
+test("extractDigestBodyFromTranscript samples head+tail when there are many prompts", () => {
+  const many = transcript(Array.from({ length: 30 }, (_, i) => userLine(`prompt number ${i}`)));
+  const body = extractDigestBodyFromTranscript(many)!;
+  expect(body.split("\n").length).toBeLessThanOrEqual(15);
+  expect(body).toContain("more prompts");
+});
+
+test("writeSessionDigestFromTranscript writes a digest marked hook: session-end", async () => {
+  await withTempSoma(async (somaHome) => {
+    const dir = await mkdtemp(join(tmpdir(), "soma-tx-"));
+    const tp = join(dir, "t.jsonl");
+    await writeFile(tp, SEVEN_PROMPTS, "utf8");
+    const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp });
+    expect(result.outcome).toBe("written");
+    expect(result.digest!.note.hook).toBe("session-end");
+    const onDisk = parseMemoryNote(await readFile(result.digest!.path, "utf8"));
+    expect(onDisk.hook).toBe("session-end");
+    await rm(dir, { recursive: true, force: true });
+  });
+});
+
+test("a sub-agent invocation is suppressed and writes nothing (ADR 0014)", async () => {
+  await withTempSoma(async (somaHome) => {
+    const dir = await mkdtemp(join(tmpdir(), "soma-tx-"));
+    const tp = join(dir, "t.jsonl");
+    await writeFile(tp, SEVEN_PROMPTS, "utf8");
+    const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp, agentId: "agt-1" });
+    expect(result.outcome).toBe("suppressed");
+    expect(result.digest).toBeUndefined();
+    await rm(dir, { recursive: true, force: true });
+  });
+});
+
+test("forcePrimary overrides sub-agent suppression", async () => {
+  await withTempSoma(async (somaHome) => {
+    const dir = await mkdtemp(join(tmpdir(), "soma-tx-"));
+    const tp = join(dir, "t.jsonl");
+    await writeFile(tp, SEVEN_PROMPTS, "utf8");
+    const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp, agentId: "agt-1", forcePrimary: true });
+    expect(result.outcome).toBe("written");
+    await rm(dir, { recursive: true, force: true });
+  });
+});
+
+test("the fallback no-ops when an assistant-authored digest already exists", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeSessionDigest({ somaHome, now: NOW, sessionId: SESSION, body: DIGEST_BODY }); // assistant-authored, no hook:
+    const dir = await mkdtemp(join(tmpdir(), "soma-tx-"));
+    const tp = join(dir, "t.jsonl");
+    await writeFile(tp, SEVEN_PROMPTS, "utf8");
+    const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp });
+    expect(result.outcome).toBe("duplicate");
+    await rm(dir, { recursive: true, force: true });
+  });
+});
+
+test("an unreadable transcript skips silently (never throws)", async () => {
+  await withTempSoma(async (somaHome) => {
+    const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: "/no/such/transcript.jsonl" });
+    expect(result.outcome).toBe("skipped");
+  });
+});
+
+test("parseMemoryArgs digest accepts --transcript and rejects --body + --transcript together", () => {
+  const parsed = parseMemoryArgs(["memory", "digest", "--session", "s", "--transcript", "/t.jsonl"]);
+  expect(parsed.options).toMatchObject({ mode: "transcript" });
+  expect(() => parseMemoryArgs(["memory", "digest", "--session", "s", "--body", "b", "--transcript", "/t.jsonl"])).toThrow(/exactly one/);
 });

--- a/test/memory-episodic.test.ts
+++ b/test/memory-episodic.test.ts
@@ -1,10 +1,9 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import {
   parseMemoryNote,
-  runSomaLifecycleSessionEnd,
   somaMemoryEventsPath,
   writeMemoryAction,
   writeSessionDigest,
@@ -305,7 +304,7 @@ test("writeSessionDigestFromTranscript writes a digest marked hook: session-end"
 test("a sub-agent invocation is suppressed and writes nothing (ADR 0014)", async () => {
   await withTempSoma((somaHome) =>
     withTranscriptFile(SEVEN_PROMPTS, async (tp) => {
-      const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp, agentId: "agt-1" });
+      const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp, subagentId: "agt-1" });
       expect(result.outcome).toBe("suppressed");
       expect(result.digest).toBeUndefined();
     }),
@@ -324,7 +323,7 @@ test("forceSubagent suppresses even when forcePrimary is also set (precedence)",
 test("forcePrimary overrides sub-agent suppression", async () => {
   await withTempSoma((somaHome) =>
     withTranscriptFile(SEVEN_PROMPTS, async (tp) => {
-      const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp, agentId: "agt-1", forcePrimary: true });
+      const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp, subagentId: "agt-1", forcePrimary: true });
       expect(result.outcome).toBe("written");
     }),
   );
@@ -347,14 +346,27 @@ test("an unreadable transcript reports 'unreadable' (distinct from a thin sessio
   });
 });
 
-test("lifecycle session-end writes the deterministic fallback digest for claude-code", async () => {
+test("the SPAWNED `soma lifecycle session-end` CLI writes the fallback for claude-code", async () => {
+  // Spawn the real CLI (fresh process) so registration happens ONLY through the
+  // composition-layer side-effect import — NOT primed by this test file importing the
+  // adapter. This proves the exported CLI path writes the fallback end to end.
   await withTempSoma((somaHome) =>
     withTranscriptFile(SEVEN_PROMPTS, async (tp) => {
-      await runSomaLifecycleSessionEnd({ somaHome, substrate: "claude-code", sessionId: SESSION, transcriptPath: tp });
-      // The lifecycle-dispatched fallback wrote the session digest — a fresh fallback
-      // now no-ops (date-independent one-per-session gate), proving it was written.
-      const again = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp });
-      expect(again.outcome).toBe("duplicate");
+      const cli = join(import.meta.dirname, "..", "src", "cli.ts");
+      const proc = Bun.spawnSync(["bun", "run", cli, "lifecycle", "session-end", "--session-id", "spawned-x", "--transcript", tp, "--substrate", "claude-code", "--soma-home", somaHome]);
+      expect(proc.exitCode).toBe(0);
+      // A digest marked as the machine-extracted fallback now exists (month-agnostic:
+      // the spawned CLI uses the real clock).
+      const base = join(somaHome, "memory/episodic/sessions");
+      const months = await readdir(base).catch(() => [] as string[]);
+      let body = "";
+      for (const month of months) {
+        const files = await readdir(join(base, month)).catch(() => [] as string[]);
+        const digest = files.find((f) => f.includes("spawned-x"));
+        if (digest) body = await readFile(join(base, month, digest), "utf8");
+      }
+      expect(body).toContain("hook: session-end");
+      expect(body).toContain("provenance: tool:claude-session-end");
     }),
   );
 });

--- a/test/memory-episodic.test.ts
+++ b/test/memory-episodic.test.ts
@@ -265,59 +265,72 @@ test("extractDigestBodyFromTranscript samples head+tail when there are many prom
   expect(body).toContain("more prompts");
 });
 
-test("writeSessionDigestFromTranscript writes a digest marked hook: session-end", async () => {
-  await withTempSoma(async (somaHome) => {
-    const dir = await mkdtemp(join(tmpdir(), "soma-tx-"));
+/** Write `content` to a temp .jsonl file, run `fn(path)`, then clean up. */
+async function withTranscriptFile<T>(content: string, fn: (transcriptPath: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "soma-tx-"));
+  try {
     const tp = join(dir, "t.jsonl");
-    await writeFile(tp, SEVEN_PROMPTS, "utf8");
-    const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp });
-    expect(result.outcome).toBe("written");
-    expect(result.digest!.note.hook).toBe("session-end");
-    const onDisk = parseMemoryNote(await readFile(result.digest!.path, "utf8"));
-    expect(onDisk.hook).toBe("session-end");
+    await writeFile(tp, content, "utf8");
+    return await fn(tp);
+  } finally {
     await rm(dir, { recursive: true, force: true });
-  });
+  }
+}
+
+test("writeSessionDigestFromTranscript writes a digest marked hook: session-end", async () => {
+  await withTempSoma((somaHome) =>
+    withTranscriptFile(SEVEN_PROMPTS, async (tp) => {
+      const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp });
+      expect(result.outcome).toBe("written");
+      expect(result.digest!.note.hook).toBe("session-end");
+      const onDisk = parseMemoryNote(await readFile(result.digest!.path, "utf8"));
+      expect(onDisk.hook).toBe("session-end");
+    }),
+  );
 });
 
 test("a sub-agent invocation is suppressed and writes nothing (ADR 0014)", async () => {
-  await withTempSoma(async (somaHome) => {
-    const dir = await mkdtemp(join(tmpdir(), "soma-tx-"));
-    const tp = join(dir, "t.jsonl");
-    await writeFile(tp, SEVEN_PROMPTS, "utf8");
-    const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp, agentId: "agt-1" });
-    expect(result.outcome).toBe("suppressed");
-    expect(result.digest).toBeUndefined();
-    await rm(dir, { recursive: true, force: true });
-  });
+  await withTempSoma((somaHome) =>
+    withTranscriptFile(SEVEN_PROMPTS, async (tp) => {
+      const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp, agentId: "agt-1" });
+      expect(result.outcome).toBe("suppressed");
+      expect(result.digest).toBeUndefined();
+    }),
+  );
+});
+
+test("forceSubagent suppresses even when forcePrimary is also set (precedence)", async () => {
+  await withTempSoma((somaHome) =>
+    withTranscriptFile(SEVEN_PROMPTS, async (tp) => {
+      const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp, forcePrimary: true, forceSubagent: true });
+      expect(result.outcome).toBe("suppressed");
+    }),
+  );
 });
 
 test("forcePrimary overrides sub-agent suppression", async () => {
-  await withTempSoma(async (somaHome) => {
-    const dir = await mkdtemp(join(tmpdir(), "soma-tx-"));
-    const tp = join(dir, "t.jsonl");
-    await writeFile(tp, SEVEN_PROMPTS, "utf8");
-    const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp, agentId: "agt-1", forcePrimary: true });
-    expect(result.outcome).toBe("written");
-    await rm(dir, { recursive: true, force: true });
-  });
+  await withTempSoma((somaHome) =>
+    withTranscriptFile(SEVEN_PROMPTS, async (tp) => {
+      const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp, agentId: "agt-1", forcePrimary: true });
+      expect(result.outcome).toBe("written");
+    }),
+  );
 });
 
 test("the fallback no-ops when an assistant-authored digest already exists", async () => {
-  await withTempSoma(async (somaHome) => {
-    await writeSessionDigest({ somaHome, now: NOW, sessionId: SESSION, body: DIGEST_BODY }); // assistant-authored, no hook:
-    const dir = await mkdtemp(join(tmpdir(), "soma-tx-"));
-    const tp = join(dir, "t.jsonl");
-    await writeFile(tp, SEVEN_PROMPTS, "utf8");
-    const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp });
-    expect(result.outcome).toBe("duplicate");
-    await rm(dir, { recursive: true, force: true });
-  });
+  await withTempSoma((somaHome) =>
+    withTranscriptFile(SEVEN_PROMPTS, async (tp) => {
+      await writeSessionDigest({ somaHome, now: NOW, sessionId: SESSION, body: DIGEST_BODY }); // assistant-authored, no hook:
+      const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: tp });
+      expect(result.outcome).toBe("duplicate");
+    }),
+  );
 });
 
-test("an unreadable transcript skips silently (never throws)", async () => {
+test("an unreadable transcript reports 'unreadable' (distinct from a thin session) and never throws", async () => {
   await withTempSoma(async (somaHome) => {
     const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: "/no/such/transcript.jsonl" });
-    expect(result.outcome).toBe("skipped");
+    expect(result.outcome).toBe("unreadable");
   });
 });
 

--- a/test/memory-episodic.test.ts
+++ b/test/memory-episodic.test.ts
@@ -277,14 +277,19 @@ test("extractDigestBodyFromTranscript samples head+tail when there are many prom
   expect(body).toContain("more prompts");
 });
 
-/** Write `content` to a temp .jsonl file, run `fn(path)`, then clean up. */
+/** Write `content` to a temp .jsonl file, point the transcript-root allowlist at the
+ *  temp dir (so path validation accepts the fixture), run `fn(path)`, then clean up. */
 async function withTranscriptFile<T>(content: string, fn: (transcriptPath: string) => Promise<T>): Promise<T> {
   const dir = await mkdtemp(join(tmpdir(), "soma-tx-"));
+  const prev = process.env.SOMA_CLAUDE_TRANSCRIPT_ROOT;
   try {
     const tp = join(dir, "t.jsonl");
     await writeFile(tp, content, "utf8");
+    process.env.SOMA_CLAUDE_TRANSCRIPT_ROOT = dir;
     return await fn(tp);
   } finally {
+    if (prev === undefined) delete process.env.SOMA_CLAUDE_TRANSCRIPT_ROOT;
+    else process.env.SOMA_CLAUDE_TRANSCRIPT_ROOT = prev;
     await rm(dir, { recursive: true, force: true });
   }
 }
@@ -339,10 +344,27 @@ test("the fallback no-ops when an assistant-authored digest already exists", asy
   );
 });
 
-test("an unreadable transcript reports 'unreadable' (distinct from a thin session) and never throws", async () => {
+test("a transcript path OUTSIDE the allowed root is REFUSED (not read)", async () => {
   await withTempSoma(async (somaHome) => {
-    const result = await writeSessionDigestFromTranscript({ somaHome, now: NOW, sessionId: SESSION, transcriptPath: "/no/such/transcript.jsonl" });
-    expect(result.outcome).toBe("unreadable");
+    // Absolute .jsonl, but not under transcriptRoot → refused before any read.
+    const result = await writeSessionDigestFromTranscript({
+      somaHome, now: NOW, sessionId: SESSION, transcriptPath: "/etc/anything.jsonl", transcriptRoot: "/tmp/soma-allowed-root",
+    });
+    expect(result.outcome).toBe("refused");
+  });
+});
+
+test("a missing transcript INSIDE the allowed root reports 'unreadable' and never throws", async () => {
+  await withTempSoma(async (somaHome) => {
+    const dir = await mkdtemp(join(tmpdir(), "soma-tx-"));
+    try {
+      const result = await writeSessionDigestFromTranscript({
+        somaHome, now: NOW, sessionId: SESSION, transcriptPath: join(dir, "missing.jsonl"), transcriptRoot: dir,
+      });
+      expect(result.outcome).toBe("unreadable");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -354,7 +376,12 @@ test("the SPAWNED `soma lifecycle session-end` CLI writes the fallback for claud
   await withTempSoma((somaHome) =>
     withTranscriptFile(SEVEN_PROMPTS, async (tp) => {
       const cli = join(import.meta.dirname, "..", "src", "cli.ts");
-      const proc = Bun.spawnSync(["bun", "run", cli, "lifecycle", "session-end", "--session-id", "spawned-x", "--transcript", tp, "--substrate", "claude-code", "--soma-home", somaHome]);
+      const proc = Bun.spawnSync(
+        ["bun", "run", cli, "lifecycle", "session-end", "--session-id", "spawned-x", "--transcript", tp, "--substrate", "claude-code", "--soma-home", somaHome],
+        // Pass the transcript-root allowlist explicitly (the fixture dir) so the child's
+        // path validation accepts the temp transcript.
+        { env: { ...process.env, SOMA_CLAUDE_TRANSCRIPT_ROOT: join(tp, "..") } },
+      );
       expect(proc.exitCode).toBe(0);
       // A digest marked as the machine-extracted fallback now exists (month-agnostic:
       // the spawned CLI uses the real clock).


### PR DESCRIPTION
M5b — the deferred SessionEnd hook, on JC's HYBRID authorship decision. PRIMARY: assistant self-authors a digest at wrap-up (`soma memory digest --body`, real summary; guided by the Memory skill's Remember workflow). FALLBACK (deterministic/no-LLM): on SessionEnd a transcript-extraction path writes an 8–15-line body, marked `lifecycleEvent: session-end` (→ the note's M0 `hook:` field) + `provenance: tool:claude-session-end`, ONLY if no digest exists yet (one-per-session gate, checked before reading the transcript).

Extraction filters command/system/tool_result + sidechain lines, quotes+labels each principal prompt (JSON-escaped; REDUCES, not eliminates, injection risk), control-collapses tool names into a rollup, head/tail-samples, returns undefined below 6 prompts (thin sessions are DROPPED — the fallback neither checks nor guarantees an assistant digest exists). Prompt/tool text are control-collapsed+truncated pointers, not verbatim; malformed JSONL lines are silently skipped (best-effort, not a complete record).

Sub-agent suppression (ADR 0014) is MARKED-only: the hook-runner reads Claude Code's own payload keys `agent_id`/`agent_type` and forwards them as Soma's qualified `--subagent-id`/`--subagent-type` (bare `agent` is banned in Soma surfaces → fields `subagentId`/`subagentType`); an UNMARKED sub-agent is NOT detected and falls through. `forcePrimary`/env overrides.

Architecture: `soma memory digest` stays body-only/substrate-neutral. The fallback routes through `soma lifecycle session-end` via DEPENDENCY INVERSION — core lifecycle owns `registerSessionEndTranscriptHandler(substrate, handler)` and looks it up by substrate; the Claude adapter registers its fallback at module load; the composition layer (cli/lifecycle.ts) side-effect-imports it. Core imports NO adapter. The fallback writes through the GOVERNED M5 memory-write path (schema + one-per-session gate + provenance validation + memory.digest event), not the tool-activity writeback queue.

Verification: CI on this branch is green — **Deterministic portability** (full `bun test` suite) + **gate / confidentiality-gate** both SUCCESS (see the Checks tab); the pre-push smoke gate reruns the full suite on every push. Locally: bunx tsc --noEmit clean; hook-runner.mjs `node --check` passes; a spawned-CLI test (`soma lifecycle session-end --transcript`, fresh process) asserts the fallback digest lands with hook:session-end + the tool provenance, and `soma memory digest --transcript` is rejected.