### PR TITLE
fix(memory): #422 review follow-ups — apply-path guard + atomicity polish (#423)

### DIFF
--- a/src/memory-consolidate.ts
+++ b/src/memory-consolidate.ts
@@ -1,5 +1,5 @@
 import { mkdir, readdir, readFile, rename, lstat, unlink, writeFile } from "node:fs/promises";
-import { basename, dirname, join, relative, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, sep } from "node:path";
 import { createPaths } from "./paths";
 import { isEnoent } from "./fs-utils";
 import { listMemoryNotes } from "./memory-fs";
@@ -563,6 +563,27 @@ export async function planConsolidation(paths: SomaPaths, options: SomaMemoryCon
  * rollback (`writeNotesAtomically`, memory-write.ts) is a different,
  * single-mutation path.
  */
+/**
+ * A plan produced by `planConsolidation` only ever holds paths under the memory
+ * tree. But `applyConsolidationPlan` is exported (for the plan-immutability test),
+ * so treat the plan as a trust boundary: reject any mutation-target path that
+ * escapes the soma home before touching the filesystem, so a forged plan cannot
+ * drive writes/renames/unlinks outside the tree.
+ */
+function assertPlanPathsInsideRoot(somaHome: string, plan: ConsolidationPlan): void {
+  const assertInside = (target: string): void => {
+    const rel = relative(somaHome, target);
+    if (rel === "" || (!rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel))) return;
+    throw new Error(`Soma consolidation plan path escapes the soma home: ${target}`);
+  };
+  for (const m of plan.staleMarks) assertInside(m.path);
+  for (const rel of plan.stateGc) assertInside(join(somaHome, rel)); // `rel` could carry `..`
+  for (const e of plan.episodic) {
+    assertInside(e.from);
+    assertInside(e.to);
+  }
+}
+
 export async function applyConsolidationPlan(
   paths: SomaPaths,
   plan: ConsolidationPlan,
@@ -570,6 +591,7 @@ export async function applyConsolidationPlan(
   substrate: SomaMemoryConsolidateOptions["substrate"],
 ): Promise<ConsolidationApplied> {
   const somaHome = paths.root();
+  assertPlanPathsInsideRoot(somaHome, plan);
 
   const archivedOmissions = await applyEpisodicArchive(paths, plan.episodic);
   const { skipped: staleSkipped } = await applyStaleMarks(plan.staleMarks);

--- a/src/memory-consolidate.ts
+++ b/src/memory-consolidate.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, rename, lstat, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, realpath, rename, lstat, unlink, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, sep } from "node:path";
 import { createPaths } from "./paths";
 import { isEnoent } from "./fs-utils";
@@ -564,23 +564,52 @@ export async function planConsolidation(paths: SomaPaths, options: SomaMemoryCon
  * single-mutation path.
  */
 /**
- * A plan produced by `planConsolidation` only ever holds paths under the memory
+ * A plan produced by `planConsolidation` only ever holds paths under the MEMORY
  * tree. But `applyConsolidationPlan` is exported (for the plan-immutability test),
  * so treat the plan as a trust boundary: reject any mutation-target path that
- * escapes the soma home before touching the filesystem, so a forged plan cannot
- * drive writes/renames/unlinks outside the tree.
+ * escapes `<somaHome>/memory` before touching the filesystem, so a forged plan
+ * cannot drive writes/renames/unlinks outside the Memory compartment (not merely
+ * outside the whole Soma home — consolidation must never touch Identity/Purpose/…).
+ *
+ * Two layers, because a lexical `..` check alone is not enough — a forged
+ * in-tree path could route through a symlinked ancestor that resolves outside:
+ *   (1) lexical: reject `..`/absolute escapes even for paths that don't exist yet;
+ *   (2) real: resolve the deepest EXISTING ancestor (a write/rename/unlink can
+ *       only land where its parent already resolves) and require the real path to
+ *       stay inside the real memory root — catching a symlinked ancestor.
  */
-function assertPlanPathsInsideRoot(somaHome: string, plan: ConsolidationPlan): void {
-  const assertInside = (target: string): void => {
-    const rel = relative(somaHome, target);
-    if (rel === "" || (!rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel))) return;
-    throw new Error(`Soma consolidation plan path escapes the soma home: ${target}`);
+async function assertPlanPathsInsideMemory(somaHome: string, memoryRoot: string, plan: ConsolidationPlan): Promise<void> {
+  const realMemoryRoot = await realpath(memoryRoot).catch(() => memoryRoot);
+  const escapes = (root: string, target: string): boolean => {
+    const rel = relative(root, target);
+    return rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel);
   };
-  for (const m of plan.staleMarks) assertInside(m.path);
-  for (const rel of plan.stateGc) assertInside(join(somaHome, rel)); // `rel` could carry `..`
+  const assertInside = async (target: string): Promise<void> => {
+    if (escapes(memoryRoot, target)) {
+      throw new Error(`Soma consolidation plan path escapes the memory tree: ${target}`);
+    }
+    // Resolve symlinks on the deepest existing ancestor.
+    let probe = target;
+    for (;;) {
+      const real = await realpath(probe).catch(() => undefined);
+      if (real !== undefined) {
+        if (escapes(realMemoryRoot, real)) {
+          throw new Error(`Soma consolidation plan path resolves outside the memory tree: ${target}`);
+        }
+        return;
+      }
+      const parent = dirname(probe);
+      if (parent === probe) return; // hit the fs root without resolving; the lexical check already passed
+      probe = parent;
+    }
+  };
+  for (const m of plan.staleMarks) await assertInside(m.path);
+  // `stateGc` rels are soma-home-relative (applyStateGc joins them onto the home)
+  // and could carry `..`, so resolve against `somaHome` then require memory-tree containment.
+  for (const rel of plan.stateGc) await assertInside(join(somaHome, rel));
   for (const e of plan.episodic) {
-    assertInside(e.from);
-    assertInside(e.to);
+    await assertInside(e.from);
+    await assertInside(e.to);
   }
 }
 
@@ -591,7 +620,7 @@ export async function applyConsolidationPlan(
   substrate: SomaMemoryConsolidateOptions["substrate"],
 ): Promise<ConsolidationApplied> {
   const somaHome = paths.root();
-  assertPlanPathsInsideRoot(somaHome, plan);
+  await assertPlanPathsInsideMemory(somaHome, paths.memory(), plan);
 
   const archivedOmissions = await applyEpisodicArchive(paths, plan.episodic);
   const { skipped: staleSkipped } = await applyStaleMarks(plan.staleMarks);

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -161,9 +161,13 @@ async function appendMutationEvent(
 
 /**
  * One staged file write for {@link writeNotesAtomically}: what to write, and
- * how to undo it. `priorRaw` is required for an overwrite (`"w"`) — captured
- * BEFORE the write runs, since undoing it means restoring exactly those bytes;
- * a create (`"wx"`) needs no prior bytes, since undoing it is a plain unlink.
+ * how to undo it. For an overwrite (`"w"`) the type requires `priorRaw`, but the
+ * temporal contract is the CALLER's to honour and cannot be type-enforced: it
+ * must be the target's current bytes read BEFORE the write runs, since undoing
+ * the write means restoring exactly those bytes. (The production callers —
+ * merge/supersede/verify — read the note file for other reasons first and pass
+ * that same content.) A create (`"wx"`) needs no prior bytes: undoing it is a
+ * plain unlink.
  * Exported for the atomicity-shape acceptance test (a mid-write failure and a
  * post-write event-append failure must produce the SAME error shape) — not
  * public index API; create/merge/supersede/verify remain the only production

--- a/test/memory-consolidate.test.ts
+++ b/test/memory-consolidate.test.ts
@@ -369,24 +369,55 @@ test("planConsolidation's plan is frozen and untouched by applyConsolidationPlan
   });
 });
 
-test("applyConsolidationPlan rejects a forged plan path that escapes the soma home (#423 hardening)", async () => {
+// A plan built by planConsolidation only ever holds in-memory-tree paths, but
+// applyConsolidationPlan is exported — a forged plan must not drive a mutation
+// outside the Memory compartment, whether by `..` traversal, into a non-Memory
+// compartment, or through a symlinked ancestor. (#423 hardening)
+const forgedPlan = (somaHome: string, staleMark: string, extra: Partial<ConsolidationPlan> = {}): ConsolidationPlan => ({
+  somaHome,
+  indexPath: join(somaHome, "memory", "INDEX.md"),
+  episodic: [],
+  digestsWritten: [],
+  staleMarks: staleMark ? [{ path: staleMark, rel: "forged", note: note({ id: "x", type: "semantic", body: "forged mark" }) }] : [],
+  similarPairs: [],
+  stateGc: [],
+  unreadable: [],
+  mutated: true,
+  ...extra,
+});
+
+test("applyConsolidationPlan rejects a forged `..` path escaping the memory tree (#423)", async () => {
   await withTempSoma(async (somaHome) => {
-    const paths = createPaths(somaHome);
-    const escapeTarget = join(somaHome, "..", "escaped-stale.md"); // outside the memory tree
-    // A plan built by planConsolidation only ever holds in-tree paths, but the
-    // function is exported — a forged plan must not drive a write outside the root.
-    const forged: ConsolidationPlan = {
-      somaHome,
-      indexPath: join(somaHome, "memory", "INDEX.md"),
-      episodic: [],
-      digestsWritten: [],
-      staleMarks: [{ path: escapeTarget, rel: "../escaped-stale.md", note: note({ id: "x", type: "semantic", body: "forged mark" }) }],
-      similarPairs: [],
-      stateGc: [],
-      unreadable: [],
-      mutated: true,
-    };
-    await expect(applyConsolidationPlan(paths, forged, NOW, undefined)).rejects.toThrow(/escapes the soma home/);
-    expect(await exists(escapeTarget)).toBe(false); // threw BEFORE any out-of-tree write
+    const escapeTarget = join(somaHome, "..", "escaped-stale.md");
+    await expect(applyConsolidationPlan(createPaths(somaHome), forgedPlan(somaHome, escapeTarget), NOW, undefined)).rejects.toThrow(
+      /escapes the memory tree/,
+    );
+    expect(await exists(escapeTarget)).toBe(false);
+  });
+});
+
+test("applyConsolidationPlan rejects a forged path into a non-Memory compartment (#423)", async () => {
+  await withTempSoma(async (somaHome) => {
+    // Inside the soma home but OUTSIDE memory/ — consolidation must never touch Identity/Purpose/…
+    const target = join(somaHome, "profile", "purpose.md");
+    await expect(applyConsolidationPlan(createPaths(somaHome), forgedPlan(somaHome, target), NOW, undefined)).rejects.toThrow(
+      /escapes the memory tree/,
+    );
+    expect(await exists(target)).toBe(false);
+  });
+});
+
+test("applyConsolidationPlan rejects a forged path through a symlinked in-tree ancestor (#423)", async () => {
+  await withTempSoma(async (somaHome) => {
+    const outside = join(somaHome, "..", "outside-target");
+    await mkdir(outside, { recursive: true });
+    const link = join(somaHome, "memory", "evil-link"); // lexically in-tree, resolves outside
+    await mkdir(join(somaHome, "memory"), { recursive: true });
+    await symlink(outside, link);
+    const target = join(link, "note.md");
+    await expect(applyConsolidationPlan(createPaths(somaHome), forgedPlan(somaHome, target), NOW, undefined)).rejects.toThrow(
+      /resolves outside the memory tree/,
+    );
+    expect(await exists(join(outside, "note.md"))).toBe(false);
   });
 });

--- a/test/memory-consolidate.test.ts
+++ b/test/memory-consolidate.test.ts
@@ -7,7 +7,7 @@ import { memoryIndexPath } from "../src/memory-index";
 import { createPaths } from "../src/paths";
 // Plan/apply internals are module-private (not public index API) — import direct,
 // for the #412 plan-immutability acceptance test.
-import { applyConsolidationPlan, planConsolidation } from "../src/memory-consolidate";
+import { applyConsolidationPlan, planConsolidation, type ConsolidationPlan } from "../src/memory-consolidate";
 
 const NOW = new Date("2026-07-04T10:00:00.000Z");
 
@@ -366,5 +366,27 @@ test("planConsolidation's plan is frozen and untouched by applyConsolidationPlan
     // The apply actually happened on disk.
     expect(await exists(join(somaHome, "memory/archive/episodic/sessions/2026-03/20260301-old.md"))).toBe(true);
     expect(parseMemoryNote(await readFile(join(somaHome, "memory/semantic/old-fact.md"), "utf8")).review).toBe("stale");
+  });
+});
+
+test("applyConsolidationPlan rejects a forged plan path that escapes the soma home (#423 hardening)", async () => {
+  await withTempSoma(async (somaHome) => {
+    const paths = createPaths(somaHome);
+    const escapeTarget = join(somaHome, "..", "escaped-stale.md"); // outside the memory tree
+    // A plan built by planConsolidation only ever holds in-tree paths, but the
+    // function is exported — a forged plan must not drive a write outside the root.
+    const forged: ConsolidationPlan = {
+      somaHome,
+      indexPath: join(somaHome, "memory", "INDEX.md"),
+      episodic: [],
+      digestsWritten: [],
+      staleMarks: [{ path: escapeTarget, rel: "../escaped-stale.md", note: note({ id: "x", type: "semantic", body: "forged mark" }) }],
+      similarPairs: [],
+      stateGc: [],
+      unreadable: [],
+      mutated: true,
+    };
+    await expect(applyConsolidationPlan(paths, forged, NOW, undefined)).rejects.toThrow(/escapes the soma home/);
+    expect(await exists(escapeTarget)).toBe(false); // threw BEFORE any out-of-tree write
   });
 });

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -660,8 +660,11 @@ test("writeNotesAtomically: a mid-write failure rolls back every staged write wi
     // primitive for.
     const firstPath = memoryNotePath(somaHome, "semantic", "atomic-first");
     const secondPath = memoryNotePath(somaHome, "semantic", "atomic-second");
-    const priorRaw = "restored-content-from-rollback\n";
-    await writeFile(secondPath, "current-content-before-the-call\n", "utf8");
+    // priorRaw is EXACTLY the target's current on-disk bytes — the way a real
+    // overwrite captures it (not an arbitrary sentinel), so the assertion below
+    // proves genuine prior-state restoration.
+    const priorRaw = "the-notes-actual-prior-on-disk-bytes\n";
+    await writeFile(secondPath, priorRaw, "utf8");
 
     const writes: AtomicNoteWrite[] = [
       { path: firstPath, flag: "wx", note: rawNote({ id: "atomic-first", body: "first note body alpha beta" }) },
@@ -697,10 +700,11 @@ test("writeNotesAtomically: a mid-write failure rolls back every staged write wi
     expect(error.message).toBe("Soma memory test.atomic-write write failed; rolled back the file mutation.");
     expect(error.cause).toBeDefined();
 
-    // Every staged write was rolled back: the first write's file is gone...
+    // Every staged write was rolled back: the first write's file is gone
+    // (this is the proof the rollback actually ran)...
     await expect(readNote(firstPath)).rejects.toThrow();
-    // ...and the second write's target was restored to the caller-supplied prior
-    // bytes (proving the rollback actually ran, not merely that nothing changed).
+    // ...and the second write's target still holds its exact prior on-disk bytes —
+    // the failed overwrite left it uncorrupted, restored to its captured state.
     expect(await readFile(secondPath, "utf8")).toBe(priorRaw);
   });
 });


### PR DESCRIPTION
Closes #423 — the three non-blocking follow-ups from sage's review of #422 (the plan/apply + atomicity PR).

### 1. Harden the exported `applyConsolidationPlan` against forged plan paths
`applyConsolidationPlan` is exported (for the #412 plan-immutability test). A plan from `planConsolidation` only ever holds in-tree paths, but the export makes the plan a trust boundary. New `assertPlanPathsInsideRoot` rejects any mutation-target path that escapes the soma home **before** any filesystem write/rename/unlink — covering `staleMarks[].path` (absolute), `stateGc[]` (relative, could carry `..`), and `episodic[].from`/`.to`. New test forges an escaping `staleMark` path and asserts it throws with nothing written outside the tree.

### 2. `AtomicNoteWrite` "w" doc: caller contract, not type guarantee
The type requires `priorRaw: string` for `"w"`, but "captured BEFORE the write" is a temporal contract TypeScript can't enforce. Reworded to say so explicitly (the production merge/supersede/verify callers read the note first and pass that content).

### 3. Atomicity rollback test proves prior-STATE restoration
The test wrote `"current-content"` to disk but passed `priorRaw = "restored-content"` — proving rollback writes the caller's bytes, not that it restored actual prior state. Now `priorRaw` is exactly the target's on-disk bytes (realistic capture); the "rollback ran" proof is the first staged file being unlinked, and the second file is asserted to retain its prior bytes uncorrupted.

**Verification:** `bun run typecheck` clean; `bun test` **1804 pass / 0 fail** (baseline 1803 + 1 new guard test, 0 removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzijJAY7wa47Bm4CH8Ux5


---

### Review round 2 (sage #431)
- Guard scoped to `<somaHome>/memory` (was the whole soma home) — a forged path into a non-Memory compartment is now rejected.
- Guard also resolves the deepest existing ancestor via `realpath` and requires the REAL path inside the real memory root — catches a symlinked in-tree ancestor. Added non-Memory-compartment + symlinked-ancestor rejection tests.

### Verification evidence (this branch, HEAD)
```
$ bun run typecheck
$ tsc --noEmit

$ bun test  (tail)
 1806 pass
 0 fail
Ran 1806 tests across 116 files. [90.85s]
```
