### PR TITLE
feat(memory): low-friction resurface signal so recalled notes reach INDEX (#427)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -190,7 +190,17 @@ failure — the PROMOTED file and note already landed, but a later bookkeeping s
 re-thrown, because by then the caller must know the promotion is durable but
 unrecorded. So the fail-closed refusal itself is guaranteed by the promote API and
 the CLI; the sync hook's own contract stays narrower and deliberately best-effort
-for everything short of that authority precondition. `soma memory backfill`'s
+for everything short of that authority precondition. A fourth governed path —
+the second that does NOT mint or elevate trust — is `soma memory used <id>`
+(`resurfaceMemoryNote`, #427): a low-friction "this recalled note helped" signal
+that bumps an already-existing `assistant`-trust note's `resurface_count += 1` /
+`last_verified` through the same governance + atomicity path, so recalled-and-useful
+notes cross the INDEX admission threshold (`resurface_count ≥ 2`). It is
+trust-scoped — `assistant` bumped freely (the `used` act self-authorizes this one
+decay-signal field, reachable from the public CLI unlike `verify`'s SDK-only
+`consolidationAuthority`), `principal` a no-op (already admitted), `quarantined`
+refused — moves no body content or trust tier, and appends one `memory.resurface`
+event that #425's `verify-follows-recall` metric counts. `soma memory backfill`'s
 source walk skips `PROMOTED/` subtrees owned by a promotion store dir (its
 `include` hook, `isPromotionOwnedPromotedSubtree`), so backfill's forward source
 walk no longer creates a `quarantined` clone that would shadow the lesson's own

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -4,6 +4,7 @@ import {
   promoteAlgorithmRunMemory,
   rebuildMemoryIndex,
   recallMemory,
+  resurfaceMemoryNote,
   runMemoryBackfill,
   searchSomaMemory,
   verifyMemoryNote,
@@ -33,6 +34,8 @@ import type {
   SomaMemoryPromotionStore,
   SomaMemoryRecallOptions,
   SomaMemoryRecallResult,
+  SomaMemoryResurfaceOptions,
+  SomaMemoryResurfaceResult,
   SomaMemorySearchOptions,
   SomaMemorySearchResult,
   SomaMemoryVerifyOptions,
@@ -82,6 +85,13 @@ export interface ParsedMemoryVerifyArgs {
   options: SomaMemoryVerifyOptions;
 }
 
+/** #427 — the low-friction "this recalled note helped" signal (`soma memory used <id>`). */
+export interface ParsedMemoryUsedArgs {
+  command: "memory";
+  action: "used";
+  options: SomaMemoryResurfaceOptions;
+}
+
 export interface ParsedMemoryReindexArgs {
   command: "memory";
   action: "reindex";
@@ -124,6 +134,7 @@ export type ParsedMemoryArgs =
   | ParsedMemoryPromoteArgs
   | ParsedMemoryWriteArgs
   | ParsedMemoryVerifyArgs
+  | ParsedMemoryUsedArgs
   | ParsedMemoryReindexArgs
   | ParsedMemoryDigestArgs
   | ParsedMemoryActionArgs
@@ -131,11 +142,11 @@ export type ParsedMemoryArgs =
   | ParsedMemoryAuditArgs
   | ParsedMemoryBackfillArgs;
 
-const MEMORY_ACTIONS = ["search", "recall", "promote", "write", "verify", "reindex", "digest", "action", "consolidate", "audit", "backfill"] as const;
+const MEMORY_ACTIONS = ["search", "recall", "promote", "write", "verify", "used", "reindex", "digest", "action", "consolidate", "audit", "backfill"] as const;
 type MemoryAction = (typeof MEMORY_ACTIONS)[number];
 
 export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAction, string> } = {
-  usage: "Usage: soma memory <search|recall|promote|write|verify|reindex|digest|action|consolidate|audit|backfill> ...",
+  usage: "Usage: soma memory <search|recall|promote|write|verify|used|reindex|digest|action|consolidate|audit|backfill> ...",
   subcommands: {
     search: "Usage: soma memory search [query] [--query <text>] [--limit <n>] [--home-dir <dir>] [--soma-home <dir>]",
     recall:
@@ -161,6 +172,14 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
     verify:
       "Usage: soma memory verify <id> [--id <id>] [--principal-authority] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
       "Verifying a principal-trust note requires --principal-authority (assistant-trust notes are an internal SDK path).",
+    used:
+      "Usage: soma memory used <id> [--id <id>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
+      "#427 — the low-friction 'this recalled note helped' signal: performs the SAME bump verify does " +
+      "(last_verified = today, resurface_count += 1), distinct from verify (an assertion the FACT still holds) " +
+      "in that it asserts USEFULNESS observed and needs no authority flag. assistant-trust notes are bumped " +
+      "freely (the whole point — verify's assistant path is an internal-only SDK capability, unreachable here); " +
+      "principal-trust notes no-op (already always-admitted); quarantined notes are refused. " +
+      "Emits a `memory.resurface` event, counted by `soma memory audit`'s verify-follows-recall probe.",
     reindex:
       "Usage: soma memory reindex [--home-dir <dir>] [--soma-home <dir>]. " +
       "Rebuild memory/INDEX.md from note frontmatter (earned-inclusion ladder, retention-score budget); " +
@@ -212,6 +231,8 @@ export function parseMemoryArgs(args: string[]): ParsedMemoryArgs {
       return { command, action, options: parseMemoryWriteArgs(rest) };
     case "verify":
       return { command, action, options: parseMemoryVerifyArgs(rest) };
+    case "used":
+      return { command, action, options: parseMemoryUsedArgs(rest) };
     case "reindex":
       return { command, action, options: parseMemoryReindexArgs(rest) };
     case "digest":
@@ -785,6 +806,59 @@ function parseMemoryVerifyArgs(args: string[]): SomaMemoryVerifyOptions {
   return options as SomaMemoryVerifyOptions;
 }
 
+/**
+ * #427 — `soma memory used <id>`. No `--principal-authority`/consolidation flag:
+ * unlike verify, the "used" signal needs no per-call authority (see
+ * `resurfaceMemoryNote`'s docstring in `memory-write.ts` for the trust-scoping).
+ */
+function parseMemoryUsedArgs(args: string[]): SomaMemoryResurfaceOptions {
+  const options: Partial<SomaMemoryResurfaceOptions> = {};
+  let positionalId: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(args, index, arg);
+        index += 1;
+        break;
+      case "--substrate":
+        options.substrate = parseSubstrate(readOption(args, index, arg));
+        index += 1;
+        break;
+      case "--id":
+        options.id = readOption(args, index, arg);
+        index += 1;
+        break;
+      default:
+        if (arg.startsWith("-")) {
+          throw new Error(`Unknown option: ${arg}`);
+        }
+        if (positionalId !== undefined) {
+          throw new Error(`soma memory used accepts only one positional id; unexpected argument: ${arg}`);
+        }
+        positionalId = arg;
+    }
+  }
+
+  // Reject a conflicting positional + --id rather than silently preferring one —
+  // used is a mutating command, so an ignored id must not slip through.
+  if (options.id !== undefined && positionalId !== undefined && options.id !== positionalId) {
+    throw new Error(`soma memory used got two different ids ("${positionalId}" and --id "${options.id}"); pass only one.`);
+  }
+  options.id ??= positionalId;
+  if (!options.id) {
+    throw new Error("soma memory used needs a note id; pass it as the first argument or --id <id>.");
+  }
+
+  return options as SomaMemoryResurfaceOptions;
+}
+
 export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
   switch (parsed.action) {
     case "promote":
@@ -793,6 +867,8 @@ export async function runMemoryCli(parsed: ParsedMemoryArgs): Promise<string> {
       return formatMemoryWriteResult(await writeMemoryNote(parsed.options));
     case "verify":
       return formatMemoryVerifyResult(await verifyMemoryNote(parsed.options));
+    case "used":
+      return formatMemoryResurfaceResult(await resurfaceMemoryNote(parsed.options));
     case "search":
       return formatMemorySearchResult(await searchSomaMemory(parsed.options));
     case "recall":
@@ -969,6 +1045,26 @@ function formatMemoryVerifyResult(result: SomaMemoryVerifyResult): string {
     `resurface_count: ${result.note.resurface_count}`,
     `path: ${result.path}`,
     `event: ${result.event.id}`,
+  ].join("\n");
+}
+
+function formatMemoryResurfaceResult(result: SomaMemoryResurfaceResult): string {
+  if (!result.mutated) {
+    return [
+      "Soma memory used",
+      `id: ${result.note.id}`,
+      `trust: ${result.note.trust}`,
+      "no-op: already unconditionally admitted (principal-trust) — nothing written.",
+      `path: ${result.path}`,
+    ].join("\n");
+  }
+  return [
+    "Soma memory used",
+    `id: ${result.note.id}`,
+    `last_verified: ${result.note.last_verified}`,
+    `resurface_count: ${result.note.resurface_count}`,
+    `path: ${result.path}`,
+    `event: ${result.event?.id}`,
   ].join("\n");
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,8 @@ export type {
   SomaMemoryWriteResult,
   SomaMemoryVerifyOptions,
   SomaMemoryVerifyResult,
+  SomaMemoryResurfaceOptions,
+  SomaMemoryResurfaceResult,
   SomaMemoryDuplicateCandidate,
 } from "./types";
 
@@ -461,7 +463,7 @@ export { MemoryNoteError, parseMemoryNote, serializeMemoryNote } from "./memory-
 // findDuplicateCandidates, MEMORY_DEDUP_JACCARD_THRESHOLD) stay module-private so
 // the storage layout and dedup threshold are not frozen as stable API — internal
 // soma modules (M2/M3/M6) and tests import them from "./memory-write" directly.
-export { writeMemoryNote, verifyMemoryNote } from "./memory-write";
+export { writeMemoryNote, verifyMemoryNote, resurfaceMemoryNote } from "./memory-write";
 export { recallMemory } from "./memory-recall";
 // Public surface is the CLI-facing rebuild only. renderMemoryIndex / retentionScore
 // / collectAllNotes / memoryIndexPath stay module-private (the scoring model and

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -33,8 +33,8 @@ import type {
  * root (root-integrity), an unparseable note (schema), an INDEX older by mtime than
  * the corpus (freshness — NOT a content check), archived notes missing from their
  * month's digest (orphaned-archive), a coarse event/note ratio, and (#425) a
- * retrieval-quality signal read from the `memory.recall`/`memory.verify` journal.
- * The retrieval-quality metric is over PARSEABLE journal events only — a malformed
+ * retrieval-quality signal read from the `memory.recall`/`memory.verify`/(#427)
+ * `memory.resurface` journal. The retrieval-quality metric is over PARSEABLE journal events only — a malformed
  * JSONL line is skipped and surfaced as a count (`skippedEventLines`), so that one
  * probe is honestly "ground truth over the parseable journal", not the complete
  * journal. A HEALTHY exit means no health-GATING drift was detected — the
@@ -333,8 +333,8 @@ function probeEventRatio(lines: number, notes: number): { probe: SomaMemoryAudit
 
 /**
  * The subsequent-event window the retrieval-quality metric searches, chronologically
- * after a `memory.recall` event, for a `memory.verify` of one of its returned ids.
- * No existing audit window applies here (the consolidate TTLs are day-based
+ * after a `memory.recall` event, for a `memory.verify` OR (#427) `memory.resurface`
+ * of one of its returned ids. No existing audit window applies here (the consolidate TTLs are day-based
  * staleness thresholds for a different concern), so this is a fresh, documented
  * default rather than a reused constant — events, not days, keep the correlation
  * deterministic and independent of clock/timezone handling. The window is counted
@@ -351,9 +351,24 @@ function recallEventNoteIds(event: SomaMemoryEvent): string[] {
   return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === "string") : [];
 }
 
-/** The note id a `memory.verify` event bumped (`memory-write.ts`'s verify path
- *  records it as `metadata.id`), or `undefined` if absent/malformed. */
+/**
+ * #427 — the second event kind that satisfies a pending recall, alongside
+ * `memory.verify`: `memory.resurface` (`memory-write.ts`'s `resurfaceMemoryNote`,
+ * the low-friction "this recalled note helped" signal). Both record the bumped
+ * note id the same way (`metadata.id`) and both assert the recalled note was
+ * useful — one by hand-authored re-confirmation, the other by observed usage —
+ * so both count toward `verifyFollowsRecallRate`; the metric name stays
+ * `verifyFollowsRecallRate` (not renamed) since it is still measuring "did a
+ * recall get reinforced", just via either turning force.
+ */
+const VERIFY_LIKE_EVENT_KINDS = new Set(["memory.verify", "memory.resurface"]);
+
+/** The note id a `memory.verify`/`memory.resurface` event bumped
+ *  (`memory-write.ts`'s verify/resurface paths both record it as
+ *  `metadata.id`), or `undefined` if the event is neither kind, or the id is
+ *  absent/malformed. */
 function verifyEventNoteId(event: SomaMemoryEvent): string | undefined {
+  if (!VERIFY_LIKE_EVENT_KINDS.has(event.kind)) return undefined;
   const raw = event.metadata?.id;
   return typeof raw === "string" ? raw : undefined;
 }
@@ -382,12 +397,13 @@ function newRetrievalAccumulator(): RetrievalAccumulator {
  * Fold one PARSEABLE event into the accumulator, preserving the exact
  * array-based semantics of the prior implementation: the current event is a
  * SUBSEQUENT event for every earlier pending recall (so it decrements each window
- * and may satisfy one via a matching verify), and only AFTER that does the event
- * — if it is itself a recall — become pending (a recall never verifies itself).
+ * and may satisfy one via a matching verify OR #427 resurface), and only AFTER
+ * that does the event — if it is itself a recall — become pending (a recall
+ * never verifies/resurfaces itself).
  */
 function foldRetrievalEvent(acc: RetrievalAccumulator, event: SomaMemoryEvent): void {
   if (acc.pending.length > 0) {
-    const verifiedId = event.kind === "memory.verify" ? verifyEventNoteId(event) : undefined;
+    const verifiedId = verifyEventNoteId(event);
     const stillPending: RetrievalAccumulator["pending"][number][] = [];
     for (const p of acc.pending) {
       p.remaining -= 1;
@@ -476,12 +492,14 @@ async function streamJournalStats(eventsPath: string): Promise<{ eventLines: num
  * new state) — informational, never gates `healthy`. Three AUTOMEM-inspired
  * numbers over `memory.recall` events: recall volume, empty-recall rate (0
  * returned ids), and verify-follows-recall rate (a returned id gets a
- * `memory.verify` within `RECALL_VERIFY_WINDOW_EVENTS` subsequent parseable
- * journal events — the "recalled → actually useful" proxy). The verify-follow
- * denominator is recalls WITH results, not every recall: an empty recall can
- * structurally never be verify-followed, so folding it in would just re-encode
- * the empty-recall rate a second time. Malformed journal lines are skipped and
- * surfaced (`skippedEventLines`) so the rates read as "over the parseable journal".
+ * `memory.verify` OR (#427) `memory.resurface` within `RECALL_VERIFY_WINDOW_EVENTS`
+ * subsequent parseable journal events — the "recalled → actually useful" proxy,
+ * satisfied either by a hand-authored re-confirmation or the cheaper observed-use
+ * signal). The verify-follow denominator is recalls WITH results, not every
+ * recall: an empty recall can structurally never be verify-followed, so folding
+ * it in would just re-encode the empty-recall rate a second time. Malformed
+ * journal lines are skipped and surfaced (`skippedEventLines`) so the rates read
+ * as "over the parseable journal".
  */
 function probeRetrievalQuality(retrieval: SomaMemoryRetrievalQuality): { probe: SomaMemoryAuditProbe } {
   const skipped = retrieval.skippedEventLines > 0 ? `, ${retrieval.skippedEventLines} malformed line(s) skipped` : "";

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -355,9 +355,12 @@ function recallEventNoteIds(event: SomaMemoryEvent): string[] {
  * #427 — the second event kind that satisfies a pending recall, alongside
  * `memory.verify`: `memory.resurface` (`memory-write.ts`'s `resurfaceMemoryNote`,
  * the low-friction "this recalled note helped" signal). Both record the bumped
- * note id the same way (`metadata.id`) and both assert the recalled note was
- * useful — one by hand-authored re-confirmation, the other by observed usage —
- * so both count toward `verifyFollowsRecallRate`; the metric name stays
+ * note id the same way (`metadata.id`) and both count toward
+ * `verifyFollowsRecallRate` as "the recall got reinforced" — but they assert
+ * different things: `memory.resurface` asserts observed USEFULNESS, while
+ * `memory.verify` asserts a fact was RE-CONFIRMED (which can happen independently
+ * of a note actually being useful). The rate conflates the two deliberately as a
+ * reinforcement proxy, not as a pure usefulness measure; the metric name stays
  * `verifyFollowsRecallRate` (not renamed) since it is still measuring "did a
  * recall get reinforced", just via either turning force.
  */

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -14,6 +14,8 @@ import type {
   SomaMemoryDuplicateCandidate,
   SomaMemoryNote,
   SomaMemoryNoteType,
+  SomaMemoryResurfaceOptions,
+  SomaMemoryResurfaceResult,
   SomaMemoryTrust,
   SomaMemoryVerifyOptions,
   SomaMemoryVerifyResult,
@@ -971,4 +973,96 @@ export async function verifyMemoryNote(options: SomaMemoryVerifyOptions): Promis
   });
 
   return { somaHome, path, note: verified, event };
+}
+
+// --- resurface (#427) ---------------------------------------------------------
+
+/**
+ * Close the recall→useful→admission loop with a low-friction turning force
+ * (#427): the caller observes that an already-recalled note was USEFUL, and
+ * that observation performs the SAME bump `verify` does (`last_verified` =
+ * today, `resurface_count += 1`) — through the SAME governance +
+ * atomicity path (`resolveMutationGovernance` / `writeNotesAtomically`), so a
+ * mid-write failure rolls back identically and the journal records the same
+ * shape of authority metadata.
+ *
+ * The trust-scoping is deliberately DIFFERENT from `verify`'s, because
+ * "recalled and used" is a cheaper, weaker claim than "I re-confirmed this
+ * fact": the target's own tier's authority isn't asked for; the fact that this
+ * narrow, single-purpose call fired at all IS the authority for the one tier
+ * that needs one.
+ * - `quarantined` — refused. A quarantined note never earns an INDEX line
+ *   (`memory-index.ts`'s `isAdmitted`); resurfacing one would only feed a
+ *   number nobody reads and could mask that the note still needs re-authoring
+ *   at higher trust.
+ * - `principal` — a no-op. Principal notes are unconditionally admitted
+ *   already, so there is nothing for the signal to unlock; returned with
+ *   `mutated: false` and no event (no file write, no journal line) rather than
+ *   erroring — the caller asked a reasonable question and got a reasonable,
+ *   harmless answer.
+ * - `assistant` — bumped, freely. This is the entire point of #427: `verify`
+ *   requires `consolidationAuthority`, an internal M6-only capability NOT
+ *   reachable from the public CLI (see `cli/memory.ts`'s verify help), so
+ *   today NOTHING can move an assistant-trust note's resurface_count from the
+ *   CLI. `resurfaceMemoryNote` supplies `consolidationAuthority: true` to
+ *   `resolveMutationGovernance` itself for this one call — not a bypass of the
+ *   gate, but the gate's OWN mechanism, satisfied by the narrower thing this
+ *   function asserts. Unlike `consolidation`, "used" never injects or mutates
+ *   note BODY content — the only field this ever changes is the decay signal
+ *   verify already owns.
+ *
+ * Emits a distinct `memory.resurface` event (not `memory.verify`) so the two
+ * kinds of "turning force" — hand-authored re-confirmation vs. observed
+ * usefulness — stay tellable apart in the journal, while still counting as a
+ * `memory.verify`-equivalent satisfier for #425's verify-follows-recall probe
+ * (`memory-audit.ts`'s `foldRetrievalEvent`).
+ */
+export async function resurfaceMemoryNote(options: SomaMemoryResurfaceOptions): Promise<SomaMemoryResurfaceResult> {
+  assertNonEmpty(options.id, "id");
+  const somaHome = createPaths(options).root();
+  const now = options.now ?? new Date();
+  const { path, type, note, raw } = await loadNoteById(somaHome, options.id);
+
+  // A superseded note is closed — reinforcing its freshness signal is meaningless
+  // (and would resurrect it in retention scoring). Refuse, same as verify.
+  if (note.valid_until !== null) {
+    throw new MemoryNoteError(`Cannot resurface superseded note ${note.id} (valid_until set ${note.valid_until}).`, "id");
+  }
+
+  // Quarantined never earns admission — resurfacing it has nothing to unlock and
+  // would only misrepresent the note's standing. Refused, NOT silently ignored
+  // (unlike verify, which lets a quarantined note's own freshness signal move
+  // freely since it never affects admission either way).
+  if (note.trust === "quarantined") {
+    throw new MemoryNoteError(
+      `Cannot resurface quarantined note ${note.id} — quarantined notes never earn an INDEX line; re-author it at a higher trust first.`,
+      "id",
+    );
+  }
+
+  // Principal notes are already unconditionally admitted (memory-index.ts's
+  // isAdmitted) — the resurface signal has nothing to add. A true no-op: no file
+  // write, no journal event, no rollback machinery invoked.
+  if (note.trust === "principal") {
+    return { somaHome, path, note, mutated: false };
+  }
+
+  // Assistant tier: the "used" signal IS the authority for this call (see the
+  // module docstring above) — resolved through the SAME governance function
+  // verify uses, so the audit-meta shape never drifts from the mutation it
+  // documents.
+  const governance = resolveMutationGovernance(undefined, note, { consolidationAuthority: true });
+
+  const resurfaced: SomaMemoryNote = {
+    ...note,
+    last_verified: isoDate(now),
+    resurface_count: note.resurface_count + 1,
+  };
+  const event = await writeNotesAtomically(somaHome, now, options.substrate, "memory.resurface", [{ path, flag: "w", note: resurfaced, priorRaw: raw }], {
+    summary: `Resurfaced memory note ${resurfaced.id} (${type}); resurface_count ${resurfaced.resurface_count}`,
+    artifactPaths: [path],
+    metadata: { id: resurfaced.id, type, resurfaceCount: resurfaced.resurface_count, ...governance.eventMeta },
+  });
+
+  return { somaHome, path, note: resurfaced, mutated: true, event };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2527,6 +2527,43 @@ export interface SomaMemoryVerifyResult {
   event: SomaMemoryEvent;
 }
 
+/**
+ * #427 — the low-friction "this recalled note helped" signal. Distinct from
+ * `verify`: `verify` is the caller ASSERTING a fact still holds (authority-gated,
+ * requires `--principal-authority`/`consolidationAuthority` per tier); `resurface`
+ * is the caller observing that a recall was USEFUL, which is a weaker, cheaper
+ * claim — so it needs no per-call authority flag at all. It performs the identical
+ * frontmatter bump (`last_verified` = today, `resurface_count += 1`) through the
+ * same governance + atomicity path, but with its OWN trust-scoping instead of
+ * verify's: `assistant` notes are bumped freely (the resurface act IS the
+ * authority — the whole point is a path reachable from the public CLI, unlike
+ * `consolidationAuthority`), `principal` notes are a no-op (already
+ * unconditionally admitted, see `memory-index.ts`'s `isAdmitted`), and
+ * `quarantined` notes are refused outright (never admitted; resurfacing one would
+ * only mislead the retention score). No new authority surface, no change to the
+ * admission threshold or retention formula.
+ */
+export interface SomaMemoryResurfaceOptions {
+  homeDir?: string;
+  somaHome?: string;
+  substrate?: SubstrateId;
+  now?: Date;
+  id: string;
+}
+
+export interface SomaMemoryResurfaceResult {
+  somaHome: string;
+  path: string;
+  note: SomaMemoryNote;
+  /**
+   * `false` for the principal-trust no-op (already admitted — nothing written,
+   * `event` is `undefined`). `true` for the assistant-trust bump (`event` is set).
+   * Quarantined never reaches a result — `resurfaceMemoryNote` throws instead.
+   */
+  mutated: boolean;
+  event?: SomaMemoryEvent;
+}
+
 // Memory subsystem M8 (backfill). Bulk-import a principal's existing free-form
 // markdown memory into schema-valid, governed notes through the M1 write path.
 // Deterministic, no LLM: bodies are imported verbatim (no wrapper/preamble),
@@ -2830,16 +2867,16 @@ export interface SomaMemoryAuditProbe {
  * note, so folding it into this rate would just re-encode `emptyRecallRate` a
  * second time. `verifyWindowEvents` is the number of SUBSEQUENT parseable journal
  * events (any kind) searched, chronologically after a recall, for a
- * `memory.verify` of one of its returned ids — a fixed default (see
- * `memory-audit.ts`), not yet configurable; a future slice may gate on this
- * metric, this one only measures it.
+ * `memory.verify` OR (#427) `memory.resurface` of one of its returned ids — a
+ * fixed default (see `memory-audit.ts`), not yet configurable; a future slice
+ * may gate on this metric, this one only measures it.
  */
 export interface SomaMemoryRetrievalQuality {
   /** Total `memory.recall` events in the journal. */
   recallVolume: number;
   /** Fraction of recalls returning 0 note ids (AUTOMEM's "empty-search rate"). 0 when recallVolume is 0. */
   emptyRecallRate: number;
-  /** Fraction of non-empty recalls followed by a `memory.verify` of a returned id within the window. 0 when recallsWithResults is 0. */
+  /** Fraction of non-empty recalls followed by a `memory.verify` OR (#427) `memory.resurface` of a returned id within the window. 0 when recallsWithResults is 0. */
   verifyFollowsRecallRate: number;
   /** Denominator for verifyFollowsRecallRate: recalls that returned ≥1 note id. */
   recallsWithResults: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2540,8 +2540,12 @@ export interface SomaMemoryVerifyResult {
  * `consolidationAuthority`), `principal` notes are a no-op (already
  * unconditionally admitted, see `memory-index.ts`'s `isAdmitted`), and
  * `quarantined` notes are refused outright (never admitted; resurfacing one would
- * only mislead the retention score). No new authority surface, no change to the
- * admission threshold or retention formula.
+ * only mislead the retention score). This DOES introduce a narrow new governed
+ * authority — the resurface act self-authorizes an assistant-tier `resurface_count`
+ * bump that is reachable from the public CLI (justified above: it moves only a
+ * decay signal, never body content or trust tier, so "the `used` call fired" is
+ * sufficient authority for it). It adds no new note-CONTENT authority, and no
+ * change to the admission threshold or retention formula.
  */
 export interface SomaMemoryResurfaceOptions {
   homeDir?: string;

--- a/test/memory-audit.test.ts
+++ b/test/memory-audit.test.ts
@@ -2,7 +2,16 @@ import { appendFile, mkdir, mkdtemp, rm, symlink, utimes, writeFile } from "node
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
-import { appendSomaMemoryEvent, auditMemory, rebuildMemoryIndex, somaMemoryEventsPath, writeMemoryNote, writeSessionDigest } from "../src/index";
+import {
+  appendSomaMemoryEvent,
+  auditMemory,
+  rebuildMemoryIndex,
+  recallMemory,
+  resurfaceMemoryNote,
+  somaMemoryEventsPath,
+  writeMemoryNote,
+  writeSessionDigest,
+} from "../src/index";
 import { parseMemoryArgs, runMemoryCli } from "../src/cli/memory";
 
 const NOW = new Date("2026-07-04T10:00:00.000Z");
@@ -22,6 +31,13 @@ async function withTempSoma<T>(fn: (somaHome: string) => Promise<T>): Promise<T>
 /** Write a valid semantic note directly (bypassing the write path's clock). */
 async function writeNote(somaHome: string, id: string, body: string): Promise<string> {
   const r = await writeMemoryNote({ somaHome, now: NOW, mode: "create", trigger: "import", id, type: "semantic", body, provenance: "import" });
+  return r.path;
+}
+
+/** Write an assistant-trust semantic note (#427 resurface needs assistant, not
+ *  quarantined, trust to actually mutate — quarantined is refused outright). */
+async function writeAssistantNote(somaHome: string, id: string, body: string): Promise<string> {
+  const r = await writeMemoryNote({ somaHome, now: NOW, mode: "create", trigger: "consolidation", consolidationAuthority: true, id, type: "semantic", body });
   return r.path;
 }
 
@@ -47,6 +63,17 @@ async function seedVerifyEvent(somaHome: string, id: string): Promise<void> {
     substrate: "custom",
     kind: "memory.verify",
     summary: `Verified memory note ${id}`,
+    metadata: { id, type: "semantic", resurfaceCount: 1 },
+  });
+}
+
+/** Seed a `memory.resurface` journal event directly (#427), matching the shape
+ *  `resurfaceMemoryNote` (memory-write.ts) actually writes (`metadata.id`). */
+async function seedResurfaceEvent(somaHome: string, id: string): Promise<void> {
+  await appendSomaMemoryEvent(somaHome, {
+    substrate: "custom",
+    kind: "memory.resurface",
+    summary: `Resurfaced memory note ${id}`,
     metadata: { id, type: "semantic", resurfaceCount: 1 },
   });
 }
@@ -358,6 +385,44 @@ test("retrieval-quality: the event-ratio line count includes a malformed line (c
     // but only 1 parseable event fed the retrieval metric
     expect(result.retrieval.recallVolume).toBe(1);
     expect(result.retrieval.skippedEventLines).toBe(1);
+  });
+});
+
+// --- #427 resurface counts as a verify-follows-recall satisfier --------------
+
+test("retrieval-quality: a memory.resurface event (#427) satisfies a pending recall exactly like memory.verify", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seedRecallEvent(somaHome, ["note-a"]);
+    await seedResurfaceEvent(somaHome, "note-a");
+    await seedRecallEvent(somaHome, ["note-b"]); // never followed
+    await seedRecallEvent(somaHome, []); // empty, excluded from the denominator
+
+    const result = await auditMemory({ somaHome });
+    expect(result.retrieval.recallVolume).toBe(3);
+    expect(result.retrieval.recallsWithResults).toBe(2);
+    expect(result.retrieval.verifyFollowsRecallRate).toBeCloseTo(1 / 2);
+  });
+});
+
+test("retrieval-quality: a real recall(#425) followed by soma memory used (#427) on the recalled note moves verify-follows-recall-rate", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeAssistantNote(somaHome, "reporter-stack", "Reporter uses Bun and SQLite for its storage layer.");
+
+    const recall = await recallMemory({ somaHome, query: "Bun SQLite storage", now: NOW });
+    expect(recall.matches.length).toBeGreaterThan(0); // sanity: the recall actually matched the seeded note
+    const recalledId = recall.matches[0]!.id;
+    expect(recalledId).toBe("reporter-stack");
+
+    // Before "used" fires, nothing has reinforced the recall.
+    const before = await auditMemory({ somaHome });
+    expect(before.retrieval.recallsWithResults).toBe(1);
+    expect(before.retrieval.verifyFollowsRecallRate).toBe(0);
+
+    await resurfaceMemoryNote({ somaHome, id: recalledId, now: NOW });
+
+    const after = await auditMemory({ somaHome });
+    expect(after.retrieval.recallsWithResults).toBe(1);
+    expect(after.retrieval.verifyFollowsRecallRate).toBe(1);
   });
 });
 

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -5,6 +5,8 @@ import { expect, test } from "bun:test";
 import {
   MemoryNoteError,
   parseMemoryNote,
+  rebuildMemoryIndex,
+  resurfaceMemoryNote,
   somaMemoryEventsPath,
   verifyMemoryNote,
   writeMemoryNote,
@@ -21,7 +23,7 @@ import {
   writeNotesAtomically,
   type AtomicNoteWrite,
 } from "../src/memory-write";
-import { parseMemoryArgs } from "../src/cli/memory";
+import { parseMemoryArgs, runMemoryCli } from "../src/cli/memory";
 
 const NOW = new Date("2026-07-03T10:00:00.000Z");
 const LATER = new Date("2026-08-01T12:00:00.000Z");
@@ -502,6 +504,107 @@ test("verifying an assistant note needs consolidation-authority", async () => {
     await expect(verifyMemoryNote({ somaHome, id: "asst", now: LATER })).rejects.toThrow(/requires consolidation authority/);
     const ok = await verifyMemoryNote({ somaHome, id: "asst", consolidationAuthority: true, now: LATER });
     expect(ok.note.resurface_count).toBe(1);
+  });
+});
+
+// --- resurfaceMemoryNote (#427) -----------------------------------------------
+
+test("resurfacing an assistant note bumps last_verified/resurface_count with ONE memory.resurface event, no authority flag needed", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(
+      createOpts(somaHome, { id: "asst-note", trigger: "consolidation", consolidationAuthority: true, body: "assistant fact resurfaced chi psi omega" }),
+    );
+    const result = await resurfaceMemoryNote({ somaHome, id: "asst-note", now: LATER });
+
+    expect(result.mutated).toBe(true);
+    expect(result.note.last_verified).toBe("2026-08-01");
+    expect(result.note.resurface_count).toBe(1);
+    expect(result.event?.kind).toBe("memory.resurface");
+    expect(result.event?.metadata?.id).toBe("asst-note");
+
+    const persisted = await readNote(result.path);
+    expect(persisted.resurface_count).toBe(1);
+    expect(await countEvents(somaHome)).toBe(2); // create + resurface
+  });
+});
+
+test("a second resurface crosses RESURFACE_ADMIT and the note appears in the next INDEX rebuild", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(
+      createOpts(somaHome, { id: "asst-note", trigger: "consolidation", consolidationAuthority: true, body: "assistant fact earning admission" }),
+    );
+
+    let before = await rebuildMemoryIndex({ somaHome, now: LATER });
+    expect(before.admitted).toBe(0); // resurface_count 0 < RESURFACE_ADMIT (2) — not yet earned
+
+    await resurfaceMemoryNote({ somaHome, id: "asst-note", now: LATER });
+    const afterOne = await resurfaceMemoryNote({ somaHome, id: "asst-note", now: LATER });
+    expect(afterOne.note.resurface_count).toBe(2);
+
+    const after = await rebuildMemoryIndex({ somaHome, now: LATER });
+    expect(after.admitted).toBe(1);
+    expect(after.content).toContain("asst-note");
+  });
+});
+
+test("resurfacing a quarantined note is refused", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "imported", trigger: "import", principalAuthority: false, body: "imported fact for resurface test" }));
+    await expect(resurfaceMemoryNote({ somaHome, id: "imported", now: LATER })).rejects.toThrow(/Cannot resurface quarantined note/);
+  });
+});
+
+test("resurfacing a principal note is a no-op — already unconditionally admitted, nothing written", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "trusted" })); // principal
+    const before = await countEvents(somaHome);
+
+    const result = await resurfaceMemoryNote({ somaHome, id: "trusted", now: LATER });
+
+    expect(result.mutated).toBe(false);
+    expect(result.event).toBeUndefined();
+    expect(result.note.resurface_count).toBe(0);
+    expect(await countEvents(somaHome)).toBe(before); // no new event appended
+
+    const persisted = await readNote(result.path);
+    expect(persisted.last_verified).not.toBe("2026-08-01"); // untouched on disk too
+  });
+});
+
+test("resurfacing a superseded note is refused", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(createOpts(somaHome, { id: "old" }));
+    await writeMemoryNote(createOpts(somaHome, { mode: "supersede", id: "new", targetId: "old", body: "replacement body for resurface test" }));
+    await expect(resurfaceMemoryNote({ somaHome, id: "old", now: LATER })).rejects.toThrow(/Cannot resurface superseded note/);
+  });
+});
+
+test("resurfacing a missing id throws a typed error", async () => {
+  await withTempSoma(async (somaHome) => {
+    await expect(resurfaceMemoryNote({ somaHome, id: "ghost" })).rejects.toThrow(MemoryNoteError);
+  });
+});
+
+test("CLI: soma memory used parses a positional id, --id, and rejects a conflicting pair", () => {
+  const parsed = parseMemoryArgs(["memory", "used", "some-id"]);
+  expect(parsed.action).toBe("used");
+  expect(parsed.action === "used" && parsed.options.id).toBe("some-id");
+
+  const viaFlag = parseMemoryArgs(["memory", "used", "--id", "some-id"]);
+  expect(viaFlag.action === "used" && viaFlag.options.id).toBe("some-id");
+
+  expect(() => parseMemoryArgs(["memory", "used", "old", "--id", "new"])).toThrow(/two different ids/);
+  expect(() => parseMemoryArgs(["memory", "used"])).toThrow(/needs a note id/);
+});
+
+test("CLI: soma memory used runs resurfaceMemoryNote end to end", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(
+      createOpts(somaHome, { id: "asst-note", trigger: "consolidation", consolidationAuthority: true, body: "assistant fact for CLI resurface" }),
+    );
+    const out = await runMemoryCli(parseMemoryArgs(["memory", "used", "asst-note", "--soma-home", somaHome]));
+    expect(out).toContain("Soma memory used");
+    expect(out).toContain("resurface_count: 1");
   });
 });
 


### PR DESCRIPTION
## Why

The INDEX admission ladder needs `resurface_count >= 2` for non-principal notes (`memory-index.ts`'s `RESURFACE_ADMIT`), but the only thing that ever bumps `resurface_count` is the manual, authority-gated `verify` action — and for `assistant`-trust notes, `verify` requires `consolidationAuthority`, an internal M6-only capability that is **not reachable from the public CLI at all** (`cli/memory.ts`'s verify help: "assistant-trust notes are an internal SDK path"). So today there is no way, via the CLI, to ever move an assistant-trust note's `resurface_count` — most `assistant`-trust notes can never cross the admission threshold and never earn an INDEX line.

## What this PR adds

A new, low-friction "this recalled note helped" signal, distinct from authoring `verify`:

| | `verify` | `used` (this PR) |
|---|---|---|
| Asserts | a fact still holds (re-confirmation) | a recalled note was useful (observed usage) |
| Function | `verifyMemoryNote` | `resurfaceMemoryNote` |
| CLI | `soma memory verify <id> [--principal-authority]` | `soma memory used <id>` |
| assistant-trust note | requires internal `consolidationAuthority` (SDK-only, **not reachable from the CLI**) | bumped **freely** — the call itself is the authority |
| principal-trust note | requires `--principal-authority` | **no-op** — already unconditionally admitted, nothing written |
| quarantined note | allowed freely (harmless — never admitted either way) | **refused** (`MemoryNoteError`) |
| Event kind | `memory.verify` | `memory.resurface` (new, distinct kind) |

Both perform the *identical* frontmatter bump (`last_verified` = today, `resurface_count += 1`) through the *same* mutation-governance + atomicity path: `resolveMutationGovernance` (VERIFY shape) and `writeNotesAtomically` (the #409/#412 gate) — nothing hand-rolled. For the assistant-tier bump, `resurfaceMemoryNote` supplies `consolidationAuthority: true` to `resolveMutationGovernance` itself; this isn't a bypass of that gate, it's the gate's own mechanism, satisfied by the narrower thing `used` actually asserts (it never injects or mutates note *body* content — only the decay signal `verify` already owns).

### Why a new event kind (`memory.resurface`) instead of reusing `memory.verify`

The issue offered either option. A distinct kind keeps "hand-authored re-confirmation" and "observed usefulness" tellable apart in the journal (useful for future analysis of which turning force is actually driving admissions), at the cost of one small, contained update to #425's probe:

- `src/memory-audit.ts`: `verifyEventNoteId` now recognizes both `memory.verify` and `memory.resurface` (`VERIFY_LIKE_EVENT_KINDS`), and `foldRetrievalEvent` folds either kind into `verifyFollowsRecallRate` — so the metric's *name* and *meaning* ("did a recall get reinforced") are unchanged, only the set of events that can satisfy it grows.
- Doc comments in `memory-audit.ts` and the `SomaMemoryRetrievalQuality` type (`types.ts`) updated to say `memory.verify`/`memory.resurface` everywhere the old text named only `memory.verify`.

### Trust-scoping (per the issue)

- **`assistant`** — bumped freely (the point of this issue).
- **`principal`** — no-op: already unconditionally admitted (`memory-index.ts`'s `isAdmitted`), so the signal has nothing to unlock. Returns `{ mutated: false }`, no file write, no event — not an error.
- **`quarantined`** — refused (`MemoryNoteError`): a quarantined note never earns an INDEX line, so resurfacing it would only mislead the retention score.
- **superseded** (`valid_until` set) — refused, same as `verify`.

### Recall purity — untouched

`memory-recall.ts` is not modified in this PR. Recall still appends exactly one `memory.recall` event and mutates no note frontmatter. The new signal only fires on an explicit `soma memory used <id>` call *after* a recall — never automatically on a bare recall — so the "signal must mean 'used', not 'returned'" non-goal from the issue holds.

### No change to the admission threshold or retention formula

`RESURFACE_ADMIT` (`memory-index.ts:49`) and the retention/freshness formula are untouched.

## #427 verification checklist

- [x] `used`/resurface an assistant note → `resurface_count` +1, `last_verified` = today, ONE `memory.resurface` journal event — `test/memory-write.test.ts`: *"resurfacing an assistant note bumps last_verified/resurface_count with ONE memory.resurface event, no authority flag needed"*.
- [x] A second use crosses `RESURFACE_ADMIT` and the note appears in the next INDEX rebuild — `test/memory-write.test.ts`: *"a second resurface crosses RESURFACE_ADMIT and the note appears in the next INDEX rebuild"*.
- [x] Quarantined note rejected — `test/memory-write.test.ts`: *"resurfacing a quarantined note is refused"*.
- [x] Principal note is a no-op (already admitted) — `test/memory-write.test.ts`: *"resurfacing a principal note is a no-op — already unconditionally admitted, nothing written"* (asserts `mutated: false`, no event appended, on-disk `last_verified` untouched).
- [x] #425's verify-follows-recall rate moves when the signal fires — `test/memory-audit.test.ts`: *"retrieval-quality: a memory.resurface event (#427) satisfies a pending recall exactly like memory.verify"* (seeded-event unit test) AND *"retrieval-quality: a real recall(#425) followed by soma memory used (#427) on the recalled note moves verify-follows-recall-rate"* (end-to-end: real `recallMemory` call, then `resurfaceMemoryNote` on the returned id, then `auditMemory` shows the rate move from 0 → 1).

Also covered: superseded-note refusal, missing-id typed error, CLI arg parsing (positional id / `--id` / conflicting-id rejection), and a CLI end-to-end run through `runMemoryCli`.

## Test / typecheck numbers

- `bun run typecheck` — clean (no errors).
- `bun test` — **1828 pass / 0 fail** (baseline on `main` was 1818 pass / 0 fail; this PR adds exactly 10 new tests: 8 in `memory-write.test.ts`, 2 in `memory-audit.test.ts`). Re-ran the full suite twice; both runs identical (1828/0), no flake observed.

## Diff is additive — no epic/#425 file or test removed

```
$ git diff --stat origin/main HEAD
 src/cli/memory.ts         | 100 ++++++++++++++++++++++++++++++++++++++++++-
 src/index.ts              |   4 +-
 src/memory-audit.ts       |  48 ++++++++++++++-------
 src/memory-write.ts       |  94 +++++++++++++++++++++++++++++++++++++++++
 src/types.ts              |  45 ++++++++++++++++++--
 test/memory-audit.test.ts |  67 ++++++++++++++++++++++++++++-
 test/memory-write.test.ts | 105 +++++++++++++++++++++++++++++++++++++++++++++-
 7 files changed, 439 insertions(+), 24 deletions(-)
```

Seven files touched, zero files deleted, zero test cases removed. The 24 deletions are in-place doc-comment rewording (old wording replaced by new wording naming both `memory.verify` and `memory.resurface`) and one line in `foldRetrievalEvent` (`event.kind === "memory.verify" ? verifyEventNoteId(event) : undefined` → `verifyEventNoteId(event)`, with the kind-check moved inside `verifyEventNoteId` itself) — no epic or #425 logic/tests were removed or weakened.

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzijJAY7wa47Bm4CH8Ux5
