### PR TITLE
feat(memory): soma memory backfill — bulk legacy-markdown importer (M8)

### DIFF
--- a/Plans/declarative-twirling-lampson.md
+++ b/Plans/declarative-twirling-lampson.md
@@ -52,10 +52,13 @@ in the source dir).
 
 **Skipped, never imported:** reserved dirs `STATE`, `episodic`, `semantic`,
 `procedural`, `archive`, `imports`; any `README.md` (case-insensitive);
-non-markdown files; symlinks anywhere (loud refusal, matching the migrator's
-stance). Files sitting directly under the root are skipped **only for the
-default `<somaHome>/memory` root** (README/`INDEX.md` territory); a custom
-`--from <dir>` imports its top-level markdown (category `""` → semantic).
+non-markdown files. **Symlink handling** (not a whole-run guarantee): the source
+root and every entry the walk returns are lstat-refused if a symlink; the leaf
+read then uses `O_NOFOLLOW` and re-checks the opened file's `dev`+`ino` against
+the scan, so a leaf- or ancestor-swap between scan and read is refused at read
+time. Files sitting directly under the root are skipped **only for the default
+`<somaHome>/memory` root** (README/`INDEX.md` territory); a custom `--from <dir>`
+imports its top-level markdown (category `""` → semantic).
 
 ### Per-file note synthesis (deterministic)
 
@@ -77,7 +80,7 @@ For each eligible source file at relative path `rel`:
 
 ### Result / reporting
 
-`runMemoryBackfill` returns `{ somaHome, from, dryRun, writtenCount, skippedManifestCount, skippedDuplicateCount, errorCount, manifestPath, entries }` (each `entries[]` item carries `relativePath`, `noteId`, `type`, `created`, `target`, and a per-file `status`); CLI prints a summary table. `--dry-run` prints the plan without writing or touching the manifest.
+`runMemoryBackfill` returns `{ somaHome, from, dryRun, writtenCount, skippedManifestCount, skippedDuplicateCount, errorCount, manifestPath, entries }` (each `entries[]` item carries `relativePath`, `noteId`, `type`, `created`, `target`, and a per-file `status`); CLI prints a summary table. `--dry-run` previews without writing or touching the manifest/INDEX — it is manifest-aware (already-imported files show as `skipped-manifest`) but does **not** run the corpus scan, so a would-import entry may still turn into a `skipped-duplicate` at a real run.
 
 ## Files to create / modify
 

--- a/Plans/declarative-twirling-lampson.md
+++ b/Plans/declarative-twirling-lampson.md
@@ -16,7 +16,7 @@ M1 trust-governance model. This is milestone **M8 — backfill**.
 
 **Key design facts established during exploration:**
 - The `import` write trigger is the sanctioned bulk path: `SOMA_MEMORY_TRIGGER_TRUST.import → "quarantined"`, needs **no authority signal** (`memory-write.ts:30`, MINJA defense). Backfilled content lands untrusted by design.
-- Lifecycle is correct, not a dead end: **recall INCLUDES quarantined notes** with a ⚠ untrusted banner (`memory-recall.ts:136,162` — only `valid_until===null` is filtered, not trust), while **INDEX EXCLUDES quarantined** (`memory-index.ts:17`). So imports are pull-discoverable immediately and earn always-on INDEX only after the principal verifies/elevates them.
+- Lifecycle is correct, not a dead end: **recall INCLUDES quarantined notes** with a ⚠ untrusted banner (`memory-recall.ts:136,162` — only `valid_until===null` is filtered, not trust), while **INDEX EXCLUDES quarantined** (`memory-index.ts:17`). So imports are pull-discoverable immediately and earn always-on INDEX only after the principal re-authors them at higher trust (the admission filter excludes quarantined unconditionally, so `verify` — freshness only — cannot promote them; `principal-correction`/`supersede` can).
 - `writeMemoryNote({mode:"create", trigger:"import", …})` (`memory-write.ts:779`) already does schema serialization, per-note dedup (recall-first refusal, Jaccard ≥0.6 / exact-body), and event journaling. Backfill is a **batch importer over this existing path**, not a new writer.
 - Idempotency pattern to mirror: `src/pai-memory-migrator.ts` (SHA manifest, skip-unchanged, byte-stable no-op rerun, symlink refusal).
 

--- a/Plans/declarative-twirling-lampson.md
+++ b/Plans/declarative-twirling-lampson.md
@@ -65,21 +65,21 @@ For each eligible source file at relative path `rel`:
 - **source_of_truth** = absolute path of the original file (so a human can verify against the archived original).
 - **project** = `--project` or `null`; **links** = `[]`; **resurface_count** = 0.
 - **hook** = short humanized recall phrase from the stem (optional; aids recall matching).
-- **body** = original file content, prefixed with a one-line blockquote preamble noting the backfill origin.
+- **body** = original file content **verbatim** — no injected preamble (a shared preamble inflates token overlap and makes the recall-first dedup over-fire on short files; origin lives in frontmatter instead). Only `.md`/`.markdown` files are imported.
 
 ### Dedup & idempotency
 
 - Files processed **sequentially** (not concurrent) so later files see earlier-written ones and the recall-first refusal dedups within the batch deterministically.
 - A per-file **recall-first refusal** (exact/near-dup already in corpus) is caught and counted as `skipped-duplicate`, not a batch abort (`memory-write.ts:618` builds the refusal — implementation inspects that surface to classify).
-- Manifest `<somaHome>/imports/backfill/.manifest.json` (schema `soma.memory-backfill.v1`, entries `{relativePath, noteId, type, sha256, mtimeMs}`). Rerun skips files whose source SHA matches AND whose target note still exists → byte-stable no-op. Source drift in v1 = re-import as a new note (documented limitation; no auto-supersede yet).
+- Manifest `<somaHome>/memory/STATE/imports/backfill/.manifest.json` (schema `soma.memory-backfill.v1`, entries `{relativePath, noteId, type, sha256, mtimeMs}`) — inside the Memory compartment, under the reserved STATE dir the source walk never re-imports. Rerun skips a file only when its source SHA matches, its resolved type matches the prior import, AND its target note still exists; the prior entry is re-emitted verbatim → byte-stable no-op (even across a `touch`). Source drift = re-import as a new note (documented limitation; no auto-supersede yet).
 
 ### Result / reporting
 
-`runMemoryBackfill` returns `{ writtenCount, skippedDuplicateCount, skippedManifestCount, errors[], notes[] }`; CLI prints a summary table. `--dry-run` prints the same plan without writing or touching the manifest.
+`runMemoryBackfill` returns `{ somaHome, from, dryRun, writtenCount, skippedManifestCount, skippedDuplicateCount, errorCount, manifestPath, entries }` (each `entries[]` item carries `relativePath`, `noteId`, `type`, `created`, `target`, and a per-file `status`); CLI prints a summary table. `--dry-run` prints the plan without writing or touching the manifest.
 
 ## Files to create / modify
 
-1. **`src/memory-backfill.ts`** (new, ~250 LOC) — `planMemoryBackfill()` + `runMemoryBackfill()`; category map, file walk (skip/symlink rules), id derivation + collision handling, mtime→date, body preamble, manifest read/render, sequential loop calling `writeMemoryNote`. Reuses the write path (serialization, dedup, events) rather than re-implementing note I/O.
+1. **`src/memory-backfill.ts`** (new, ~250 LOC) — `planMemoryBackfill()` + `runMemoryBackfill()`; category map, markdown-only file walk (skip/symlink rules), id derivation + collision handling, mtime→date, verbatim body, manifest read/render, sequential loop calling `writeMemoryNote`. Reuses the write path (serialization, dedup, events) rather than re-implementing note I/O.
 2. **`src/types.ts`** — add `SomaMemoryBackfillOptions`, `SomaMemoryBackfillPlanEntry`, `SomaMemoryBackfillResult`, manifest types, and `SOMA_MEMORY_BACKFILL_TYPE_MAP` constant (near the other memory-subsystem types).
 3. **`src/cli/memory.ts`** — add `"backfill"` to `MEMORY_ACTIONS`; `ParsedMemoryBackfillArgs` + union member; `parseMemoryBackfillArgs`; a `MEMORY_COMMAND_HELP.subcommands.backfill` usage string; dispatch `case "backfill"`; handler calling `runMemoryBackfill` + a `formatMemoryBackfillResult`.
 4. **`test/memory-backfill.test.ts`** (new) — mirror `pai-memory-migrator.test.ts` + `memory-write.test.ts` patterns: category→type mapping, id derivation + collision, mtime→created, trust=quarantined, dedup skip, `--dry-run` no-op, idempotent rerun (byte-stable manifest), symlink refusal, reserved-dir skipping.

--- a/Plans/declarative-twirling-lampson.md
+++ b/Plans/declarative-twirling-lampson.md
@@ -1,0 +1,105 @@
+# Plan: `soma memory backfill` — bulk legacy-content importer (M8)
+
+## Context
+
+The note-based Memory subsystem (M0–M7) shipped, but on a freshly-migrated store
+the **durable corpus is empty**: `memory/` has no `semantic/` or `procedural/`
+directory — only auto-generated `episodic/` digests plus **legacy pre-M0
+content** in free-form category dirs (`LEARNING/`, `KNOWLEDGE/`, `WORK/`, …).
+Legacy files can even carry a stopgap banner: *"re-promote via `soma memory
+write` once M1 ships."*
+
+For **shipping Soma to other users**, we need a first-class, reusable command
+that takes a user's existing markdown memory and turns it into schema-valid,
+governed notes — deterministically, no LLM (subsystem invariant), respecting the
+M1 trust-governance model. This is milestone **M8 — backfill**.
+
+**Key design facts established during exploration:**
+- The `import` write trigger is the sanctioned bulk path: `SOMA_MEMORY_TRIGGER_TRUST.import → "quarantined"`, needs **no authority signal** (`memory-write.ts:30`, MINJA defense). Backfilled content lands untrusted by design.
+- Lifecycle is correct, not a dead end: **recall INCLUDES quarantined notes** with a ⚠ untrusted banner (`memory-recall.ts:136,162` — only `valid_until===null` is filtered, not trust), while **INDEX EXCLUDES quarantined** (`memory-index.ts:17`). So imports are pull-discoverable immediately and earn always-on INDEX only after a human verifies/elevates them.
+- `writeMemoryNote({mode:"create", trigger:"import", …})` (`memory-write.ts:779`) already does schema serialization, per-note dedup (recall-first refusal, Jaccard ≥0.6 / exact-body), and event journaling. Backfill is a **batch adapter over this existing path**, not a new writer.
+- Idempotency pattern to mirror: `src/pai-memory-migrator.ts` (SHA manifest, skip-unchanged, byte-stable no-op rerun, symlink refusal).
+
+## Approach
+
+New subcommand:
+
+```
+soma memory backfill [--from <dir>] [--type semantic|procedural]
+                     [--project <key>] [--dry-run]
+                     [--soma-home <dir>] [--home-dir <dir>]
+```
+
+- **`--from`** (default `<somaHome>/memory`): source root walked recursively.
+- **`--type`**: force ALL notes to one type, overriding the category map.
+- **`--project`**: set note `project` field (default `null`).
+- **`--dry-run`**: print the plan table, touch nothing.
+
+### Category → type mapping (the chosen model)
+
+Map by the **top-level category dir** (first path segment under the source root):
+
+| Category dir | Note type |
+|---|---|
+| `LEARNING` (incl. `ALGORITHM/`, `PROMOTED/`, `REFLECTIONS/`) | `procedural` (how-to / behavioral lessons) |
+| `KNOWLEDGE` (incl. `PROMOTED/`, `Research/`) | `semantic` (facts) |
+| any other category | `semantic` (fallback) |
+
+`--type` overrides the map entirely. Trust is **always `quarantined`** (derived
+from the `import` trigger — the map affects *type*, never trust; elevating trust
+deterministically would blow open the MINJA hole for anyone who can drop a file
+in the source dir).
+
+**Skipped, never imported:** reserved dirs `STATE`, `episodic`, `semantic`,
+`procedural`, `archive`, `imports`; files directly under the root (READMEs,
+`INDEX.md`); any `README.md`; symlinks anywhere (loud refusal, matching the
+migrator's stance).
+
+### Per-file note synthesis (deterministic)
+
+For each eligible source file at relative path `rel`:
+- **id** = `slugify("<category>-<stem>")`, ≤64 chars, collision-suffixed (`-2`, `-3`) against both the in-run set and the existing corpus. Must satisfy the note SLUG shape (the write path binds `id` → `<type>/<id>.md` filename).
+- **type** = category map (or `--type`).
+- **created / last_verified** = file **mtime** → `YYYY-MM-DD` UTC (injected via `writeMemoryNote`'s `now` option, set per-file to `new Date(mtimeMs)`).
+- **provenance** = `import`; **trust** = `quarantined` (derived).
+- **source_of_truth** = absolute path of the original file (so a human can verify against the archived original).
+- **project** = `--project` or `null`; **links** = `[]`; **resurface_count** = 0.
+- **hook** = short humanized recall phrase from the stem (optional; aids recall matching).
+- **body** = original file content, prefixed with a one-line blockquote preamble noting the backfill origin.
+
+### Dedup & idempotency
+
+- Files processed **sequentially** (not concurrent) so later files see earlier-written ones and the recall-first refusal dedups within the batch deterministically.
+- A per-file **recall-first refusal** (exact/near-dup already in corpus) is caught and counted as `skipped-duplicate`, not a batch abort (`memory-write.ts:618` builds the refusal — implementation inspects that surface to classify).
+- Manifest `<somaHome>/imports/backfill/.manifest.json` (schema `soma.memory-backfill.v1`, entries `{relativePath, noteId, type, sha256, mtimeMs}`). Rerun skips files whose source SHA matches AND whose target note still exists → byte-stable no-op. Source drift in v1 = re-import as a new note (documented limitation; no auto-supersede yet).
+
+### Result / reporting
+
+`runMemoryBackfill` returns `{ writtenCount, skippedDuplicateCount, skippedManifestCount, errors[], notes[] }`; CLI prints a summary table. `--dry-run` prints the same plan without writing or touching the manifest.
+
+## Files to create / modify
+
+1. **`src/memory-backfill.ts`** (new, ~250 LOC) — `planMemoryBackfill()` + `runMemoryBackfill()`; category map, file walk (skip/symlink rules), id derivation + collision handling, mtime→date, body preamble, manifest read/render, sequential loop calling `writeMemoryNote`. Reuses the write path (serialization, dedup, events) rather than re-implementing note I/O.
+2. **`src/types.ts`** — add `SomaMemoryBackfillOptions`, `SomaMemoryBackfillPlanEntry`, `SomaMemoryBackfillResult`, manifest types, and `SOMA_MEMORY_BACKFILL_TYPE_MAP` constant (near the other memory-subsystem types).
+3. **`src/cli/memory.ts`** — add `"backfill"` to `MEMORY_ACTIONS`; `ParsedMemoryBackfillArgs` + union member; `parseMemoryBackfillArgs`; a `MEMORY_COMMAND_HELP.subcommands.backfill` usage string; dispatch `case "backfill"`; handler calling `runMemoryBackfill` + a `formatMemoryBackfillResult`.
+4. **`test/memory-backfill.test.ts`** (new) — mirror `pai-memory-migrator.test.ts` + `memory-write.test.ts` patterns: category→type mapping, id derivation + collision, mtime→created, trust=quarantined, dedup skip, `--dry-run` no-op, idempotent rerun (byte-stable manifest), symlink refusal, reserved-dir skipping.
+5. **Docs** — one usage line in `docs/memory-policy-v0.md` (or the M-milestones list) noting M8; short README mention if the Memory section enumerates subcommands.
+
+## Verification
+
+- `bun test test/memory-backfill.test.ts` — unit coverage above.
+- `bun test` — full suite green (no regression in `memory-*`, `pai-migration-*`).
+- Typecheck + LSP diagnostics clean on the three edited/new source files.
+- **Live acceptance against a throwaway `--soma-home` fixture:**
+  - `soma memory backfill --dry-run` → shows `KNOWLEDGE/*`→semantic, `LEARNING/*`→procedural, nothing written.
+  - Real run: notes land in `semantic/`/`procedural/`, `trust: quarantined`, `provenance: import`, `created` = source mtime.
+  - `soma memory audit` passes (schema-valid, INDEX fresh).
+  - `soma memory recall <term>` surfaces a backfilled note **with the ⚠ untrusted banner**; `soma memory reindex` keeps them **out** of INDEX (quarantined) — confirming the intended lifecycle.
+  - Rerun `backfill` → 0 written / all skipped, manifest byte-identical.
+
+## Out of scope (v1)
+
+- LLM distillation of legacy content (subsystem is deterministic-only; bodies are wrapped verbatim).
+- Auto-supersede on source drift (rerun re-imports changed files as new notes).
+- Trust elevation of imports (stays `quarantined`; a human elevates later via the verify/supersede path — a separate, deliberate step).
+- Non-markdown / recall-SQLite sources (SQLite-as-canon explicitly rejected, plan v2 §fatal-flaws).

--- a/Plans/declarative-twirling-lampson.md
+++ b/Plans/declarative-twirling-lampson.md
@@ -10,14 +10,14 @@ Legacy files can even carry a stopgap banner: *"re-promote via `soma memory
 write` once M1 ships."*
 
 For **shipping Soma to other users**, we need a first-class, reusable command
-that takes a user's existing markdown memory and turns it into schema-valid,
+that takes a principal's existing markdown memory and turns it into schema-valid,
 governed notes — deterministically, no LLM (subsystem invariant), respecting the
 M1 trust-governance model. This is milestone **M8 — backfill**.
 
 **Key design facts established during exploration:**
 - The `import` write trigger is the sanctioned bulk path: `SOMA_MEMORY_TRIGGER_TRUST.import → "quarantined"`, needs **no authority signal** (`memory-write.ts:30`, MINJA defense). Backfilled content lands untrusted by design.
-- Lifecycle is correct, not a dead end: **recall INCLUDES quarantined notes** with a ⚠ untrusted banner (`memory-recall.ts:136,162` — only `valid_until===null` is filtered, not trust), while **INDEX EXCLUDES quarantined** (`memory-index.ts:17`). So imports are pull-discoverable immediately and earn always-on INDEX only after a human verifies/elevates them.
-- `writeMemoryNote({mode:"create", trigger:"import", …})` (`memory-write.ts:779`) already does schema serialization, per-note dedup (recall-first refusal, Jaccard ≥0.6 / exact-body), and event journaling. Backfill is a **batch adapter over this existing path**, not a new writer.
+- Lifecycle is correct, not a dead end: **recall INCLUDES quarantined notes** with a ⚠ untrusted banner (`memory-recall.ts:136,162` — only `valid_until===null` is filtered, not trust), while **INDEX EXCLUDES quarantined** (`memory-index.ts:17`). So imports are pull-discoverable immediately and earn always-on INDEX only after the principal verifies/elevates them.
+- `writeMemoryNote({mode:"create", trigger:"import", …})` (`memory-write.ts:779`) already does schema serialization, per-note dedup (recall-first refusal, Jaccard ≥0.6 / exact-body), and event journaling. Backfill is a **batch importer over this existing path**, not a new writer.
 - Idempotency pattern to mirror: `src/pai-memory-migrator.ts` (SHA manifest, skip-unchanged, byte-stable no-op rerun, symlink refusal).
 
 ## Approach
@@ -51,9 +51,11 @@ deterministically would blow open the MINJA hole for anyone who can drop a file
 in the source dir).
 
 **Skipped, never imported:** reserved dirs `STATE`, `episodic`, `semantic`,
-`procedural`, `archive`, `imports`; files directly under the root (READMEs,
-`INDEX.md`); any `README.md`; symlinks anywhere (loud refusal, matching the
-migrator's stance).
+`procedural`, `archive`, `imports`; any `README.md` (case-insensitive);
+non-markdown files; symlinks anywhere (loud refusal, matching the migrator's
+stance). Files sitting directly under the root are skipped **only for the
+default `<somaHome>/memory` root** (README/`INDEX.md` territory); a custom
+`--from <dir>` imports its top-level markdown (category `""` → semantic).
 
 ### Per-file note synthesis (deterministic)
 
@@ -62,7 +64,7 @@ For each eligible source file at relative path `rel`:
 - **type** = category map (or `--type`).
 - **created / last_verified** = file **mtime** → `YYYY-MM-DD` UTC (injected via `writeMemoryNote`'s `now` option, set per-file to `new Date(mtimeMs)`).
 - **provenance** = `import`; **trust** = `quarantined` (derived).
-- **source_of_truth** = absolute path of the original file (so a human can verify against the archived original).
+- **source_of_truth** = absolute path of the original file (so the principal can verify against the archived original).
 - **project** = `--project` or `null`; **links** = `[]`; **resurface_count** = 0.
 - **hook** = short humanized recall phrase from the stem (optional; aids recall matching).
 - **body** = original file content **verbatim** — no injected preamble (a shared preamble inflates token overlap and makes the recall-first dedup over-fire on short files; origin lives in frontmatter instead). Only `.md`/`.markdown` files are imported.
@@ -101,5 +103,5 @@ For each eligible source file at relative path `rel`:
 
 - LLM distillation of legacy content (subsystem is deterministic-only; bodies are wrapped verbatim).
 - Auto-supersede on source drift (rerun re-imports changed files as new notes).
-- Trust elevation of imports (stays `quarantined`; a human elevates later via the verify/supersede path — a separate, deliberate step).
+- Trust elevation of imports (stays `quarantined`; the principal elevates later via the verify/supersede path — a separate, deliberate step).
 - Non-markdown / recall-SQLite sources (SQLite-as-canon explicitly rejected, plan v2 §fatal-flaws).

--- a/Plans/declarative-twirling-lampson.md
+++ b/Plans/declarative-twirling-lampson.md
@@ -71,7 +71,7 @@ For each eligible source file at relative path `rel`:
 
 - Files processed **sequentially** (not concurrent) so later files see earlier-written ones and the recall-first refusal dedups within the batch deterministically.
 - A per-file **recall-first refusal** (exact/near-dup already in corpus) is caught and counted as `skipped-duplicate`, not a batch abort (`memory-write.ts:618` builds the refusal — implementation inspects that surface to classify).
-- Manifest `<somaHome>/memory/STATE/imports/backfill/.manifest.json` (schema `soma.memory-backfill.v1`, entries `{relativePath, noteId, type, sha256, mtimeMs}`) — inside the Memory compartment, under the reserved STATE dir the source walk never re-imports. Rerun skips a file only when its source SHA matches, its resolved type matches the prior import, AND its target note still exists; the prior entry is re-emitted verbatim → byte-stable no-op (even across a `touch`). Source drift = re-import as a new note (documented limitation; no auto-supersede yet).
+- Manifest `<somaHome>/memory/STATE/imports/backfill/.manifest.json` (schema `soma.memory-backfill.v1`, entries `{relativePath, noteId, type, sha256, mtimeMs}`) — inside the Memory compartment, under the reserved STATE dir the source walk never re-imports. Rerun skips a file only when its source SHA matches, its resolved type matches the prior import, AND its target note still exists; the prior entry is re-emitted verbatim → byte-stable no-op (even across a `touch`). An edited source (new SHA) is re-processed through the write path — written as a *new* note, OR classified `skipped-duplicate` if the edited body still trips the recall-first refusal against an existing note (no auto-supersede in v1).
 
 ### Result / reporting
 

--- a/Plans/declarative-twirling-lampson.md
+++ b/Plans/declarative-twirling-lampson.md
@@ -95,7 +95,7 @@ For each eligible source file at relative path `rel`:
 - **Live acceptance against a throwaway `--soma-home` fixture:**
   - `soma memory backfill --dry-run` → shows `KNOWLEDGE/*`→semantic, `LEARNING/*`→procedural, nothing written.
   - Real run: notes land in `semantic/`/`procedural/`, `trust: quarantined`, `provenance: import`, `created` = source mtime.
-  - `soma memory audit` passes (schema-valid, INDEX fresh).
+  - `soma memory audit` passes (schema-valid, INDEX fresh) — backfill rebuilds the INDEX after writing, so index-freshness holds without a separate `reindex` step.
   - `soma memory recall <term>` surfaces a backfilled note **with the ⚠ untrusted banner**; `soma memory reindex` keeps them **out** of INDEX (quarantined) — confirming the intended lifecycle.
   - Rerun `backfill` → 0 written / all skipped, manifest byte-identical.
 

--- a/README.md
+++ b/README.md
@@ -403,7 +403,8 @@ free-form markdown (default source: the legacy `<somaHome>/memory` category dirs
 schema-valid notes through the same governed write path — deterministically, no
 LLM, idempotent via a SHA manifest. Every imported note lands at `quarantined`
 trust (recall-discoverable with a ⚠ banner, held out of the INDEX until the
-principal verifies it); the category dir maps to a note type (`LEARNING`→procedural,
+principal re-authors it at higher trust — `verify` alone does not elevate a
+quarantined note); the category dir maps to a note type (`LEARNING`→procedural,
 `KNOWLEDGE`→semantic) unless `--type` forces one. The note subsystem also ships
 as the portable **Memory** skill,
 which routes a remember/recall/log/maintain/audit request to the right

--- a/README.md
+++ b/README.md
@@ -402,8 +402,8 @@ it can gate CI. `soma memory backfill` bulk-imports a principal's existing
 free-form markdown (default source: the legacy `<somaHome>/memory` category dirs) into
 schema-valid notes through the same governed write path — deterministically, no
 LLM, idempotent via a SHA manifest. Every imported note lands at `quarantined`
-trust (recall-discoverable with a ⚠ banner, held out of the INDEX until a human
-verifies it); the category dir maps to a note type (`LEARNING`→procedural,
+trust (recall-discoverable with a ⚠ banner, held out of the INDEX until the
+principal verifies it); the category dir maps to a note type (`LEARNING`→procedural,
 `KNOWLEDGE`→semantic) unless `--type` forces one. The note subsystem also ships
 as the portable **Memory** skill,
 which routes a remember/recall/log/maintain/audit request to the right

--- a/README.md
+++ b/README.md
@@ -398,8 +398,8 @@ aged-unverified semantic notes `review: stale`, flags near-duplicate pairs for
 review, and rebuilds the INDEX — it never auto-merges notes. `soma memory audit`
 is a deterministic smoke check (note-root integrity, schema validity, INDEX
 freshness, digest coverage) that exits non-zero on any health-gating failure, so
-it can gate CI. `soma memory backfill` bulk-imports a user's existing free-form
-markdown (default source: the legacy `<somaHome>/memory` category dirs) into
+it can gate CI. `soma memory backfill` bulk-imports a principal's existing
+free-form markdown (default source: the legacy `<somaHome>/memory` category dirs) into
 schema-valid notes through the same governed write path — deterministically, no
 LLM, idempotent via a SHA manifest. Every imported note lands at `quarantined`
 trust (recall-discoverable with a ⚠ banner, held out of the INDEX until a human

--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ soma memory recall "client sovereignty"   # note-aware, read-only, with links
 soma memory digest --session <id> --body "..."   # the one session digest
 soma memory consolidate --dry-run          # deterministic maintenance, plan only
 soma memory audit                          # health check; exits non-zero on failure
+soma memory backfill --dry-run             # bulk-import legacy markdown → notes (plan only)
 ```
 
 `soma memory recall` retrieves durable notes with a verification banner and
@@ -397,7 +398,14 @@ aged-unverified semantic notes `review: stale`, flags near-duplicate pairs for
 review, and rebuilds the INDEX — it never auto-merges notes. `soma memory audit`
 is a deterministic smoke check (note-root integrity, schema validity, INDEX
 freshness, digest coverage) that exits non-zero on any health-gating failure, so
-it can gate CI. The note subsystem also ships as the portable **Memory** skill,
+it can gate CI. `soma memory backfill` bulk-imports a user's existing free-form
+markdown (default source: the legacy `<somaHome>/memory` category dirs) into
+schema-valid notes through the same governed write path — deterministically, no
+LLM, idempotent via a SHA manifest. Every imported note lands at `quarantined`
+trust (recall-discoverable with a ⚠ banner, held out of the INDEX until a human
+verifies it); the category dir maps to a note type (`LEARNING`→procedural,
+`KNOWLEDGE`→semantic) unless `--type` forces one. The note subsystem also ships
+as the portable **Memory** skill,
 which routes a remember/recall/log/maintain/audit request to the right
 subcommand. See [docs/architecture.md](docs/architecture.md#memory) for the full
 model.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,13 +128,14 @@ markdown; the **memory-note subsystem** (plan v2, milestones M0–M8) is a
 root. Both are sub-stores within the single Memory compartment, not peer Soma
 compartments. `soma memory backfill` (M8) bridges the two for a migrating
 principal: it walks the legacy category dirs and writes each markdown file
-(READMEs excluded) as a `quarantined` note through the governed write path
-(below), mapping the category
-to a note type (`LEARNING`→procedural, `KNOWLEDGE`→semantic). It is deterministic
-(bodies verbatim, `created` from the source mtime, no LLM) and idempotent via a SHA
-manifest at `memory/STATE/imports/backfill/.manifest.json`. Imports stay recall-discoverable
-(with a ⚠ untrusted banner) but out of the always-loaded INDEX until the
-principal verifies them.
+(READMEs excluded) as a `quarantined` note — as a **batch caller of the governed
+`write` path** (below), not a distinct governed path of its own — mapping the
+category to a note type (`LEARNING`→procedural, `KNOWLEDGE`→semantic). It is
+deterministic (bodies verbatim, `created` from the source mtime, no LLM) and
+idempotent via a SHA manifest at `memory/STATE/imports/backfill/.manifest.json`,
+and rebuilds the INDEX after writing so the store stays audit-clean. Imports stay
+recall-discoverable (with a ⚠ untrusted banner) but out of the always-loaded
+INDEX until the principal verifies them.
 
 Each note is one file: strict frontmatter (id, type, trust, provenance,
 bi-temporal `valid_until`, `last_verified`, `resurface_count`, links) plus a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,11 +122,18 @@ The initial version should avoid requiring a vector database. Search can start
 with filenames, frontmatter, ripgrep, and small deterministic indexes.
 
 The uppercase-named legacy stores (`WORK`, `KNOWLEDGE`, …) hold free-form
-markdown; the **memory-note subsystem** (plan v2, milestones M0–M7) is a
+markdown; the **memory-note subsystem** (plan v2, milestones M0–M8) is a
 *separate*, schema-governed durable store whose lowercase-named directories
 (`semantic`, `procedural`, `episodic`) sit as siblings under the same `memory/`
 root. Both are sub-stores within the single Memory compartment, not peer Soma
-compartments.
+compartments. `soma memory backfill` (M8) bridges the two for a migrating user:
+it walks the legacy category dirs and writes each file as a `quarantined` note
+through the governed write path (below), mapping the category to a note type
+(`LEARNING`→procedural, `KNOWLEDGE`→semantic). It is deterministic (bodies
+verbatim, `created` from the source mtime, no LLM) and idempotent via a SHA
+manifest at `imports/backfill/.manifest.json`. Imports stay recall-discoverable
+(with a ⚠ untrusted banner) but out of the always-loaded INDEX until a human
+verifies them.
 
 Each note is one file: strict frontmatter (id, type, trust, provenance,
 bi-temporal `valid_until`, `last_verified`, `resurface_count`, links) plus a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,11 +126,11 @@ markdown; the **memory-note subsystem** (plan v2, milestones M0–M8) is a
 *separate*, schema-governed durable store whose lowercase-named directories
 (`semantic`, `procedural`, `episodic`) sit as siblings under the same `memory/`
 root. Both are sub-stores within the single Memory compartment, not peer Soma
-compartments. `soma memory backfill` (M8) bridges the two for a migrating user:
-it walks the legacy category dirs and writes each file as a `quarantined` note
-through the governed write path (below), mapping the category to a note type
-(`LEARNING`→procedural, `KNOWLEDGE`→semantic). It is deterministic (bodies
-verbatim, `created` from the source mtime, no LLM) and idempotent via a SHA
+compartments. `soma memory backfill` (M8) bridges the two for a migrating
+principal: it walks the legacy category dirs and writes each markdown file as a
+`quarantined` note through the governed write path (below), mapping the category
+to a note type (`LEARNING`→procedural, `KNOWLEDGE`→semantic). It is deterministic
+(bodies verbatim, `created` from the source mtime, no LLM) and idempotent via a SHA
 manifest at `imports/backfill/.manifest.json`. Imports stay recall-discoverable
 (with a ⚠ untrusted banner) but out of the always-loaded INDEX until a human
 verifies them.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,7 +131,7 @@ principal: it walks the legacy category dirs and writes each markdown file as a
 `quarantined` note through the governed write path (below), mapping the category
 to a note type (`LEARNING`→procedural, `KNOWLEDGE`→semantic). It is deterministic
 (bodies verbatim, `created` from the source mtime, no LLM) and idempotent via a SHA
-manifest at `imports/backfill/.manifest.json`. Imports stay recall-discoverable
+manifest at `memory/STATE/imports/backfill/.manifest.json`. Imports stay recall-discoverable
 (with a ⚠ untrusted banner) but out of the always-loaded INDEX until a human
 verifies them.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,7 +135,9 @@ deterministic (bodies verbatim, `created` from the source mtime, no LLM) and
 idempotent via a SHA manifest at `memory/STATE/imports/backfill/.manifest.json`,
 and rebuilds the INDEX after writing so the store stays audit-clean. Imports stay
 recall-discoverable (with a ⚠ untrusted banner) but out of the always-loaded
-INDEX until the principal verifies them.
+INDEX until the principal re-authors them at higher trust (the admission filter
+excludes quarantined unconditionally, so `verify` alone — which only bumps
+freshness — cannot promote them; `principal-correction`/`supersede` can).
 
 Each note is one file: strict frontmatter (id, type, trust, provenance,
 bi-temporal `valid_until`, `last_verified`, `resurface_count`, links) plus a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -133,8 +133,8 @@ principal: it walks the legacy category dirs and writes each markdown file
 to a note type (`LEARNING`→procedural, `KNOWLEDGE`→semantic). It is deterministic
 (bodies verbatim, `created` from the source mtime, no LLM) and idempotent via a SHA
 manifest at `memory/STATE/imports/backfill/.manifest.json`. Imports stay recall-discoverable
-(with a ⚠ untrusted banner) but out of the always-loaded INDEX until a human
-verifies them.
+(with a ⚠ untrusted banner) but out of the always-loaded INDEX until the
+principal verifies them.
 
 Each note is one file: strict frontmatter (id, type, trust, provenance,
 bi-temporal `valid_until`, `last_verified`, `resurface_count`, links) plus a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,8 +127,9 @@ markdown; the **memory-note subsystem** (plan v2, milestones M0–M8) is a
 (`semantic`, `procedural`, `episodic`) sit as siblings under the same `memory/`
 root. Both are sub-stores within the single Memory compartment, not peer Soma
 compartments. `soma memory backfill` (M8) bridges the two for a migrating
-principal: it walks the legacy category dirs and writes each markdown file as a
-`quarantined` note through the governed write path (below), mapping the category
+principal: it walks the legacy category dirs and writes each markdown file
+(READMEs excluded) as a `quarantined` note through the governed write path
+(below), mapping the category
 to a note type (`LEARNING`→procedural, `KNOWLEDGE`→semantic). It is deterministic
 (bodies verbatim, `created` from the source mtime, no LLM) and idempotent via a SHA
 manifest at `memory/STATE/imports/backfill/.manifest.json`. Imports stay recall-discoverable

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -179,7 +179,7 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
     backfill:
       "Usage: soma memory backfill [--from <dir>] [--type <semantic|procedural>] [--project <key>] [--dry-run] [--home-dir <dir>] [--soma-home <dir>]. " +
       "Bulk-import legacy free-form markdown (default source: <somaHome>/memory category dirs) into schema-valid notes via the import trigger. " +
-      "Every note lands at QUARANTINED trust (recall-discoverable with a ⚠ banner, excluded from INDEX until verified); category dir → type is mapped (LEARNING→procedural, KNOWLEDGE→semantic) unless --type forces one. " +
+      "Every note lands at QUARANTINED trust (recall-discoverable with a ⚠ banner, excluded from INDEX until re-authored at higher trust); category dir → type is mapped (LEARNING→procedural, KNOWLEDGE→semantic) unless --type forces one. " +
       "Deterministic, idempotent (SHA manifest); --dry-run prints the plan without writing.",
   },
 };
@@ -843,7 +843,7 @@ function formatMemoryBackfillResult(result: SomaMemoryBackfillResult): string {
   };
   appendSection(
     "written",
-    "imported (quarantined — recall-discoverable, elevate via verify to reach INDEX):",
+    "imported (quarantined — recall-discoverable with a ⚠ banner; excluded from INDEX until re-authored at higher trust via principal-correction/supersede — verify alone does not elevate):",
     (e) => `  ${e.relativePath} → ${e.type}/${e.noteId}.md`,
   );
   appendSection("skipped-duplicate", "skipped as duplicates of existing notes:", (e) => `  ${e.relativePath}: ${e.detail ?? ""}`);

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -4,6 +4,7 @@ import {
   promoteAlgorithmRunMemory,
   rebuildMemoryIndex,
   recallMemory,
+  runMemoryBackfill,
   searchSomaMemory,
   verifyMemoryNote,
   writeMemoryAction,
@@ -18,6 +19,8 @@ import type {
   SomaMemoryActionResult,
   SomaMemoryAuditOptions,
   SomaMemoryAuditResult,
+  SomaMemoryBackfillOptions,
+  SomaMemoryBackfillResult,
   SomaMemoryConsolidateOptions,
   SomaMemoryConsolidateResult,
   SomaMemoryDigestOptions,
@@ -108,6 +111,12 @@ export interface ParsedMemoryAuditArgs {
   options: SomaMemoryAuditOptions;
 }
 
+export interface ParsedMemoryBackfillArgs {
+  command: "memory";
+  action: "backfill";
+  options: SomaMemoryBackfillOptions;
+}
+
 export type ParsedMemoryArgs =
   | ParsedMemorySearchArgs
   | ParsedMemoryRecallArgs
@@ -118,13 +127,14 @@ export type ParsedMemoryArgs =
   | ParsedMemoryDigestArgs
   | ParsedMemoryActionArgs
   | ParsedMemoryConsolidateArgs
-  | ParsedMemoryAuditArgs;
+  | ParsedMemoryAuditArgs
+  | ParsedMemoryBackfillArgs;
 
-const MEMORY_ACTIONS = ["search", "recall", "promote", "write", "verify", "reindex", "digest", "action", "consolidate", "audit"] as const;
+const MEMORY_ACTIONS = ["search", "recall", "promote", "write", "verify", "reindex", "digest", "action", "consolidate", "audit", "backfill"] as const;
 type MemoryAction = (typeof MEMORY_ACTIONS)[number];
 
 export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAction, string> } = {
-  usage: "Usage: soma memory <search|recall|promote|write|verify|reindex|digest|action|consolidate|audit> ...",
+  usage: "Usage: soma memory <search|recall|promote|write|verify|reindex|digest|action|consolidate|audit|backfill> ...",
   subcommands: {
     search: "Usage: soma memory search [query] [--query <text>] [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
     recall:
@@ -166,6 +176,11 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
       "Usage: soma memory audit [--home-dir <dir>] [--soma-home <dir>]. " +
       "Deterministic, read-only health check of the memory tree (no LLM): schema validity, INDEX freshness, " +
       "digest coverage, orphaned archive notes, event/note ratio. EXITS NON-ZERO on any health-gating failure: an abnormal note root (root-integrity), a schema-invalid note, or a stale INDEX.",
+    backfill:
+      "Usage: soma memory backfill [--from <dir>] [--type <semantic|procedural>] [--project <key>] [--dry-run] [--home-dir <dir>] [--soma-home <dir>]. " +
+      "Bulk-import legacy free-form markdown (default source: <somaHome>/memory category dirs) into schema-valid notes via the import trigger. " +
+      "Every note lands at QUARANTINED trust (recall-discoverable with a ⚠ banner, excluded from INDEX until verified); category dir → type is mapped (LEARNING→procedural, KNOWLEDGE→semantic) unless --type forces one. " +
+      "Deterministic, idempotent (SHA manifest); --dry-run prints the plan without writing.",
   },
 };
 
@@ -201,7 +216,53 @@ export function parseMemoryArgs(args: string[]): ParsedMemoryArgs {
       return { command, action, options: parseMemoryConsolidateArgs(rest) };
     case "audit":
       return { command, action, options: parseMemoryAuditArgs(rest) };
+    case "backfill":
+      return { command, action, options: parseMemoryBackfillArgs(rest) };
   }
+}
+
+function parseMemoryBackfillArgs(args: string[]): SomaMemoryBackfillOptions {
+  const options: SomaMemoryBackfillOptions = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--substrate":
+        options.substrate = parseSubstrate(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--from":
+        options.from = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--type": {
+        const value = readOption(args, index, arg);
+        if (value !== "semantic" && value !== "procedural") {
+          throw new Error(MEMORY_COMMAND_HELP.subcommands.backfill);
+        }
+        options.type = value;
+        index += 1;
+        break;
+      }
+      case "--project":
+        options.project = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      default:
+        throw new Error(MEMORY_COMMAND_HELP.subcommands.backfill);
+    }
+  }
+  return options;
 }
 
 function parseMemoryAuditArgs(args: string[]): SomaMemoryAuditOptions {
@@ -742,7 +803,49 @@ export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
       if (!audit.healthy) throw new SomaCliError(report, 1);
       return report;
     }
+    case "backfill": {
+      const result = await runMemoryBackfill(parsed.options);
+      const report = formatMemoryBackfillResult(result);
+      // A non-dry-run with per-file write errors exits NON-ZERO so a scripted
+      // backfill surfaces partial failure (the full account is on the error).
+      if (!result.dryRun && result.errorCount > 0) throw new SomaCliError(report, 1);
+      return report;
+    }
   }
+}
+
+function formatMemoryBackfillResult(result: SomaMemoryBackfillResult): string {
+  if (result.dryRun) {
+    const lines = [
+      `Soma memory backfill (dry-run — nothing changed) from ${result.from}`,
+      `would import ${result.entries.length} file(s):`,
+      ...result.entries.map((e) => `  ${e.relativePath} → ${e.type}/${e.noteId}.md (created ${e.created})`),
+    ];
+    if (result.entries.length === 0) lines.push("  (no eligible source files found)");
+    return lines.join("\n");
+  }
+  const lines = [
+    `Soma memory backfill from ${result.from}`,
+    `written: ${result.writtenCount} · skipped (already imported): ${result.skippedManifestCount} · ` +
+      `skipped (duplicate): ${result.skippedDuplicateCount} · errors: ${result.errorCount}`,
+    `manifest: ${result.manifestPath}`,
+  ];
+  const written = result.entries.filter((e) => e.status === "written");
+  if (written.length > 0) {
+    lines.push("imported (quarantined — recall-discoverable, elevate via verify to reach INDEX):");
+    for (const e of written) lines.push(`  ${e.relativePath} → ${e.type}/${e.noteId}.md`);
+  }
+  const dups = result.entries.filter((e) => e.status === "skipped-duplicate");
+  if (dups.length > 0) {
+    lines.push("skipped as duplicates of existing notes:");
+    for (const e of dups) lines.push(`  ${e.relativePath}: ${e.detail ?? ""}`);
+  }
+  const errors = result.entries.filter((e) => e.status === "error");
+  if (errors.length > 0) {
+    lines.push("errors:");
+    for (const e of errors) lines.push(`  ${e.relativePath}: ${e.detail ?? ""}`);
+  }
+  return lines.join("\n");
 }
 
 function formatMemoryAuditResult(result: SomaMemoryAuditResult): string {

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -816,10 +816,16 @@ export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
 
 function formatMemoryBackfillResult(result: SomaMemoryBackfillResult): string {
   if (result.dryRun) {
+    const wouldImport = result.entries.filter((e) => e.status === undefined);
+    const alreadyImported = result.entries.filter((e) => e.status === "skipped-manifest");
+    const errored = result.entries.filter((e) => e.status === "error");
+    const skipSummary = alreadyImported.length > 0 ? `, skip ${alreadyImported.length} already imported` : "";
     const lines = [
       `Soma memory backfill (dry-run — nothing changed) from ${result.from}`,
-      `would import ${result.entries.length} file(s):`,
-      ...result.entries.map((e) => `  ${e.relativePath} → ${e.type}/${e.noteId}.md (created ${e.created})`),
+      `would import ${wouldImport.length} file(s)${skipSummary}:`,
+      ...wouldImport.map((e) => `  ${e.relativePath} → ${e.type}/${e.noteId}.md (created ${e.created})`),
+      ...alreadyImported.map((e) => `  [skip] ${e.relativePath} → ${e.type}/${e.noteId}.md (already imported)`),
+      ...errored.map((e) => `  [error] ${e.relativePath}: ${e.detail ?? ""}`),
     ];
     if (result.entries.length === 0) lines.push("  (no eligible source files found)");
     return lines.join("\n");

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -830,10 +830,11 @@ function formatMemoryBackfillResult(result: SomaMemoryBackfillResult): string {
       `skipped (duplicate): ${result.skippedDuplicateCount} · errors: ${result.errorCount}`,
     `manifest: ${result.manifestPath}`,
   ];
+  type BackfillEntry = SomaMemoryBackfillResult["entries"][number];
   const appendSection = (
-    status: SomaMemoryBackfillResult["entries"][number]["status"],
+    status: BackfillEntry["status"],
     heading: string,
-    format: (e: SomaMemoryBackfillResult["entries"][number]) => string,
+    format: (e: BackfillEntry) => string,
   ): void => {
     const matched = result.entries.filter((e) => e.status === status);
     if (matched.length === 0) return;

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -830,21 +830,23 @@ function formatMemoryBackfillResult(result: SomaMemoryBackfillResult): string {
       `skipped (duplicate): ${result.skippedDuplicateCount} · errors: ${result.errorCount}`,
     `manifest: ${result.manifestPath}`,
   ];
-  const written = result.entries.filter((e) => e.status === "written");
-  if (written.length > 0) {
-    lines.push("imported (quarantined — recall-discoverable, elevate via verify to reach INDEX):");
-    for (const e of written) lines.push(`  ${e.relativePath} → ${e.type}/${e.noteId}.md`);
-  }
-  const dups = result.entries.filter((e) => e.status === "skipped-duplicate");
-  if (dups.length > 0) {
-    lines.push("skipped as duplicates of existing notes:");
-    for (const e of dups) lines.push(`  ${e.relativePath}: ${e.detail ?? ""}`);
-  }
-  const errors = result.entries.filter((e) => e.status === "error");
-  if (errors.length > 0) {
-    lines.push("errors:");
-    for (const e of errors) lines.push(`  ${e.relativePath}: ${e.detail ?? ""}`);
-  }
+  const appendSection = (
+    status: SomaMemoryBackfillResult["entries"][number]["status"],
+    heading: string,
+    format: (e: SomaMemoryBackfillResult["entries"][number]) => string,
+  ): void => {
+    const matched = result.entries.filter((e) => e.status === status);
+    if (matched.length === 0) return;
+    lines.push(heading);
+    for (const e of matched) lines.push(format(e));
+  };
+  appendSection(
+    "written",
+    "imported (quarantined — recall-discoverable, elevate via verify to reach INDEX):",
+    (e) => `  ${e.relativePath} → ${e.type}/${e.noteId}.md`,
+  );
+  appendSection("skipped-duplicate", "skipped as duplicates of existing notes:", (e) => `  ${e.relativePath}: ${e.detail ?? ""}`);
+  appendSection("error", "errors:", (e) => `  ${e.relativePath}: ${e.detail ?? ""}`);
   return lines.join("\n");
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -496,6 +496,7 @@ export {
 } from "./work-registry";
 export { applySomaWriteback, type SomaWritebackOptions, type SomaWritebackResult } from "./writeback";
 export { promoteAlgorithmRunMemory } from "./memory-promotion";
+export { planMemoryBackfill, runMemoryBackfill } from "./memory-backfill";
 export {
   syncAlgorithmRunFromVsa,
   formatSyncResult,

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -21,7 +21,7 @@
  *   - Trust is ALWAYS `quarantined` — the `import` trigger derives it and no
  *     caller flag can elevate it (MINJA defense). Backfilled notes are recall-
  *     pull-discoverable immediately (with a ⚠ untrusted banner) but stay out of
- *     the always-loaded INDEX until a human verifies/elevates them.
+ *     the always-loaded INDEX until the principal verifies/elevates them.
  *   - Files are processed SEQUENTIALLY so the recall-first refusal dedups within
  *     the batch deterministically (a later near-duplicate sees earlier writes).
  *

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -354,42 +354,51 @@ export async function runMemoryBackfill(
   let errorCount = 0;
 
   for (const src of sources) {
+    // `type` and `created` are pure (no I/O) — safe to compute before the try so
+    // an error entry can still report them if a later fallible step throws.
     const type = resolveType(options, src.category);
-    const content = await readSourceNoFollow(src.absPath, { dev: src.dev, ino: src.ino });
-    const sha = sha256Hex(content);
     const created = isoDate(new Date(src.mtimeMs));
-
-    // Already backfilled and unchanged (same bytes AND same resolved type) with
-    // its note still present? Re-emit the PRIOR manifest entry VERBATIM (including
-    // its stored mtimeMs) so a no-op rerun is byte-stable even if the source was
-    // merely `touch`ed. The type guard keeps `--type` honest: rerunning with a
-    // different --type than a prior import is NOT a hit — it falls through to the
-    // write path (where the identical body is caught by the recall-first gate).
-    const prior = previous?.map.get(src.relativePath);
-    if (prior?.sha256 === sha && prior.type === type) {
-      if (await pathExists(memoryNotePath(somaHome, prior.type, prior.noteId))) {
-        entries.push({
-          relativePath: src.relativePath,
-          source: src.absPath,
-          noteId: prior.noteId,
-          type: prior.type,
-          created,
-          target: memoryNotePath(somaHome, prior.type, prior.noteId),
-          status: "skipped-manifest",
-        });
-        manifestFiles.push({ ...prior });
-        used.add(prior.noteId);
-        skippedManifestCount += 1;
-        continue;
-      }
-    }
-
-    const id = await uniqueNoteId(somaHome, slugifyId(src.category, src.stem), used);
-    used.add(id);
-    const target = memoryNotePath(somaHome, type, id);
-    const hook = hookFromStem(src.stem);
+    // `id` is assigned once allocated; a read failure before allocation leaves it
+    // empty, which the error entry reports as an unknown target.
+    let id = "";
 
     try {
+      // EVERY fallible step lives inside the try so a single bad source (deleted,
+      // unreadable, symlink-swapped, identity-changed, or a write/dedup refusal)
+      // becomes a per-file entry — never a batch abort.
+      const content = await readSourceNoFollow(src.absPath, { dev: src.dev, ino: src.ino });
+      const sha = sha256Hex(content);
+
+      // Already backfilled and unchanged (same bytes AND same resolved type) with
+      // its note still present? Re-emit the PRIOR manifest entry VERBATIM (including
+      // its stored mtimeMs) so a no-op rerun is byte-stable even if the source was
+      // merely `touch`ed. The type guard keeps `--type` honest: rerunning with a
+      // different --type than a prior import is NOT a hit — it falls through to the
+      // write path (where the identical body is caught by the recall-first gate).
+      const prior = previous?.map.get(src.relativePath);
+      if (prior?.sha256 === sha && prior.type === type) {
+        if (await pathExists(memoryNotePath(somaHome, prior.type, prior.noteId))) {
+          entries.push({
+            relativePath: src.relativePath,
+            source: src.absPath,
+            noteId: prior.noteId,
+            type: prior.type,
+            created,
+            target: memoryNotePath(somaHome, prior.type, prior.noteId),
+            status: "skipped-manifest",
+          });
+          manifestFiles.push({ ...prior });
+          used.add(prior.noteId);
+          skippedManifestCount += 1;
+          continue;
+        }
+      }
+
+      id = await uniqueNoteId(somaHome, slugifyId(src.category, src.stem), used);
+      used.add(id);
+      const target = memoryNotePath(somaHome, type, id);
+      const hook = hookFromStem(src.stem);
+
       await writeMemoryNote({
         somaHome,
         substrate: options.substrate,
@@ -428,20 +437,16 @@ export async function runMemoryBackfill(
         noteId: id,
         type,
         created,
-        target,
+        target: id ? memoryNotePath(somaHome, type, id) : "",
         status: isDuplicate ? "skipped-duplicate" : "error",
         detail: message,
       });
-      if (isDuplicate) {
-        // A near/exact duplicate already lives in the corpus — the desired
-        // outcome, not a failure. It is NOT recorded in the manifest (no note
-        // was created for this file); a later rerun re-scans and re-skips it.
-        used.delete(id);
-        skippedDuplicateCount += 1;
-      } else {
-        used.delete(id);
-        errorCount += 1;
-      }
+      // Release a tentatively-claimed id: a duplicate maps to an existing note
+      // (not recorded in the manifest → re-scanned next run); an error produced no
+      // note at all. A read failure before allocation leaves id empty (no-op).
+      if (id) used.delete(id);
+      if (isDuplicate) skippedDuplicateCount += 1;
+      else errorCount += 1;
     }
   }
 

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -33,7 +33,8 @@
  * was merely `touch`ed (mtime bumped, bytes unchanged).
  */
 import { createHash } from "node:crypto";
-import { lstat, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { constants as FS } from "node:fs";
+import { lstat, mkdir, open, readFile, readdir, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, relative, resolve, sep } from "node:path";
 import { MemoryNoteError } from "./memory-note";
@@ -81,6 +82,30 @@ function sha256Hex(content: Buffer | string): string {
 /** Format a Date as YYYY-MM-DD in UTC (the note schema's date grammar). */
 function isoDate(date: Date): string {
   return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Read a source file refusing to follow a symlink at the final path component
+ * (`O_NOFOLLOW`). Closes the collect→read TOCTOU: even if a vetted `.md` file is
+ * swapped for a symlink to a sensitive target between the walk and the read, the
+ * open fails (ELOOP) rather than importing the target's bytes. The walk already
+ * rejects symlink *directories* in the tree.
+ */
+async function readSourceNoFollow(path: string): Promise<string> {
+  let fh;
+  try {
+    fh = await open(path, FS.O_RDONLY | FS.O_NOFOLLOW);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ELOOP") {
+      throw new Error(`Soma memory backfill refused symlink at source path: ${path}`, { cause: error });
+    }
+    throw error;
+  }
+  try {
+    return await fh.readFile("utf8");
+  } finally {
+    await fh.close();
+  }
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -160,7 +185,7 @@ const MARKDOWN_EXT = /\.(?:md|markdown)$/i;
  * migrators' stance). Returns entries sorted by relative path for deterministic
  * ordering.
  */
-async function collectSources(root: string): Promise<SourceFile[]> {
+async function collectSources(root: string, skipRootFiles: boolean): Promise<SourceFile[]> {
   const files: SourceFile[] = [];
 
   async function visit(dir: string, depth: number): Promise<void> {
@@ -177,19 +202,21 @@ async function collectSources(root: string): Promise<SourceFile[]> {
       if (entry.isSymbolicLink()) {
         throw new Error(`Soma memory backfill refused symlink path: ${rel}`);
       }
-      const category = rel.split("/")[0];
-      if (depth === 0 && (RESERVED_CATEGORIES.has(entry.name) || entry.isFile())) {
-        // Reserved top-level dir, or a file directly under the root (README /
-        // INDEX.md territory) — never a backfill source.
-        continue;
-      }
+      // Reserved top-level names (the note stores + STATE/archive/imports) are
+      // never descended into — they are subsystem territory, not sources.
+      if (depth === 0 && RESERVED_CATEGORIES.has(entry.name)) continue;
       if (entry.isDirectory()) {
         await visit(abs, depth + 1);
         continue;
       }
       if (!entry.isFile()) continue;
+      // A file directly under the root is README/INDEX territory ONLY for the
+      // default memory root; a custom `--from <dir>` may legitimately hold its
+      // markdown right at the top, so those are imported (category "" → semantic).
+      if (depth === 0 && skipRootFiles) continue;
       if (/^readme\.md$/i.test(entry.name)) continue;
       if (!MARKDOWN_EXT.test(entry.name)) continue;
+      const category = rel.includes("/") ? rel.split("/")[0] : "";
       const stat = await lstat(abs);
       files.push({
         relativePath: rel,
@@ -244,8 +271,9 @@ export async function planMemoryBackfill(
   options: SomaMemoryBackfillOptions = {},
 ): Promise<SomaMemoryBackfillResult> {
   const somaHome = resolveSomaHome(options);
-  const from = resolve(options.from ?? join(somaHome, "memory"));
-  const sources = await collectSources(from);
+  const defaultRoot = resolve(join(somaHome, "memory"));
+  const from = resolve(options.from ?? defaultRoot);
+  const sources = await collectSources(from, from === defaultRoot);
 
   const used = new Set<string>();
   const entries: SomaMemoryBackfillEntry[] = [];
@@ -286,14 +314,15 @@ export async function runMemoryBackfill(
   options: SomaMemoryBackfillOptions = {},
 ): Promise<SomaMemoryBackfillResult> {
   const somaHome = resolveSomaHome(options);
-  const from = resolve(options.from ?? join(somaHome, "memory"));
+  const defaultRoot = resolve(join(somaHome, "memory"));
+  const from = resolve(options.from ?? defaultRoot);
   const manifestPath = join(somaHome, MANIFEST_RELATIVE);
 
   if (options.dryRun) {
     return planMemoryBackfill(options);
   }
 
-  const sources = await collectSources(from);
+  const sources = await collectSources(from, from === defaultRoot);
   const previous = await readManifest(somaHome);
 
   const used = new Set<string>();
@@ -306,7 +335,7 @@ export async function runMemoryBackfill(
 
   for (const src of sources) {
     const type = resolveType(options, src.category);
-    const content = await readFile(src.absPath, "utf8");
+    const content = await readSourceNoFollow(src.absPath);
     const sha = sha256Hex(content);
     const created = isoDate(new Date(src.mtimeMs));
 

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -49,7 +49,13 @@ import type {
 } from "./types";
 
 const MANIFEST_SCHEMA = "soma.memory-backfill.v1";
-const MANIFEST_RELATIVE = "imports/backfill/.manifest.json";
+// Backfill is a Memory-subsystem operation, so its bookkeeping lives INSIDE the
+// Memory compartment (`memory/`), under STATE (the subsystem's runtime-state dir,
+// alongside events.jsonl) — not at the Soma root. STATE is a reserved category
+// that the source walk never re-imports, and the manifest is `.json` (never a
+// markdown source), so it can never round-trip into a note.
+const MANIFEST_RELATIVE = "memory/STATE/imports/backfill/.manifest.json";
+const MANIFEST_DIR_RELATIVE = "memory/STATE/imports/backfill";
 
 // Category dirs (or root children) that are never backfill sources: STATE is
 // runtime JSON, episodic/semantic/procedural are the note stores themselves,
@@ -304,11 +310,14 @@ export async function runMemoryBackfill(
     const sha = sha256Hex(content);
     const created = isoDate(new Date(src.mtimeMs));
 
-    // Already backfilled and unchanged (same bytes) with its note still present?
-    // Re-emit the PRIOR manifest entry VERBATIM (including its stored mtimeMs) so
-    // a no-op rerun is byte-stable even if the source was merely `touch`ed.
+    // Already backfilled and unchanged (same bytes AND same resolved type) with
+    // its note still present? Re-emit the PRIOR manifest entry VERBATIM (including
+    // its stored mtimeMs) so a no-op rerun is byte-stable even if the source was
+    // merely `touch`ed. The type guard keeps `--type` honest: rerunning with a
+    // different --type than a prior import is NOT a hit — it falls through to the
+    // write path (where the identical body is caught by the recall-first gate).
     const prior = previous?.map.get(src.relativePath);
-    if (prior?.sha256 === sha) {
+    if (prior?.sha256 === sha && prior.type === type) {
       if (await pathExists(memoryNotePath(somaHome, prior.type, prior.noteId))) {
         entries.push({
           relativePath: src.relativePath,
@@ -390,7 +399,7 @@ export async function runMemoryBackfill(
   // Manifest reflects exactly the files currently backfilled to a present note
   // (written this run + previously-written-and-still-present). Vanished sources
   // drop out; duplicates are excluded (they map to a note this run did not own).
-  await mkdir(join(somaHome, "imports/backfill"), { recursive: true });
+  await mkdir(join(somaHome, MANIFEST_DIR_RELATIVE), { recursive: true });
   const importedAt =
     writtenCount === 0 && previous ? previous.importedAt : (options.now ?? new Date()).toISOString();
   const manifest: SomaMemoryBackfillManifest = {

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -11,7 +11,12 @@
  * once, in one place.
  *
  * Deterministic by contract:
- *   - No LLM. Bodies are wrapped verbatim (with a one-line provenance preamble).
+ *   - No LLM. Bodies are the legacy content VERBATIM — no injected preamble (a
+ *     shared preamble would inflate token overlap and make the recall-first
+ *     dedup over-fire on short files); origin lives in frontmatter instead.
+ *   - Only `.md`/`.markdown` files are imported — non-markdown files under a
+ *     category dir (JSON, `.env`, binaries, editor artifacts) are skipped so
+ *     they never become garbage notes.
  *   - `created`/`last_verified` come from the source file's mtime, not the clock.
  *   - Trust is ALWAYS `quarantined` — the `import` trigger derives it and no
  *     caller flag can elevate it (MINJA defense). Backfilled notes are recall-
@@ -22,9 +27,10 @@
  *
  * Idempotency mirrors `pai-memory-migrator.ts`: a SHA manifest at
  * `imports/backfill/.manifest.json` lets a rerun skip already-imported files
- * whose source bytes are unchanged and whose target note still exists. A pure
- * no-op rerun writes a byte-identical manifest (the `importedAt` is preserved
- * when nothing new was written).
+ * whose source bytes are unchanged and whose target note still exists. A no-op
+ * rerun (nothing new written) re-emits each prior manifest entry verbatim and
+ * preserves `importedAt`, so the manifest is byte-identical — even if a source
+ * was merely `touch`ed (mtime bumped, bytes unchanged).
  */
 import { createHash } from "node:crypto";
 import { lstat, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
@@ -36,6 +42,7 @@ import { SOMA_MEMORY_BACKFILL_TYPE_MAP } from "./types";
 import type {
   SomaMemoryBackfillEntry,
   SomaMemoryBackfillManifest,
+  SomaMemoryBackfillManifestEntry,
   SomaMemoryBackfillOptions,
   SomaMemoryBackfillResult,
   WritableNoteType,
@@ -135,11 +142,17 @@ interface SourceFile {
   mtimeMs: number;
 }
 
+// Markdown is the only backfill input: a category dir may hold JSON, `.env`,
+// exports, or binaries that would become garbage (or sensitive) notes if read as
+// UTF-8 and imported. Restrict to markdown extensions.
+const MARKDOWN_EXT = /\.(?:md|markdown)$/i;
+
 /**
- * Recursively collect eligible source files under `root`. Skips reserved
- * categories, root-level files (READMEs/INDEX territory), any README.md, and
- * refuses symlinks loudly (matching the migrators' stance). Returns entries
- * sorted by relative path for deterministic ordering.
+ * Recursively collect eligible source files under `root`. Imports only markdown
+ * files; skips reserved categories, root-level files (READMEs/INDEX territory),
+ * any README.md, and non-markdown files; refuses symlinks loudly (matching the
+ * migrators' stance). Returns entries sorted by relative path for deterministic
+ * ordering.
  */
 async function collectSources(root: string): Promise<SourceFile[]> {
   const files: SourceFile[] = [];
@@ -170,6 +183,7 @@ async function collectSources(root: string): Promise<SourceFile[]> {
       }
       if (!entry.isFile()) continue;
       if (entry.name === "README.md") continue;
+      if (!MARKDOWN_EXT.test(entry.name)) continue;
       const stat = await lstat(abs);
       files.push({
         relativePath: rel,
@@ -193,16 +207,22 @@ function resolveType(
   return SOMA_MEMORY_BACKFILL_TYPE_MAP[category] ?? "semantic";
 }
 
+/**
+ * Read the manifest once into a `relativePath → full entry` map (the whole
+ * record, not just the SHA), so the run loop can check the SHA, reuse the note
+ * id/type, and re-emit the prior entry verbatim without re-reading the file per
+ * source. Returns null when the manifest is missing or corrupt (→ re-import).
+ */
 async function readManifest(
   somaHome: string,
-): Promise<{ map: Map<string, string>; importedAt: string } | null> {
+): Promise<{ map: Map<string, SomaMemoryBackfillManifestEntry>; importedAt: string } | null> {
   const path = join(somaHome, MANIFEST_RELATIVE);
   if (!(await pathExists(path))) return null;
   try {
     const parsed = JSON.parse(await readFile(path, "utf8")) as SomaMemoryBackfillManifest;
     if (!Array.isArray(parsed.files)) return null;
-    const map = new Map<string, string>();
-    for (const entry of parsed.files) map.set(entry.relativePath, entry.sha256);
+    const map = new Map<string, SomaMemoryBackfillManifestEntry>();
+    for (const entry of parsed.files) map.set(entry.relativePath, entry);
     return { map, importedAt: parsed.importedAt };
   } catch {
     return null;
@@ -284,28 +304,23 @@ export async function runMemoryBackfill(
     const sha = sha256Hex(content);
     const created = isoDate(new Date(src.mtimeMs));
 
-    // Already backfilled and unchanged? Keep the prior manifest entry and skip.
-    const priorSha = previous?.map.get(src.relativePath);
-    if (priorSha && priorSha === sha) {
-      const existing = await noteExistsForRelative(somaHome, src.relativePath, previous);
-      if (existing) {
+    // Already backfilled and unchanged (same bytes) with its note still present?
+    // Re-emit the PRIOR manifest entry VERBATIM (including its stored mtimeMs) so
+    // a no-op rerun is byte-stable even if the source was merely `touch`ed.
+    const prior = previous?.map.get(src.relativePath);
+    if (prior?.sha256 === sha) {
+      if (await pathExists(memoryNotePath(somaHome, prior.type, prior.noteId))) {
         entries.push({
           relativePath: src.relativePath,
           source: src.absPath,
-          noteId: existing.id,
-          type: existing.type,
+          noteId: prior.noteId,
+          type: prior.type,
           created,
-          target: memoryNotePath(somaHome, existing.type, existing.id),
+          target: memoryNotePath(somaHome, prior.type, prior.noteId),
           status: "skipped-manifest",
         });
-        manifestFiles.push({
-          relativePath: src.relativePath,
-          noteId: existing.id,
-          type: existing.type,
-          sha256: sha,
-          mtimeMs: src.mtimeMs,
-        });
-        used.add(existing.id);
+        manifestFiles.push({ ...prior });
+        used.add(prior.noteId);
         skippedManifestCount += 1;
         continue;
       }
@@ -400,22 +415,4 @@ export async function runMemoryBackfill(
     manifestPath,
     entries,
   };
-}
-
-/**
- * For a manifest-hit relative path, locate its still-present note. The manifest
- * records the note id + type, so this checks that the target file survives.
- */
-async function noteExistsForRelative(
-  somaHome: string,
-  relativePath: string,
-  previous: { map: Map<string, string>; importedAt: string } | null,
-): Promise<{ id: string; type: WritableNoteType } | null> {
-  const manifestPath = join(somaHome, MANIFEST_RELATIVE);
-  if (!previous || !(await pathExists(manifestPath))) return null;
-  const parsed = JSON.parse(await readFile(manifestPath, "utf8")) as SomaMemoryBackfillManifest;
-  const record = parsed.files.find((f) => f.relativePath === relativePath);
-  if (!record) return null;
-  if (!(await pathExists(memoryNotePath(somaHome, record.type, record.noteId)))) return null;
-  return { id: record.noteId, type: record.type };
 }

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -303,52 +303,26 @@ async function readManifest(
 }
 
 /**
- * Plan the backfill without touching anything: which source files map to which
- * note id/type/target. Duplicate detection is NOT part of the plan — it needs a
- * corpus scan at write time, so a real run may additionally skip near-duplicates.
+ * Plan the backfill without touching anything — a thin wrapper over the single
+ * manifest-aware core in {@link runMemoryBackfill}, so the preview reflects
+ * exactly what a real run would do (manifest hits show as `skipped-manifest`, not
+ * as fresh imports). Near-duplicate detection is still NOT part of the plan — it
+ * needs the corpus scan the write path performs, so a real run may additionally
+ * skip some `would-import` files as duplicates.
  */
 export async function planMemoryBackfill(
   options: SomaMemoryBackfillOptions = {},
 ): Promise<SomaMemoryBackfillResult> {
-  const somaHome = resolveSomaHome(options);
-  const defaultRoot = resolve(join(somaHome, "memory"));
-  const from = resolve(options.from ?? defaultRoot);
-  const sources = await collectSources(from, from === defaultRoot);
-
-  const used = new Set<string>();
-  const entries: SomaMemoryBackfillEntry[] = [];
-  for (const src of sources) {
-    const type = resolveType(options, src.category);
-    const id = await uniqueNoteId(somaHome, slugifyId(src.category, src.stem), used);
-    used.add(id);
-    entries.push({
-      relativePath: src.relativePath,
-      source: src.absPath,
-      noteId: id,
-      type,
-      created: isoDate(new Date(src.mtimeMs)),
-      target: memoryNotePath(somaHome, type, id),
-    });
-  }
-
-  return {
-    somaHome,
-    from,
-    dryRun: true,
-    writtenCount: 0,
-    skippedManifestCount: 0,
-    skippedDuplicateCount: 0,
-    errorCount: 0,
-    manifestPath: join(somaHome, MANIFEST_RELATIVE),
-    entries,
-  };
+  return runMemoryBackfill({ ...options, dryRun: true });
 }
 
 /**
- * Run the backfill. Writes each eligible source file as a `quarantined` note via
- * the M1 write path, sequentially so intra-batch dedup is deterministic. Returns
- * a per-file account; `--dry-run` returns the plan without writing or touching
- * the manifest.
+ * The single backfill core. Reads the (root-gated) manifest, then per source:
+ * re-emits a `skipped-manifest` entry for an unchanged prior import, else writes
+ * the file as a `quarantined` note via the M1 write path — sequentially, so
+ * intra-batch dedup is deterministic. With `dryRun`, every step runs EXCEPT the
+ * note write, manifest write, and INDEX rebuild: would-import entries carry no
+ * status (a plan), manifest hits still show as `skipped-manifest`.
  */
 export async function runMemoryBackfill(
   options: SomaMemoryBackfillOptions = {},
@@ -357,10 +331,7 @@ export async function runMemoryBackfill(
   const defaultRoot = resolve(join(somaHome, "memory"));
   const from = resolve(options.from ?? defaultRoot);
   const manifestPath = join(somaHome, MANIFEST_RELATIVE);
-
-  if (options.dryRun) {
-    return planMemoryBackfill(options);
-  }
+  const dryRun = options.dryRun ?? false;
 
   const sources = await collectSources(from, from === defaultRoot);
   // The manifest lives at one path per soma-home but its relative paths are keyed
@@ -422,8 +393,15 @@ export async function runMemoryBackfill(
       id = await uniqueNoteId(somaHome, slugifyId(src.category, src.stem), used);
       used.add(id);
       const target = memoryNotePath(somaHome, type, id);
-      const hook = hookFromStem(src.stem);
 
+      if (dryRun) {
+        // A plan entry (no status) — a real run would write this, unless the
+        // corpus scan (only done at write time) reveals it as a near-duplicate.
+        entries.push({ relativePath: src.relativePath, source: src.absPath, noteId: id, type, created, target });
+        continue;
+      }
+
+      const hook = hookFromStem(src.stem);
       await writeMemoryNote({
         somaHome,
         substrate: options.substrate,
@@ -475,35 +453,38 @@ export async function runMemoryBackfill(
     }
   }
 
-  // Manifest reflects exactly the files currently backfilled to a present note
-  // (written this run + previously-written-and-still-present). Vanished sources
-  // drop out; duplicates are excluded (they map to a note this run did not own).
-  await mkdir(join(somaHome, MANIFEST_DIR_RELATIVE), { recursive: true });
-  const importedAt =
-    writtenCount === 0 && previous ? previous.importedAt : (options.now ?? new Date()).toISOString();
-  const manifest: SomaMemoryBackfillManifest = {
-    schema: MANIFEST_SCHEMA,
-    somaHome,
-    from,
-    importedAt,
-    files: manifestFiles.sort((a, b) =>
-      a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0,
-    ),
-  };
-  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  // A dry-run previews only — it never touches the manifest or the INDEX.
+  if (!dryRun) {
+    // Manifest reflects exactly the files currently backfilled to a present note
+    // (written this run + previously-written-and-still-present). Vanished sources
+    // drop out; duplicates are excluded (they map to a note this run did not own).
+    await mkdir(join(somaHome, MANIFEST_DIR_RELATIVE), { recursive: true });
+    const importedAt =
+      writtenCount === 0 && previous ? previous.importedAt : (options.now ?? new Date()).toISOString();
+    const manifest: SomaMemoryBackfillManifest = {
+      schema: MANIFEST_SCHEMA,
+      somaHome,
+      from,
+      importedAt,
+      files: manifestFiles.sort((a, b) =>
+        a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0,
+      ),
+    };
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 
-  // Rebuild the INDEX after writing notes so the store stays audit-clean: fresh
-  // note files are newer than INDEX.md, which would fail the audit's index-freshness
-  // probe until a rebuild. Quarantined imports never earn an INDEX line (admission
-  // filter), so this refreshes INDEX.md's mtime without surfacing untrusted content.
-  if (writtenCount > 0) {
-    await rebuildMemoryIndex({ somaHome });
+    // Rebuild the INDEX after writing notes so the store stays audit-clean: fresh
+    // note files are newer than INDEX.md, which would fail the audit's index-freshness
+    // probe until a rebuild. Quarantined imports never earn an INDEX line (admission
+    // filter), so this refreshes INDEX.md's mtime without surfacing untrusted content.
+    if (writtenCount > 0) {
+      await rebuildMemoryIndex({ somaHome });
+    }
   }
 
   return {
     somaHome,
     from,
-    dryRun: false,
+    dryRun,
     writtenCount,
     skippedManifestCount,
     skippedDuplicateCount,

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -21,7 +21,9 @@
  *   - Trust is ALWAYS `quarantined` — the `import` trigger derives it and no
  *     caller flag can elevate it (MINJA defense). Backfilled notes are recall-
  *     pull-discoverable immediately (with a ⚠ untrusted banner) but stay out of
- *     the always-loaded INDEX until the principal verifies/elevates them.
+ *     the always-loaded INDEX until re-authored at higher trust (the INDEX
+ *     admission filter excludes quarantined unconditionally, so `verify` — which
+ *     only bumps freshness — cannot promote one; principal-correction/supersede can).
  *   - Files are processed SEQUENTIALLY so the recall-first refusal dedups within
  *     the batch deterministically (a later near-duplicate sees earlier writes).
  *
@@ -241,7 +243,15 @@ async function collectSources(root: string, skipRootFiles: boolean): Promise<Sou
       if (/^readme\.(?:md|markdown)$/i.test(entry.name)) continue;
       if (!MARKDOWN_EXT.test(entry.name)) continue;
       const category = rel.includes("/") ? rel.split("/")[0] : "";
-      const stat = await lstat(abs);
+      // A file can vanish between `readdir` and `lstat` (concurrent cleanup). Skip
+      // it rather than aborting the whole scan; a genuinely broken FS still throws.
+      let stat;
+      try {
+        stat = await lstat(abs);
+      } catch (error) {
+        if (error instanceof Error && "code" in error && error.code === "ENOENT") continue;
+        throw error;
+      }
       files.push({
         relativePath: rel,
         absPath: abs,

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -188,7 +188,7 @@ async function collectSources(root: string): Promise<SourceFile[]> {
         continue;
       }
       if (!entry.isFile()) continue;
-      if (entry.name === "README.md") continue;
+      if (/^readme\.md$/i.test(entry.name)) continue;
       if (!MARKDOWN_EXT.test(entry.name)) continue;
       const stat = await lstat(abs);
       files.push({

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -1,0 +1,421 @@
+/**
+ * Memory subsystem M8 — bulk backfill of legacy free-form markdown into
+ * schema-valid, governed notes (plan v2 §"shipping"; see
+ * `Plans/declarative-twirling-lampson.md`).
+ *
+ * A freshly-migrated store has an empty durable corpus (`semantic/` +
+ * `procedural/`) but a pile of pre-M0 markdown under category dirs
+ * (`LEARNING/`, `KNOWLEDGE/`, …). This command turns that content into notes
+ * through the M1 write path, so every governance invariant (schema validation,
+ * recall-first dedup, event journaling, trust derivation) is enforced exactly
+ * once, in one place.
+ *
+ * Deterministic by contract:
+ *   - No LLM. Bodies are wrapped verbatim (with a one-line provenance preamble).
+ *   - `created`/`last_verified` come from the source file's mtime, not the clock.
+ *   - Trust is ALWAYS `quarantined` — the `import` trigger derives it and no
+ *     caller flag can elevate it (MINJA defense). Backfilled notes are recall-
+ *     pull-discoverable immediately (with a ⚠ untrusted banner) but stay out of
+ *     the always-loaded INDEX until a human verifies/elevates them.
+ *   - Files are processed SEQUENTIALLY so the recall-first refusal dedups within
+ *     the batch deterministically (a later near-duplicate sees earlier writes).
+ *
+ * Idempotency mirrors `pai-memory-migrator.ts`: a SHA manifest at
+ * `imports/backfill/.manifest.json` lets a rerun skip already-imported files
+ * whose source bytes are unchanged and whose target note still exists. A pure
+ * no-op rerun writes a byte-identical manifest (the `importedAt` is preserved
+ * when nothing new was written).
+ */
+import { createHash } from "node:crypto";
+import { lstat, mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join, relative, resolve, sep } from "node:path";
+import { MemoryNoteError } from "./memory-note";
+import { memoryNotePath, writeMemoryNote } from "./memory-write";
+import { SOMA_MEMORY_BACKFILL_TYPE_MAP } from "./types";
+import type {
+  SomaMemoryBackfillEntry,
+  SomaMemoryBackfillManifest,
+  SomaMemoryBackfillOptions,
+  SomaMemoryBackfillResult,
+  WritableNoteType,
+} from "./types";
+
+const MANIFEST_SCHEMA = "soma.memory-backfill.v1";
+const MANIFEST_RELATIVE = "imports/backfill/.manifest.json";
+
+// Category dirs (or root children) that are never backfill sources: STATE is
+// runtime JSON, episodic/semantic/procedural are the note stores themselves,
+// archive/imports are subsystem bookkeeping. Matched against the FIRST path
+// segment under the source root.
+const RESERVED_CATEGORIES = new Set([
+  "STATE",
+  "episodic",
+  "semantic",
+  "procedural",
+  "archive",
+  "imports",
+]);
+
+function resolveSomaHome(options: SomaMemoryBackfillOptions): string {
+  return resolve(options.somaHome ?? join(resolve(options.homeDir ?? homedir()), ".soma"));
+}
+
+function sha256Hex(content: Buffer | string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+/** Format a Date as YYYY-MM-DD in UTC (the note schema's date grammar). */
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+/**
+ * Slugify `<category>-<stem>` into a note id: lowercase, non-alphanumeric runs
+ * collapse to a single hyphen, no leading/trailing/double hyphens, ≤64 chars.
+ * Matches the note SLUG grammar (`/^[a-z0-9]+(?:-[a-z0-9]+)*$/`, id ≤ 64).
+ */
+function slugifyId(category: string, stem: string): string {
+  const raw = `${category}-${stem}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64)
+    .replace(/-+$/g, "");
+  return raw || "note";
+}
+
+/** True iff a note with `id` already exists as either a semantic or procedural note. */
+async function noteExists(somaHome: string, id: string): Promise<boolean> {
+  return (
+    (await pathExists(memoryNotePath(somaHome, "semantic", id))) ||
+    (await pathExists(memoryNotePath(somaHome, "procedural", id)))
+  );
+}
+
+/**
+ * Resolve a unique note id from a base slug, suffixing `-2`, `-3`, … against
+ * both the existing corpus and the ids already claimed in this run. The base is
+ * trimmed to leave room for the suffix so the result stays ≤ 64 chars.
+ */
+async function uniqueNoteId(somaHome: string, base: string, used: Set<string>): Promise<string> {
+  if (!used.has(base) && !(await noteExists(somaHome, base))) return base;
+  for (let n = 2; ; n += 1) {
+    const suffix = `-${n}`;
+    const candidate = `${base.slice(0, 64 - suffix.length).replace(/-+$/g, "")}${suffix}`;
+    if (!used.has(candidate) && !(await noteExists(somaHome, candidate))) return candidate;
+  }
+}
+
+/** A single humanized recall-trigger line from the filename stem (no newlines). */
+function hookFromStem(stem: string): string {
+  return stem
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 80)
+    .trim();
+}
+
+interface SourceFile {
+  relativePath: string; // POSIX, under the source root
+  absPath: string;
+  category: string; // first path segment
+  stem: string;
+  mtimeMs: number;
+}
+
+/**
+ * Recursively collect eligible source files under `root`. Skips reserved
+ * categories, root-level files (READMEs/INDEX territory), any README.md, and
+ * refuses symlinks loudly (matching the migrators' stance). Returns entries
+ * sorted by relative path for deterministic ordering.
+ */
+async function collectSources(root: string): Promise<SourceFile[]> {
+  const files: SourceFile[] = [];
+
+  async function visit(dir: string, depth: number): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+      throw error;
+    }
+    for (const entry of entries) {
+      const abs = join(dir, entry.name);
+      const rel = relative(root, abs).split(sep).join("/");
+      if (entry.isSymbolicLink()) {
+        throw new Error(`Soma memory backfill refused symlink path: ${rel}`);
+      }
+      const category = rel.split("/")[0];
+      if (depth === 0 && (RESERVED_CATEGORIES.has(entry.name) || entry.isFile())) {
+        // Reserved top-level dir, or a file directly under the root (README /
+        // INDEX.md territory) — never a backfill source.
+        continue;
+      }
+      if (entry.isDirectory()) {
+        await visit(abs, depth + 1);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (entry.name === "README.md") continue;
+      const stat = await lstat(abs);
+      files.push({
+        relativePath: rel,
+        absPath: abs,
+        category,
+        stem: entry.name.replace(/\.[^.]+$/, ""),
+        mtimeMs: stat.mtimeMs,
+      });
+    }
+  }
+
+  await visit(root, 0);
+  return files.sort((a, b) => (a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0));
+}
+
+function resolveType(
+  options: SomaMemoryBackfillOptions,
+  category: string,
+): WritableNoteType {
+  if (options.type) return options.type;
+  return SOMA_MEMORY_BACKFILL_TYPE_MAP[category] ?? "semantic";
+}
+
+async function readManifest(
+  somaHome: string,
+): Promise<{ map: Map<string, string>; importedAt: string } | null> {
+  const path = join(somaHome, MANIFEST_RELATIVE);
+  if (!(await pathExists(path))) return null;
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as SomaMemoryBackfillManifest;
+    if (!Array.isArray(parsed.files)) return null;
+    const map = new Map<string, string>();
+    for (const entry of parsed.files) map.set(entry.relativePath, entry.sha256);
+    return { map, importedAt: parsed.importedAt };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Plan the backfill without touching anything: which source files map to which
+ * note id/type/target. Duplicate detection is NOT part of the plan — it needs a
+ * corpus scan at write time, so a real run may additionally skip near-duplicates.
+ */
+export async function planMemoryBackfill(
+  options: SomaMemoryBackfillOptions = {},
+): Promise<SomaMemoryBackfillResult> {
+  const somaHome = resolveSomaHome(options);
+  const from = resolve(options.from ?? join(somaHome, "memory"));
+  const sources = await collectSources(from);
+
+  const used = new Set<string>();
+  const entries: SomaMemoryBackfillEntry[] = [];
+  for (const src of sources) {
+    const type = resolveType(options, src.category);
+    const id = await uniqueNoteId(somaHome, slugifyId(src.category, src.stem), used);
+    used.add(id);
+    entries.push({
+      relativePath: src.relativePath,
+      source: src.absPath,
+      noteId: id,
+      type,
+      created: isoDate(new Date(src.mtimeMs)),
+      target: memoryNotePath(somaHome, type, id),
+    });
+  }
+
+  return {
+    somaHome,
+    from,
+    dryRun: true,
+    writtenCount: 0,
+    skippedManifestCount: 0,
+    skippedDuplicateCount: 0,
+    errorCount: 0,
+    manifestPath: join(somaHome, MANIFEST_RELATIVE),
+    entries,
+  };
+}
+
+/**
+ * Run the backfill. Writes each eligible source file as a `quarantined` note via
+ * the M1 write path, sequentially so intra-batch dedup is deterministic. Returns
+ * a per-file account; `--dry-run` returns the plan without writing or touching
+ * the manifest.
+ */
+export async function runMemoryBackfill(
+  options: SomaMemoryBackfillOptions = {},
+): Promise<SomaMemoryBackfillResult> {
+  const somaHome = resolveSomaHome(options);
+  const from = resolve(options.from ?? join(somaHome, "memory"));
+  const manifestPath = join(somaHome, MANIFEST_RELATIVE);
+
+  if (options.dryRun) {
+    return planMemoryBackfill(options);
+  }
+
+  const sources = await collectSources(from);
+  const previous = await readManifest(somaHome);
+
+  const used = new Set<string>();
+  const entries: SomaMemoryBackfillEntry[] = [];
+  const manifestFiles: SomaMemoryBackfillManifest["files"] = [];
+  let writtenCount = 0;
+  let skippedManifestCount = 0;
+  let skippedDuplicateCount = 0;
+  let errorCount = 0;
+
+  for (const src of sources) {
+    const type = resolveType(options, src.category);
+    const content = await readFile(src.absPath, "utf8");
+    const sha = sha256Hex(content);
+    const created = isoDate(new Date(src.mtimeMs));
+
+    // Already backfilled and unchanged? Keep the prior manifest entry and skip.
+    const priorSha = previous?.map.get(src.relativePath);
+    if (priorSha && priorSha === sha) {
+      const existing = await noteExistsForRelative(somaHome, src.relativePath, previous);
+      if (existing) {
+        entries.push({
+          relativePath: src.relativePath,
+          source: src.absPath,
+          noteId: existing.id,
+          type: existing.type,
+          created,
+          target: memoryNotePath(somaHome, existing.type, existing.id),
+          status: "skipped-manifest",
+        });
+        manifestFiles.push({
+          relativePath: src.relativePath,
+          noteId: existing.id,
+          type: existing.type,
+          sha256: sha,
+          mtimeMs: src.mtimeMs,
+        });
+        used.add(existing.id);
+        skippedManifestCount += 1;
+        continue;
+      }
+    }
+
+    const id = await uniqueNoteId(somaHome, slugifyId(src.category, src.stem), used);
+    used.add(id);
+    const target = memoryNotePath(somaHome, type, id);
+    const hook = hookFromStem(src.stem);
+
+    try {
+      await writeMemoryNote({
+        somaHome,
+        substrate: options.substrate,
+        now: new Date(src.mtimeMs),
+        mode: "create",
+        trigger: "import",
+        type,
+        id,
+        // Body is the legacy content VERBATIM — no boilerplate preamble. A shared
+        // preamble would inflate token overlap and make the recall-first dedup
+        // over-fire on short files; the origin lives in frontmatter instead
+        // (provenance: import, source_of_truth: <path>), which recall surfaces.
+        body: content,
+        provenance: "import",
+        sourceOfTruth: src.absPath,
+        project: options.project ?? null,
+        ...(hook ? { hook } : {}),
+      });
+      entries.push({
+        relativePath: src.relativePath,
+        source: src.absPath,
+        noteId: id,
+        type,
+        created,
+        target,
+        status: "written",
+      });
+      manifestFiles.push({ relativePath: src.relativePath, noteId: id, type, sha256: sha, mtimeMs: src.mtimeMs });
+      writtenCount += 1;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const isDuplicate = error instanceof MemoryNoteError && message.startsWith("Recall-first refusal:");
+      entries.push({
+        relativePath: src.relativePath,
+        source: src.absPath,
+        noteId: id,
+        type,
+        created,
+        target,
+        status: isDuplicate ? "skipped-duplicate" : "error",
+        detail: message,
+      });
+      if (isDuplicate) {
+        // A near/exact duplicate already lives in the corpus — the desired
+        // outcome, not a failure. It is NOT recorded in the manifest (no note
+        // was created for this file); a later rerun re-scans and re-skips it.
+        used.delete(id);
+        skippedDuplicateCount += 1;
+      } else {
+        used.delete(id);
+        errorCount += 1;
+      }
+    }
+  }
+
+  // Manifest reflects exactly the files currently backfilled to a present note
+  // (written this run + previously-written-and-still-present). Vanished sources
+  // drop out; duplicates are excluded (they map to a note this run did not own).
+  await mkdir(join(somaHome, "imports/backfill"), { recursive: true });
+  const importedAt =
+    writtenCount === 0 && previous ? previous.importedAt : (options.now ?? new Date()).toISOString();
+  const manifest: SomaMemoryBackfillManifest = {
+    schema: MANIFEST_SCHEMA,
+    somaHome,
+    from,
+    importedAt,
+    files: manifestFiles.sort((a, b) =>
+      a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0,
+    ),
+  };
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+  return {
+    somaHome,
+    from,
+    dryRun: false,
+    writtenCount,
+    skippedManifestCount,
+    skippedDuplicateCount,
+    errorCount,
+    manifestPath,
+    entries,
+  };
+}
+
+/**
+ * For a manifest-hit relative path, locate its still-present note. The manifest
+ * records the note id + type, so this checks that the target file survives.
+ */
+async function noteExistsForRelative(
+  somaHome: string,
+  relativePath: string,
+  previous: { map: Map<string, string>; importedAt: string } | null,
+): Promise<{ id: string; type: WritableNoteType } | null> {
+  const manifestPath = join(somaHome, MANIFEST_RELATIVE);
+  if (!previous || !(await pathExists(manifestPath))) return null;
+  const parsed = JSON.parse(await readFile(manifestPath, "utf8")) as SomaMemoryBackfillManifest;
+  const record = parsed.files.find((f) => f.relativePath === relativePath);
+  if (!record) return null;
+  if (!(await pathExists(memoryNotePath(somaHome, record.type, record.noteId)))) return null;
+  return { id: record.noteId, type: record.type };
+}

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -26,7 +26,7 @@
  *     the batch deterministically (a later near-duplicate sees earlier writes).
  *
  * Idempotency mirrors `pai-memory-migrator.ts`: a SHA manifest at
- * `imports/backfill/.manifest.json` lets a rerun skip already-imported files
+ * `memory/STATE/imports/backfill/.manifest.json` lets a rerun skip already-imported files
  * whose source bytes are unchanged and whose target note still exists. A no-op
  * rerun (nothing new written) re-emits each prior manifest entry verbatim and
  * preserves `importedAt`, so the manifest is byte-identical — even if a source
@@ -88,10 +88,13 @@ function isoDate(date: Date): string {
  * Read a source file refusing to follow a symlink at the final path component
  * (`O_NOFOLLOW`). Closes the collect→read TOCTOU: even if a vetted `.md` file is
  * swapped for a symlink to a sensitive target between the walk and the read, the
- * open fails (ELOOP) rather than importing the target's bytes. The walk already
- * rejects symlink *directories* in the tree.
+ * open fails (ELOOP) rather than importing the target's bytes. To also close the
+ * *ancestor* race (a vetted directory swapped for a symlink after the walk, which
+ * `O_NOFOLLOW` on the leaf would not catch), the opened file's `dev`+`ino` are
+ * compared against what the walk `lstat`ed — a redirected ancestor resolves to a
+ * different inode and is refused.
  */
-async function readSourceNoFollow(path: string): Promise<string> {
+async function readSourceNoFollow(path: string, expect: { dev: number; ino: number }): Promise<string> {
   let fh;
   try {
     fh = await open(path, FS.O_RDONLY | FS.O_NOFOLLOW);
@@ -102,6 +105,10 @@ async function readSourceNoFollow(path: string): Promise<string> {
     throw error;
   }
   try {
+    const st = await fh.stat();
+    if (st.dev !== expect.dev || st.ino !== expect.ino) {
+      throw new Error(`Soma memory backfill refused source that changed identity between scan and read: ${path}`);
+    }
     return await fh.readFile("utf8");
   } finally {
     await fh.close();
@@ -171,6 +178,8 @@ interface SourceFile {
   category: string; // first path segment
   stem: string;
   mtimeMs: number;
+  dev: number; // captured at scan; re-checked at read to catch ancestor-symlink swaps
+  ino: number;
 }
 
 // Markdown is the only backfill input: a category dir may hold JSON, `.env`,
@@ -224,6 +233,8 @@ async function collectSources(root: string, skipRootFiles: boolean): Promise<Sou
         category,
         stem: entry.name.replace(/\.[^.]+$/, ""),
         mtimeMs: stat.mtimeMs,
+        dev: stat.dev,
+        ino: stat.ino,
       });
     }
   }
@@ -244,11 +255,15 @@ function resolveType(
  * Read the manifest once into a `relativePath → full entry` map (the whole
  * record, not just the SHA), so the run loop can check the SHA, reuse the note
  * id/type, and re-emit the prior entry verbatim without re-reading the file per
- * source. Returns null when the manifest is missing or corrupt (→ re-import).
+ * source. Also returns the recorded source root so the caller can reject a
+ * manifest built for a *different* `--from` (relative paths would false-hit).
+ * Returns null only when the manifest is absent, unreadable, non-JSON, or its
+ * `files` is not an array — a structurally-valid-but-semantically-odd manifest
+ * is accepted (each entry is still re-validated against the corpus + SHA at use).
  */
 async function readManifest(
   somaHome: string,
-): Promise<{ map: Map<string, SomaMemoryBackfillManifestEntry>; importedAt: string } | null> {
+): Promise<{ map: Map<string, SomaMemoryBackfillManifestEntry>; importedAt: string; from: string } | null> {
   const path = join(somaHome, MANIFEST_RELATIVE);
   if (!(await pathExists(path))) return null;
   try {
@@ -256,7 +271,7 @@ async function readManifest(
     if (!Array.isArray(parsed.files)) return null;
     const map = new Map<string, SomaMemoryBackfillManifestEntry>();
     for (const entry of parsed.files) map.set(entry.relativePath, entry);
-    return { map, importedAt: parsed.importedAt };
+    return { map, importedAt: parsed.importedAt, from: parsed.from };
   } catch {
     return null;
   }
@@ -323,7 +338,12 @@ export async function runMemoryBackfill(
   }
 
   const sources = await collectSources(from, from === defaultRoot);
-  const previous = await readManifest(somaHome);
+  // The manifest lives at one path per soma-home but its relative paths are keyed
+  // to the root it was built for. A rerun against a DIFFERENT `--from` must not
+  // treat same-relative-path files as hits — ignore a manifest built elsewhere
+  // (the run then rewrites it for the current root).
+  const rawPrevious = await readManifest(somaHome);
+  const previous = rawPrevious?.from === from ? rawPrevious : null;
 
   const used = new Set<string>();
   const entries: SomaMemoryBackfillEntry[] = [];
@@ -335,7 +355,7 @@ export async function runMemoryBackfill(
 
   for (const src of sources) {
     const type = resolveType(options, src.category);
-    const content = await readSourceNoFollow(src.absPath);
+    const content = await readSourceNoFollow(src.absPath, { dev: src.dev, ino: src.ino });
     const sha = sha256Hex(content);
     const created = isoDate(new Date(src.mtimeMs));
 

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -214,7 +214,7 @@ async function collectSources(root: string, skipRootFiles: boolean): Promise<Sou
       // default memory root; a custom `--from <dir>` may legitimately hold its
       // markdown right at the top, so those are imported (category "" → semantic).
       if (depth === 0 && skipRootFiles) continue;
-      if (/^readme\.md$/i.test(entry.name)) continue;
+      if (/^readme\.(?:md|markdown)$/i.test(entry.name)) continue;
       if (!MARKDOWN_EXT.test(entry.name)) continue;
       const category = rel.includes("/") ? rel.split("/")[0] : "";
       const stat = await lstat(abs);

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -37,6 +37,7 @@ import { constants as FS } from "node:fs";
 import { lstat, mkdir, open, readFile, readdir, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join, relative, resolve, sep } from "node:path";
+import { rebuildMemoryIndex } from "./memory-index";
 import { MemoryNoteError } from "./memory-note";
 import { memoryNotePath, writeMemoryNote } from "./memory-write";
 import { SOMA_MEMORY_BACKFILL_TYPE_MAP } from "./types";
@@ -196,6 +197,20 @@ const MARKDOWN_EXT = /\.(?:md|markdown)$/i;
  */
 async function collectSources(root: string, skipRootFiles: boolean): Promise<SourceFile[]> {
   const files: SourceFile[] = [];
+
+  // Refuse a symlinked source ROOT up front — the per-entry walk below only guards
+  // entries *within* the tree, so without this a `--from` pointing at a symlink
+  // would be traversed. A non-existent root simply yields no sources.
+  let rootStat;
+  try {
+    rootStat = await lstat(root);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return files;
+    throw error;
+  }
+  if (rootStat.isSymbolicLink()) {
+    throw new Error(`Soma memory backfill refused symlink source root: ${root}`);
+  }
 
   async function visit(dir: string, depth: number): Promise<void> {
     let entries;
@@ -466,6 +481,14 @@ export async function runMemoryBackfill(
     ),
   };
   await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+  // Rebuild the INDEX after writing notes so the store stays audit-clean: fresh
+  // note files are newer than INDEX.md, which would fail the audit's index-freshness
+  // probe until a rebuild. Quarantined imports never earn an INDEX line (admission
+  // filter), so this refreshes INDEX.md's mtime without surfacing untrusted content.
+  if (writtenCount > 0) {
+    await rebuildMemoryIndex({ somaHome });
+  }
 
   return {
     somaHome,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2491,6 +2491,97 @@ export interface SomaMemoryVerifyResult {
   event: SomaMemoryEvent;
 }
 
+// Memory subsystem M8 (backfill). Bulk-import a user's existing free-form
+// markdown memory into schema-valid, governed notes through the M1 write path.
+// Deterministic, no LLM: bodies are wrapped verbatim, `created` comes from the
+// source mtime, and every note lands at `quarantined` trust via the `import`
+// trigger (MINJA defense — bulk-imported content is never trusted incidentally;
+// a human elevates it later via verify/supersede). The top-level category dir is
+// mapped to a note type by {@link SOMA_MEMORY_BACKFILL_TYPE_MAP}; `--type` forces
+// a single type for all files. Idempotent via a SHA manifest at
+// `imports/backfill/.manifest.json` (mirrors the pai-memory-migrator pattern).
+
+/**
+ * Top-level source category dir → note type. Categories not listed here fall
+ * back to `semantic`. The map affects TYPE only — trust is always `quarantined`
+ * (derived from the `import` trigger), never selectable here.
+ */
+export const SOMA_MEMORY_BACKFILL_TYPE_MAP: Record<string, "semantic" | "procedural"> = {
+  LEARNING: "procedural",
+  KNOWLEDGE: "semantic",
+};
+
+/** The durable, backfillable note types (episodic is written via digest/action, not backfill). */
+export type WritableNoteType = Exclude<SomaMemoryNoteType, "episodic">;
+
+export interface SomaMemoryBackfillOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate?: SubstrateId;
+  /** Injected clock for deterministic manifest `importedAt`. Defaults to now. */
+  now?: Date;
+  /** Source root walked recursively. Defaults to `<somaHome>/memory`. */
+  from?: string;
+  /** Force ALL notes to this type, overriding the category map. */
+  type?: "semantic" | "procedural";
+  /** Sets each note's `project` field. Defaults to null. */
+  project?: string | null;
+  /** Plan only — print the intended imports and touch nothing (no manifest write). */
+  dryRun?: boolean;
+}
+
+export type SomaMemoryBackfillEntryStatus =
+  | "written"
+  | "skipped-manifest"
+  | "skipped-duplicate"
+  | "error";
+
+/** One planned/attempted source-file → note import. */
+export interface SomaMemoryBackfillEntry {
+  /** POSIX relative path under the source root. */
+  relativePath: string;
+  /** Absolute source path (also recorded as the note's `source_of_truth`). */
+  source: string;
+  noteId: string;
+  type: "semantic" | "procedural";
+  /** `created`/`last_verified` date derived from the source mtime (YYYY-MM-DD, UTC). */
+  created: string;
+  /** Target note path (written, or would-be for a dry-run). */
+  target: string;
+  /** Populated after a real run; absent for a dry-run plan entry. */
+  status?: SomaMemoryBackfillEntryStatus;
+  /** Present for `skipped-duplicate` / `error`: the reason. */
+  detail?: string;
+}
+
+export interface SomaMemoryBackfillResult {
+  somaHome: string;
+  from: string;
+  dryRun: boolean;
+  writtenCount: number;
+  skippedManifestCount: number;
+  skippedDuplicateCount: number;
+  errorCount: number;
+  manifestPath: string;
+  entries: SomaMemoryBackfillEntry[];
+}
+
+export interface SomaMemoryBackfillManifestEntry {
+  relativePath: string;
+  noteId: string;
+  type: "semantic" | "procedural";
+  sha256: string;
+  mtimeMs: number;
+}
+
+export interface SomaMemoryBackfillManifest {
+  schema: "soma.memory-backfill.v1";
+  somaHome: string;
+  from: string;
+  importedAt: string;
+  files: SomaMemoryBackfillManifestEntry[];
+}
+
 // Memory subsystem M5 (episodic capture). Plan v2 §M5: session digests + a
 // first-class action log, stored as `episodic` notes under
 // `memory/episodic/{sessions,actions}/YYYY-MM/YYYYMMDD-<slug>.md`. Deterministic,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2491,7 +2491,7 @@ export interface SomaMemoryVerifyResult {
   event: SomaMemoryEvent;
 }
 
-// Memory subsystem M8 (backfill). Bulk-import a user's existing free-form
+// Memory subsystem M8 (backfill). Bulk-import a principal's existing free-form
 // markdown memory into schema-valid, governed notes through the M1 write path.
 // Deterministic, no LLM: bodies are wrapped verbatim, `created` comes from the
 // source mtime, and every note lands at `quarantined` trust via the `import`

--- a/src/types.ts
+++ b/src/types.ts
@@ -2496,8 +2496,9 @@ export interface SomaMemoryVerifyResult {
 // Deterministic, no LLM: bodies are imported verbatim (no wrapper/preamble),
 // `created` comes from the source mtime, and every note lands at `quarantined` trust via the `import`
 // trigger (MINJA defense — bulk-imported content is never trusted incidentally;
-// the principal elevates it later via verify/supersede). The top-level category
-// dir is mapped to a note type by {@link SOMA_MEMORY_BACKFILL_TYPE_MAP}; `--type`
+// the principal re-authors it later at higher trust via principal-correction/
+// supersede — verify alone does not elevate a quarantined note). The top-level
+// category dir is mapped to a note type by {@link SOMA_MEMORY_BACKFILL_TYPE_MAP}; `--type`
 // forces a single type for all files. Idempotent via a SHA manifest at
 // `memory/STATE/imports/backfill/.manifest.json` (mirrors pai-memory-migrator).
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2496,23 +2496,23 @@ export interface SomaMemoryVerifyResult {
 // Deterministic, no LLM: bodies are wrapped verbatim, `created` comes from the
 // source mtime, and every note lands at `quarantined` trust via the `import`
 // trigger (MINJA defense — bulk-imported content is never trusted incidentally;
-// a human elevates it later via verify/supersede). The top-level category dir is
-// mapped to a note type by {@link SOMA_MEMORY_BACKFILL_TYPE_MAP}; `--type` forces
-// a single type for all files. Idempotent via a SHA manifest at
-// `imports/backfill/.manifest.json` (mirrors the pai-memory-migrator pattern).
+// the principal elevates it later via verify/supersede). The top-level category
+// dir is mapped to a note type by {@link SOMA_MEMORY_BACKFILL_TYPE_MAP}; `--type`
+// forces a single type for all files. Idempotent via a SHA manifest at
+// `memory/STATE/imports/backfill/.manifest.json` (mirrors pai-memory-migrator).
+
+/** The durable, backfillable note types (episodic is written via digest/action, not backfill). */
+export type WritableNoteType = Exclude<SomaMemoryNoteType, "episodic">;
 
 /**
  * Top-level source category dir → note type. Categories not listed here fall
  * back to `semantic`. The map affects TYPE only — trust is always `quarantined`
  * (derived from the `import` trigger), never selectable here.
  */
-export const SOMA_MEMORY_BACKFILL_TYPE_MAP: Record<string, "semantic" | "procedural"> = {
+export const SOMA_MEMORY_BACKFILL_TYPE_MAP: Record<string, WritableNoteType> = {
   LEARNING: "procedural",
   KNOWLEDGE: "semantic",
 };
-
-/** The durable, backfillable note types (episodic is written via digest/action, not backfill). */
-export type WritableNoteType = Exclude<SomaMemoryNoteType, "episodic">;
 
 export interface SomaMemoryBackfillOptions {
   homeDir?: string;
@@ -2523,7 +2523,7 @@ export interface SomaMemoryBackfillOptions {
   /** Source root walked recursively. Defaults to `<somaHome>/memory`. */
   from?: string;
   /** Force ALL notes to this type, overriding the category map. */
-  type?: "semantic" | "procedural";
+  type?: WritableNoteType;
   /** Sets each note's `project` field. Defaults to null. */
   project?: string | null;
   /** Plan only — print the intended imports and touch nothing (no manifest write). */
@@ -2543,7 +2543,7 @@ export interface SomaMemoryBackfillEntry {
   /** Absolute source path (also recorded as the note's `source_of_truth`). */
   source: string;
   noteId: string;
-  type: "semantic" | "procedural";
+  type: WritableNoteType;
   /** `created`/`last_verified` date derived from the source mtime (YYYY-MM-DD, UTC). */
   created: string;
   /** Target note path (written, or would-be for a dry-run). */
@@ -2569,7 +2569,7 @@ export interface SomaMemoryBackfillResult {
 export interface SomaMemoryBackfillManifestEntry {
   relativePath: string;
   noteId: string;
-  type: "semantic" | "procedural";
+  type: WritableNoteType;
   sha256: string;
   mtimeMs: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2493,8 +2493,8 @@ export interface SomaMemoryVerifyResult {
 
 // Memory subsystem M8 (backfill). Bulk-import a principal's existing free-form
 // markdown memory into schema-valid, governed notes through the M1 write path.
-// Deterministic, no LLM: bodies are wrapped verbatim, `created` comes from the
-// source mtime, and every note lands at `quarantined` trust via the `import`
+// Deterministic, no LLM: bodies are imported verbatim (no wrapper/preamble),
+// `created` comes from the source mtime, and every note lands at `quarantined` trust via the `import`
 // trigger (MINJA defense — bulk-imported content is never trusted incidentally;
 // the principal elevates it later via verify/supersede). The top-level category
 // dir is mapped to a note type by {@link SOMA_MEMORY_BACKFILL_TYPE_MAP}; `--type`

--- a/test/memory-backfill.test.ts
+++ b/test/memory-backfill.test.ts
@@ -9,6 +9,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from 
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
+import { auditMemory } from "../src/index";
 import { planMemoryBackfill, runMemoryBackfill } from "../src/memory-backfill";
 import { parseMemoryNote } from "../src/memory-note";
 import { parseMemoryArgs } from "../src/cli/memory";
@@ -128,6 +129,28 @@ test("skips reserved dirs, root-level files, and README.md", async () => {
     const result = await runMemoryBackfill({ somaHome });
     expect(result.writtenCount).toBe(1);
     expect(result.entries.map((e) => e.relativePath)).toEqual(["KNOWLEDGE/keep.md"]);
+  });
+});
+
+test("refuses a symlinked source root", async () => {
+  await withTempSoma(async (somaHome) => {
+    const real = join(somaHome, "real-src");
+    await mkdir(join(real, "KNOWLEDGE"), { recursive: true });
+    await writeFile(join(real, "KNOWLEDGE", "n.md"), "a note under the real source", "utf8");
+    const link = join(somaHome, "linked-src");
+    await symlink(real, link);
+    await expect(runMemoryBackfill({ somaHome, from: link })).rejects.toThrow(/refused symlink source root/i);
+  });
+});
+
+test("leaves the store audit-clean: INDEX rebuilt after writes", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/a.md", "an imported fact for audit health");
+    await seed(somaHome, "LEARNING/b.md", "a lesson for audit health check");
+    const result = await runMemoryBackfill({ somaHome });
+    expect(result.writtenCount).toBe(2);
+    const audit = await auditMemory({ somaHome });
+    expect(audit.healthy).toBe(true);
   });
 });
 

--- a/test/memory-backfill.test.ts
+++ b/test/memory-backfill.test.ts
@@ -53,6 +53,24 @@ test("maps category dir → note type (LEARNING→procedural, KNOWLEDGE→semant
   });
 });
 
+test("a custom --from root imports markdown sitting directly under it (category \"\" → semantic)", async () => {
+  await withTempSoma(async (somaHome) => {
+    const from = join(somaHome, "external-notes");
+    await mkdir(from, { recursive: true });
+    await writeFile(join(from, "loose-note.md"), "a note living at the custom root", "utf8");
+    await mkdir(join(from, "TOPIC"), { recursive: true });
+    await writeFile(join(from, "TOPIC", "nested.md"), "a nested note under a topic dir", "utf8");
+
+    const result = await runMemoryBackfill({ somaHome, from });
+    expect(result.writtenCount).toBe(2);
+    const byRel = new Map(result.entries.map((e) => [e.relativePath, e]));
+    // Root-level file is imported (not treated as README/INDEX territory).
+    expect(byRel.get("loose-note.md")?.type).toBe("semantic");
+    expect(byRel.get("loose-note.md")?.noteId).toBe("loose-note");
+    expect(byRel.get("TOPIC/nested.md")?.type).toBe("semantic");
+  });
+});
+
 test("--type forces a single type, overriding the category map", async () => {
   await withTempSoma(async (somaHome) => {
     await seed(somaHome, "KNOWLEDGE/x.md", "forced type body one two three");

--- a/test/memory-backfill.test.ts
+++ b/test/memory-backfill.test.ts
@@ -210,6 +210,21 @@ test("idempotent rerun: 0 written, all skipped-manifest, byte-identical manifest
   });
 });
 
+test("rerun with a different --type is not a silent manifest hit (type guard keeps --type honest)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/x.md", "distinct body content alpha beta gamma");
+    const first = await runMemoryBackfill({ somaHome }); // KNOWLEDGE → semantic
+    expect(first.entries[0].type).toBe("semantic");
+
+    // Rerun forcing procedural: NOT a manifest hit (type differs). The identical
+    // body is caught by the recall-first gate → skipped-duplicate, not skipped-manifest.
+    const second = await runMemoryBackfill({ somaHome, type: "procedural" });
+    expect(second.skippedManifestCount).toBe(0);
+    expect(second.skippedDuplicateCount).toBe(1);
+    expect(second.writtenCount).toBe(0);
+  });
+});
+
 test("a changed source file after import is re-imported as a new note on rerun", async () => {
   await withTempSoma(async (somaHome) => {
     await seed(somaHome, "KNOWLEDGE/a.md", "original imported body one two three");

--- a/test/memory-backfill.test.ts
+++ b/test/memory-backfill.test.ts
@@ -113,6 +113,38 @@ test("skips reserved dirs, root-level files, and README.md", async () => {
   });
 });
 
+test("imports only markdown files — non-markdown under a category dir is skipped", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/note.md", "a real markdown note body");
+    await seed(somaHome, "KNOWLEDGE/creds.env", "SECRET=should-never-be-imported");
+    await seed(somaHome, "KNOWLEDGE/data.json", '{"not":"a note"}');
+    await seed(somaHome, "KNOWLEDGE/deep.markdown", "a .markdown file is also imported");
+
+    const result = await runMemoryBackfill({ somaHome });
+    expect(result.entries.map((e) => e.relativePath).sort()).toEqual([
+      "KNOWLEDGE/deep.markdown",
+      "KNOWLEDGE/note.md",
+    ]);
+    expect(result.writtenCount).toBe(2);
+  });
+});
+
+test("no-op rerun is byte-stable even when a source is touched (mtime bumped, bytes unchanged)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/a.md", "stable body content one two three", new Date("2025-01-01T00:00:00Z"));
+    const first = await runMemoryBackfill({ somaHome, now: new Date("2026-07-04T00:00:00Z") });
+    expect(first.writtenCount).toBe(1);
+    const manifest1 = await readFile(first.manifestPath, "utf8");
+
+    // Touch the source: mtime changes, bytes (and thus SHA) do not.
+    await utimes(join(somaHome, "memory", "KNOWLEDGE", "a.md"), new Date("2025-06-06T00:00:00Z"), new Date("2025-06-06T00:00:00Z"));
+    const second = await runMemoryBackfill({ somaHome, now: new Date("2026-07-05T00:00:00Z") });
+    expect(second.skippedManifestCount).toBe(1);
+    expect(second.writtenCount).toBe(0);
+    expect(await readFile(second.manifestPath, "utf8")).toBe(manifest1);
+  });
+});
+
 test("refuses symlinks loudly", async () => {
   await withTempSoma(async (somaHome) => {
     await seed(somaHome, "KNOWLEDGE/real.md", "a real file body here");

--- a/test/memory-backfill.test.ts
+++ b/test/memory-backfill.test.ts
@@ -271,6 +271,24 @@ test("--dry-run plans without writing or touching the manifest", async () => {
   });
 });
 
+test("--dry-run is manifest-aware: already-imported files show as skipped, not fresh imports", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/a.md", "already imported body one two three");
+    await runMemoryBackfill({ somaHome });
+
+    // Now add a new file and dry-run: the prior file must show as a manifest skip
+    // (keeping its original id), only the new file as a would-import.
+    await seed(somaHome, "KNOWLEDGE/b.md", "a brand new body four five six");
+    const plan = await runMemoryBackfill({ somaHome, dryRun: true });
+    const byRel = new Map(plan.entries.map((e) => [e.relativePath, e]));
+    expect(byRel.get("KNOWLEDGE/a.md")?.status).toBe("skipped-manifest");
+    expect(byRel.get("KNOWLEDGE/a.md")?.noteId).toBe("knowledge-a");
+    expect(byRel.get("KNOWLEDGE/b.md")?.status).toBeUndefined(); // would import
+    expect(plan.skippedManifestCount).toBe(1);
+    expect(plan.writtenCount).toBe(0);
+  });
+});
+
 test("planMemoryBackfill matches the dry-run plan shape", async () => {
   await withTempSoma(async (somaHome) => {
     await seed(somaHome, "LEARNING/y.md", "plan shape body content");

--- a/test/memory-backfill.test.ts
+++ b/test/memory-backfill.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Memory subsystem M8 — backfill (`src/memory-backfill.ts`).
+ *
+ * Bulk-import legacy free-form markdown into schema-valid notes through the M1
+ * write path. Deterministic, no LLM, `import`-trigger → `quarantined` trust,
+ * SHA-manifest idempotency. See `Plans/declarative-twirling-lampson.md`.
+ */
+import { mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { expect, test } from "bun:test";
+import { planMemoryBackfill, runMemoryBackfill } from "../src/memory-backfill";
+import { parseMemoryNote } from "../src/memory-note";
+import { parseMemoryArgs } from "../src/cli/memory";
+import type { SomaMemoryNote } from "../src/types";
+
+async function withTempSoma<T>(fn: (somaHome: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "soma-backfill-"));
+  const somaHome = join(dir, ".soma");
+  try {
+    return await fn(somaHome);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+/** Write a legacy source file under `<somaHome>/memory/<rel>` with an optional mtime. */
+async function seed(somaHome: string, rel: string, body: string, mtime?: Date): Promise<string> {
+  const path = join(somaHome, "memory", rel);
+  await mkdir(join(path, ".."), { recursive: true });
+  await writeFile(path, body, "utf8");
+  if (mtime) await utimes(path, mtime, mtime);
+  return path;
+}
+
+async function readNote(path: string): Promise<SomaMemoryNote> {
+  return parseMemoryNote(await readFile(path, "utf8"));
+}
+
+test("maps category dir → note type (LEARNING→procedural, KNOWLEDGE→semantic, other→semantic)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "LEARNING/a-lesson.md", "how to do the thing well");
+    await seed(somaHome, "KNOWLEDGE/a-fact.md", "the sky is a certain color today");
+    await seed(somaHome, "RELATIONSHIP/a-note.md", "some other category content here");
+
+    const result = await runMemoryBackfill({ somaHome });
+
+    expect(result.writtenCount).toBe(3);
+    const byRel = new Map(result.entries.map((e) => [e.relativePath, e]));
+    expect(byRel.get("LEARNING/a-lesson.md")?.type).toBe("procedural");
+    expect(byRel.get("KNOWLEDGE/a-fact.md")?.type).toBe("semantic");
+    expect(byRel.get("RELATIONSHIP/a-note.md")?.type).toBe("semantic");
+  });
+});
+
+test("--type forces a single type, overriding the category map", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/x.md", "forced type body one two three");
+    const result = await runMemoryBackfill({ somaHome, type: "procedural" });
+    expect(result.entries[0]?.type).toBe("procedural");
+  });
+});
+
+test("every backfilled note lands at quarantined trust with import provenance and source_of_truth", async () => {
+  await withTempSoma(async (somaHome) => {
+    const src = await seed(somaHome, "KNOWLEDGE/fact.md", "an imported fact worth keeping around");
+    const result = await runMemoryBackfill({ somaHome });
+    const note = await readNote(result.entries[0].target);
+    expect(note.trust).toBe("quarantined");
+    expect(note.provenance).toBe("import");
+    expect(note.source_of_truth).toBe(src);
+    expect(note.body).toContain("an imported fact worth keeping around");
+    // Body is verbatim legacy content — no injected preamble (would inflate dedup).
+    expect(note.body).not.toContain("Backfilled from");
+  });
+});
+
+test("created/last_verified derive from the source mtime, not the clock", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/dated.md", "content with a known mtime abc def", new Date("2025-03-14T10:00:00Z"));
+    const result = await runMemoryBackfill({ somaHome });
+    const note = await readNote(result.entries[0].target);
+    expect(note.created).toBe("2025-03-14");
+    expect(note.last_verified).toBe("2025-03-14");
+    expect(result.entries[0].created).toBe("2025-03-14");
+  });
+});
+
+test("id derivation slugifies <category>-<stem> and disambiguates collisions", async () => {
+  await withTempSoma(async (somaHome) => {
+    // Same stem in two subdirs of the same category → same base slug → collision.
+    await seed(somaHome, "LEARNING/ALGORITHM/deploy_ci.md", "first distinct body about deploy ci alpha");
+    await seed(somaHome, "LEARNING/REFLECTIONS/deploy_ci.md", "second distinct body about deploy ci beta");
+    const result = await runMemoryBackfill({ somaHome });
+    const ids = result.entries.map((e) => e.noteId).sort();
+    expect(ids).toEqual(["learning-deploy-ci", "learning-deploy-ci-2"]);
+    // Both are valid slugs and unique.
+    expect(new Set(ids).size).toBe(2);
+  });
+});
+
+test("skips reserved dirs, root-level files, and README.md", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/keep.md", "keep this real knowledge body");
+    await seed(somaHome, "KNOWLEDGE/README.md", "readme skip");
+    await seed(somaHome, "STATE/current-work-x.json", "{}");
+    await seed(somaHome, "episodic/sessions/x.md", "episodic skip");
+    await seed(somaHome, "README.md", "root readme skip");
+
+    const result = await runMemoryBackfill({ somaHome });
+    expect(result.writtenCount).toBe(1);
+    expect(result.entries.map((e) => e.relativePath)).toEqual(["KNOWLEDGE/keep.md"]);
+  });
+});
+
+test("refuses symlinks loudly", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/real.md", "a real file body here");
+    const linkPath = join(somaHome, "memory", "KNOWLEDGE", "link.md");
+    await symlink(join(somaHome, "memory", "KNOWLEDGE", "real.md"), linkPath);
+    await expect(runMemoryBackfill({ somaHome })).rejects.toThrow(/refused symlink/i);
+  });
+});
+
+test("near-duplicate bodies are skipped as duplicates, not errors (sequential intra-batch dedup)", async () => {
+  await withTempSoma(async (somaHome) => {
+    const body = "the federation deploy runbook lives in cortex and runs nightly at midnight";
+    await seed(somaHome, "KNOWLEDGE/a.md", body);
+    await seed(somaHome, "KNOWLEDGE/b.md", body);
+    const result = await runMemoryBackfill({ somaHome });
+    expect(result.writtenCount).toBe(1);
+    expect(result.skippedDuplicateCount).toBe(1);
+    expect(result.errorCount).toBe(0);
+    const dup = result.entries.find((e) => e.status === "skipped-duplicate");
+    expect(dup?.detail).toMatch(/Recall-first refusal/);
+  });
+});
+
+test("--dry-run plans without writing or touching the manifest", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/x.md", "dry run body content here");
+    const plan = await runMemoryBackfill({ somaHome, dryRun: true });
+    expect(plan.dryRun).toBe(true);
+    expect(plan.entries).toHaveLength(1);
+    expect(plan.writtenCount).toBe(0);
+    // Nothing on disk.
+    await expect(readFile(plan.entries[0].target, "utf8")).rejects.toThrow();
+    await expect(readFile(plan.manifestPath, "utf8")).rejects.toThrow();
+  });
+});
+
+test("planMemoryBackfill matches the dry-run plan shape", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "LEARNING/y.md", "plan shape body content");
+    const plan = await planMemoryBackfill({ somaHome });
+    expect(plan.dryRun).toBe(true);
+    expect(plan.entries[0]?.type).toBe("procedural");
+    expect(plan.entries[0]?.noteId).toBe("learning-y");
+  });
+});
+
+test("idempotent rerun: 0 written, all skipped-manifest, byte-identical manifest", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/a.md", "idempotency body alpha one");
+    await seed(somaHome, "LEARNING/b.md", "idempotency body beta two");
+
+    const first = await runMemoryBackfill({ somaHome, now: new Date("2026-07-04T00:00:00Z") });
+    expect(first.writtenCount).toBe(2);
+    const manifest1 = await readFile(first.manifestPath, "utf8");
+
+    const second = await runMemoryBackfill({ somaHome, now: new Date("2026-07-05T00:00:00Z") });
+    expect(second.writtenCount).toBe(0);
+    expect(second.skippedManifestCount).toBe(2);
+    const manifest2 = await readFile(second.manifestPath, "utf8");
+
+    // importedAt preserved (no writes) → byte-stable manifest despite a later clock.
+    expect(manifest2).toBe(manifest1);
+  });
+});
+
+test("a changed source file after import is re-imported as a new note on rerun", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/a.md", "original imported body one two three");
+    await runMemoryBackfill({ somaHome });
+
+    // Edit the source (new SHA) → no longer a manifest hit; distinct body avoids the dedup gate.
+    await seed(somaHome, "KNOWLEDGE/a.md", "wholly rewritten body four five six seven eight");
+    const rerun = await runMemoryBackfill({ somaHome });
+    expect(rerun.writtenCount).toBe(1);
+  });
+});
+
+test("CLI parses backfill flags and rejects an unknown --type", async () => {
+  const parsed = parseMemoryArgs([
+    "memory",
+    "backfill",
+    "--from",
+    "/tmp/src",
+    "--type",
+    "semantic",
+    "--project",
+    "soma",
+    "--dry-run",
+    "--soma-home",
+    "/tmp/soma",
+  ]);
+  expect(parsed.action).toBe("backfill");
+  if (parsed.action === "backfill") {
+    expect(parsed.options.from).toBe("/tmp/src");
+    expect(parsed.options.type).toBe("semantic");
+    expect(parsed.options.project).toBe("soma");
+    expect(parsed.options.dryRun).toBe(true);
+    expect(parsed.options.somaHome).toBe("/tmp/soma");
+  }
+  expect(() => parseMemoryArgs(["memory", "backfill", "--type", "bogus"])).toThrow();
+});

--- a/test/memory-backfill.test.ts
+++ b/test/memory-backfill.test.ts
@@ -190,6 +190,25 @@ test("near-duplicate bodies are skipped as duplicates, not errors (sequential in
   });
 });
 
+test("a manifest built for a different --from root is not treated as a hit", async () => {
+  await withTempSoma(async (somaHome) => {
+    const dirA = join(somaHome, "a");
+    const dirB = join(somaHome, "b");
+    await mkdir(dirA, { recursive: true });
+    await mkdir(dirB, { recursive: true });
+    await writeFile(join(dirA, "note.md"), "body from root A one two three", "utf8");
+    await writeFile(join(dirB, "note.md"), "distinct body from root B four five six", "utf8");
+
+    const first = await runMemoryBackfill({ somaHome, from: dirA });
+    expect(first.writtenCount).toBe(1);
+
+    // Same relative path ("note.md") but a different root — must NOT skip-manifest.
+    const second = await runMemoryBackfill({ somaHome, from: dirB });
+    expect(second.skippedManifestCount).toBe(0);
+    expect(second.writtenCount).toBe(1);
+  });
+});
+
 test("--dry-run plans without writing or touching the manifest", async () => {
   await withTempSoma(async (somaHome) => {
     await seed(somaHome, "KNOWLEDGE/x.md", "dry run body content here");

--- a/test/memory-backfill.test.ts
+++ b/test/memory-backfill.test.ts
@@ -119,6 +119,9 @@ test("imports only markdown files — non-markdown under a category dir is skipp
     await seed(somaHome, "KNOWLEDGE/creds.env", "SECRET=should-never-be-imported");
     await seed(somaHome, "KNOWLEDGE/data.json", '{"not":"a note"}');
     await seed(somaHome, "KNOWLEDGE/deep.markdown", "a .markdown file is also imported");
+    // READMEs are skipped case-insensitively.
+    await seed(somaHome, "KNOWLEDGE/Readme.md", "readme variant skip");
+    await seed(somaHome, "KNOWLEDGE/README.MD", "readme variant skip two");
 
     const result = await runMemoryBackfill({ somaHome });
     expect(result.entries.map((e) => e.relativePath).sort()).toEqual([

--- a/test/memory-backfill.test.ts
+++ b/test/memory-backfill.test.ts
@@ -137,9 +137,10 @@ test("imports only markdown files — non-markdown under a category dir is skipp
     await seed(somaHome, "KNOWLEDGE/creds.env", "SECRET=should-never-be-imported");
     await seed(somaHome, "KNOWLEDGE/data.json", '{"not":"a note"}');
     await seed(somaHome, "KNOWLEDGE/deep.markdown", "a .markdown file is also imported");
-    // READMEs are skipped case-insensitively.
+    // READMEs are skipped case-insensitively, for both markdown extensions.
     await seed(somaHome, "KNOWLEDGE/Readme.md", "readme variant skip");
     await seed(somaHome, "KNOWLEDGE/README.MD", "readme variant skip two");
+    await seed(somaHome, "KNOWLEDGE/README.markdown", "readme variant skip three");
 
     const result = await runMemoryBackfill({ somaHome });
     expect(result.entries.map((e) => e.relativePath).sort()).toEqual([

--- a/test/memory-backfill.test.ts
+++ b/test/memory-backfill.test.ts
@@ -5,7 +5,7 @@
  * write path. Deterministic, no LLM, `import`-trigger → `quarantined` trust,
  * SHA-manifest idempotency. See `Plans/declarative-twirling-lampson.md`.
  */
-import { mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
@@ -206,6 +206,32 @@ test("a manifest built for a different --from root is not treated as a hit", asy
     const second = await runMemoryBackfill({ somaHome, from: dirB });
     expect(second.skippedManifestCount).toBe(0);
     expect(second.writtenCount).toBe(1);
+  });
+});
+
+test("an unreadable source is recorded as a per-file error, not a batch abort", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seed(somaHome, "KNOWLEDGE/good.md", "a healthy note body one two three");
+    const badPath = await seed(somaHome, "KNOWLEDGE/bad.md", "an unreadable body four five six");
+    await chmod(badPath, 0o000);
+    // Under root, mode 000 doesn't restrict reads — detect and relax the assertion.
+    let restricted: boolean;
+    try {
+      await readFile(badPath, "utf8");
+      restricted = false;
+    } catch {
+      restricted = true;
+    }
+
+    // The key property: one bad source never aborts the whole batch.
+    const result = await runMemoryBackfill({ somaHome });
+    expect(result.entries.some((e) => e.relativePath === "KNOWLEDGE/good.md" && e.status === "written")).toBe(true);
+    if (restricted) {
+      expect(result.errorCount).toBe(1);
+      const bad = result.entries.find((e) => e.relativePath === "KNOWLEDGE/bad.md");
+      expect(bad?.status).toBe("error");
+    }
+    await chmod(badPath, 0o600); // let withTempSoma clean up
   });
 });
 


### PR DESCRIPTION
## What

Ships `soma memory backfill` — a first-class, reusable command that turns a principal's existing free-form markdown memory into schema-valid, governed notes. The on-ramp missing for adopting Soma with a non-empty legacy store (a freshly-migrated store has an empty `semantic/`+`procedural/` corpus but a pile of pre-M0 markdown in `LEARNING/`, `KNOWLEDGE/`, …).

```
soma memory backfill [--from <dir>] [--type semantic|procedural] [--project <key>] [--dry-run]
```

## Design

- **Batch caller of the M1 write path** (`writeMemoryNote` + `import` trigger) — not a new governed path, so schema serialization, recall-first dedup, and event journaling are enforced in one place.
- **Markdown only** (`.md`/`.markdown`, read with `O_NOFOLLOW` + dev/ino re-check); reserved dirs, READMEs (case-insensitive), non-markdown, and symlinks (entries and the source root) are skipped/refused. Root-level files are skipped only for the default memory root; a custom `--from <dir>` imports its top-level markdown (category `""`→semantic).
- **Category→type mapping**: `LEARNING`→procedural, `KNOWLEDGE`→semantic, else semantic; `--type` forces flat (honoured on rerun — a type-switch is not a silent manifest hit).
- **`import` trigger → `quarantined` trust** for everything (MINJA-safe). Imports are recall-discoverable with a ⚠ untrusted banner but held out of the always-loaded INDEX until re-authored at higher trust — the admission filter excludes quarantined unconditionally, so `verify` (freshness only) cannot promote them; `principal-correction`/`supersede` can. (recall includes quarantined `memory-recall.ts:136,162`; INDEX excludes them `memory-index.ts:17`.)
- **Deterministic**: bodies imported verbatim (no preamble — it would inflate dedup similarity), `created` from source mtime, no LLM.
- **Idempotent** via a SHA manifest at `memory/STATE/imports/backfill/.manifest.json` (inside the Memory compartment, keyed to the source root). A no-op rerun re-emits prior entries verbatim → byte-stable even across a `touch`. Rebuilds INDEX after writes so the store stays audit-clean. A single bad source (unreadable/deleted/swapped) becomes a per-file `error` entry, never a batch abort.

## Verification

Reproduce on this branch:

```
$ bun run typecheck        # tsc --noEmit → exit 0, clean
$ bun test test/memory-backfill.test.ts   # 21 pass / 0 fail
$ bun test                 # full suite → 1744 pass / 0 fail across 112 files
```

Live acceptance on a throwaway `--soma-home` fixture: notes land in `semantic/`/`procedural/` with `trust: quarantined`, `provenance: import`, `created` = source mtime, `source_of_truth` = origin; `soma memory recall <term>` shows a `⚠ QUARANTINED (untrusted)` banner; `soma memory audit` → HEALTHY (backfill rebuilds INDEX); rerun → `0 written`, byte-identical manifest; a second identical-body file → `skipped-duplicate` (recall-first refusal), not an error.

## Out of scope (v1)

LLM distillation (deterministic-only), auto-supersede on source drift, trust elevation of imports (the principal re-authors later via `principal-correction`/`supersede`), non-markdown / recall-SQLite sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)