### PR TITLE
feat: add code-only projection mode

### DIFF
--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -2,6 +2,10 @@ import type { SomaAdapter, Projection, ProjectionInput, SomaTask } from "../type
 import { renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills, withProvenance } from "./shared";
 import { activeVsaBundleFile } from "../adapter-active-vsa";
 
+export function isClaudeCodeSkillProjectionPath(_path: string): boolean {
+  return false;
+}
+
 function renderInstructions(input: ProjectionInput): string {
   return [
     "# Soma Claude Code Context",

--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -12,6 +12,10 @@ import { somaMemoryPrivateRoots, somaProjectionPrivateRoots } from "../../projec
 import { defaultInboundContentSecurityConfig } from "../../inbound-security";
 import { rewriteSubstrateProjectionContent } from "../../substrate-projection-rewrites";
 
+export function isCodexSkillProjectionPath(path: string): boolean {
+  return path.startsWith("skills/");
+}
+
 /**
  * Compute the runtime config the soma-lifecycle.mjs hook reads at
  * startup from a colocated soma-lifecycle.config.json. Replaces the

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -27,6 +27,10 @@ export const CURSOR_HOME_FILE_PATHS = [
   CURSOR_MCP_PATH,
 ] as const;
 
+export function isCursorSkillProjectionPath(_path: string): boolean {
+  return false;
+}
+
 export function cursorWorkspaceSubstrateHome(cwd: string = process.cwd()): string {
   return resolve(cwd);
 }

--- a/src/adapters/grok/adapter.ts
+++ b/src/adapters/grok/adapter.ts
@@ -30,6 +30,10 @@ import {
 import { readGrokHookAsset } from "./hooks/assets";
 import { GROK_PRE_TOOL_USE_VERB } from "./hooks/grok-hook-verbs.mjs";
 
+export function isGrokSkillProjectionPath(path: string): boolean {
+  return path.startsWith("skills/");
+}
+
 /**
  * Resolve the user-level Grok home (`~/.grok`). `detect()` probes this
  * directory's existence: unlike Codex (`CODEX_HOME`) or Cursor

--- a/src/adapters/pi-dev/adapter.ts
+++ b/src/adapters/pi-dev/adapter.ts
@@ -7,6 +7,10 @@ import { projectableSkills, renderAssistantCore, renderMemoryLayout, renderPolic
 import { activeVsaBundleFile } from "../../adapter-active-vsa";
 import { SOMA_VERSION } from "../../version";
 
+export function isPiDevSkillProjectionPath(path: string): boolean {
+  return path.startsWith("agent/skills/");
+}
+
 function renderInstructions(input: ProjectionInput): string {
   return [
     "# Soma Pi.dev Context",

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -96,9 +96,10 @@ export type ParsedSubstrateLifecycleArgs =
 export const INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code", "cursor", "grok"] as const satisfies readonly InstallSubstrate[];
 
 const substrateList = INSTALL_SUBSTRATES.join("|");
-const installOptions = "[--dry-run] [--apply] [--workspace] [--no-mode-classifier] [--no-policy-guard] [--claude-md] [--skills <name[,name…]>] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
-// Shared by uninstall, reproject, and upgrade — all workspace-capable verbs.
+const installOptions = "[--dry-run] [--apply] [--workspace] [--code-only] [--no-mode-classifier] [--no-policy-guard] [--claude-md] [--skills <name[,name…]>] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
+// Shared by uninstall and projection verbs for common workspace/home flags.
 const workspaceVerbOptions = "[--workspace] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
+const projectionVerbOptions = "[--workspace] [--code-only] [--home-dir <dir>] [--soma-home <dir>] [--substrate-home <dir>]";
 const uninstallOptions = workspaceVerbOptions;
 
 function lifecycleUsage(command: string, target: string, options: string): string {
@@ -158,10 +159,10 @@ export const SUBSTRATE_LIFECYCLE_COMMAND_HELP: Record<
     subcommands: lifecycleSubcommandUsage("uninstall", uninstallOptions),
   },
   reproject: {
-    usage: lifecycleUsage("reproject", `<${substrateList}>`, workspaceVerbOptions),
+    usage: lifecycleUsage("reproject", `<${substrateList}>`, projectionVerbOptions),
   },
   upgrade: {
-    usage: lifecycleUsage("upgrade", `<${substrateList}>`, workspaceVerbOptions),
+    usage: lifecycleUsage("upgrade", `<${substrateList}>`, projectionVerbOptions),
   },
   export: {
     usage: lifecycleUsage("export", `<${substrateList}>`, "[--out <dir>] [--home-dir <dir>] [--soma-home <dir>]"),
@@ -205,6 +206,7 @@ function parseSubstrateLifecycleOptions<TOptions extends SomaInstallOptions = So
   substrate: InstallSubstrate,
   rest: string[],
   extra: (arg: string, index: number, options: TOptions) => boolean,
+  parserOptions: { allowCodeOnly?: boolean } = {},
 ): { workspace: boolean; options: TOptions } {
   const options = {} as TOptions;
   let workspace = false;
@@ -216,6 +218,10 @@ function parseSubstrateLifecycleOptions<TOptions extends SomaInstallOptions = So
     switch (arg) {
       case "--workspace":
         workspace = true;
+        continue;
+      case "--code-only":
+        if (parserOptions.allowCodeOnly !== true) break;
+        options.codeOnly = true;
         continue;
       case "--home-dir":
         options.homeDir = readOption(rest, index, arg);
@@ -288,7 +294,7 @@ export function parseInstallArgs(args: string[]): ParsedInstallArgs {
         return true;
     }
     return false;
-  });
+  }, { allowCodeOnly: true });
   if (options.modeClassifier !== undefined && substrate !== "claude-code") {
     throw new Error("--mode-classifier / --no-mode-classifier is only supported for claude-code installs.");
   }
@@ -336,7 +342,9 @@ function parseLifecycleVerbArgs(
     throw new Error(commandUsage(verb));
   }
 
-  const { workspace, options } = parseSubstrateLifecycleOptions(substrate, rest, () => false);
+  const { workspace, options } = parseSubstrateLifecycleOptions(substrate, rest, () => false, {
+    allowCodeOnly: verb === "reproject" || verb === "upgrade",
+  });
   return { substrate, workspace, options };
 }
 

--- a/src/home-projection.ts
+++ b/src/home-projection.ts
@@ -4,8 +4,13 @@ import { join, resolve } from "node:path";
 import { dirname } from "node:path";
 import { CURSOR_RULES_BLOCK_BEGIN, CURSOR_RULES_BLOCK_END, CURSOR_RULES_PATH } from "./adapters/cursor";
 import { projectClaudeCodeHome, projectCodexHome, projectCursorHome, projectGrokHome, projectPiDevHome } from "./adapters";
+import { isClaudeCodeSkillProjectionPath } from "./adapters/claude-code";
+import { isCodexSkillProjectionPath } from "./adapters/codex/adapter";
+import { isCursorSkillProjectionPath } from "./adapters/cursor";
+import { isGrokSkillProjectionPath } from "./adapters/grok/adapter";
 import { isGrokPortableSkillProjectionPath } from "./adapters/grok/install";
 import { reconcileGrokPortableSkillProjection, writeGrokInstallManifest } from "./adapters/grok/install-manifest";
+import { isPiDevSkillProjectionPath } from "./adapters/pi-dev/adapter";
 import { writeProjection } from "./projection";
 import { defaultSomaRepoPath } from "./repo-path";
 import { defaultSubstrateHome } from "./install-spec-registry";
@@ -42,11 +47,27 @@ function buildHomeProjectionFor(
   };
 }
 
+type SkillProjectionPathPredicate = (path: string) => boolean;
+
+function maybeCodeOnlyProjection(
+  projection: Projection,
+  options: SomaHomeProjectionOptions,
+  isSkillProjectionPath: SkillProjectionPathPredicate,
+): Projection {
+  if (options.codeOnly !== true) return projection;
+  return {
+    ...projection,
+    files: projection.files.filter((file) => !isSkillProjectionPath(file.path)),
+  };
+}
+
 export function buildCodexHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
   const homeDir = resolve(options.homeDir ?? homedir());
   const somaRepoPath = resolve(options.somaRepoPath ?? defaultSomaRepoPath());
 
-  return buildHomeProjectionFor("codex", options, (paths) => projectCodexHome(input, paths.somaHome, homeDir, somaRepoPath));
+  return buildHomeProjectionFor("codex", options, (paths) =>
+    maybeCodeOnlyProjection(projectCodexHome(input, paths.somaHome, homeDir, somaRepoPath), options, isCodexSkillProjectionPath),
+  );
 }
 
 export async function installCodexHomeProjection(
@@ -58,7 +79,9 @@ export async function installCodexHomeProjection(
 }
 
 export function buildPiDevHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
-  return buildHomeProjectionFor("pi-dev", options, (paths) => projectPiDevHome(input, paths.somaHome));
+  return buildHomeProjectionFor("pi-dev", options, (paths) =>
+    maybeCodeOnlyProjection(projectPiDevHome(input, paths.somaHome), options, isPiDevSkillProjectionPath),
+  );
 }
 
 export async function installPiDevHomeProjection(
@@ -78,7 +101,9 @@ export function buildClaudeCodeHomeProjection(
   input: ProjectionInput,
   options: SomaHomeProjectionOptions = {},
 ): SomaHomeProjection {
-  return buildHomeProjectionFor("claude-code", options, () => projectClaudeCodeHome(input));
+  return buildHomeProjectionFor("claude-code", options, () =>
+    maybeCodeOnlyProjection(projectClaudeCodeHome(input), options, isClaudeCodeSkillProjectionPath),
+  );
 }
 
 export async function installClaudeCodeHomeProjection(
@@ -90,7 +115,7 @@ export async function installClaudeCodeHomeProjection(
 }
 
 export function buildCursorHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
-  return buildHomeProjectionFor("cursor", options, () => projectCursorHome(input));
+  return buildHomeProjectionFor("cursor", options, () => maybeCodeOnlyProjection(projectCursorHome(input), options, isCursorSkillProjectionPath));
 }
 
 export function buildGrokHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
@@ -101,7 +126,11 @@ export function buildGrokHomeProjection(input: ProjectionInput, options: SomaHom
   // resolved substrate home — including a substrateHome override — and
   // the trusted repo path flow into the projection.
   return buildHomeProjectionFor("grok", options, (paths) =>
-    projectGrokHome(input, paths.somaHome, { homeDir, somaRepoPath, grokHome: paths.substrateHome }),
+    maybeCodeOnlyProjection(
+      projectGrokHome(input, paths.somaHome, { homeDir, somaRepoPath, grokHome: paths.substrateHome }),
+      options,
+      isGrokSkillProjectionPath,
+    ),
   );
 }
 
@@ -136,6 +165,9 @@ export async function installGrokHomeProjection(
   const projection = buildGrokHomeProjection(input, options);
   const portableFiles = projection.bundle.files.filter((file) => isGrokPortableSkillProjectionPath(file.path));
   const written = await writeProjection(projection.bundle, projection.substrateHome);
+  if (options.codeOnly === true) {
+    return written;
+  }
   // U6 follow-up: the manifest records the dynamically-named
   // portable-skill files (path + content hash) on the Soma side so
   // uninstall can round-trip them. Before refreshing it, reconcile:

--- a/src/install.ts
+++ b/src/install.ts
@@ -127,36 +127,45 @@ async function installSomaForSubstrate(
   // r1 caught a bypass that trusted `process.versions.bun`, which
   // doesn't prove anything about the hook's later spawn environment.
   requireBunInPath();
-  const somaHome = await bootstrapSomaHome(options);
-  // soma#329 MIGRATION SHIM (removable once all homes are reprojected past the
-  // ISA→VSA rename): prune the renamed-away "ISA" skill from the SOURCE home
-  // BEFORE the VSA baseline is (re)written and BEFORE loadSomaHome enumerates
-  // skills below. `loadSomaSkills` projects EVERY dir under <somaHome>/skills, so a
-  // stale ISA here would re-propagate to every substrate on each install. Cheap +
-  // idempotent (a no-op readdir+gate once ISA is gone). Provenance-gated
-  // (frontmatter name: ISA + identity marker) — a user "ISA" skill is preserved.
-  await pruneLegacyVsaSkill(createPaths(somaHome.somaHome).skills());
-  const somaRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();
-  // Install VSA skill into Soma home (canonical baseline) so other
-  // tooling reading <somaHome>/skills/VSA continues to work.
-  await installVsaSkillProjection({
+  const codeOnly = options.codeOnly === true;
+  const somaHome = await bootstrapSomaHome({
     homeDir: options.homeDir,
-    somaHome: somaHome.somaHome,
-    somaRepoPath,
+    somaHome: options.somaHome,
+    includeSkills: !codeOnly,
   });
-  // bootstrapSomaHome captured its context snapshot BEFORE the VSA skill
-  // baseline above existed, so its skill list is empty on a first install.
-  // Re-read the Soma home now that <somaHome>/skills/VSA is on disk: without
-  // this, the first install projects a skills.md that reads "No Soma skills
-  // were declared." and only the second install converges. Reloading makes
-  // the very first projection already list the VSA skill — install #1 is
-  // correct and byte-identical to every re-run.
-  const projectionContext = await loadSomaHome(somaHome.somaHome);
+  const somaRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();
+  let projectionContext = somaHome.context;
+  if (!codeOnly) {
+    // soma#329 MIGRATION SHIM (removable once all homes are reprojected past the
+    // ISA→VSA rename): prune the renamed-away "ISA" skill from the SOURCE home
+    // BEFORE the VSA baseline is (re)written and BEFORE loadSomaHome enumerates
+    // skills below. `loadSomaSkills` projects EVERY dir under <somaHome>/skills, so a
+    // stale ISA here would re-propagate to every substrate on each install. Cheap +
+    // idempotent (a no-op readdir+gate once ISA is gone). Provenance-gated
+    // (frontmatter name: ISA + identity marker) — a user "ISA" skill is preserved.
+    await pruneLegacyVsaSkill(createPaths(somaHome.somaHome).skills());
+    // Install VSA skill into Soma home (canonical baseline) so other
+    // tooling reading <somaHome>/skills/VSA continues to work.
+    await installVsaSkillProjection({
+      homeDir: options.homeDir,
+      somaHome: somaHome.somaHome,
+      somaRepoPath,
+    });
+    // bootstrapSomaHome captured its context snapshot BEFORE the VSA skill
+    // baseline above existed, so its skill list is empty on a first install.
+    // Re-read the Soma home now that <somaHome>/skills/VSA is on disk: without
+    // this, the first install projects a skills.md that reads "No Soma skills
+    // were declared." and only the second install converges. Reloading makes
+    // the very first projection already list the VSA skill — install #1 is
+    // correct and byte-identical to every re-run.
+    projectionContext = await loadSomaHome(somaHome.somaHome);
+  }
   const projectionOptions = {
     homeDir: options.homeDir,
     somaHome: options.somaHome,
     substrateHome: options.substrateHome,
     somaRepoPath,
+    codeOnly,
   };
   // Per-substrate skill projection (#37 AC-3). Each substrate gets the
   // versioned VSA skill under its native skills dir, with independent
@@ -165,15 +174,17 @@ async function installSomaForSubstrate(
   const resolvedHomeDir = resolve(options.homeDir ?? homedir());
   const substrateRoot = resolve(options.substrateHome ?? join(resolvedHomeDir, spec.defaultHome));
   await spec.validator?.(substrateRoot);
-  await spec.vsaSkillProjection.prepare?.(substrateRoot);
-  await installVsaSkillProjection({
-    homeDir: options.homeDir,
-    somaHome: somaHome.somaHome,
-    somaRepoPath,
-    skillDestinationDir: spec.vsaSkillProjection.destinationDir(substrateRoot),
-    skillNameOverride: spec.vsaSkillProjection.skillNameOverride,
-    projectionSubstrate: substrate,
-  });
+  if (!codeOnly) {
+    await spec.vsaSkillProjection.prepare?.(substrateRoot);
+    await installVsaSkillProjection({
+      homeDir: options.homeDir,
+      somaHome: somaHome.somaHome,
+      somaRepoPath,
+      skillDestinationDir: spec.vsaSkillProjection.destinationDir(substrateRoot),
+      skillNameOverride: spec.vsaSkillProjection.skillNameOverride,
+      projectionSubstrate: substrate,
+    });
+  }
   // Populate the projection input with the active VSA so each substrate writes its
   // `active-vsa.md` file (#37 AC-1/AC-2), and with the memory index (M4) so
   // memory-aware substrates project their always-loaded memory file. Both are
@@ -280,7 +291,7 @@ async function runPostProjectionSteps(
 async function installHomeProjectionFor(
   substrate: InstallSubstrate,
   context: ProjectionInput,
-  options: { homeDir?: string; somaHome?: string; substrateHome?: string; somaRepoPath: string },
+  options: { homeDir?: string; somaHome?: string; substrateHome?: string; somaRepoPath: string; codeOnly?: boolean },
 ) {
   switch (substrate) {
     case "codex":

--- a/src/soma-home.ts
+++ b/src/soma-home.ts
@@ -6,6 +6,10 @@ import { SOMA_MEMORY_CATEGORIES, SOMA_MEMORY_CATEGORY_READMES } from "./memory-r
 import { createPaths } from "./paths";
 import type { ProjectionInput, SomaHomeBootstrapOptions, SomaHomeBootstrapResult, SomaSkill } from "./types";
 
+export interface LoadSomaHomeOptions {
+  includeSkills?: boolean;
+}
+
 // #88 / DD-2: canonical PAI v5.0.0 memory taxonomy (17 substrate-neutral +
 // 2 PAI-bound). The directory list and per-category README content live in
 // `memory-readmes.ts` so the install planner, bootstrap, and tests all share
@@ -240,9 +244,9 @@ export async function loadSomaProfile(somaHome: string): Promise<Omit<Projection
   };
 }
 
-export async function loadSomaHome(somaHome: string): Promise<ProjectionInput> {
+export async function loadSomaHome(somaHome: string, options: LoadSomaHomeOptions = {}): Promise<ProjectionInput> {
   const profile = await loadSomaProfile(somaHome);
-  const skills = await loadSomaSkills(somaHome);
+  const skills = options.includeSkills === false ? [] : await loadSomaSkills(somaHome);
 
   return {
     profile: {
@@ -346,7 +350,7 @@ export async function bootstrapSomaHome(options: SomaHomeBootstrapOptions = {}):
 
   return {
     somaHome,
-    context: await loadSomaHome(somaHome),
+    context: await loadSomaHome(somaHome, { includeSkills: options.includeSkills }),
     files: writtenFiles,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -597,6 +597,7 @@ export interface SomaHomeProjectionOptions {
   somaHome?: string;
   substrateHome?: string;
   somaRepoPath?: string;
+  codeOnly?: boolean;
 }
 
 export interface SomaHomeProjection {
@@ -609,6 +610,7 @@ export interface SomaHomeProjection {
 export interface SomaHomeBootstrapOptions {
   homeDir?: string;
   somaHome?: string;
+  includeSkills?: boolean;
 }
 
 export interface SomaHomeBootstrapResult {
@@ -622,6 +624,7 @@ export interface SomaInstallOptions {
   somaHome?: string;
   substrateHome?: string;
   somaRepoPath?: string;
+  codeOnly?: boolean;
 }
 
 export interface SomaInstallResult {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2143,20 +2143,39 @@ test("cli uninstall codex/pi-dev is a reserved stub", async () => {
 
 test("cli reproject codex routes through the install applier", async () => {
   await withTempHome(async (homeDir) => {
-    const output = await runSomaCli(["reproject", "codex", "--home-dir", homeDir]);
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    await mkdir(join(somaHome, "skills", "Widget"), { recursive: true });
+    await writeFile(join(somaHome, "skills", "Widget", "SKILL.md"), "---\nname: Widget\n---\n\nWidget skill.\n", "utf8");
+    await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);
+    const projectedSkill = join(homeDir, ".codex", "skills", "Widget", "SKILL.md");
+    expect(await readFile(projectedSkill, "utf8")).toContain("Widget skill");
+    const staleOwnedFile = join(homeDir, ".codex", "memories", "soma", "stale.md");
+    await writeFile(staleOwnedFile, "stale generated projection\n", "utf8");
+
+    const output = await runSomaCli(["reproject", "codex", "--code-only", "--home-dir", homeDir]);
 
     expect(output).toContain("Soma install applied");
     expect(output).toContain(`substrate: codex`);
     await expect(stat(join(homeDir, ".codex/rules/soma.rules"))).resolves.toBeDefined();
+    expect(await readFile(projectedSkill, "utf8")).toContain("Widget skill");
+    await expect(readFile(staleOwnedFile, "utf8")).rejects.toThrow();
   });
 });
 
 test("cli upgrade codex routes through the install applier", async () => {
   await withTempHome(async (homeDir) => {
-    const output = await runSomaCli(["upgrade", "codex", "--home-dir", homeDir]);
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    await mkdir(join(somaHome, "skills", "Widget"), { recursive: true });
+    await writeFile(join(somaHome, "skills", "Widget", "SKILL.md"), "---\nname: Widget\n---\n\nWidget skill.\n", "utf8");
+    await runSomaCli(["install", "codex", "--apply", "--home-dir", homeDir]);
+    const projectedSkill = join(homeDir, ".codex", "skills", "Widget", "SKILL.md");
+    expect(await readFile(projectedSkill, "utf8")).toContain("Widget skill");
+
+    const output = await runSomaCli(["upgrade", "codex", "--code-only", "--home-dir", homeDir]);
 
     expect(output).toContain("Soma install applied");
     expect(output).toContain(`substrate: codex`);
+    expect(await readFile(projectedSkill, "utf8")).toContain("Widget skill");
   });
 });
 

--- a/test/grok-install.test.ts
+++ b/test/grok-install.test.ts
@@ -65,6 +65,13 @@ test("every lifecycle verb accepts grok", () => {
   expect(parseExportArgs(["export", "grok"]).substrate).toBe("grok");
 });
 
+test("code-only is accepted for projection lifecycle verbs", () => {
+  expect(parseInstallArgs(["install", "grok", "--code-only"]).options.codeOnly).toBe(true);
+  expect(parseReprojectArgs(["reproject", "grok", "--code-only"]).options.codeOnly).toBe(true);
+  expect(parseUpgradeArgs(["upgrade", "grok", "--code-only"]).options.codeOnly).toBe(true);
+  expect(() => parseUninstallArgs(["uninstall", "grok", "--code-only"])).toThrow("Unknown option: --code-only");
+});
+
 test("workspace grok install targets a .grok home, not the .codex fallback", () => {
   // Regression for workspaceSubstrateHome's silent `.codex` else-branch:
   // an unrecognized substrate would have fallen through to `.codex`.

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1521,3 +1521,26 @@ test("#88 AC-3: bootstrap is idempotent — re-running install does not overwrit
     expect(second).toBe("# OBSERVABILITY (user-edited)\n\nCustom notes.\n");
   });
 });
+
+
+test("code-only codex install skips skill projection and preserves existing projected skills", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const skillDir = join(homeDir, ".soma", "skills", "Widget");
+    await mkdir(join(skillDir, "references"), { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "---\nname: Widget\n---\n\nWidget skill.\n", "utf8");
+    await writeFile(join(skillDir, "references", "guide.md"), "# Guide\n", "utf8");
+
+    await installSomaForCodex({ homeDir });
+    const projectedSkill = join(homeDir, ".codex", "skills", "Widget", "SKILL.md");
+    expect(await readFile(projectedSkill, "utf8")).toContain("Widget skill");
+    const staleOwnedFile = join(homeDir, ".codex", "memories", "soma", "stale.md");
+    await writeFile(staleOwnedFile, "stale generated projection\n", "utf8");
+
+    const result = await installSomaForCodex({ homeDir, codeOnly: true });
+
+    expect(result.substrateHome.files.some((file) => file.includes("/skills/"))).toBe(false);
+    expect(await readFile(projectedSkill, "utf8")).toContain("Widget skill");
+    await expect(readFile(staleOwnedFile, "utf8")).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add --code-only for install --apply, reproject, and upgrade
- skip Soma skill enumeration and VSA/portable skill projection in code-only mode
- filter skill payload files through adapter-owned path classifiers, including explicit no-skill classifiers for Claude Code and Cursor
- continue reconciling owned non-skill projection subtrees; regression coverage proves Codex install/reproject/upgrade preserve an existing projected skill and reproject prunes stale owned non-skill files

## Verification
- bun test test/cli.test.ts test/grok-install.test.ts test/install.test.ts
- bun run typecheck
- bun test