### PR TITLE
refactor(memory): name episodic digest pointer grammar

### DIFF
--- a/src/episodic-digest.ts
+++ b/src/episodic-digest.ts
@@ -1,0 +1,74 @@
+import type { SomaMemoryNote } from "./types";
+
+/**
+ * First non-empty body line, control-stripped + truncated — the digest pointer text.
+ * This is a display summary only; the note id is the durable parse target.
+ */
+function digestPointerText(note: SomaMemoryNote): string {
+  const line = note.body.split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
+  return line.replace(/[\x00-\x1f\x7f-\x9f]+/g, " ").slice(0, 120);
+}
+
+/** Escape the id segment so the first unescaped colon remains the grammar boundary. */
+function escapeDigestPointerId(id: string): string {
+  return id.replace(/\\/g, "\\\\").replace(/:/g, "\\:");
+}
+
+function unescapeDigestPointerId(id: string): string {
+  let out = "";
+  let escaping = false;
+  for (const ch of id) {
+    if (escaping) {
+      out += ch;
+      escaping = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaping = true;
+      continue;
+    }
+    out += ch;
+  }
+  if (escaping) out += "\\";
+  return out;
+}
+
+function parseDigestPointerId(line: string): string | undefined {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("- ")) return undefined;
+
+  const body = trimmed.slice(2);
+  let escaping = false;
+  for (let i = 0; i < body.length; i += 1) {
+    const ch = body[i];
+    if (escaping) {
+      escaping = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escaping = true;
+      continue;
+    }
+    if (ch === ":") {
+      const id = body.slice(0, i).trim();
+      if (id.length === 0) return undefined;
+      return unescapeDigestPointerId(id);
+    }
+  }
+  return undefined;
+}
+
+/** Render one monthly episodic digest pointer line. */
+export function renderDigestPointer(note: SomaMemoryNote): string {
+  return `- ${escapeDigestPointerId(note.id)}: ${digestPointerText(note)}`;
+}
+
+/** Parse all note ids from monthly episodic digest pointer lines. */
+export function parseDigestPointerIds(content: string): string[] {
+  const ids: string[] = [];
+  for (const line of content.split("\n")) {
+    const id = parseDigestPointerId(line);
+    if (id !== undefined) ids.push(id);
+  }
+  return ids;
+}

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -1,6 +1,7 @@
 import { type Dirent, constants as fsConstants } from "node:fs";
 import { lstat, readFile, readdir } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative } from "node:path";
+import { parseDigestPointerIds } from "./episodic-digest";
 import { createPaths } from "./paths";
 import { isEnoent } from "./fs-utils";
 import { runBoundedConcurrent } from "./internal-concurrency";
@@ -337,8 +338,8 @@ function probeEventRatio(lines: number, notes: number): { probe: SomaMemoryAudit
 /**
  * Digest-referenced ids keyed by MONTH (the digest's `YYYY-MM.md` basename). Keyed
  * by month so the orphan check can require a note to appear in ITS created-month
- * digest — a reference in the wrong month is drift, not coverage. Each digest line
- * is `- <id>: <text>`.
+ * digest — a reference in the wrong month is drift, not coverage. The digest
+ * pointer grammar is owned by `episodic-digest.ts` so producer and consumer stay paired.
  */
 async function collectDigestIdsByMonth(digestFiles: string[]): Promise<Map<string, Set<string>>> {
   const byMonth = new Map<string, Set<string>>();
@@ -351,9 +352,8 @@ async function collectDigestIdsByMonth(digestFiles: string[]): Promise<Map<strin
   );
   for (const { month, content } of parsedFiles) {
     const ids = byMonth.get(month) ?? new Set<string>();
-    for (const line of content.split("\n")) {
-      const match = /^-\s+([^:\s]+):/.exec(line.trim());
-      if (match) ids.add(match[1]);
+    for (const id of parseDigestPointerIds(content)) {
+      ids.add(id);
     }
     byMonth.set(month, ids);
   }

--- a/src/memory-consolidate.ts
+++ b/src/memory-consolidate.ts
@@ -4,6 +4,7 @@ import { createPaths } from "./paths";
 import { isEnoent } from "./fs-utils";
 import { appendSomaMemoryEvent } from "./memory";
 import { parseMemoryNote, serializeMemoryNote, MemoryNoteError } from "./memory-note";
+import { renderDigestPointer } from "./episodic-digest";
 import { collectDurableNotes } from "./memory-write";
 import { runBoundedConcurrent } from "./internal-concurrency";
 import { memoryTermSet } from "./memory-terms";
@@ -130,12 +131,6 @@ function parseNotesBounded(paths: string[]): Promise<{ path: string; note: SomaM
     async (path) => ({ path, note: await readFile(path, "utf8").then(parseMemoryNote).catch(() => undefined) }),
     16,
   );
-}
-
-/** First non-empty body line, control-stripped + truncated — the digest pointer text. */
-function firstBodyLine(note: SomaMemoryNote): string {
-  const line = note.body.split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
-  return line.replace(/[\x00-\x1f\x7f-\x9f]+/g, " ").slice(0, 120);
 }
 
 function jaccard(a: Set<string>, b: Set<string>): number {
@@ -377,7 +372,7 @@ async function regenerateMonthlyDigests(paths: SomaPaths, months: Set<string>): 
       .sort((a, b) => a.id.localeCompare(b.id));
     if (notes.length === 0) continue;
     const digestPath = paths.resolve("memory", "episodic", "digests", `${month}.md`);
-    const body = notes.map((n) => `- ${n.id}: ${firstBodyLine(n)}`).join("\n");
+    const body = notes.map(renderDigestPointer).join("\n");
     // The digests-dir parent chain was preflighted in the plan phase (before any
     // move), so no symlinked-parent refusal can strike here after notes have moved.
     await mkdir(dirname(digestPath), { recursive: true });

--- a/test/episodic-digest.test.ts
+++ b/test/episodic-digest.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import { parseDigestPointerIds, renderDigestPointer } from "../src/episodic-digest";
+import type { SomaMemoryNote } from "../src/types";
+
+function note(id: string, body: string): SomaMemoryNote {
+  return {
+    id,
+    type: "episodic",
+    created: "2026-07-04",
+    last_verified: "2026-07-04",
+    valid_until: null,
+    provenance: "tool:test",
+    trust: "assistant",
+    source_of_truth: null,
+    project: null,
+    links: [],
+    resurface_count: 0,
+    body,
+  } as SomaMemoryNote;
+}
+
+test("episodic digest pointer rendering and parsing are mutual for normal ids", () => {
+  const notes = [
+    note("20260704-a", "first summary\nsecond line"),
+    note("20260704-b", "\n\nsecond summary"),
+  ];
+
+  const content = notes.map(renderDigestPointer).join("\n");
+
+  expect(content).toContain("- 20260704-a: first summary");
+  expect(content).toContain("- 20260704-b: second summary");
+  expect(parseDigestPointerIds(content)).toEqual(notes.map((n) => n.id));
+});
+
+test("episodic digest pointer grammar round-trips ids containing colons", () => {
+  const notes = [
+    note("session:alpha", "alpha body"),
+    note("session:beta:with-more", "beta body"),
+  ];
+
+  const content = notes.map(renderDigestPointer).join("\n");
+
+  expect(content).toContain("- session\\:alpha: alpha body");
+  expect(content).toContain("- session\\:beta\\:with-more: beta body");
+  expect(parseDigestPointerIds(content)).toEqual(notes.map((n) => n.id));
+});


### PR DESCRIPTION
## Summary

Closes #411.

Names the monthly episodic digest pointer grammar in a shared module so the producer (`memory-consolidate`) and consumer (`memory-audit`) cannot drift independently.

Changes:
- Add `src/episodic-digest.ts` with `renderDigestPointer(note)` and `parseDigestPointerIds(content)`.
- Route monthly digest generation through `renderDigestPointer`.
- Route orphaned-archive audit coverage parsing through `parseDigestPointerIds` instead of a private regex.
- Add round-trip tests, including ids containing `:`.

## Verification

- `bun test test/episodic-digest.test.ts test/memory-consolidate.test.ts test/memory-audit.test.ts` → 30 pass
- `bun test` → 1747 pass
- `bun run typecheck` → pass

Note: the isolated worktree needed `bun install --frozen-lockfile` before typecheck because it initially had no `node_modules` / `bun-types`.
