### PR TITLE
refactor(memory): name the shared corpus operations (#410)

### DIFF
--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -12,6 +12,7 @@ import {
   writeSessionDigest,
 } from "../index";
 import { WRITABLE_NOTE_TYPES, isWritableNoteType } from "../memory-write";
+import { sanitizeNoteText } from "../memory-corpus";
 import { SOMA_MEMORY_ACTION_APPROVALS, SOMA_MEMORY_PROMOTION_STORES } from "../types";
 import type {
   SomaMemoryActionApproval,
@@ -977,27 +978,6 @@ function formatMemorySearchResult(result: SomaMemorySearchResult): string {
 }
 
 /**
- * Strip terminal control sequences from note-authored text before it reaches the
- * terminal. Memory notes can hold imported / quarantined tool/web content, and a
- * malicious note body or `source_of_truth` could smuggle ANSI CSI / OSC escapes
- * that spoof output, rewrite earlier lines, or poke the terminal's title and
- * clipboard state when the principal runs `soma memory recall`. Removes:
- *   - ESC-introduced sequences (CSI `ESC [ … final`, OSC `ESC ] … BEL|ST`, and
- *     any other `ESC <byte>` form), plus the C1 CSI byte 0x9b, and
- *   - remaining C0/C1 control chars, keeping only tab and newline (the layout
- *     this formatter itself relies on).
- * Deliberately conservative: it discards control bytes rather than escaping them,
- * since recall output is human-facing text, not a round-trippable channel.
- */
-function sanitizeForTerminal(text: string): string {
-  return text
-    .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "") // OSC … terminated by BEL or ST
-    .replace(/\x1b[@-_][0-?]*[ -/]*[@-~]/g, "")         // CSI and other two-byte ESC sequences
-    .replace(/\x1b./g, "")                                // any stray ESC + following byte
-    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g, ""); // C0/C1 controls except \t (\x09) and \n (\x0a)
-}
-
-/**
  * Render one recalled note to its output lines (heading + banner + body). Every
  * note-derived field is sanitized here — the id/linkedFrom are slug-validated by
  * the parser (they cannot hold control chars in a note that parsed at all), but
@@ -1005,12 +985,12 @@ function sanitizeForTerminal(text: string): string {
  * no future edit can reintroduce a raw one.
  */
 function formatRecalledMatch(match: SomaMemoryRecallResult["matches"][number]): string[] {
-  const id = sanitizeForTerminal(match.id);
+  const id = sanitizeNoteText(match.id);
   const heading =
     match.via === "match"
       ? `━━ ${id} [${match.type}] · ${match.score} term${match.score === 1 ? "" : "s"} matched`
-      : `━━ ${id} [${match.type}] · via link from ${sanitizeForTerminal(match.linkedFrom ?? "")}`;
-  return [heading, sanitizeForTerminal(match.banner), "", sanitizeForTerminal(match.note.body), ""];
+      : `━━ ${id} [${match.type}] · via link from ${sanitizeNoteText(match.linkedFrom ?? "")}`;
+  return [heading, sanitizeNoteText(match.banner), "", sanitizeNoteText(match.note.body), ""];
 }
 
 function formatMemoryRecallResult(result: SomaMemoryRecallResult): string {
@@ -1019,11 +999,11 @@ function formatMemoryRecallResult(result: SomaMemoryRecallResult): string {
     // The query is principal-supplied and the note body/banner can carry imported
     // or quarantined tool/web content — never render any of it to the terminal raw
     // (ANSI/OSC escapes could spoof output or touch clipboard/title state).
-    `query: ${sanitizeForTerminal(result.query)}`,
-    `terms: ${result.terms.length > 0 ? result.terms.map(sanitizeForTerminal).join(", ") : "(none — needs a 3+char term)"}`,
+    `query: ${sanitizeNoteText(result.query)}`,
+    `terms: ${result.terms.length > 0 ? result.terms.map((term) => sanitizeNoteText(term)).join(", ") : "(none — needs a 3+char term)"}`,
     // somaHome is derived from a caller-supplied --soma-home; a path with ANSI/OSC
     // bytes must not reach the terminal raw either.
-    `somaHome: ${sanitizeForTerminal(result.somaHome)}`,
+    `somaHome: ${sanitizeNoteText(result.somaHome)}`,
     "",
   ];
 
@@ -1036,12 +1016,12 @@ function formatMemoryRecallResult(result: SomaMemoryRecallResult): string {
   // Surface both blind spots explicitly — recall never hides an unresolved link or
   // an unreadable corpus file behind a clean-looking result.
   if (result.unresolvedLinks.length > 0) {
-    const rendered = result.unresolvedLinks.map(sanitizeForTerminal).join(", ");
+    const rendered = result.unresolvedLinks.map((link) => sanitizeNoteText(link)).join(", ");
     lines.push(`Unresolved 1-hop links (missing or superseded): ${rendered}`);
   }
   if (result.unreadable.length > 0) {
     lines.push(`⚠ ${result.unreadable.length} corpus file(s) unreadable — recall was partial:`);
-    for (const path of result.unreadable) lines.push(`  - ${sanitizeForTerminal(path)}`);
+    for (const path of result.unreadable) lines.push(`  - ${sanitizeNoteText(path)}`);
   }
 
   return lines.join("\n").trimEnd();

--- a/src/episodic-digest.ts
+++ b/src/episodic-digest.ts
@@ -1,12 +1,16 @@
+import { sanitizeNoteText } from "./memory-corpus";
 import type { SomaMemoryNote } from "./types";
 
 /**
- * First non-empty body line, control-stripped + truncated — the digest pointer text.
+ * First non-empty body line, sanitized + truncated — the digest pointer text.
  * This is a display summary only; the note id is the durable parse target.
+ * Sanitization (#410) is the shared `sanitizeNoteText` that also guards recall
+ * and the INDEX — a digest is a rendered artifact too, so the same strong
+ * escape-sequence strip applies here rather than a third, weaker copy.
  */
 function digestPointerText(note: SomaMemoryNote): string {
   const line = note.body.split("\n").map((l) => l.trim()).find((l) => l.length > 0) ?? "";
-  return line.replace(/[\x00-\x1f\x7f-\x9f]+/g, " ").slice(0, 120);
+  return sanitizeNoteText(line, { oneLine: true }).slice(0, 120);
 }
 
 /** Escape the id segment so the first unescaped colon remains the grammar boundary. */

--- a/src/memory-backfill.ts
+++ b/src/memory-backfill.ts
@@ -40,7 +40,7 @@ import { lstat, mkdir, open, readFile, writeFile } from "node:fs/promises";
 import { basename, dirname, relative, resolve, sep } from "node:path";
 import { listMemoryNotes } from "./memory-fs";
 import { rebuildMemoryIndex } from "./memory-index";
-import { MemoryNoteError } from "./memory-note";
+import { MemoryNoteError, toNoteIdSlug, NOTE_ID_MAX_LEN } from "./memory-note";
 import { memoryNotePath, writeMemoryNote } from "./memory-write";
 import { createPaths } from "./paths";
 import { SOMA_MEMORY_BACKFILL_TYPE_MAP } from "./types";
@@ -127,18 +127,13 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 /**
- * Slugify `<category>-<stem>` into a note id: lowercase, non-alphanumeric runs
- * collapse to a single hyphen, no leading/trailing/double hyphens, ≤64 chars.
- * Matches the note SLUG grammar (`/^[a-z0-9]+(?:-[a-z0-9]+)*$/`, id ≤ 64).
+ * Slugify `<category>-<stem>` into a note id — delegates to the shared,
+ * valid-by-construction `toNoteIdSlug` (memory-note.ts, #410) next to the
+ * id-grammar definition, so this call site never re-approximates the grammar
+ * or re-validates the result.
  */
 function slugifyId(category: string, stem: string): string {
-  const raw = `${category}-${stem}`
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 64)
-    .replace(/-+$/g, "");
-  return raw || "note";
+  return toNoteIdSlug(`${category}-${stem}`, { fallback: "note" });
 }
 
 /** True iff a note with `id` already exists as either a semantic or procedural note. */
@@ -152,13 +147,13 @@ async function noteExists(somaHome: string, id: string): Promise<boolean> {
 /**
  * Resolve a unique note id from a base slug, suffixing `-2`, `-3`, … against
  * both the existing corpus and the ids already claimed in this run. The base is
- * trimmed to leave room for the suffix so the result stays ≤ 64 chars.
+ * trimmed to leave room for the suffix so the result stays ≤ NOTE_ID_MAX_LEN chars.
  */
 async function uniqueNoteId(somaHome: string, base: string, used: Set<string>): Promise<string> {
   if (!used.has(base) && !(await noteExists(somaHome, base))) return base;
   for (let n = 2; ; n += 1) {
     const suffix = `-${n}`;
-    const candidate = `${base.slice(0, 64 - suffix.length).replace(/-+$/g, "")}${suffix}`;
+    const candidate = `${base.slice(0, NOTE_ID_MAX_LEN - suffix.length).replace(/-+$/g, "")}${suffix}`;
     if (!used.has(candidate) && !(await noteExists(somaHome, candidate))) return candidate;
   }
 }

--- a/src/memory-consolidate.ts
+++ b/src/memory-consolidate.ts
@@ -4,11 +4,12 @@ import { createPaths } from "./paths";
 import { isEnoent } from "./fs-utils";
 import { listMemoryNotes } from "./memory-fs";
 import { appendSomaMemoryEvent } from "./memory";
-import { parseMemoryNote, serializeMemoryNote, MemoryNoteError } from "./memory-note";
+import { parseMemoryNote, serializeMemoryNote, MemoryNoteError, NOTE_ID_PATTERN, NOTE_ID_MAX_LEN } from "./memory-note";
 import { renderDigestPointer } from "./episodic-digest";
 import { collectDurableNotes } from "./memory-write";
 import { runBoundedConcurrent } from "./internal-concurrency";
 import { memoryTermSet } from "./memory-terms";
+import { jaccard, ageDays, NEAR_DUPLICATE_JACCARD_THRESHOLD } from "./memory-corpus";
 import { rebuildMemoryIndex, memoryIndexPath } from "./memory-index";
 import type {
   SomaMemoryConsolidateOptions,
@@ -60,14 +61,13 @@ const EPISODIC_SESSION_TTL_DAYS = 90;
 const EPISODIC_ACTION_TTL_DAYS = 180;
 const SEMANTIC_STALE_DAYS = 180;
 const STATE_GC_DAYS = 7;
-// Same near-duplicate floor as the M1 write-path dedup gate.
-const NEAR_DUPLICATE_JACCARD = 0.6;
 // Cap on the similar-pair report (highest-scored kept) — a duplicated corpus could
 // otherwise surface n(n-1)/2 pairs.
 const MAX_SIMILAR_PAIRS = 50;
 
+// Used directly against raw file mtimes (state GC) — not an ISO-date age, so it
+// stays local rather than routing through the shared `ageDays` (#410).
 const MS_PER_DAY = 86_400_000;
-const NOTE_ID_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 /** A real `YYYY-MM-DD` CALENDAR date (the M0 parser already enforces this; this is a
  *  defensive re-check before age/month math). Round-trips through UTC so impossible
@@ -77,16 +77,6 @@ function isIsoDate(s: string): boolean {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(s)) return false;
   const [y, m, d] = s.split("-").map(Number);
   return new Date(Date.UTC(y, m - 1, d)).toISOString().slice(0, 10) === s;
-}
-
-function dateMs(isoDate: string): number {
-  const [y, m, d] = isoDate.split("-").map(Number);
-  return Date.UTC(y, m - 1, d);
-}
-
-/** Whole days between a `YYYY-MM-DD` date and `now` (negative if the date is future). */
-function ageDays(isoDate: string, now: Date): number {
-  return Math.floor((now.getTime() - dateMs(isoDate)) / MS_PER_DAY);
 }
 
 /** True iff `path` is a real (non-symlink) entry of the wanted kind. */
@@ -126,14 +116,6 @@ function parseNotesBounded(paths: string[]): Promise<{ path: string; note: SomaM
     async (path) => ({ path, note: await readFile(path, "utf8").then(parseMemoryNote).catch(() => undefined) }),
     16,
   );
-}
-
-function jaccard(a: Set<string>, b: Set<string>): number {
-  if (a.size === 0 && b.size === 0) return 0;
-  let intersection = 0;
-  for (const token of a) if (b.has(token)) intersection += 1;
-  const union = a.size + b.size - intersection;
-  return union === 0 ? 0 : intersection / union;
 }
 
 /**
@@ -206,7 +188,7 @@ async function planEpisodicArchive(
       unreadable.push(relative(root, path)); // surfaced, not silently dropped
       continue;
     }
-    if (!NOTE_ID_SLUG.test(parsed.id) || parsed.id.length > 64) {
+    if (!NOTE_ID_PATTERN.test(parsed.id) || parsed.id.length > NOTE_ID_MAX_LEN) {
       // Defense in depth: an id that isn't a plain slug could form a traversal path.
       throw new MemoryNoteError(`episodic note ${path} has an unsafe id "${parsed.id}".`, "id");
     }
@@ -296,7 +278,7 @@ function planSimilarPairs(notes: { note: SomaMemoryNote }[]): SomaMemorySimilarP
     }
     for (const j of candidates) {
       const score = jaccard(tokens[i], tokens[j]);
-      if (score >= NEAR_DUPLICATE_JACCARD) {
+      if (score >= NEAR_DUPLICATE_JACCARD_THRESHOLD) {
         const [a, b] = [active[i].id, active[j].id].sort();
         pairs.push({ a, b, score });
         if (pairs.length >= flushAt) {

--- a/src/memory-corpus.ts
+++ b/src/memory-corpus.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared corpus operations (#410). Compare / date / sanitize decisions over the
+ * note corpus were previously re-decided per call site — `jaccard` duplicated in
+ * memory-write.ts + memory-consolidate.ts (with the `0.6` threshold as a second,
+ * separately-duplicated literal); `dateMs`/`ageDays` triplicated in memory-index.ts,
+ * memory-recall.ts, and memory-consolidate.ts (each with its own future-timestamp
+ * nuance); and note-text sanitization split across three strippers of differing
+ * strength (`cli/memory.ts`'s full ANSI/OSC strip, wired only into recall;
+ * memory-index.ts's weaker `oneLine`, guarding the ALWAYS-LOADED INDEX;
+ * episodic-digest.ts's third strip for the digest pointer). Named here so a new
+ * output surface can't silently reinvent (or skip) a defense, and so the two
+ * near-duplicate paths can't silently disagree on the threshold.
+ */
+
+const MS_PER_DAY = 86_400_000;
+
+// --- near-duplicate scoring ---------------------------------------------------
+
+/** Jaccard similarity of two token sets — |intersection| / |union|; 0 when both are empty. */
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  let intersection = 0;
+  for (const token of a) {
+    if (b.has(token)) intersection += 1;
+  }
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * The near-duplicate floor shared by the M1 write-path refusal gate
+ * (`findDuplicateCandidates` in memory-write.ts) and the M6 consolidation
+ * near-duplicate report (`planSimilarPairs` in memory-consolidate.ts) — one
+ * number, so the two paths can never silently disagree on what counts as
+ * "near-duplicate".
+ */
+export const NEAR_DUPLICATE_JACCARD_THRESHOLD = 0.6;
+
+// --- note dates ----------------------------------------------------------------
+
+/** UTC-midnight ms for a `YYYY-MM-DD` date; the note schema guarantees the shape. */
+export function noteDateMs(isoDate: string): number {
+  const [y, m, d] = isoDate.split("-").map(Number);
+  return Date.UTC(y, m - 1, d);
+}
+
+/**
+ * Whole days between a `YYYY-MM-DD` date and `now`, clamped at 0 for a future
+ * date — a clock-skewed or future-dated note must never read as having a
+ * negative age.
+ */
+export function ageDays(isoDate: string, now: Date): number {
+  const delta = now.getTime() - noteDateMs(isoDate);
+  return delta <= 0 ? 0 : Math.floor(delta / MS_PER_DAY);
+}
+
+// --- note-text sanitization (SECURITY-CRITICAL) --------------------------------
+
+const OSC_SEQUENCE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g; // OSC … terminated by BEL or ST
+const CSI_SEQUENCE = /\x1b[@-_][0-?]*[ -/]*[@-~]/g; // CSI and other two-byte ESC sequences
+const STRAY_ESC = /\x1b./g; // any stray ESC + following byte
+const C0_C1_KEEP_TAB_NL = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g; // C0/C1 controls except \t (\x09) and \n (\x0a)
+
+/**
+ * Strip terminal control sequences from note-authored text before it reaches
+ * ANY output surface. Memory notes can hold imported/quarantined tool/web
+ * content, and a malicious note body or `source_of_truth` could otherwise
+ * smuggle ANSI CSI/OSC escapes that spoof output, rewrite earlier lines, or
+ * poke the terminal's title/clipboard state — on recall, on the always-loaded
+ * INDEX, or in a regenerated episodic digest. Removes:
+ *   - ESC-introduced sequences (CSI `ESC [ … final`, OSC `ESC ] … BEL|ST`, and
+ *     any other `ESC <byte>` form), and
+ *   - remaining C0/C1 control chars, keeping tab and newline UNLESS `oneLine`.
+ * Deliberately conservative: it discards control bytes rather than escaping
+ * them, since every surface this guards renders human-facing text, not a
+ * round-trippable channel.
+ *
+ * `oneLine: true` additionally collapses all whitespace (including the
+ * tab/newline otherwise preserved) into single spaces and trims — the shape a
+ * one-line pointer descriptor (the INDEX line, the episodic digest pointer)
+ * needs. Default `false` preserves layout, matching recall's multi-line
+ * banner + body rendering.
+ */
+export function sanitizeNoteText(text: string, options: { oneLine?: boolean } = {}): string {
+  const stripped = text
+    .replace(OSC_SEQUENCE, "")
+    .replace(CSI_SEQUENCE, "")
+    .replace(STRAY_ESC, "")
+    .replace(C0_C1_KEEP_TAB_NL, "");
+  return options.oneLine ? stripped.replace(/\s+/g, " ").trim() : stripped;
+}

--- a/src/memory-corpus.ts
+++ b/src/memory-corpus.ts
@@ -7,9 +7,12 @@
  * nuance); and note-text sanitization split across three strippers of differing
  * strength (`cli/memory.ts`'s full ANSI/OSC strip, wired only into recall;
  * memory-index.ts's weaker `oneLine`, guarding the ALWAYS-LOADED INDEX;
- * episodic-digest.ts's third strip for the digest pointer). Named here so a new
- * output surface can't silently reinvent (or skip) a defense, and so the two
- * near-duplicate paths can't silently disagree on the threshold.
+ * episodic-digest.ts's third strip for the digest pointer). Named here so every
+ * output surface has ONE strong sanitizer to reach for instead of reinventing a
+ * weaker one, and so the two near-duplicate paths can't silently disagree on the
+ * threshold. This is a convention, not an enforced invariant — exporting
+ * `sanitizeNoteText` does not compel a future surface to call it; it only
+ * removes the excuse that no shared, strong one existed.
  */
 
 const MS_PER_DAY = 86_400_000;

--- a/src/memory-corpus.ts
+++ b/src/memory-corpus.ts
@@ -58,6 +58,12 @@ export function ageDays(isoDate: string, now: Date): number {
 
 const OSC_SEQUENCE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g; // OSC … terminated by BEL or ST
 const CSI_SEQUENCE = /\x1b[@-_][0-?]*[ -/]*[@-~]/g; // CSI and other two-byte ESC sequences
+// 8-bit C1 forms: a single introducer byte (0x9b CSI / 0x9d OSC) with no
+// leading ESC. Strip the WHOLE sequence, not just the introducer — otherwise
+// the C0/C1 byte strip below removes 0x9b but leaves its parameters ("31m") as
+// literal text, understating the removal.
+const C1_CSI_SEQUENCE = /\x9b[0-?]*[ -/]*[@-~]/g; // C1 CSI (0x9b … final)
+const C1_OSC_SEQUENCE = /\x9d[^\x07\x1b\x9c]*(?:\x07|\x1b\\|\x9c)/g; // C1 OSC … terminated by BEL, ST, or C1 ST
 const STRAY_ESC = /\x1b./g; // any stray ESC + following byte
 const C0_C1_KEEP_TAB_NL = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g; // C0/C1 controls except \t (\x09) and \n (\x0a)
 
@@ -69,7 +75,9 @@ const C0_C1_KEEP_TAB_NL = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g; // C0/C1 con
  * poke the terminal's title/clipboard state — on recall, on the always-loaded
  * INDEX, or in a regenerated episodic digest. Removes:
  *   - ESC-introduced sequences (CSI `ESC [ … final`, OSC `ESC ] … BEL|ST`, and
- *     any other `ESC <byte>` form), and
+ *     any other `ESC <byte>` form),
+ *   - the 8-bit C1 equivalents as WHOLE sequences (C1 CSI `0x9b … final`, C1
+ *     OSC `0x9d … BEL|ST`), not just their introducer byte, and
  *   - remaining C0/C1 control chars, keeping tab and newline UNLESS `oneLine`.
  * Deliberately conservative: it discards control bytes rather than escaping
  * them, since every surface this guards renders human-facing text, not a
@@ -85,6 +93,8 @@ export function sanitizeNoteText(text: string, options: { oneLine?: boolean } = 
   const stripped = text
     .replace(OSC_SEQUENCE, "")
     .replace(CSI_SEQUENCE, "")
+    .replace(C1_OSC_SEQUENCE, "")
+    .replace(C1_CSI_SEQUENCE, "")
     .replace(STRAY_ESC, "")
     .replace(C0_C1_KEEP_TAB_NL, "");
   return options.oneLine ? stripped.replace(/\s+/g, " ").trim() : stripped;

--- a/src/memory-episodic.ts
+++ b/src/memory-episodic.ts
@@ -4,7 +4,14 @@ import { dirname, join } from "node:path";
 import { createPaths } from "./paths";
 import { isEnoent } from "./fs-utils";
 import { appendSomaMemoryEvent } from "./memory";
-import { serializeMemoryNote, parseMemoryNote, MemoryNoteError } from "./memory-note";
+import {
+  serializeMemoryNote,
+  parseMemoryNote,
+  MemoryNoteError,
+  NOTE_ID_PATTERN,
+  NOTE_ID_MAX_LEN,
+  noteIdSlugSegment,
+} from "./memory-note";
 import { SOMA_MEMORY_ACTION_APPROVALS } from "./types";
 import type {
   SomaMemoryActionOptions,
@@ -48,9 +55,6 @@ import type {
  * reconciled by the M7 audit.
  */
 
-// Same slug grammar as the M0 note id / M1 write boundary.
-const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-
 // Digest body bounds (plan §M5): a digest is 8–15 non-empty lines.
 const DIGEST_MIN_LINES = 8;
 const DIGEST_MAX_LINES = 15;
@@ -61,8 +65,10 @@ function assertNonEmpty(value: string | undefined, field: string): asserts value
   }
 }
 
-function assertSlug(slug: string, field: string, maxLen = 64): void {
-  if (!SLUG.test(slug) || slug.length > maxLen) {
+// Same slug grammar as the M0 note id / M1 write boundary (memory-note.ts's
+// NOTE_ID_PATTERN, #410).
+function assertSlug(slug: string, field: string, maxLen = NOTE_ID_MAX_LEN): void {
+  if (!NOTE_ID_PATTERN.test(slug) || slug.length > maxLen) {
     throw new MemoryNoteError(`${field} "${slug}" is not a valid slug (lowercase [a-z0-9-], <=${maxLen} chars).`, field);
   }
 }
@@ -71,7 +77,7 @@ function assertSlug(slug: string, field: string, maxLen = 64): void {
 // caller-supplied action slug is capped so `${date}-${slug}` stays a valid id —
 // caught at the `slug` field (clear error) rather than surfacing later as a
 // confusing `action id` failure.
-const MAX_ID_SLUG = 64 - "YYYYMMDD-".length;
+const MAX_ID_SLUG = NOTE_ID_MAX_LEN - "YYYYMMDD-".length;
 
 function isEexist(error: unknown): boolean {
   return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "EEXIST";
@@ -102,12 +108,10 @@ function monthDir(now: Date): string {
  * characters, the hash alone identifies it.
  */
 function sessionSlug(sessionId: string): string {
-  const readable = sessionId
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 32)
-    .replace(/-+$/g, "");
+  // The shared slug-shape builder (memory-note.ts, #410) — this is the ONE
+  // caller that needs the possibly-empty raw form: the collision-resistant
+  // hash suffix (not a generic placeholder) is the empty-input fallback here.
+  const readable = noteIdSlugSegment(sessionId, 32);
   const hash = createHash("sha256").update(sessionId).digest("hex").slice(0, 8);
   return readable.length > 0 ? `${readable}-${hash}` : hash;
 }

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -116,9 +116,10 @@ function isAdmitted(note: SomaMemoryNote): boolean {
 /**
  * Collapse to a single sanitized line and truncate — index descriptors are one
  * line. Sanitization (#410) is the SAME strong stripper that guards recall's
- * terminal output (full ANSI CSI/OSC escape removal, not just a blanked
- * control byte) — the always-loaded INDEX is the highest-stakes surface for
- * note-authored text and must never be the weakest-guarded one.
+ * terminal output (whole-sequence removal of ESC-introduced AND 8-bit C1
+ * CSI/OSC escapes, not just a blanked introducer byte) — the always-loaded
+ * INDEX is the highest-stakes surface for note-authored text and must never be
+ * the weakest-guarded one.
  */
 function oneLine(text: string, max: number): string {
   const collapsed = sanitizeNoteText(text, { oneLine: true });

--- a/src/memory-index.ts
+++ b/src/memory-index.ts
@@ -3,6 +3,7 @@ import { dirname } from "node:path";
 import { createPaths } from "./paths";
 import { isEnoent } from "./fs-utils";
 import { collectDurableNotes } from "./memory-write";
+import { noteDateMs, ageDays, sanitizeNoteText } from "./memory-corpus";
 import type { SomaMemoryIndexResult, SomaMemoryNote, SomaMemoryNoteType, SomaMemoryTrust } from "./types";
 
 /**
@@ -74,18 +75,6 @@ const SECTION_TITLE: Record<SomaMemoryNoteType, string> = {
 const MS_PER_DAY = 86_400_000;
 const DESCRIPTOR_MAX = 80;
 
-/** UTC-midnight ms for a `YYYY-MM-DD` date; the note schema guarantees the shape. */
-function dateMs(isoDate: string): number {
-  const [y, m, d] = isoDate.split("-").map(Number);
-  return Date.UTC(y, m - 1, d);
-}
-
-/** Whole days between `isoDate` and `now`, clamped at 0 for a future date. */
-function ageDays(isoDate: string, now: Date): number {
-  const delta = now.getTime() - dateMs(isoDate);
-  return delta <= 0 ? 0 : Math.floor(delta / MS_PER_DAY);
-}
-
 /**
  * Freshness term — recall's decay curve on frontmatter. Never-resurfaced notes
  * (`resurface_count === 0`) score 0 on this term; a future `last_verified`
@@ -94,7 +83,7 @@ function ageDays(isoDate: string, now: Date): number {
 function freshness(note: SomaMemoryNote, now: Date, halflifeDays: number): number {
   const count = note.resurface_count > 0 ? note.resurface_count : 0;
   if (count === 0) return 0;
-  const dt = now.getTime() - dateMs(note.last_verified);
+  const dt = now.getTime() - noteDateMs(note.last_verified);
   if (dt <= 0) return count; // future/equal timestamp → no decay
   const days = dt / MS_PER_DAY;
   const hl = halflifeDays > 0 ? halflifeDays : DEFAULT_HALFLIFE_DAYS;
@@ -124,12 +113,15 @@ function isAdmitted(note: SomaMemoryNote): boolean {
   return note.resurface_count >= RESURFACE_ADMIT;
 }
 
-/** Collapse to a single sanitized line and truncate — index descriptors are one line. */
+/**
+ * Collapse to a single sanitized line and truncate — index descriptors are one
+ * line. Sanitization (#410) is the SAME strong stripper that guards recall's
+ * terminal output (full ANSI CSI/OSC escape removal, not just a blanked
+ * control byte) — the always-loaded INDEX is the highest-stakes surface for
+ * note-authored text and must never be the weakest-guarded one.
+ */
 function oneLine(text: string, max: number): string {
-  const collapsed = text
-    .replace(/[\x00-\x1f\x7f-\x9f]+/g, " ") // control chars (incl. newlines/tabs) → space
-    .replace(/\s+/g, " ")
-    .trim();
+  const collapsed = sanitizeNoteText(text, { oneLine: true });
   return collapsed.length > max ? `${collapsed.slice(0, max - 1)}…` : collapsed;
 }
 
@@ -157,7 +149,7 @@ function compareScored(a: ScoredLine, b: ScoredLine): number {
   return (
     b.score - a.score ||
     TRUST_WEIGHT[b.note.trust] - TRUST_WEIGHT[a.note.trust] ||
-    dateMs(b.note.last_verified) - dateMs(a.note.last_verified) ||
+    noteDateMs(b.note.last_verified) - noteDateMs(a.note.last_verified) ||
     a.note.id.localeCompare(b.note.id)
   );
 }
@@ -166,11 +158,13 @@ function pointerLine(note: SomaMemoryNote, now: Date): string {
   // "verified Nd ago" is computed HERE, at rebuild time, from the injected now —
   // never a wall clock at projection time (M4 invariant AC-4). Both id and
   // descriptor go through oneLine, which enforces the one-line pointer invariant
-  // and strips control chars — NOT a semantic prompt-injection defense: the
-  // descriptor deliberately projects note-authored hook/body text (that IS the
-  // index). What keeps untrusted text out is the admission ladder upstream
-  // (quarantined excluded, non-principal admitted only after verified resurfacing).
-  // trust is an enum and the age a number, so both are safe as-is.
+  // and strips terminal escapes/control chars — NOT a semantic prompt-injection
+  // defense: the descriptor deliberately projects note-authored hook/body text
+  // (that IS the index). What keeps untrusted CONTENT out is the admission
+  // ladder upstream (quarantined excluded, non-principal admitted only after
+  // verified resurfacing); sanitization only keeps admitted text from spoofing
+  // the terminal it's rendered to. trust is an enum and the age a number, so
+  // both are safe as-is.
   const id = oneLine(note.id, DESCRIPTOR_MAX);
   return `- ${id} — ${descriptorFor(note)} · ${note.trust}, verified ${ageDays(note.last_verified, now)}d ago`;
 }

--- a/src/memory-note.ts
+++ b/src/memory-note.ts
@@ -27,10 +27,64 @@ export class MemoryNoteError extends Error {
   }
 }
 
-const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+// The note-id / slug grammar (#410's "id grammar definition"): lowercase
+// [a-z0-9], single hyphens between runs, no leading/trailing/double hyphens.
+// Exported so every module that validates or MINTS an id (memory-write.ts's
+// write-boundary guard, memory-consolidate.ts's episodic-id safety re-check,
+// memory-episodic.ts's slug validation, and the generative slugifiers below)
+// shares this ONE definition instead of re-declaring the same regex.
+export const NOTE_ID_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const NOTE_ID_MAX_LEN = 64;
 const DATE = /^\d{4}-\d{2}-\d{2}$/;
 const NOTE_TYPES: readonly SomaMemoryNoteType[] = SOMA_MEMORY_NOTE_TYPES;
 const TRUSTS: readonly SomaMemoryTrust[] = SOMA_MEMORY_TRUSTS;
+
+/** True iff `id` matches the note-id slug grammar and fits within `maxLen`
+ *  (default 64, the frontmatter `id` field's own cap; a caller building a
+ *  narrower id — e.g. an episodic action id that must leave room for its
+ *  `YYYYMMDD-` prefix — passes a smaller cap). */
+export function isValidNoteId(id: string, maxLen: number = NOTE_ID_MAX_LEN): boolean {
+  return NOTE_ID_PATTERN.test(id) && id.length <= maxLen;
+}
+
+/**
+ * Pure slug-shape transform: lowercase, collapse non-[a-z0-9] runs to a single
+ * hyphen, trim leading/trailing hyphens, cap at `maxLen` (re-trimming a hyphen
+ * that truncation may expose). May return `""` if nothing sluggable remains — the
+ * building block for {@link toNoteIdSlug} below, exposed directly for a
+ * composing caller that needs its own non-generic empty-input fallback (e.g.
+ * memory-episodic.ts's collision-resistant session slug, which appends a hash
+ * suffix rather than a placeholder word).
+ */
+export function noteIdSlugSegment(base: string, maxLen: number = NOTE_ID_MAX_LEN): string {
+  return base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, maxLen)
+    .replace(/-+$/g, "");
+}
+
+/**
+ * Slugify `base` into a note-id-shaped slug — valid-by-construction: a caller
+ * never needs to re-test the result against {@link isValidNoteId}. Replaces
+ * the produce-then-validate scatter across memory-backfill.ts's `slugifyId`
+ * and memory-promotion.ts's `slugify` (both delegate to this).
+ *
+ * If nothing sluggable remains (e.g. an all-punctuation title), returns
+ * `fallback` (default `"note"`) — asserted to itself be a valid slug so this
+ * function can never silently break its own guarantee.
+ */
+export function toNoteIdSlug(base: string, options: { maxLen?: number; fallback?: string } = {}): string {
+  const maxLen = options.maxLen ?? NOTE_ID_MAX_LEN;
+  const slug = noteIdSlugSegment(base, maxLen);
+  if (slug.length > 0) return slug;
+  const fallback = options.fallback ?? "note";
+  if (!isValidNoteId(fallback, maxLen)) {
+    throw new Error(`toNoteIdSlug: fallback "${fallback}" is not itself a valid slug (<=${maxLen} chars).`);
+  }
+  return fallback;
+}
 
 // Provenance is a closed set plus the open `tool:<name>` family (plan v2 §2.2,
 // design doc line 105): conversation | consolidation | import | tool:<name>.
@@ -76,7 +130,7 @@ function parseLinks(raw: string): string[] {
   if (inner === "") return [];
   const items = inner.split(",").map((s) => s.trim());
   for (const item of items) {
-    assert(SLUG.test(item), `links entry "${item}" is not a valid slug`, "links");
+    assert(NOTE_ID_PATTERN.test(item), `links entry "${item}" is not a valid slug`, "links");
   }
   return items;
 }
@@ -160,7 +214,7 @@ export function parseMemoryNote(content: string): SomaMemoryNote {
   }
 
   const id = raw.id;
-  assert(SLUG.test(id) && id.length <= 64, `id "${id}" is not a valid slug (<=64 chars)`, "id");
+  assert(isValidNoteId(id), `id "${id}" is not a valid slug (<=${NOTE_ID_MAX_LEN} chars)`, "id");
   assert((NOTE_TYPES as readonly string[]).includes(raw.type), `type "${raw.type}" is not valid`, "type");
   assert((TRUSTS as readonly string[]).includes(raw.trust), `trust "${raw.trust}" is not valid`, "trust");
   assert(isCalendarDate(raw.created), `created "${raw.created}" must be a valid YYYY-MM-DD date`, "created");

--- a/src/memory-promotion.ts
+++ b/src/memory-promotion.ts
@@ -4,6 +4,7 @@ import { readAlgorithmRunById, writeAlgorithmRun } from "./algorithm-store";
 import { appendAlgorithmProvenance } from "./algorithm-provenance";
 import { appendSomaMemoryEvent } from "./memory";
 import { createPaths } from "./paths";
+import { toNoteIdSlug } from "./memory-note";
 import { getCriteria, getGoal } from "./vsa-accessors";
 import { getRunPhase } from "./algorithm-lifecycle";
 import type { AlgorithmRun, SomaMemoryPromotionOptions, SomaMemoryPromotionResult } from "./types";
@@ -14,14 +15,13 @@ function assertNonEmpty(value: string, field: string): void {
   }
 }
 
+// These promoted files are plain lesson markdown (no frontmatter `id`), so this
+// slug is a FILENAME component, not a note-id field — it keeps its own historical
+// 80-char cap (wider than the 64-char note-id cap) rather than the id-grammar
+// default. Delegates to the shared, valid-by-construction `toNoteIdSlug`
+// (memory-note.ts, #410) instead of re-approximating the grammar locally.
 function slugify(value: string): string {
-  return (
-    value
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "")
-      .slice(0, 80) || "memory"
-  );
+  return toNoteIdSlug(value, { maxLen: 80, fallback: "memory" });
 }
 
 function checkedCriteria(run: AlgorithmRun): string[] {

--- a/src/memory-recall.ts
+++ b/src/memory-recall.ts
@@ -2,6 +2,9 @@ import { createPaths } from "./paths";
 import { collectDurableNotes } from "./memory-write";
 import type { ScannedNote } from "./memory-write";
 import { memoryTerms } from "./memory-terms";
+// Aliased: `toRecalledNote` below binds a local `ageDays` (the field name on
+// SomaMemoryRecalledNote), so the imported function keeps a distinct name.
+import { noteDateMs, ageDays as ageDaysSince } from "./memory-corpus";
 import type {
   SomaMemoryNote,
   SomaMemoryRecallOptions,
@@ -38,7 +41,6 @@ import type {
  * let a mere read keep a note artificially alive in the M3 index).
  */
 
-const MS_PER_DAY = 86_400_000;
 const DEFAULT_LIMIT = 3;
 
 /**
@@ -91,18 +93,6 @@ function scoreNote(note: SomaMemoryNote, terms: string[]): NoteScore {
     }
   }
   return { matched, freq };
-}
-
-/** UTC midnight ms for a `YYYY-MM-DD` date; the note schema guarantees the shape. */
-function dateMs(isoDate: string): number {
-  const [y, m, d] = isoDate.split("-").map(Number);
-  return Date.UTC(y, m - 1, d);
-}
-
-/** Whole days since `last_verified`, clamped at 0 for a future date. Derived from injected `now`. */
-function ageDaysSince(lastVerified: string, now: Date): number {
-  const delta = now.getTime() - dateMs(lastVerified);
-  return delta <= 0 ? 0 : Math.floor(delta / MS_PER_DAY);
 }
 
 /**
@@ -179,7 +169,7 @@ export async function recallMemory(options: SomaMemoryRecallOptions): Promise<So
       (a, b) =>
         b.matched - a.matched ||
         b.freq - a.freq ||
-        dateMs(b.scanned.note.last_verified) - dateMs(a.scanned.note.last_verified) ||
+        noteDateMs(b.scanned.note.last_verified) - noteDateMs(a.scanned.note.last_verified) ||
         a.scanned.note.id.localeCompare(b.scanned.note.id),
     );
 

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -6,8 +6,9 @@ import { createPaths } from "./paths";
 import { listMemoryNotes } from "./memory-fs";
 import { runBoundedConcurrent } from "./internal-concurrency";
 import { appendSomaMemoryEvent } from "./memory";
-import { parseMemoryNote, serializeMemoryNote, MemoryNoteError } from "./memory-note";
+import { parseMemoryNote, serializeMemoryNote, MemoryNoteError, isValidNoteId, NOTE_ID_MAX_LEN } from "./memory-note";
 import { memoryTermSet } from "./memory-terms";
+import { jaccard, NEAR_DUPLICATE_JACCARD_THRESHOLD } from "./memory-corpus";
 import { SOMA_MEMORY_NOTE_TYPES, SOMA_MEMORY_TRIGGER_TRUST } from "./types";
 import type {
   SomaMemoryDuplicateCandidate,
@@ -60,10 +61,12 @@ import type {
  * stay within the Soma memory tree under `memory/semantic/` + `memory/procedural/`.
  */
 
-// The recall-first refusal fires at/above this Jaccard token-set overlap.
-// Adapted from recall's dedup concept (see Plans/2026-07-02-recall-adoption-analysis.md);
-// Soma owns the constant after port.
-export const MEMORY_DEDUP_JACCARD_THRESHOLD = 0.6;
+// The recall-first refusal fires at/above this Jaccard token-set overlap — the
+// same shared floor (#410) the M6 consolidation near-dup report scores against
+// (memory-consolidate.ts's `planSimilarPairs`). Re-exported under this file's
+// established name: internal soma modules and tests import it from here (see
+// index.ts's public-surface note), not from memory-corpus.ts directly.
+export { NEAR_DUPLICATE_JACCARD_THRESHOLD as MEMORY_DEDUP_JACCARD_THRESHOLD };
 
 // The durable, dedup-gated corpus. Episodic notes live elsewhere (M5) and are
 // not written through this path.
@@ -95,16 +98,15 @@ function assertNonEmpty(value: string | undefined, field: string): asserts value
   }
 }
 
-// Same slug grammar the M0 parser enforces on `id`. Validated HERE at the write
-// boundary — before the id is ever joined into a filesystem path — so a
-// traversal id (`../../evil`) is refused up front rather than incidentally by
-// serialize's round-trip re-parse. Defense in depth: memoryNotePath must never
-// receive an unvalidated id.
-const NOTE_ID_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
-
+// Same slug grammar the M0 parser enforces on `id` (memory-note.ts's
+// NOTE_ID_PATTERN). Validated HERE at the write boundary — before the id is
+// ever joined into a filesystem path — so a traversal id (`../../evil`) is
+// refused up front rather than incidentally by serialize's round-trip
+// re-parse. Defense in depth: memoryNotePath must never receive an
+// unvalidated id.
 function assertNoteId(id: string): void {
-  if (!NOTE_ID_SLUG.test(id) || id.length > 64) {
-    throw new MemoryNoteError(`id "${id}" is not a valid slug (lowercase [a-z0-9-], <=64 chars).`, "id");
+  if (!isValidNoteId(id)) {
+    throw new MemoryNoteError(`id "${id}" is not a valid slug (lowercase [a-z0-9-], <=${NOTE_ID_MAX_LEN} chars).`, "id");
   }
 }
 
@@ -198,16 +200,6 @@ function bodyHash(body: string): string {
 
 function bodyTokens(body: string): Set<string> {
   return tokensFromLower(body.toLowerCase());
-}
-
-function jaccard(a: Set<string>, b: Set<string>): number {
-  if (a.size === 0 && b.size === 0) return 0;
-  let intersection = 0;
-  for (const token of a) {
-    if (b.has(token)) intersection += 1;
-  }
-  const union = a.size + b.size - intersection;
-  return union === 0 ? 0 : intersection / union;
 }
 
 export interface ScannedNote {
@@ -463,7 +455,7 @@ export async function findDuplicateCandidates(somaHome: string, body: string): P
     const lower = note.body.toLowerCase(); // one pass, feeds both hash and tokens
     const exact = hashFromLower(lower) === hash;
     const score = exact ? 1 : jaccard(tokens, tokensFromLower(lower));
-    if (exact || score >= MEMORY_DEDUP_JACCARD_THRESHOLD) {
+    if (exact || score >= NEAR_DUPLICATE_JACCARD_THRESHOLD) {
       candidates.push({ id: note.id, type, path, score, exact });
     }
   }

--- a/test/episodic-digest.test.ts
+++ b/test/episodic-digest.test.ts
@@ -32,6 +32,16 @@ test("episodic digest pointer rendering and parsing are mutual for normal ids", 
   expect(parseDigestPointerIds(content)).toEqual(notes.map((n) => n.id));
 });
 
+test("episodic digest pointer text strips ANSI/OSC escapes from an untrusted body (#410 shared sanitizer)", () => {
+  const payload = "\x1b[31mALERT\x1b[0m click \x1b]8;;http://evil.example\x07here\x1b]8;;\x07 now";
+  const content = renderDigestPointer(note("20260704-untrusted", payload));
+
+  expect(content).not.toContain("\x1b");
+  expect(content).not.toContain("\x07");
+  expect(content).not.toContain("evil.example");
+  expect(content).toBe("- 20260704-untrusted: ALERT click here now");
+});
+
 test("episodic digest pointer grammar round-trips ids containing colons", () => {
   const notes = [
     note("session:alpha", "alpha body"),

--- a/test/memory-corpus.test.ts
+++ b/test/memory-corpus.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test";
+import { jaccard, NEAR_DUPLICATE_JACCARD_THRESHOLD, noteDateMs, ageDays, sanitizeNoteText } from "../src/memory-corpus";
+
+// --- jaccard -------------------------------------------------------------------
+
+test("jaccard is 0 for two empty sets", () => {
+  expect(jaccard(new Set(), new Set())).toBe(0);
+});
+
+test("jaccard is 1 for identical non-empty sets", () => {
+  const a = new Set(["gateway", "retries"]);
+  expect(jaccard(a, new Set(a))).toBe(1);
+});
+
+test("jaccard is |intersection|/|union| for partially overlapping sets", () => {
+  const a = new Set(["gateway", "retries", "thrice"]);
+  const b = new Set(["gateway", "retries", "dead-letter"]);
+  // intersection = {gateway, retries} = 2; union = {gateway, retries, thrice, dead-letter} = 4
+  expect(jaccard(a, b)).toBe(0.5);
+});
+
+test("jaccard is 0 for disjoint non-empty sets", () => {
+  expect(jaccard(new Set(["a"]), new Set(["b"]))).toBe(0);
+});
+
+test("NEAR_DUPLICATE_JACCARD_THRESHOLD is the shared 0.6 floor", () => {
+  expect(NEAR_DUPLICATE_JACCARD_THRESHOLD).toBe(0.6);
+});
+
+// --- dates -----------------------------------------------------------------
+
+test("noteDateMs resolves a YYYY-MM-DD date to UTC midnight", () => {
+  expect(noteDateMs("2026-07-04")).toBe(Date.UTC(2026, 6, 4));
+});
+
+test("ageDays computes whole days since a past date", () => {
+  const now = new Date("2026-07-14T10:00:00.000Z");
+  expect(ageDays("2026-07-04", now)).toBe(10);
+});
+
+test("ageDays clamps a future/clock-skewed date to 0, never negative", () => {
+  const now = new Date("2026-07-04T10:00:00.000Z");
+  expect(ageDays("2026-08-01", now)).toBe(0);
+});
+
+// --- sanitizeNoteText (SECURITY-CRITICAL) ---------------------------------------
+
+test("sanitizeNoteText strips a CSI color escape and a stray BEL, keeping visible text", () => {
+  const payload = "Alert \x1b[31mRED\x1b[0m gateway \x07 done";
+  const out = sanitizeNoteText(payload);
+  expect(out).not.toContain("\x1b");
+  expect(out).not.toContain("\x07");
+  expect(out).toBe("Alert RED gateway  done");
+});
+
+test("sanitizeNoteText strips an OSC 8 hyperlink-spoofing payload", () => {
+  // OSC 8 ; params ; URI ST "label" OSC 8 ;; ST — a terminal that honors this
+  // renders "label" as a clickable hyperlink to an attacker-controlled URI.
+  const payload = "click \x1b]8;;http://evil.example\x07here\x1b]8;;\x07 now";
+  const out = sanitizeNoteText(payload);
+  expect(out).not.toContain("\x1b");
+  expect(out).not.toContain("evil.example");
+  expect(out).toBe("click here now");
+});
+
+test("sanitizeNoteText (default) preserves tabs and newlines for multi-line rendering", () => {
+  expect(sanitizeNoteText("line one\nline\ttwo")).toBe("line one\nline\ttwo");
+});
+
+test("sanitizeNoteText({ oneLine: true }) collapses all whitespace (incl. newlines) to single spaces and trims", () => {
+  expect(sanitizeNoteText("  first line  \n\n  second line  ", { oneLine: true })).toBe("first line second line");
+});
+
+test("sanitizeNoteText({ oneLine: true }) also strips escapes before collapsing", () => {
+  const payload = "\x1b[31malert\x1b[0m\nline two";
+  expect(sanitizeNoteText(payload, { oneLine: true })).toBe("alert line two");
+});

--- a/test/memory-corpus.test.ts
+++ b/test/memory-corpus.test.ts
@@ -63,6 +63,26 @@ test("sanitizeNoteText strips an OSC 8 hyperlink-spoofing payload", () => {
   expect(out).toBe("click here now");
 });
 
+test("sanitizeNoteText strips an 8-bit C1 CSI sequence as a whole (params too, not just the introducer)", () => {
+  // 0x9b is the single-byte C1 CSI introducer — no leading ESC. A naive
+  // control-byte strip removes 0x9b but leaves "31m" as literal text.
+  const payload = "Alert \x9b31mRED\x9b0m gateway done";
+  const out = sanitizeNoteText(payload);
+  expect(out).not.toContain("\x9b");
+  expect(out).not.toContain("31m");
+  expect(out).not.toContain("0m");
+  expect(out).toBe("Alert RED gateway done");
+});
+
+test("sanitizeNoteText strips an 8-bit C1 OSC hyperlink-spoofing payload", () => {
+  // 0x9d is the single-byte C1 OSC introducer; 0x9c (C1 ST) terminates it.
+  const payload = "click \x9d8;;http://evil.example\x9chere\x9d8;;\x9c now";
+  const out = sanitizeNoteText(payload);
+  expect(out).not.toContain("\x9d");
+  expect(out).not.toContain("evil.example");
+  expect(out).toBe("click here now");
+});
+
 test("sanitizeNoteText (default) preserves tabs and newlines for multi-line rendering", () => {
   expect(sanitizeNoteText("line one\nline\ttwo")).toBe("line one\nline\ttwo");
 });

--- a/test/memory-index.test.ts
+++ b/test/memory-index.test.ts
@@ -156,6 +156,24 @@ test("renderMemoryIndex golden output for a fixed tree and now", () => {
   expect(excluded).toBe(2);
 });
 
+// --- sanitization (SECURITY-CRITICAL, #410) -----------------------------------
+
+test("an ANSI/OSC spoofing payload in a note body renders inert through the INDEX surface", () => {
+  // A CSI color escape + an OSC 8 hyperlink-spoofing payload (would render as a
+  // clickable link to an attacker-controlled URI in a terminal that honors it),
+  // both embedded in a principal-trust note body — the descriptor is the FIRST
+  // body line the INDEX ever admits verbatim.
+  const payload = "\x1b[31mALERT\x1b[0m click \x1b]8;;http://evil.example\x07here\x1b]8;;\x07 now";
+  const notes = [note({ id: "spoof-note", trust: "principal", body: payload })];
+
+  const { content } = renderMemoryIndex(notes, NOW);
+
+  expect(content).not.toContain("\x1b");
+  expect(content).not.toContain("\x07");
+  expect(content).not.toContain("evil.example");
+  expect(content).toContain("ALERT click here now");
+});
+
 // --- budget ------------------------------------------------------------------
 
 test("line budget sheds the lowest-score notes first", () => {
@@ -255,6 +273,21 @@ test("rebuildMemoryIndex writes memory/INDEX.md and returns counts", async () =>
     expect(onDisk).toBe(result.content);
     expect(onDisk).toContain("- earned —");
     expect(onDisk).not.toContain("quar");
+  });
+});
+
+test("rebuildMemoryIndex writes an ANSI/OSC spoofing payload inert to memory/INDEX.md on disk", async () => {
+  await withTempSoma(async (somaHome) => {
+    const payload = "\x1b[31mALERT\x1b[0m click \x1b]8;;http://evil.example\x07here\x1b]8;;\x07 now";
+    await seed(somaHome, note({ id: "spoof-note", body: payload, trust: "principal" }));
+
+    const result = await rebuildMemoryIndex({ somaHome, now: NOW });
+    const onDisk = await readFile(result.path, "utf8");
+
+    expect(onDisk).not.toContain("\x1b");
+    expect(onDisk).not.toContain("\x07");
+    expect(onDisk).not.toContain("evil.example");
+    expect(onDisk).toContain("ALERT click here now");
   });
 });
 


### PR DESCRIPTION
## Summary

Compare / date / slugify / sanitize over the note corpus were each re-decided per call site. This names one shared operation per concern so a new caller can't silently skip a defense or diverge a threshold/date nuance. New module: `src/memory-corpus.ts`.

### jaccard + the 0.6 near-duplicate threshold

- `jaccard(a, b)` and `NEAR_DUPLICATE_JACCARD_THRESHOLD` (= 0.6) now live once in `src/memory-corpus.ts`.
- `memory-write.ts`'s `findDuplicateCandidates` (the M1 recall-first refusal gate) and `memory-consolidate.ts`'s `planSimilarPairs` (the M6 near-dup report) both import and use the same scorer and floor — the local copies of `jaccard` and the `0.6` literal in both files are deleted.
- `memory-write.ts` still exports `MEMORY_DEDUP_JACCARD_THRESHOLD` under its established name (re-exporting the shared constant), so `test/memory-write.test.ts`'s existing direct import is untouched.

### noteDateMs / ageDays

- One `noteDateMs(isoDate)` (UTC-midnight ms) and one `ageDays(isoDate, now)` (whole days, **clamped at 0** for a future/clock-skewed date) now live in `memory-corpus.ts`.
- `memory-index.ts` and `memory-recall.ts` already clamped at 0; `memory-consolidate.ts` previously computed a **negative** age for a future date (no clamp). Verified this divergence was unobservable at both of consolidate's two call sites (`ageDays(...) <= ttlDays` for episodic TTL pruning and `<= SEMANTIC_STALE_DAYS` for stale-marking) — a negative age and a clamped-0 age both fail to exceed a positive threshold, so the change is behavior-preserving for existing call sites while removing the divergence risk the issue calls out.
- `memory-recall.ts`'s local `ageDaysSince` is deleted entirely — it was byte-identical to the shared `ageDays`, so the call site now imports `ageDays` directly (aliased on import since the file also has a local variable named `ageDays`).
- `memory-index.ts`'s `freshness()` (continuous decay, not day-floored) keeps its own inline `dt <= 0` clamp — a different computation, not part of this consolidation.

### toNoteIdSlug (id grammar)

- The note-id regex `/^[a-z0-9]+(?:-[a-z0-9]+)*$/` was duplicated **four** times (`memory-note.ts` private, `memory-write.ts`, `memory-consolidate.ts`, `memory-episodic.ts`). It's now exported once as `NOTE_ID_PATTERN` (+ `NOTE_ID_MAX_LEN = 64`, + a `isValidNoteId(id, maxLen?)` helper) from `memory-note.ts`, next to the parser that enforces it. All four call sites now import it instead of re-declaring it.
- `toNoteIdSlug(base, { maxLen?, fallback? })` in `memory-note.ts` is the valid-by-construction generator (asserts its own fallback is valid, so it can never violate its own guarantee):
  - `memory-backfill.ts`'s `slugifyId` now calls `toNoteIdSlug(`${category}-${stem}`, { fallback: "note" })` — identical behavior (64-char cap, `"note"` fallback), no local regex.
  - `memory-promotion.ts`'s `slugify` now calls `toNoteIdSlug(value, { maxLen: 80, fallback: "memory" })`. Note: these promoted files are plain lesson markdown with **no frontmatter `id`** — this slug is a filename component, not a note-id field — so it deliberately keeps its own historical 80-char cap rather than the 64-char note-id default. Verified against `test/memory.test.ts`'s two exact-filename assertions (`consulting-autonomy-metric-consulting-lesson.md`, `nested-id-lesson-nested-run-id.md`) — unchanged.
  - `memory-episodic.ts`'s `sessionSlug` (a **different** concern — a collision-resistant slug that always appends an 8-hex hash suffix, using the hash alone when nothing sluggable remains) reuses the shared low-level `noteIdSlugSegment(base, maxLen)` builder that `toNoteIdSlug` is itself built on, rather than `toNoteIdSlug` directly — its empty-input fallback (the hash) isn't a generic placeholder, so it composes with the pure builder instead. Verified against `test/memory-episodic.test.ts`'s exact-id assertions (date+hash-only for a session id with no sluggable characters) — unchanged.
  - `memory-episodic.ts`'s `assertSlug` (validates a caller-supplied action slug, not a generator) now checks against the shared `NOTE_ID_PATTERN` instead of its own private copy.
  - `memory-consolidate.ts`'s episodic-id safety re-check and `memory-write.ts`'s write-boundary `assertNoteId` both now validate against the shared pattern/`isValidNoteId` instead of their own private regex + `64` literal.

### sanitizeNoteText (SECURITY-CRITICAL — the INDEX now gets the strong sanitizer)

- One `sanitizeNoteText(text, { oneLine? })` in `memory-corpus.ts`, ported byte-for-byte from `cli/memory.ts`'s `sanitizeForTerminal` (the strongest of the three: full OSC/CSI/stray-ESC sequence removal, not just blanking a control byte). `oneLine: true` additionally collapses all whitespace to single spaces and trims.
- **recall** (`cli/memory.ts`): `sanitizeForTerminal` is deleted; every call site (`formatRecalledMatch`, `formatMemoryRecallResult`) now calls `sanitizeNoteText` — unchanged behavior (default `oneLine: false` preserves the multi-line banner+body layout).
- **the always-loaded INDEX** (`memory-index.ts`): `oneLine()`'s own weaker inline strip (`replace(/[\x00-\x1f\x7f-\x9f]+/g, " ")`, which only blanks the leading escape byte and leaves the rest of an OSC/CSI sequence's parameter bytes as visible junk text) is deleted; it now calls `sanitizeNoteText(text, { oneLine: true })`. **This is the strengthening the issue calls for** — the INDEX is the highest-stakes surface (always loaded into every session) and previously had the weakest defense.
- **the episodic digest pointer** (`episodic-digest.ts`'s `digestPointerText`, consumed by `memory-consolidate.ts`'s digest regeneration): its own inline strip is deleted; it now calls `sanitizeNoteText(line, { oneLine: true })`.

## #410 Acceptance checklist

- [x] One `sanitizeNoteText` guards every note-text output surface (recall + INDEX + episodic digest, which is consolidate's rendering path); the three weaker/duplicate strippers are deleted (their bodies now delegate).
- [x] One `jaccard` + one `0.6` threshold constant; consolidate and write share the near-match scorer.
- [x] One `toNoteIdSlug` (+ shared `noteIdSlugSegment` builder + `NOTE_ID_PATTERN`); backfill and promotion call `toNoteIdSlug` directly, episodic's session slug composes the shared builder for its distinct collision-resistant semantics, and all validation call sites (write, consolidate, episodic) drop their own private regex copies.
- [x] Test: an ANSI/OSC spoofing payload (a CSI color escape + an OSC 8 hyperlink-spoofing sequence) renders inert through the INDEX surface — both at the `renderMemoryIndex` level and through `rebuildMemoryIndex`'s on-disk `memory/INDEX.md` (`test/memory-index.test.ts`). Also covered for the episodic digest pointer (`test/episodic-digest.test.ts`) and the new shared module directly (`test/memory-corpus.test.ts`, 15 tests covering jaccard, dates, both sanitize modes, and 8-bit C1 CSI/OSC payloads).

## Test / typecheck numbers

- `bun run typecheck` → clean, no errors.
- `bun test` → **1794 pass, 0 fail**, across 116 files (includes 18 new tests: 15 in the new `test/memory-corpus.test.ts` — including 8-bit C1 CSI/OSC spoofing payloads — 2 in `test/memory-index.test.ts`, 1 in `test/episodic-digest.test.ts`).
- `bun run lint`: pre-existing, unrelated lint debt exists on `main` (non-null-assertion / optional-chain / no-control-regex findings already present in `memory-index.ts`, `memory-consolidate.ts`, and the three original sanitizer sites before this PR). Verified line-for-line against `main` that this PR introduces **zero new** lint findings — the `no-control-regex` findings simply moved with the sanitizer code into `memory-corpus.ts` (4 lines flagged there vs. 4 lines flagged across the three original sites on `main`), and the non-null-assertion / optional-chain findings in `memory-index.ts` / `memory-consolidate.ts` are the same pre-existing lines, shifted by the line numbers removed.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzijJAY7wa47Bm4CH8Ux5


