### PR TITLE
refactor(memory): route path construction through the SomaPaths seam (#407)

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -12,7 +12,7 @@ import {
   writeSessionDigest,
 } from "../index";
 import { WRITABLE_NOTE_TYPES, isWritableNoteType } from "../memory-write";
-import { SOMA_MEMORY_ACTION_APPROVALS } from "../types";
+import { SOMA_MEMORY_ACTION_APPROVALS, SOMA_MEMORY_PROMOTION_STORES } from "../types";
 import type {
   SomaMemoryActionApproval,
   SomaMemoryActionOptions,
@@ -568,11 +568,13 @@ function parseMemoryPromoteArgs(args: string[]): SomaMemoryPromotionOptions {
 }
 
 function parseMemoryPromotionStore(value: string): SomaMemoryPromotionStore {
-  if (value === "learning" || value === "knowledge" || value === "relationship" || value === "work") {
-    return value;
+  // Delegates to the canonical enumeration (types.ts) instead of re-listing the
+  // store literals — the same array `paths.promoted()` maps to on-disk dirs.
+  if ((SOMA_MEMORY_PROMOTION_STORES as readonly string[]).includes(value)) {
+    return value as SomaMemoryPromotionStore;
   }
 
-  throw new Error("--store must be one of learning, knowledge, relationship, or work.");
+  throw new Error(`--store must be one of ${SOMA_MEMORY_PROMOTION_STORES.join(", ")}.`);
 }
 
 function parseWriteTrigger(value: string): SomaMemoryWriteTrigger {

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -112,15 +112,15 @@ export async function auditMemory(options: SomaMemoryAuditOptions = {}): Promise
   const probes: SomaMemoryAuditProbe[] = [];
 
   // --- enumerate every note file in the tree (durable + episodic + archive) ---
-  const durableDirs = [paths.resolve("memory", "semantic"), paths.resolve("memory", "procedural")];
-  const episodicDirs = [paths.resolve("memory", "episodic", "sessions"), paths.resolve("memory", "episodic", "actions")];
-  const archiveDir = paths.resolve("memory", "archive");
+  const durableDirs = [paths.semantic(), paths.procedural()];
+  const episodicDirs = [paths.episodic("sessions"), paths.episodic("actions")];
+  const archiveDir = paths.archive();
 
   // Root integrity GATES health FIRST: a present-but-abnormal root (a symlink or
   // non-directory where a real note dir belongs) makes the corpus inaccessible/
   // untrusted — the walk skips it, so without this the tree would fail OPEN as
   // "empty and healthy". A missing root is genuinely empty and fine.
-  const rootDirs = [...durableDirs, ...episodicDirs, archiveDir, paths.resolve("memory", "episodic", "digests")];
+  const rootDirs = [...durableDirs, ...episodicDirs, archiveDir, paths.episodic("digests")];
   const treeIntegrity = await probeTreeIntegrity(rootDirs, somaHome);
 
   const durableFiles = (await Promise.all(durableDirs.map(listRealMarkdownFilesRec))).flat();
@@ -139,7 +139,7 @@ export async function auditMemory(options: SomaMemoryAuditOptions = {}): Promise
   // CANONICAL digests only: a real `<YYYY-MM>.md` DIRECTLY under the digests root. A
   // nested or oddly-named file (e.g. `digests/nested/2026-07.md`) must not satisfy
   // month coverage.
-  const digestsDir = paths.resolve("memory", "episodic", "digests");
+  const digestsDir = paths.episodic("digests");
   const digestFilesList = (await listRealMarkdownFilesRec(digestsDir)).filter(
     (p) => dirname(p) === digestsDir && /^\d{4}-\d{2}\.md$/.test(basename(p)),
   );

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -37,11 +37,11 @@
 import { createHash } from "node:crypto";
 import { constants as FS } from "node:fs";
 import { lstat, mkdir, open, readFile, readdir, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join, relative, resolve, sep } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { rebuildMemoryIndex } from "./memory-index";
 import { MemoryNoteError } from "./memory-note";
 import { memoryNotePath, writeMemoryNote } from "./memory-write";
+import { createPaths } from "./paths";
 import { SOMA_MEMORY_BACKFILL_TYPE_MAP } from "./types";
 import type {
   SomaMemoryBackfillEntry,
@@ -49,17 +49,18 @@ import type {
   SomaMemoryBackfillManifestEntry,
   SomaMemoryBackfillOptions,
   SomaMemoryBackfillResult,
+  SomaPaths,
   WritableNoteType,
 } from "./types";
 
 const MANIFEST_SCHEMA = "soma.memory-backfill.v1";
 // Backfill is a Memory-subsystem operation, so its bookkeeping lives INSIDE the
 // Memory compartment (`memory/`), under STATE (the subsystem's runtime-state dir,
-// alongside events.jsonl) — not at the Soma root. STATE is a reserved category
-// that the source walk never re-imports, and the manifest is `.json` (never a
-// markdown source), so it can never round-trip into a note.
-const MANIFEST_RELATIVE = "memory/STATE/imports/backfill/.manifest.json";
-const MANIFEST_DIR_RELATIVE = "memory/STATE/imports/backfill";
+// alongside events.jsonl) — not at the Soma root, via `paths.state(...)`. STATE
+// is a reserved category that the source walk never re-imports, and the
+// manifest is `.json` (never a markdown source), so it can never round-trip
+// into a note.
+const MANIFEST_SEGMENTS = ["imports", "backfill", ".manifest.json"] as const;
 
 // Category dirs (or root children) that are never backfill sources: STATE is
 // runtime JSON, episodic/semantic/procedural are the note stores themselves,
@@ -73,10 +74,6 @@ const RESERVED_CATEGORIES = new Set([
   "archive",
   "imports",
 ]);
-
-function resolveSomaHome(options: SomaMemoryBackfillOptions): string {
-  return resolve(options.somaHome ?? join(resolve(options.homeDir ?? homedir()), ".soma"));
-}
 
 function sha256Hex(content: Buffer | string): string {
   return createHash("sha256").update(content).digest("hex");
@@ -287,9 +284,9 @@ function resolveType(
  * is accepted (each entry is still re-validated against the corpus + SHA at use).
  */
 async function readManifest(
-  somaHome: string,
+  paths: SomaPaths,
 ): Promise<{ map: Map<string, SomaMemoryBackfillManifestEntry>; importedAt: string; from: string } | null> {
-  const path = join(somaHome, MANIFEST_RELATIVE);
+  const path = paths.state(...MANIFEST_SEGMENTS);
   if (!(await pathExists(path))) return null;
   try {
     const parsed = JSON.parse(await readFile(path, "utf8")) as SomaMemoryBackfillManifest;
@@ -327,10 +324,11 @@ export async function planMemoryBackfill(
 export async function runMemoryBackfill(
   options: SomaMemoryBackfillOptions = {},
 ): Promise<SomaMemoryBackfillResult> {
-  const somaHome = resolveSomaHome(options);
-  const defaultRoot = resolve(join(somaHome, "memory"));
+  const paths = createPaths(options);
+  const somaHome = paths.root();
+  const defaultRoot = paths.memory();
   const from = resolve(options.from ?? defaultRoot);
-  const manifestPath = join(somaHome, MANIFEST_RELATIVE);
+  const manifestPath = paths.state(...MANIFEST_SEGMENTS);
   const dryRun = options.dryRun ?? false;
 
   const sources = await collectSources(from, from === defaultRoot);
@@ -338,7 +336,7 @@ export async function runMemoryBackfill(
   // to the root it was built for. A rerun against a DIFFERENT `--from` must not
   // treat same-relative-path files as hits — ignore a manifest built elsewhere
   // (the run then rewrites it for the current root).
-  const rawPrevious = await readManifest(somaHome);
+  const rawPrevious = await readManifest(paths);
   const previous = rawPrevious?.from === from ? rawPrevious : null;
 
   const used = new Set<string>();
@@ -458,7 +456,7 @@ export async function runMemoryBackfill(
     // Manifest reflects exactly the files currently backfilled to a present note
     // (written this run + previously-written-and-still-present). Vanished sources
     // drop out; duplicates are excluded (they map to a note this run did not own).
-    await mkdir(join(somaHome, MANIFEST_DIR_RELATIVE), { recursive: true });
+    await mkdir(dirname(manifestPath), { recursive: true });
     const importedAt =
       writtenCount === 0 && previous ? previous.importedAt : (options.now ?? new Date()).toISOString();
     const manifest: SomaMemoryBackfillManifest = {

--- a/src/memory-consolidate.ts
+++ b/src/memory-consolidate.ts
@@ -146,12 +146,12 @@ function jaccard(a: Set<string>, b: Set<string>): number {
  * `memory/archive/` (`memory/episodic/…/x.md` → `memory/archive/episodic/…/x.md`),
  * so the tombstone preserves the original location AND stays under the single
  * lowercase `memory/` root (architecture.md) rather than creating a second root.
- * `paths.resolve` asserts the result stays inside the Soma root — combined with the
+ * `paths.archive` asserts the result stays inside the Soma root — combined with the
  * id-slug validation upstream, no crafted frontmatter can redirect a rename out.
  */
 function archiveTargetFor(paths: SomaPaths, sourcePath: string): string {
   const relSegments = relative(paths.memory(), sourcePath).split(sep);
-  return paths.resolve("memory", "archive", ...relSegments);
+  return paths.archive(...relSegments);
 }
 
 interface EpisodicArchive {
@@ -202,7 +202,7 @@ async function planEpisodicArchive(
   now: Date,
 ): Promise<{ archives: EpisodicArchive[]; unreadable: string[] }> {
   const root = paths.root();
-  const base = paths.resolve("memory", "episodic", kind);
+  const base = paths.episodic(kind);
   const parsedFiles = await parseNotesBounded(await listEpisodicNotes(base));
   const archives: EpisodicArchive[] = [];
   const unreadable: string[] = [];
@@ -235,7 +235,7 @@ async function planEpisodicArchive(
       from: path,
       to,
       note: parsed,
-      digestPath: paths.resolve("memory", "episodic", "digests", `${month}.md`),
+      digestPath: paths.episodic("digests", `${month}.md`),
     });
   }
   return { archives, unreadable };
@@ -371,7 +371,7 @@ async function regenerateMonthlyDigests(paths: SomaPaths, months: Set<string>): 
       .filter((n): n is SomaMemoryNote => n !== undefined && n.created.slice(0, 7) === month)
       .sort((a, b) => a.id.localeCompare(b.id));
     if (notes.length === 0) continue;
-    const digestPath = paths.resolve("memory", "episodic", "digests", `${month}.md`);
+    const digestPath = paths.episodic("digests", `${month}.md`);
     const body = notes.map(renderDigestPointer).join("\n");
     // The digests-dir parent chain was preflighted in the plan phase (before any
     // move), so no symlinked-parent refusal can strike here after notes have moved.
@@ -383,7 +383,7 @@ async function regenerateMonthlyDigests(paths: SomaPaths, months: Set<string>): 
 
 /** Real `.md` files directly under one archived-episodic `<kind>/<month>/` dir. */
 function listArchivedMonthNotes(paths: SomaPaths, kind: "sessions" | "actions", month: string): Promise<string[]> {
-  return listRealMarkdownFiles(paths.resolve("memory", "archive", "episodic", kind, month));
+  return listRealMarkdownFiles(paths.archive("episodic", kind, month));
 }
 
 /**
@@ -489,7 +489,7 @@ export async function consolidateMemory(options: SomaMemoryConsolidateOptions = 
   const verifiedDirs = new Set<string>(); // archive targets share ancestors — verify each real dir once
   for (const e of episodic) await assertSafeArchiveDest(memoryRoot, e.to, verifiedDirs);
   if (episodic.length > 0) {
-    await assertRealParentChain(memoryRoot, paths.resolve("memory", "episodic", "digests", "any.md"), verifiedDirs);
+    await assertRealParentChain(memoryRoot, paths.episodic("digests", "any.md"), verifiedDirs);
   }
 
   const durable = await collectDurableNotes(somaHome);

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -113,7 +113,7 @@ function sessionSlug(sessionId: string): string {
 }
 
 function episodicPath(somaHome: string, kind: "sessions" | "actions", now: Date, id: string): string {
-  return createPaths(somaHome).resolve("memory", "episodic", kind, monthDir(now), `${id}.md`);
+  return createPaths(somaHome).episodic(kind, monthDir(now), `${id}.md`);
 }
 
 /**
@@ -127,7 +127,7 @@ function episodicPath(somaHome: string, kind: "sessions" | "actions", now: Date,
  * atomic gate — this is only the cross-date fast-path.
  */
 async function findExistingSessionDigestPath(somaHome: string, slug: string): Promise<string | undefined> {
-  const base = createPaths(somaHome).resolve("memory", "episodic", "sessions");
+  const base = createPaths(somaHome).episodic("sessions");
   const idPattern = new RegExp(`^\\d{8}-${slug}\\.md$`); // slug is [a-z0-9-] only — no regex metachars
   let months: string[];
   try {

--- a/src/memory-promotion.ts
+++ b/src/memory-promotion.ts
@@ -1,28 +1,17 @@
 import { mkdir, unlink, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import { readAlgorithmRunById, writeAlgorithmRun } from "./algorithm-store";
 import { appendAlgorithmProvenance } from "./algorithm-provenance";
 import { appendSomaMemoryEvent } from "./memory";
+import { createPaths } from "./paths";
 import { getCriteria, getGoal } from "./vsa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
 import type { AlgorithmRun, SomaMemoryPromotionOptions, SomaMemoryPromotionResult } from "./types";
-
-const PROMOTION_STORE_DIRS = {
-  learning: "LEARNING",
-  knowledge: "KNOWLEDGE",
-  relationship: "RELATIONSHIP",
-  work: "WORK",
-} as const;
 
 function assertNonEmpty(value: string, field: string): void {
   if (value.trim().length === 0) {
     throw new Error(`Soma memory promotion ${field} must not be empty.`);
   }
-}
-
-function resolveSomaHome(options: Pick<SomaMemoryPromotionOptions, "homeDir" | "somaHome"> = {}): string {
-  return resolve(options.somaHome ?? join(options.homeDir ?? homedir(), ".soma"));
 }
 
 function slugify(value: string): string {
@@ -108,7 +97,8 @@ export async function promoteAlgorithmRunMemory(options: SomaMemoryPromotionOpti
   assertNonEmpty(options.fromRun, "source run");
   assertNonEmpty(options.title, "title");
 
-  const somaHome = resolveSomaHome(options);
+  const paths = createPaths(options);
+  const somaHome = paths.root();
   const timestamp = options.timestamp ?? new Date().toISOString();
   const { path: sourceRunPath, run } = await readAlgorithmRunById(options.fromRun, { somaHome });
   const lesson = promotionLesson(run, options.lesson);
@@ -117,8 +107,7 @@ export async function promoteAlgorithmRunMemory(options: SomaMemoryPromotionOpti
     throw new Error(`Algorithm run ${run.id} has no verification evidence or passed criteria; refusing memory promotion.`);
   }
 
-  const relativeStore = PROMOTION_STORE_DIRS[options.store];
-  const path = join(somaHome, "memory", relativeStore, "PROMOTED", `${slugify(options.title)}-${slugify(run.id)}.md`);
+  const path = join(paths.promoted(options.store), `${slugify(options.title)}-${slugify(run.id)}.md`);
   const content = `${renderPromotionContent({
     run,
     runPath: sourceRunPath,

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -7,7 +7,7 @@ import { runBoundedConcurrent } from "./internal-concurrency";
 import { appendSomaMemoryEvent } from "./memory";
 import { parseMemoryNote, serializeMemoryNote, MemoryNoteError } from "./memory-note";
 import { memoryTermSet } from "./memory-terms";
-import { SOMA_MEMORY_TRIGGER_TRUST } from "./types";
+import { SOMA_MEMORY_NOTE_TYPES, SOMA_MEMORY_TRIGGER_TRUST } from "./types";
 import type {
   SomaMemoryDuplicateCandidate,
   SomaMemoryNote,
@@ -63,17 +63,17 @@ export const MEMORY_DEDUP_JACCARD_THRESHOLD = 0.6;
 
 // The durable, dedup-gated corpus. Episodic notes live elsewhere (M5) and are
 // not written through this path.
-const WRITABLE_TYPE_DIRS: Record<Exclude<SomaMemoryNoteType, "episodic">, string> = {
-  semantic: "semantic",
-  procedural: "procedural",
-};
-
 export type WritableType = Exclude<SomaMemoryNoteType, "episodic">;
 
 // One source of truth for the writable-type enumeration — every helper that
 // walks both durable dirs reuses this instead of re-casting Object.keys. Exported
 // so the CLI validates `--type` against the same list the writer routes on.
-export const WRITABLE_NOTE_TYPES = Object.keys(WRITABLE_TYPE_DIRS) as WritableType[];
+// Derived from the canonical note-type array (types.ts) rather than a private
+// dir-name map — the on-disk dir for each type now comes from the SomaPaths
+// seam (`paths.semantic()` / `paths.procedural()`, see `typeDir` below).
+export const WRITABLE_NOTE_TYPES = SOMA_MEMORY_NOTE_TYPES.filter(
+  (type): type is WritableType => type !== "episodic",
+);
 const WRITABLE_TYPES = WRITABLE_NOTE_TYPES;
 
 /** True iff `value` is a note type the write path accepts (semantic|procedural). */
@@ -161,7 +161,8 @@ function isoDate(now: Date): string {
 
 /** Directory holding notes of a writable type. */
 function typeDir(somaHome: string, type: WritableType): string {
-  return createPaths(somaHome).resolve("memory", WRITABLE_TYPE_DIRS[type]);
+  const paths = createPaths(somaHome);
+  return type === "semantic" ? paths.semantic() : paths.procedural();
 }
 
 /**

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,5 +1,6 @@
 import { homedir } from "node:os";
 import { isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
+import { SOMA_MEMORY_PROMOTION_STORE_DIRS } from "./types";
 import type { SomaMemoryPromotionStore, SomaPaths } from "./types";
 
 export interface SomaPathsOptions {
@@ -19,16 +20,6 @@ function assertInsideRoot(root: string, target: string): void {
   throw new Error(`Soma path escapes root: ${target}`);
 }
 
-// The one place the promotion store→dir mapping lives (mirrors the dedicated
-// per-store accessors below) — `promoted()` is the sole reader, so a caller
-// never re-lists these literals (soma#407: this used to be triplicated across
-// memory-promotion.ts, memory-write.ts, and cli/memory.ts).
-const PROMOTED_STORE_DIR: Record<SomaMemoryPromotionStore, string> = {
-  learning: "LEARNING",
-  knowledge: "KNOWLEDGE",
-  relationship: "RELATIONSHIP",
-  work: "WORK",
-};
 
 export function createPaths(optionsOrSomaHome: SomaPathsOptions | string = {}): SomaPaths {
   const options = typeof optionsOrSomaHome === "string"
@@ -61,7 +52,8 @@ export function createPaths(optionsOrSomaHome: SomaPathsOptions | string = {}): 
     procedural: () => underRoot("memory", "procedural"),
     episodic: (kind: "sessions" | "actions" | "digests", ...segments: string[]) =>
       underRoot("memory", "episodic", kind, ...segments),
-    promoted: (store: SomaMemoryPromotionStore) => underRoot("memory", PROMOTED_STORE_DIR[store], "PROMOTED"),
+    promoted: (store: SomaMemoryPromotionStore) =>
+      underRoot("memory", SOMA_MEMORY_PROMOTION_STORE_DIRS[store], "PROMOTED"),
     archive: (...segments: string[]) => underRoot("memory", "archive", ...segments),
     ratings: () => underRoot("memory", "LEARNING", "SIGNALS", "ratings.jsonl"),
     opinions: () => underRoot("identity", "opinions.md"),

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,6 +1,6 @@
 import { homedir } from "node:os";
 import { isAbsolute, join, relative, resolve as resolvePath, sep } from "node:path";
-import type { SomaPaths } from "./types";
+import type { SomaMemoryPromotionStore, SomaPaths } from "./types";
 
 export interface SomaPathsOptions {
   homeDir?: string;
@@ -19,6 +19,17 @@ function assertInsideRoot(root: string, target: string): void {
   throw new Error(`Soma path escapes root: ${target}`);
 }
 
+// The one place the promotion store→dir mapping lives (mirrors the dedicated
+// per-store accessors below) — `promoted()` is the sole reader, so a caller
+// never re-lists these literals (soma#407: this used to be triplicated across
+// memory-promotion.ts, memory-write.ts, and cli/memory.ts).
+const PROMOTED_STORE_DIR: Record<SomaMemoryPromotionStore, string> = {
+  learning: "LEARNING",
+  knowledge: "KNOWLEDGE",
+  relationship: "RELATIONSHIP",
+  work: "WORK",
+};
+
 export function createPaths(optionsOrSomaHome: SomaPathsOptions | string = {}): SomaPaths {
   const options = typeof optionsOrSomaHome === "string"
     ? { somaHome: optionsOrSomaHome }
@@ -31,6 +42,8 @@ export function createPaths(optionsOrSomaHome: SomaPathsOptions | string = {}): 
     return target;
   };
 
+  const state = (...segments: string[]): string => underRoot("memory", "STATE", ...segments);
+
   return {
     root: () => root,
     identity: () => underRoot("identity"),
@@ -38,15 +51,22 @@ export function createPaths(optionsOrSomaHome: SomaPathsOptions | string = {}): 
     profile: () => underRoot("profile"),
     skills: () => underRoot("skills"),
     learning: () => underRoot("memory", "LEARNING"),
+    knowledge: () => underRoot("memory", "KNOWLEDGE"),
     signals: () => underRoot("memory", "LEARNING", "SIGNALS"),
     wisdom: () => underRoot("memory", "WISDOM"),
     relationship: () => underRoot("memory", "RELATIONSHIP"),
-    state: () => underRoot("memory", "STATE"),
+    state,
     work: () => underRoot("memory", "WORK"),
+    semantic: () => underRoot("memory", "semantic"),
+    procedural: () => underRoot("memory", "procedural"),
+    episodic: (kind: "sessions" | "actions" | "digests", ...segments: string[]) =>
+      underRoot("memory", "episodic", kind, ...segments),
+    promoted: (store: SomaMemoryPromotionStore) => underRoot("memory", PROMOTED_STORE_DIR[store], "PROMOTED"),
+    archive: (...segments: string[]) => underRoot("memory", "archive", ...segments),
     ratings: () => underRoot("memory", "LEARNING", "SIGNALS", "ratings.jsonl"),
     opinions: () => underRoot("identity", "opinions.md"),
     story: () => underRoot("identity", "our-story.md"),
-    events: () => underRoot("memory", "STATE", "events.jsonl"),
+    events: () => state("events.jsonl"),
     resolve: (...segments: string[]) => underRoot(...segments),
   };
 }

--- a/src/soma-home.ts
+++ b/src/soma-home.ts
@@ -236,7 +236,7 @@ export async function loadSomaProfile(somaHome: string): Promise<Omit<Projection
     memory: {
       root: paths.memory(),
       work: paths.work(),
-      knowledge: paths.resolve("memory", "KNOWLEDGE"),
+      knowledge: paths.knowledge(),
       learning: paths.learning(),
       relationship: paths.relationship(),
       state: paths.state(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -495,11 +495,17 @@ export interface SomaPaths {
   profile(): string;
   skills(): string;
   learning(): string;
+  knowledge(): string;
   signals(): string;
   wisdom(): string;
   relationship(): string;
-  state(): string;
+  state(...segments: string[]): string;
   work(): string;
+  semantic(): string;
+  procedural(): string;
+  episodic(kind: "sessions" | "actions" | "digests", ...segments: string[]): string;
+  promoted(store: SomaMemoryPromotionStore): string;
+  archive(...segments: string[]): string;
   ratings(): string;
   opinions(): string;
   story(): string;
@@ -1923,7 +1929,12 @@ export interface SomaResultSearchResult {
   matches: SomaResultSearchMatch[];
 }
 
-export type SomaMemoryPromotionStore = "learning" | "knowledge" | "relationship" | "work";
+// Single source of truth for the promotion-store enumeration: `promoted()`
+// (src/paths.ts) maps each of these to its on-disk dir, and the CLI's
+// `--store` validator (src/cli/memory.ts) checks against this same array —
+// neither re-lists the literals independently.
+export const SOMA_MEMORY_PROMOTION_STORES = ["learning", "knowledge", "relationship", "work"] as const;
+export type SomaMemoryPromotionStore = (typeof SOMA_MEMORY_PROMOTION_STORES)[number];
 
 export interface SomaMemoryPromotionOptions {
   homeDir?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1929,12 +1929,21 @@ export interface SomaResultSearchResult {
   matches: SomaResultSearchMatch[];
 }
 
-// Single source of truth for the promotion-store enumeration: `promoted()`
-// (src/paths.ts) maps each of these to its on-disk dir, and the CLI's
-// `--store` validator (src/cli/memory.ts) checks against this same array —
-// neither re-lists the literals independently.
-export const SOMA_MEMORY_PROMOTION_STORES = ["learning", "knowledge", "relationship", "work"] as const;
-export type SomaMemoryPromotionStore = (typeof SOMA_MEMORY_PROMOTION_STORES)[number];
+// Single source of truth for the promotion-store enumeration AND its on-disk
+// dir mapping: `promoted()` (src/paths.ts) keys this map, and the CLI's
+// `--store` validator (src/cli/memory.ts) checks against the derived array —
+// neither re-lists the literals independently (soma#419 review: the dir map
+// used to be re-declared in paths.ts, a second source list).
+export const SOMA_MEMORY_PROMOTION_STORE_DIRS = {
+  learning: "LEARNING",
+  knowledge: "KNOWLEDGE",
+  relationship: "RELATIONSHIP",
+  work: "WORK",
+} as const;
+export type SomaMemoryPromotionStore = keyof typeof SOMA_MEMORY_PROMOTION_STORE_DIRS;
+export const SOMA_MEMORY_PROMOTION_STORES = Object.keys(
+  SOMA_MEMORY_PROMOTION_STORE_DIRS,
+) as SomaMemoryPromotionStore[];
 
 export interface SomaMemoryPromotionOptions {
   homeDir?: string;

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -60,3 +60,65 @@ test("SomaPaths type is importable by migrated tools", () => {
   const paths: SomaPaths = createPaths("/tmp/soma-types");
   expect(paths.ratings()).toContain("ratings.jsonl");
 });
+
+// soma#407: the note subsystem's store layout (semantic/procedural/episodic/
+// archive/promoted/knowledge) is now named on SomaPaths — asserted here at the
+// seam, not by literal string in each memory-*.ts caller.
+test("SomaPaths names every store the note subsystem reads/writes", () => {
+  const root = "/tmp/soma-note-stores";
+  const paths = createPaths(root);
+
+  expect(paths.knowledge()).toBe(join(root, "memory", "KNOWLEDGE"));
+  expect(paths.semantic()).toBe(join(root, "memory", "semantic"));
+  expect(paths.procedural()).toBe(join(root, "memory", "procedural"));
+  expect(paths.archive()).toBe(join(root, "memory", "archive"));
+  expect(paths.archive("episodic", "sessions", "2026-07")).toBe(
+    join(root, "memory", "archive", "episodic", "sessions", "2026-07"),
+  );
+});
+
+test("SomaPaths.episodic names the sessions/actions/digests dirs and accepts nested segments", () => {
+  const root = "/tmp/soma-episodic";
+  const paths = createPaths(root);
+
+  expect(paths.episodic("sessions")).toBe(join(root, "memory", "episodic", "sessions"));
+  expect(paths.episodic("actions")).toBe(join(root, "memory", "episodic", "actions"));
+  expect(paths.episodic("digests")).toBe(join(root, "memory", "episodic", "digests"));
+  expect(paths.episodic("sessions", "2026-07", "abc.md")).toBe(
+    join(root, "memory", "episodic", "sessions", "2026-07", "abc.md"),
+  );
+});
+
+test("SomaPaths.promoted maps every promotion store to its PROMOTED dir", () => {
+  const root = "/tmp/soma-promoted";
+  const paths = createPaths(root);
+
+  expect(paths.promoted("learning")).toBe(join(root, "memory", "LEARNING", "PROMOTED"));
+  expect(paths.promoted("knowledge")).toBe(join(root, "memory", "KNOWLEDGE", "PROMOTED"));
+  expect(paths.promoted("relationship")).toBe(join(root, "memory", "RELATIONSHIP", "PROMOTED"));
+  expect(paths.promoted("work")).toBe(join(root, "memory", "WORK", "PROMOTED"));
+});
+
+test("SomaPaths.state accepts nested segments alongside the existing zero-arg form", () => {
+  const root = "/tmp/soma-state-segments";
+  const paths = createPaths(root);
+
+  expect(paths.state()).toBe(join(root, "memory", "STATE"));
+  expect(paths.state("imports", "backfill", ".manifest.json")).toBe(
+    join(root, "memory", "STATE", "imports", "backfill", ".manifest.json"),
+  );
+  expect(paths.events()).toBe(paths.state("events.jsonl"));
+});
+
+test("store accessors refuse to escape the Soma root", () => {
+  const root = "/tmp/soma-store-escape";
+  const paths = createPaths(root);
+
+  // `archive()` prepends 2 segments ("memory","archive"); 3 levels of ".."
+  // walks past the root itself.
+  expect(() => paths.archive("..", "..", "..", "escape.md")).toThrow("escapes root");
+  // `episodic("sessions", …)` prepends 3 segments; 4 levels of ".." escapes.
+  expect(() => paths.episodic("sessions", "..", "..", "..", "..", "escape.md")).toThrow("escapes root");
+  // `state()` prepends 2 segments ("memory","STATE"); 3 levels of ".." escapes.
+  expect(() => paths.state("..", "..", "..", "escape.json")).toThrow("escapes root");
+});


### PR DESCRIPTION
## What changed

Deepens the `SomaPaths` seam (`src/paths.ts` + `src/types.ts:491`) so the Memory compartment stops routing around it, per #407.

- **`createPaths(options).root()` is now the only soma-home resolver** in the Memory compartment. Replaced the hand-rolled `resolveSomaHome` in `memory-promotion.ts:24` and `memory-backfill.ts:77` (which had already forked: backfill wrapped `homeDir` in an extra `resolve()` that promotion did not) — both now inherit `assertInsideRoot` containment for free.
- **`SomaPaths` now names every store the note subsystem reads/writes**: added `knowledge()`, `semantic()`, `procedural()`, `episodic(kind, ...segments)`, `promoted(store)`, `archive(...segments)`, mirroring the existing `work()/learning()/state()` pattern. Deleted the three private store-dir maps that duplicated this knowledge:
  - `PROMOTION_STORE_DIRS` (`memory-promotion.ts:11`) → `promoted()` in `paths.ts`, backed by one `PROMOTED_STORE_DIR` map (single source of truth).
  - `WRITABLE_TYPE_DIRS` (`memory-write.ts:66`) → `typeDir()` now calls `paths.semantic()` / `paths.procedural()` directly; `WRITABLE_NOTE_TYPES` is derived from the canonical `SOMA_MEMORY_NOTE_TYPES` array instead of `Object.keys()` on a private map.
  - The re-listed store literal in `parseMemoryPromotionStore` (`cli/memory.ts:570`) → delegates to a new canonical `SOMA_MEMORY_PROMOTION_STORES` array in `types.ts`, the same array `promoted()` is keyed by.
- **`events.jsonl` / `STATE/*.json` route through `paths.events()` / `paths.state(...segments)`.** `state()` and the new `episodic()`/`archive()` accessors take an optional rest-segments tail so nested paths (e.g. `memory/STATE/imports/backfill/.manifest.json`, `memory/archive/episodic/sessions/2026-07`) still go through `assertInsideRoot` instead of being hand-joined.
- Swept `memory-audit.ts`, `memory-consolidate.ts`, and `memory-episodic.ts` — every remaining `paths.resolve("memory", <literal>)` construction for a known store now calls the corresponding named accessor. `soma-home.ts`'s `paths.resolve("memory", "KNOWLEDGE")` (issue's `soma-home.ts:235`) → `paths.knowledge()`.

## Acceptance checklist (from #407)

- [x] `grep -rn "\.soma" src/memory-*.ts` shows no hand-rolled resolver; all go through `createPaths(...).root()`. Verified — only remaining `.soma` hits are unrelated string literals (a temp-file suffix, a doc comment, and `somaHome` variable names).
- [x] `SomaPaths` exposes an accessor for every store the note subsystem touches; the three private store-dir maps are deleted (`PROMOTION_STORE_DIRS`, `WRITABLE_TYPE_DIRS`, and the literal set in `parseMemoryPromotionStore`).
- [x] **Within the Memory compartment**, `events.jsonl` and `STATE/*.json` paths come only from `paths.*` (**out of scope / deferred:** `src/lifecycle.ts`’s 8 inline `events.jsonl` reconstructions — VSA/Algorithm-lifecycle, not `memory-*.ts`; see Deferred below) — `paths.events()` now delegates to `paths.state("events.jsonl")`; the backfill manifest path/dir come from `paths.state(...MANIFEST_SEGMENTS)` + `dirname()`.
- [x] Existing tests green; a new test asserts store-path construction at the seam, not by literal — added 5 new tests to `test/paths.test.ts` covering `knowledge()/semantic()/procedural()/archive()/episodic()/promoted()/state(...)`, including root-escape refusal for the new rest-segment accessors.

## Deferred (left out to keep blast radius inside the Memory compartment)

- **`src/lifecycle.ts`** — 8 inline `join(somaHome, "memory/STATE/events.jsonl")` reconstructions + its own `resolveSomaHome`. This is the VSA/Algorithm-lifecycle module, not a `memory-*.ts` file; the issue itself flags it as optional ("include them if low-risk; if `lifecycle.ts` is out of Memory scope ... leave for a follow-up"). Left for a follow-up PR.
- **`src/vsa.ts:69`, `src/observability.ts:29`, and the other ~15 `resolveSomaHome`/inline-resolver copies** across the wider codebase (`algorithm-*.ts`, `feedback.ts`, `policy.ts`, `result-capture.ts`, `skill-projection.ts`, `snapshots.ts`, `vsa-skill-installer.ts`, `cli/migrate.ts`, `cli/substrate-lifecycle.ts`, etc.) — outside the Memory compartment; the issue's guardrail explicitly warns against ballooning this into an all-of-`src` sweep.
- **`src/memory.ts`'s `SEARCH_ROOTS`** — a flat list mixing memory sub-paths (`memory/KNOWLEDGE`, `memory/WORK`, …) with non-memory roots (`profile`, `identity`) for the legacy full-text search scan. Not one of the three named store-dir maps and structurally different (it's a search-scope list, not a store→dir mapping used for writes); left as-is to avoid touching non-memory roots.
- **`src/soma-home.ts`'s generic `MEMORY_DIRS` bootstrap loop** (`paths.resolve("memory", directory)` over all ~19 `SOMA_MEMORY_CATEGORIES`) — intentionally generic since it iterates every memory category (most of which aren't part of the note subsystem's 6 named stores); already routes through the seam's generic `resolve()`, so no containment gap.

## Test output

```
$ bun run typecheck
$ tsc --noEmit
(clean, exit 0)

$ bun test
 1763 pass
 0 fail
 6277 expect() calls
Ran 1763 tests across 114 files.
```

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 1763 pass, 0 fail (no regressions vs. `origin/main`, confirmed pre-existing lint baseline unaffected)
- [x] `grep -rn "\.soma" src/memory-*.ts` — no hand-rolled resolver
- [x] New seam-level tests added to `test/paths.test.ts`

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzijJAY7wa47Bm4CH8Ux5

