### PR TITLE
feat(memory): auto-upsert near-duplicate assistant notes (#428)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -158,7 +158,15 @@ notes `review: stale`, and (only under an explicit `--gc-state`) GCs old
 `current-work-*` state. It is governed (deterministic, event-emitting, no LLM) but
 does NOT re-derive trust — it never mints or elevates a note, only ages/relocates
 existing ones. A mutating pass appends one `memory.consolidate` event as its FINAL
-step — a post-hoc RECORD, NOT rollback-coupled. The pass is idempotent and safe to
+step — a post-hoc RECORD, NOT rollback-coupled. The **#428 auto-merge sub-op** is the
+one exception to that post-hoc shape: because collapsing two near-duplicate
+`assistant`-trust notes is a CONTENT-level mutation (not an age/relocate), each
+merged pair goes through the same governed atomic write primitive as `write`
+(`resolveMutationGovernance` + `writeNotesAtomically`) and appends its OWN
+rollback-coupled `memory.consolidate.merge` event per pair (the M1
+one-mutation-one-event discipline), emitted as the pass runs rather than as a
+post-hoc aggregate; principal-trust pairs are never auto-merged (report-only). The
+aging/relocating ops otherwise still record via the single final event. The pass is idempotent and safe to
 repeat, so the guarantee is repeatability, not atomicity: if the pass throws
 part-way, OR the event append itself fails, mutations may already be applied WITHOUT
 the event — so an absent event does NOT prove no mutation happened. A re-run

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -161,14 +161,17 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
       "(same surface as `soma memory write --principal-authority`); omitting it refuses the promotion (fail-closed).",
     write:
       "Usage: soma memory write --trigger <principal-correction|import> --body <text> " +
-      "(create: --id <slug> --type <semantic|procedural> [--force]) " +
+      "(create: --id <slug> --type <semantic|procedural> [--force | --upsert]) " +
       "(--merge <id> | --supersede <id>) " +
       "[--principal-authority] [--project <key>] [--source-of-truth <ref>] [--links a,b] " +
       "[--recall-trigger <text>] [--review <text>] " +
       "[--provenance <import|tool:name>] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
       "Trust is DERIVED from --trigger; there is no --trust flag. principal-correction requires " +
       "--principal-authority. (The consolidation trigger, which mints assistant trust, is an internal " +
-      "M6 SDK path and is not accepted on the public CLI.)",
+      "M6 SDK path and is not accepted on the public CLI.) " +
+      "--upsert (#428): on a recall-first-refusal collision, delta-merge into the BEST-scoring near-dup " +
+      "(the existing --merge semantics, target chosen automatically) instead of refusing — an opt-in " +
+      "resolution, not a silent auto-merge; governance is unchanged. Mutually exclusive with --force/--merge/--supersede.",
     verify:
       "Usage: soma memory verify <id> [--id <id>] [--principal-authority] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
       "Verifying a principal-trust note requires --principal-authority (assistant-trust notes are an internal SDK path).",
@@ -195,7 +198,9 @@ export const MEMORY_COMMAND_HELP: { usage: string; subcommands: Record<MemoryAct
     consolidate:
       "Usage: soma memory consolidate [--dry-run] [--gc-state] [--substrate <s>] [--home-dir <dir>] [--soma-home <dir>]. " +
       "Deterministic maintenance: prune aged episodic → digest+archive, mark aged-unverified semantic review:stale, " +
-      "list lexically-similar note pairs (near-duplicates for review; no semantic check), rebuild INDEX. --gc-state additionally DELETES current-work state >7d (explicit override). " +
+      "list lexically-similar note pairs (near-duplicates for review; no semantic check), auto-merge the assistant-trust " +
+      "subset of those pairs (#428 — delta-merge + close, never delete; principal-trust pairs always stay report-only), " +
+      "rebuild INDEX. --gc-state additionally DELETES current-work state >7d (explicit override). " +
       "--dry-run prints the plan without touching anything.",
     audit:
       "Usage: soma memory audit [--home-dir <dir>] [--soma-home <dir>]. " +
@@ -704,6 +709,9 @@ function parseMemoryWriteArgs(args: string[]): SomaMemoryWriteOptions {
       case "--force":
         options.force = true;
         break;
+      case "--upsert":
+        options.upsert = true;
+        break;
       case "--principal-authority":
         options.principalAuthority = true;
         break;
@@ -719,6 +727,12 @@ function parseMemoryWriteArgs(args: string[]): SomaMemoryWriteOptions {
 
   if (mergeTarget !== undefined && supersedeTarget !== undefined) {
     throw new Error("soma memory write accepts --merge or --supersede, not both.");
+  }
+  if (options.upsert === true && (mergeTarget !== undefined || supersedeTarget !== undefined)) {
+    throw new Error("soma memory write --upsert only applies to a create-mode collision; it cannot be combined with --merge or --supersede.");
+  }
+  if (options.upsert === true && options.force === true) {
+    throw new Error("soma memory write --upsert and --force are mutually exclusive (force skips the dedup scan entirely; upsert needs it to run).");
   }
   if (!options.trigger) {
     throw new Error("soma memory write needs --trigger <principal-correction|import>.");
@@ -961,7 +975,7 @@ function formatMemoryAuditResult(result: SomaMemoryAuditResult): string {
 }
 
 function formatConsolidateIndexLine(result: SomaMemoryConsolidateResult, mutated: boolean): string {
-  // INDEX is rebuilt only when something actually mutated (archive/stale/GC).
+  // INDEX is rebuilt only when something actually mutated (archive/stale/GC/auto-merge).
   if (!mutated) return `index: unchanged (no mutations${result.dryRun ? " planned" : ""})`;
   return result.dryRun ? `index: would rebuild ${result.indexPath}` : `index: rebuilt ${result.indexPath}`;
 }
@@ -979,6 +993,8 @@ function formatMemoryConsolidateResult(result: SomaMemoryConsolidateResult): str
     ...result.stateGced.map((p) => `  - ${p}`),
     `similar pairs listed: ${result.similarPairs.length} (lexical near-duplicates for review; no semantic check)`,
     ...result.similarPairs.map((c) => `  - ${c.a} ~ ${c.b} (jaccard ${c.score.toFixed(2)})`),
+    `auto-merged (assistant-trust only, #428): ${result.autoMerged.length} pair(s)`,
+    ...result.autoMerged.map((p) => `  - ${p.dropId} merged into ${p.keepId} and closed (jaccard ${p.score.toFixed(2)})`),
     indexLine,
   ];
   if (result.unreadable.length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ export type {
   SomaMemoryConsolidateOptions,
   SomaMemoryConsolidateResult,
   SomaMemorySimilarPair,
+  SomaMemoryAutoMergePlan,
   SomaMemoryArchivePlan,
   SomaMemorySearchMatch,
   SomaMemorySearchOptions,

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -490,6 +490,66 @@ async function streamJournalStats(eventsPath: string): Promise<{ eventLines: num
   return { eventLines, retrieval: finalizeRetrieval(acc, skippedEventLines) };
 }
 
+// --- #428 per-note retrieval counts (M6 auto-merge gating) --------------------
+
+/**
+ * Per-note counterpart of the #425 corpus-wide retrieval-quality signal: how
+ * many times THIS id was returned by a `memory.recall` event, and how many
+ * times it was reinforced by a `memory.verify`/(#427) `memory.resurface` event.
+ * Used by M6's #428 auto-merge to PREFER collapsing low-value churn (rarely
+ * recalled, never reinforced) over actively-useful notes when two near-dup
+ * pairs compete for the same note. This is a documented HEURISTIC — a combined
+ * count, no recency/decay weighting — rather than a true per-PAIR "was this
+ * recall useful" correlation: that would need the same recall→verify window
+ * correlation `foldRetrievalEvent` already does at the CORPUS level, and
+ * re-deriving it per-note here would be premature tuning before real recall
+ * volume exists (the #425 retrieval-quality probe documents the same
+ * young-corpus caveat). Malformed journal lines are silently skipped (not
+ * surfaced) — this is an internal gating signal, not a health probe.
+ */
+export interface SomaMemoryNoteRetrievalCount {
+  /** Times this note id appeared in a `memory.recall` event's returned ids. */
+  recalled: number;
+  /** Times this note id was bumped by `memory.verify` or `memory.resurface`. */
+  verified: number;
+}
+
+/** Stream the journal once, counting per-note recall/verify occurrences (#428). */
+export async function computeNoteRetrievalCounts(somaHome: string): Promise<Map<string, SomaMemoryNoteRetrievalCount>> {
+  const counts = new Map<string, SomaMemoryNoteRetrievalCount>();
+  const bump = (id: string, field: keyof SomaMemoryNoteRetrievalCount): void => {
+    const existing = counts.get(id) ?? { recalled: 0, verified: 0 };
+    existing[field] += 1;
+    counts.set(id, existing);
+  };
+
+  const handle = await open(somaMemoryEventsPath(somaHome), NOFOLLOW_READ).catch(() => undefined);
+  if (handle === undefined) return counts; // absent/symlinked journal → no signal, same forgiving stance as the audit
+  try {
+    const lines = createInterface({ input: handle.createReadStream({ encoding: "utf8" }), crlfDelay: Infinity });
+    for await (const line of lines) {
+      if (line.trim().length === 0) continue;
+      let event: SomaMemoryEvent | undefined;
+      try {
+        const parsed = JSON.parse(line) as Partial<SomaMemoryEvent>;
+        if (typeof parsed.kind === "string" && typeof parsed.timestamp === "string") event = parsed as SomaMemoryEvent;
+      } catch {
+        // malformed line — skipped, same forgiving stance as the retrieval-quality probe
+      }
+      if (event === undefined) continue;
+      if (event.kind === "memory.recall") {
+        for (const id of recallEventNoteIds(event)) bump(id, "recalled");
+        continue;
+      }
+      const verifiedId = verifyEventNoteId(event);
+      if (verifiedId !== undefined) bump(verifiedId, "verified");
+    }
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+  return counts;
+}
+
 /**
  * Probe: the #425 retrieval-quality signal, computed PURELY from the journal (no
  * new state) — informational, never gates `healthy`. Three AUTOMEM-inspired

--- a/src/memory-audit.ts
+++ b/src/memory-audit.ts
@@ -1,6 +1,4 @@
-import { constants as fsConstants } from "node:fs";
-import { lstat, open, readFile } from "node:fs/promises";
-import { createInterface } from "node:readline/promises";
+import { lstat, readFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative } from "node:path";
 import { parseDigestPointerIds } from "./episodic-digest";
 import { createPaths } from "./paths";
@@ -9,12 +7,15 @@ import { listMemoryNotes } from "./memory-fs";
 import { runBoundedConcurrent } from "./internal-concurrency";
 import { memoryIndexPath } from "./memory-index";
 import { somaMemoryEventsPath } from "./memory";
+// The neutral journal read-model (#425/#428) — audit sources its retrieval-quality
+// stream AND its shared O_NOFOLLOW read flag from here rather than owning them, so
+// M6 consolidation can reuse the same journal fold without depending on the audit.
+import { NOFOLLOW_READ, streamJournalStats } from "./memory-journal";
 import { parseMemoryNote } from "./memory-note";
 import type {
   SomaMemoryAuditOptions,
   SomaMemoryAuditProbe,
   SomaMemoryAuditResult,
-  SomaMemoryEvent,
   SomaMemoryNote,
   SomaMemoryRetrievalQuality,
 } from "./types";
@@ -60,11 +61,11 @@ function listRealMarkdownFilesRec(dir: string): Promise<string[]> {
   return listMemoryNotes(dir, { recursive: true, onSymlink: "skip" });
 }
 
-// Read WITHOUT following a final-component symlink — closes the TOCTOU where a listed
-// regular file is swapped for a symlink between enumeration and read. O_NOFOLLOW makes
-// the open fail (ELOOP) on a symlink, so a swapped file reads as unreadable, never
-// through the link to an outside target.
-const NOFOLLOW_READ = fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW;
+// `NOFOLLOW_READ` (O_RDONLY | O_NOFOLLOW) — the shared "read WITHOUT following a
+// final-component symlink" flag — now lives in ./memory-journal and is imported
+// above. A listed file swapped for a symlink between enumeration and read fails
+// the open (ELOOP), so it reads as unreadable, never through the link to an
+// outside target.
 
 /** Parse one note file → the note, or `undefined` if it cannot be read/parsed (incl.
  *  a symlink swapped in after enumeration, which O_NOFOLLOW rejects). */
@@ -329,226 +330,10 @@ function probeEventRatio(lines: number, notes: number): { probe: SomaMemoryAudit
   return { events: { lines, notes }, probe: { name: "event-ratio", gatesHealth: false, ok: true, detail: `${lines} event line(s) over ${notes} valid note(s)` } };
 }
 
-// --- #425 retrieval-quality (informational) -----------------------------------
-
-/**
- * The subsequent-event window the retrieval-quality metric searches, chronologically
- * after a `memory.recall` event, for a `memory.verify` OR (#427) `memory.resurface`
- * of one of its returned ids. No existing audit window applies here (the consolidate TTLs are day-based
- * staleness thresholds for a different concern), so this is a fresh, documented
- * default rather than a reused constant — events, not days, keep the correlation
- * deterministic and independent of clock/timezone handling. The window is counted
- * in PARSEABLE journal events (a malformed line is skipped, does not consume a
- * window slot). Not yet configurable; a future slice may need to tune it once real
- * recall volume exists.
- */
-const RECALL_VERIFY_WINDOW_EVENTS = 50;
-
-/** The `noteIds` a `memory.recall` event recorded (its returned note ids — both
- *  term matches and 1-hop link pulls), or `[]` if absent/malformed. */
-function recallEventNoteIds(event: SomaMemoryEvent): string[] {
-  const raw = event.metadata?.noteIds;
-  return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === "string") : [];
-}
-
-/**
- * #427 — the second event kind that satisfies a pending recall, alongside
- * `memory.verify`: `memory.resurface` (`memory-write.ts`'s `resurfaceMemoryNote`,
- * the low-friction "this recalled note helped" signal). Both record the bumped
- * note id the same way (`metadata.id`) and both count toward
- * `verifyFollowsRecallRate` as "the recall got reinforced" — but they assert
- * different things: `memory.resurface` asserts observed USEFULNESS, while
- * `memory.verify` asserts a fact was RE-CONFIRMED (which can happen independently
- * of a note actually being useful). The rate conflates the two deliberately as a
- * reinforcement proxy, not as a pure usefulness measure; the metric name stays
- * `verifyFollowsRecallRate` (not renamed) since it is still measuring "did a
- * recall get reinforced", just via either turning force.
- */
-const VERIFY_LIKE_EVENT_KINDS = new Set(["memory.verify", "memory.resurface"]);
-
-/** The note id a `memory.verify`/`memory.resurface` event bumped
- *  (`memory-write.ts`'s verify/resurface paths both record it as
- *  `metadata.id`), or `undefined` if the event is neither kind, or the id is
- *  absent/malformed. */
-function verifyEventNoteId(event: SomaMemoryEvent): string | undefined {
-  if (!VERIFY_LIKE_EVENT_KINDS.has(event.kind)) return undefined;
-  const raw = event.metadata?.id;
-  return typeof raw === "string" ? raw : undefined;
-}
-
-/**
- * The bounded, incremental retrieval-quality accumulator. Only the running counters
- * plus a window of PENDING recalls (each a non-empty recall still inside its
- * lookahead window) are resident — never the whole journal. A pending recall retires
- * as soon as a matching `memory.verify` is seen (counted as followed) OR after
- * `RECALL_VERIFY_WINDOW_EVENTS` subsequent parseable events elapse (unfollowed), so
- * `pending.length ≤ RECALL_VERIFY_WINDOW_EVENTS` at all times.
- */
-interface RetrievalAccumulator {
-  recallVolume: number;
-  emptyRecalls: number;
-  recallsWithResults: number;
-  verifiedFollows: number;
-  pending: { noteIds: Set<string>; remaining: number }[];
-}
-
-function newRetrievalAccumulator(): RetrievalAccumulator {
-  return { recallVolume: 0, emptyRecalls: 0, recallsWithResults: 0, verifiedFollows: 0, pending: [] };
-}
-
-/**
- * Fold one PARSEABLE event into the accumulator, preserving the exact
- * array-based semantics of the prior implementation: the current event is a
- * SUBSEQUENT event for every earlier pending recall (so it decrements each window
- * and may satisfy one via a matching verify OR #427 resurface), and only AFTER
- * that does the event — if it is itself a recall — become pending (a recall
- * never verifies/resurfaces itself).
- */
-function foldRetrievalEvent(acc: RetrievalAccumulator, event: SomaMemoryEvent): void {
-  if (acc.pending.length > 0) {
-    const verifiedId = verifyEventNoteId(event);
-    const stillPending: RetrievalAccumulator["pending"][number][] = [];
-    for (const p of acc.pending) {
-      p.remaining -= 1;
-      if (verifiedId !== undefined && p.noteIds.has(verifiedId)) {
-        acc.verifiedFollows += 1; // satisfied → retire, counted as followed
-      } else if (p.remaining > 0) {
-        stillPending.push(p); // window not yet exhausted → keep watching
-      }
-      // else: window exhausted unsatisfied → retire, uncounted
-    }
-    acc.pending = stillPending;
-  }
-
-  if (event.kind === "memory.recall") {
-    acc.recallVolume += 1;
-    const noteIds = recallEventNoteIds(event);
-    if (noteIds.length === 0) {
-      acc.emptyRecalls += 1;
-    } else {
-      acc.recallsWithResults += 1;
-      acc.pending.push({ noteIds: new Set(noteIds), remaining: RECALL_VERIFY_WINDOW_EVENTS });
-    }
-  }
-}
-
-function finalizeRetrieval(acc: RetrievalAccumulator, skippedEventLines: number): SomaMemoryRetrievalQuality {
-  return {
-    recallVolume: acc.recallVolume,
-    emptyRecallRate: acc.recallVolume === 0 ? 0 : acc.emptyRecalls / acc.recallVolume,
-    verifyFollowsRecallRate: acc.recallsWithResults === 0 ? 0 : acc.verifiedFollows / acc.recallsWithResults,
-    recallsWithResults: acc.recallsWithResults,
-    verifyWindowEvents: RECALL_VERIFY_WINDOW_EVENTS,
-    skippedEventLines,
-  };
-}
-
-/**
- * ONE streaming pass over the JSONL journal — read line by line via an
- * O_NOFOLLOW-opened FileHandle (a symlinked events file fails the open with ELOOP
- * and is treated as an empty journal, same forgiving stance as the rest of the
- * audit), so audit memory stays O(window + counters), not O(journal). Feeds BOTH:
- * `eventLines` (non-empty lines — the coarse event-ratio count, malformed lines
- * INCLUDED, matching the old byte-scan) and the incremental retrieval accumulator
- * (PARSEABLE events only; a malformed line is skipped and counted). A malformed
- * line is a non-empty line that is not JSON, or lacks a string `kind`/`timestamp`.
- */
-async function streamJournalStats(eventsPath: string): Promise<{ eventLines: number; retrieval: SomaMemoryRetrievalQuality }> {
-  let eventLines = 0;
-  let skippedEventLines = 0;
-  const acc = newRetrievalAccumulator();
-
-  const handle = await open(eventsPath, NOFOLLOW_READ).catch(() => undefined);
-  if (handle === undefined) {
-    // absent, symlinked (ELOOP), or otherwise unopenable → empty journal
-    return { eventLines: 0, retrieval: finalizeRetrieval(acc, 0) };
-  }
-  try {
-    const lines = createInterface({ input: handle.createReadStream({ encoding: "utf8" }), crlfDelay: Infinity });
-    for await (const line of lines) {
-      if (line.trim().length === 0) continue;
-      eventLines += 1; // event-ratio counts every non-empty line, parseable or not
-      let event: SomaMemoryEvent | undefined;
-      try {
-        const parsed = JSON.parse(line) as Partial<SomaMemoryEvent>;
-        if (typeof parsed.kind === "string" && typeof parsed.timestamp === "string") {
-          event = parsed as SomaMemoryEvent;
-        }
-      } catch {
-        // fall through to the malformed count below
-      }
-      if (event === undefined) {
-        skippedEventLines += 1;
-        continue; // malformed → does not consume a retrieval window slot
-      }
-      foldRetrievalEvent(acc, event);
-    }
-  } finally {
-    await handle.close().catch(() => undefined);
-  }
-
-  return { eventLines, retrieval: finalizeRetrieval(acc, skippedEventLines) };
-}
-
-// --- #428 per-note retrieval counts (M6 auto-merge gating) --------------------
-
-/**
- * Per-note counterpart of the #425 corpus-wide retrieval-quality signal: how
- * many times THIS id was returned by a `memory.recall` event, and how many
- * times it was reinforced by a `memory.verify`/(#427) `memory.resurface` event.
- * Used by M6's #428 auto-merge to PREFER collapsing low-value churn (rarely
- * recalled, never reinforced) over actively-useful notes when two near-dup
- * pairs compete for the same note. This is a documented HEURISTIC — a combined
- * count, no recency/decay weighting — rather than a true per-PAIR "was this
- * recall useful" correlation: that would need the same recall→verify window
- * correlation `foldRetrievalEvent` already does at the CORPUS level, and
- * re-deriving it per-note here would be premature tuning before real recall
- * volume exists (the #425 retrieval-quality probe documents the same
- * young-corpus caveat). Malformed journal lines are silently skipped (not
- * surfaced) — this is an internal gating signal, not a health probe.
- */
-export interface SomaMemoryNoteRetrievalCount {
-  /** Times this note id appeared in a `memory.recall` event's returned ids. */
-  recalled: number;
-  /** Times this note id was bumped by `memory.verify` or `memory.resurface`. */
-  verified: number;
-}
-
-/** Stream the journal once, counting per-note recall/verify occurrences (#428). */
-export async function computeNoteRetrievalCounts(somaHome: string): Promise<Map<string, SomaMemoryNoteRetrievalCount>> {
-  const counts = new Map<string, SomaMemoryNoteRetrievalCount>();
-  const bump = (id: string, field: keyof SomaMemoryNoteRetrievalCount): void => {
-    const existing = counts.get(id) ?? { recalled: 0, verified: 0 };
-    existing[field] += 1;
-    counts.set(id, existing);
-  };
-
-  const handle = await open(somaMemoryEventsPath(somaHome), NOFOLLOW_READ).catch(() => undefined);
-  if (handle === undefined) return counts; // absent/symlinked journal → no signal, same forgiving stance as the audit
-  try {
-    const lines = createInterface({ input: handle.createReadStream({ encoding: "utf8" }), crlfDelay: Infinity });
-    for await (const line of lines) {
-      if (line.trim().length === 0) continue;
-      let event: SomaMemoryEvent | undefined;
-      try {
-        const parsed = JSON.parse(line) as Partial<SomaMemoryEvent>;
-        if (typeof parsed.kind === "string" && typeof parsed.timestamp === "string") event = parsed as SomaMemoryEvent;
-      } catch {
-        // malformed line — skipped, same forgiving stance as the retrieval-quality probe
-      }
-      if (event === undefined) continue;
-      if (event.kind === "memory.recall") {
-        for (const id of recallEventNoteIds(event)) bump(id, "recalled");
-        continue;
-      }
-      const verifiedId = verifyEventNoteId(event);
-      if (verifiedId !== undefined) bump(verifiedId, "verified");
-    }
-  } finally {
-    await handle.close().catch(() => undefined);
-  }
-  return counts;
-}
+// The #425 retrieval-quality fold (`streamJournalStats`) and the #428 per-note
+// counts (`computeNoteRetrievalCounts`) moved to the neutral ./memory-journal
+// read-model, so M6 consolidation can reuse the SAME journal fold without
+// depending on this audit module. `streamJournalStats` is imported above.
 
 /**
  * Probe: the #425 retrieval-quality signal, computed PURELY from the journal (no

--- a/src/memory-consolidate.ts
+++ b/src/memory-consolidate.ts
@@ -6,7 +6,8 @@ import { listMemoryNotes } from "./memory-fs";
 import { appendSomaMemoryEvent } from "./memory";
 import { parseMemoryNote, serializeMemoryNote, MemoryNoteError, NOTE_ID_PATTERN, NOTE_ID_MAX_LEN } from "./memory-note";
 import { renderDigestPointer } from "./episodic-digest";
-import { collectDurableNotes } from "./memory-write";
+import { collectDurableNotes, mergeAndCloseAssistantPair } from "./memory-write";
+import { computeNoteRetrievalCounts, type SomaMemoryNoteRetrievalCount } from "./memory-audit";
 import { runBoundedConcurrent } from "./internal-concurrency";
 import { memoryTermSet } from "./memory-terms";
 import { jaccard, ageDays, NEAR_DUPLICATE_JACCARD_THRESHOLD } from "./memory-corpus";
@@ -15,8 +16,10 @@ import type {
   SomaMemoryConsolidateOptions,
   SomaMemoryConsolidateResult,
   SomaMemoryArchivePlan,
+  SomaMemoryAutoMergePlan,
   SomaMemorySimilarPair,
   SomaMemoryNote,
+  SomaMemoryTrust,
   SomaPaths,
 } from "./types";
 
@@ -44,21 +47,36 @@ import type {
  * 3. **List similar pairs** — active durable notes with high LEXICAL similarity
  *    (Jaccard ≥ 0.6) are surfaced for principal review as near-duplicates (which a
  *    reviewer may find to be duplicates OR contradictions) — the overlap is lexical,
- *    NOT a semantic check, and nothing is auto-merged (the write path already
- *    refuses near-duplicates).
+ *    NOT a semantic check. This report itself never merges anything.
+ * 3.5. **Auto-merge assistant near-dups (#428)** — from the pairs above, the subset
+ *    where BOTH notes are `assistant` trust is eligible for auto-merge: one note
+ *    absorbs the other's body via the SAME delta-append shape the M1 `merge` mode
+ *    uses, and the absorbed note is CLOSED (`valid_until` set, never deleted, never
+ *    re-minted under a new id — this is not `supersede`). `principal`-trust pairs
+ *    are NEVER auto-merged — those stay a read-only report only (the hard
+ *    governance line: never silently rewrite principal memory); `quarantined`
+ *    pairs are excluded from auto-merge too (unvetted content is never
+ *    auto-consolidated). Preferred order is LOW-VALUE-CHURN FIRST — pairs whose
+ *    notes were rarely recalled/verified in the #425 journal signal — a
+ *    documented heuristic (see `planAutoMergePairs`), not a hard cutoff.
  * 4. **GC state** — ONLY under the explicit `--gc-state` override (default: off),
  *    `current-work-*.json` files older than 7d are DELETED. This is the pass's only
  *    destructive mutation of protected state, and its only file deletion — notes
- *    (also in the Memory compartment) are archived, never deleted.
- * 5. **Rebuild INDEX** to reflect the archived/stale changes.
+ *    (also in the Memory compartment) are archived or closed, never deleted.
+ * 5. **Rebuild INDEX** to reflect the archived/stale/auto-merged changes.
  *
  * A real run that mutated anything appends one governed `memory.consolidate` event
- * to the journal (the consolidation counterpart of M1's one-mutation-one-event); a
- * no-op run writes none and skips the INDEX rebuild.
+ * to the journal (the consolidation counterpart of M1's one-mutation-one-event) —
+ * PLUS one `memory.consolidate.merge` event PER auto-merged pair (mirroring M1's
+ * own one-mutation-one-event discipline for that content-level mutation); a no-op
+ * run writes none and skips the INDEX rebuild.
  * Idempotent on MUTATIONS: a second run finds the aged notes already archived, the
- * stale notes already marked, the old state already gone → no archive/stale/GC ops
- * and an unchanged INDEX. (The similar-pairs list is a read-only REPORT, not a
- * mutation, so it recurs every run — it does not make the run non-idempotent.)
+ * stale notes already marked, the old state already gone, and an auto-merged pair's
+ * absorbed note already CLOSED (so `planSimilarPairs`/`findDuplicateCandidates`,
+ * which both filter on `valid_until === null`, no longer see it) → no archive/
+ * stale/GC/auto-merge ops and an unchanged INDEX. (The similar-pairs list itself is
+ * a read-only REPORT, not a mutation, so it recurs every run — it does not make the
+ * run non-idempotent.)
  */
 
 const EPISODIC_SESSION_TTL_DAYS = 90;
@@ -296,6 +314,65 @@ function planSimilarPairs(notes: { note: SomaMemoryNote }[]): SomaMemorySimilarP
   return pairs.slice(0, MAX_SIMILAR_PAIRS);
 }
 
+/**
+ * #428 — from the READ-ONLY near-duplicate report (`similarPairs`), select the
+ * subset eligible for auto-merge: BOTH notes must be `assistant` trust. Never
+ * `principal` (that stays report-only — the hard governance line: never
+ * silently rewrite principal memory) and never `quarantined` (unvetted content
+ * is never auto-consolidated either).
+ *
+ * Eligible pairs are ordered LOW-VALUE-CHURN FIRST using the #425 retrieval
+ * signal (`retrieval`, from `computeNoteRetrievalCounts`): a pair whose notes
+ * were rarely recalled/verified in the journal is preferred for collapsing over
+ * an actively-useful one. This is a per-pair PREFERENCE (an ordering), not a
+ * hard cutoff — there is no minimum-churn threshold, since #425's signal is
+ * corpus-young and a hard cutoff would be premature tuning; a future slice may
+ * add one once real recall volume exists (the same caveat the #425
+ * retrieval-quality probe documents).
+ *
+ * At most ONE merge per note per run (the `consumed` set): a note already
+ * claimed as a keep/drop in this pass cannot be claimed again, so a 3-way
+ * near-dup CHAIN (a~b~c) resolves ONE pair now and the rest on a LATER run
+ * (once the keep note's tokens shift) — a documented heuristic degrade rather
+ * than a full transitive-closure resolver, kept simple and deterministic.
+ */
+function planAutoMergePairs(
+  similarPairs: SomaMemorySimilarPair[],
+  notes: { note: SomaMemoryNote }[],
+  retrieval: Map<string, SomaMemoryNoteRetrievalCount>,
+): SomaMemoryAutoMergePlan[] {
+  const trustById = new Map<string, SomaMemoryTrust>();
+  for (const { note } of notes) trustById.set(note.id, note.trust);
+
+  const eligible = similarPairs.filter((p) => trustById.get(p.a) === "assistant" && trustById.get(p.b) === "assistant");
+
+  const churn = (id: string): number => {
+    const c = retrieval.get(id);
+    return c === undefined ? 0 : c.recalled + c.verified;
+  };
+  const ordered = [...eligible].sort(
+    (l, r) =>
+      churn(l.a) + churn(l.b) - (churn(r.a) + churn(r.b)) ||
+      r.score - l.score ||
+      l.a.localeCompare(r.a) ||
+      l.b.localeCompare(r.b),
+  );
+
+  const consumed = new Set<string>();
+  const plan: SomaMemoryAutoMergePlan[] = [];
+  for (const pair of ordered) {
+    if (consumed.has(pair.a) || consumed.has(pair.b)) continue;
+    consumed.add(pair.a);
+    consumed.add(pair.b);
+    // `similarPairs` already orders [a, b] lexicographically (planSimilarPairs'
+    // own sort) — keep the lexicographically-earlier id, drop the later. An
+    // arbitrary-but-stable, deterministic tie-break: neither note's content is
+    // objectively "better"; this only fixes which id/file survives.
+    plan.push({ keepId: pair.a, dropId: pair.b, score: pair.score });
+  }
+  return plan;
+}
+
 /** Plan the state GC: `current-work-*.json` files older than 7d. */
 async function planStateGc(paths: SomaPaths, now: Date): Promise<string[]> {
   const stateDir = paths.state();
@@ -470,6 +547,8 @@ export interface ConsolidationPlan {
   digestsWritten: string[];
   staleMarks: { path: string; rel: string; note: SomaMemoryNote }[];
   similarPairs: SomaMemorySimilarPair[];
+  /** #428 — the assistant-trust subset of `similarPairs` eligible for auto-merge. */
+  autoMergePairs: SomaMemoryAutoMergePlan[];
   /** `current-work-*.json` relative paths planned for deletion (empty unless `--gc-state`). */
   stateGc: string[];
   /** Files surfaced as unscanned/unsafe at PLAN time (episodic + durable-corpus blind spots). */
@@ -482,12 +561,15 @@ export interface ConsolidationPlan {
  * The delta a real run actually produced applying a `ConsolidationPlan` —
  * separate from the plan, never folded back into it. Differs from the plan
  * only under a TOCTOU race (a planned candidate swapped away before it could
- * be applied): `markedStale`/`stateGced` drop any swapped-away candidate, and
- * `unreadable`/`mutated` are recomputed from what actually happened.
+ * be applied): `markedStale`/`stateGced`/`autoMerged` drop any swapped-away or
+ * no-longer-eligible candidate, and `unreadable`/`mutated` are recomputed from
+ * what actually happened.
  */
 export interface ConsolidationApplied {
   markedStale: string[];
   stateGced: string[];
+  /** #428 — pairs actually auto-merged (a pair skipped by a TOCTOU race is dropped). */
+  autoMerged: SomaMemoryAutoMergePlan[];
   unreadable: string[];
   mutated: boolean;
 }
@@ -521,13 +603,17 @@ export async function planConsolidation(paths: SomaPaths, options: SomaMemoryCon
   const durable = await collectDurableNotes(somaHome);
   const staleMarks = await planStaleMarks(durable.notes, somaHome, now);
   const similarPairs = planSimilarPairs(durable.notes);
+  // #428 — gate/prefer the auto-merge subset on the #425 retrieval signal (one
+  // streaming pass over the journal, reused here rather than re-deriving it).
+  const retrievalCounts = await computeNoteRetrievalCounts(somaHome);
+  const autoMergePairs = planAutoMergePairs(similarPairs, durable.notes, retrievalCounts);
   // State GC deletes protected state, so it only runs under the explicit --gc-state
   // override (CONTEXT.md: protected data needs a deliberate destructive flag).
   const stateGc = options.gcState === true ? await planStateGc(paths, now) : [];
   // Unreadable files (episodic + durable) are surfaced, never silently skipped —
   // otherwise a run could report success while known notes went unchecked.
   const unreadable = [...sessionPlan.unreadable, ...actionPlan.unreadable, ...durable.unreadable].sort();
-  const mutated = episodic.length > 0 || staleMarks.length > 0 || stateGc.length > 0;
+  const mutated = episodic.length > 0 || staleMarks.length > 0 || stateGc.length > 0 || autoMergePairs.length > 0;
 
   const plan: ConsolidationPlan = {
     somaHome,
@@ -536,6 +622,7 @@ export async function planConsolidation(paths: SomaPaths, options: SomaMemoryCon
     digestsWritten: Array.from(new Set(episodic.map((e) => relative(somaHome, e.digestPath)))).sort(),
     staleMarks,
     similarPairs,
+    autoMergePairs,
     stateGc,
     unreadable,
     mutated,
@@ -544,6 +631,7 @@ export async function planConsolidation(paths: SomaPaths, options: SomaMemoryCon
   Object.freeze(plan.digestsWritten);
   Object.freeze(plan.staleMarks);
   Object.freeze(plan.similarPairs);
+  Object.freeze(plan.autoMergePairs);
   Object.freeze(plan.stateGc);
   Object.freeze(plan.unreadable);
   return Object.freeze(plan);
@@ -626,15 +714,28 @@ export async function applyConsolidationPlan(
   const { skipped: staleSkipped } = await applyStaleMarks(plan.staleMarks);
   const stateGced = await applyStateGc(somaHome, plan.stateGc, now);
 
+  // #428 — apply each planned auto-merge pair. `mergeAndCloseAssistantPair` is
+  // its OWN governed, atomic mutation (resolveMutationGovernance +
+  // writeNotesAtomically, appending its own `memory.consolidate.merge` event
+  // per pair — the M1 one-mutation-one-event discipline for a content-level
+  // change); it returns `undefined` for a pair no longer eligible by apply time
+  // (TOCTOU: re-authored, already closed, or vanished), which is silently
+  // dropped from `autoMerged` below rather than surfaced as an error.
+  const autoMerged: SomaMemoryAutoMergePlan[] = [];
+  for (const pair of plan.autoMergePairs) {
+    const result = await mergeAndCloseAssistantPair(somaHome, now, substrate, pair.keepId, pair.dropId);
+    if (result !== undefined) autoMerged.push(pair);
+  }
+
   // A stale mark skipped by a TOCTOU swap was NOT applied — drop it so
   // `markedStale` reflects what actually happened, and surface the swapped path.
   const skippedSet = new Set(staleSkipped);
   const markedStale = plan.staleMarks.map((s) => s.rel).filter((rel) => !skippedSet.has(rel)).sort();
   const unreadable = Array.from(new Set([...plan.unreadable, ...archivedOmissions, ...staleSkipped])).sort();
   // Recompute `mutated` from what ACTUALLY happened (post-skip markedStale + actual
-  // deletions), so a run whose planned mutations were all TOCTOU-skipped does NOT
-  // rebuild the INDEX or append an event as if it changed something.
-  const mutated = plan.episodic.length > 0 || markedStale.length > 0 || stateGced.length > 0;
+  // deletions/merges), so a run whose planned mutations were all TOCTOU-skipped does
+  // NOT rebuild the INDEX or append an event as if it changed something.
+  const mutated = plan.episodic.length > 0 || markedStale.length > 0 || stateGced.length > 0 || autoMerged.length > 0;
 
   // Only rebuild the INDEX when something actually changed — a no-op maintenance
   // run must not do corpus-scale work for an unchanged corpus.
@@ -646,20 +747,21 @@ export async function applyConsolidationPlan(
       timestamp: now.toISOString(),
       substrate: substrate ?? "custom",
       kind: "memory.consolidate",
-      summary: `Consolidation: ${plan.episodic.length} archived, ${markedStale.length} marked stale, ${stateGced.length} state GC'd.`,
+      summary: `Consolidation: ${plan.episodic.length} archived, ${markedStale.length} marked stale, ${stateGced.length} state GC'd, ${autoMerged.length} auto-merged.`,
       artifactPaths: [plan.indexPath],
       metadata: {
         archived: plan.episodic.length,
         markedStale: markedStale.length, // actual, after any TOCTOU skips
         stateGced: stateGced.length, // actual deletions, not the plan
         similarPairs: plan.similarPairs.length,
+        autoMerged: autoMerged.length, // actual, after any TOCTOU skips — each pair also carries its own memory.consolidate.merge event
         unreadableCount: unreadable.length,
         unreadablePaths: unreadable, // the actual files (incl. archived omissions), so the journal identifies them
       },
     });
   }
 
-  return { markedStale, stateGced, unreadable, mutated };
+  return { markedStale, stateGced, autoMerged, unreadable, mutated };
 }
 
 /** Combine a plan with its (optional) applied delta into the public result shape. */
@@ -674,6 +776,7 @@ function planToResult(plan: ConsolidationPlan, dryRun: boolean, applied?: Consol
     markedStale: applied ? applied.markedStale : plan.staleMarks.map((s) => s.rel).sort(),
     stateGced: applied ? applied.stateGced : [...plan.stateGc],
     similarPairs: [...plan.similarPairs],
+    autoMerged: applied ? applied.autoMerged : [...plan.autoMergePairs],
     unreadable: applied ? applied.unreadable : [...plan.unreadable],
     mutated: applied ? applied.mutated : plan.mutated,
     indexPath: plan.indexPath,

--- a/src/memory-consolidate.ts
+++ b/src/memory-consolidate.ts
@@ -7,7 +7,7 @@ import { appendSomaMemoryEvent } from "./memory";
 import { parseMemoryNote, serializeMemoryNote, MemoryNoteError, NOTE_ID_PATTERN, NOTE_ID_MAX_LEN } from "./memory-note";
 import { renderDigestPointer } from "./episodic-digest";
 import { collectDurableNotes, mergeAndCloseAssistantPair } from "./memory-write";
-import { computeNoteRetrievalCounts, type SomaMemoryNoteRetrievalCount } from "./memory-audit";
+import { computeNoteRetrievalCounts } from "./memory-journal";
 import { runBoundedConcurrent } from "./internal-concurrency";
 import { memoryTermSet } from "./memory-terms";
 import { jaccard, ageDays, NEAR_DUPLICATE_JACCARD_THRESHOLD } from "./memory-corpus";
@@ -322,13 +322,19 @@ function planSimilarPairs(notes: { note: SomaMemoryNote }[]): SomaMemorySimilarP
  * is never auto-consolidated either).
  *
  * Eligible pairs are ordered LOW-VALUE-CHURN FIRST using the #425 retrieval
- * signal (`retrieval`, from `computeNoteRetrievalCounts`): a pair whose notes
- * were rarely recalled/verified in the journal is preferred for collapsing over
- * an actively-useful one. This is a per-pair PREFERENCE (an ordering), not a
- * hard cutoff — there is no minimum-churn threshold, since #425's signal is
- * corpus-young and a hard cutoff would be premature tuning; a future slice may
- * add one once real recall volume exists (the same caveat the #425
- * retrieval-quality probe documents).
+ * signal (`computeNoteRetrievalCounts`, from the neutral journal read-model): a
+ * pair whose notes were rarely recalled/verified in the journal is preferred for
+ * collapsing over an actively-useful one. This is a per-pair PREFERENCE (an
+ * ordering), not a hard cutoff — there is no minimum-churn threshold, since
+ * #425's signal is corpus-young and a hard cutoff would be premature tuning; a
+ * future slice may add one once real recall volume exists (the same caveat the
+ * #425 retrieval-quality probe documents).
+ *
+ * PERF (#428 review R2): the O(events) journal scan for that ordering is only
+ * paid when there IS at least one assistant-trust pair to rank — the trust
+ * filter runs FIRST, and a corpus with no eligible pair (the common maintenance
+ * case, incl. every principal-only or dup-free tree) returns early WITHOUT
+ * reading the journal at all.
  *
  * At most ONE merge per note per run (the `consumed` set): a note already
  * claimed as a keep/drop in this pass cannot be claimed again, so a 3-way
@@ -336,16 +342,19 @@ function planSimilarPairs(notes: { note: SomaMemoryNote }[]): SomaMemorySimilarP
  * (once the keep note's tokens shift) — a documented heuristic degrade rather
  * than a full transitive-closure resolver, kept simple and deterministic.
  */
-function planAutoMergePairs(
+async function planAutoMergePairs(
+  somaHome: string,
   similarPairs: SomaMemorySimilarPair[],
   notes: { note: SomaMemoryNote }[],
-  retrieval: Map<string, SomaMemoryNoteRetrievalCount>,
-): SomaMemoryAutoMergePlan[] {
+): Promise<SomaMemoryAutoMergePlan[]> {
   const trustById = new Map<string, SomaMemoryTrust>();
   for (const { note } of notes) trustById.set(note.id, note.trust);
 
   const eligible = similarPairs.filter((p) => trustById.get(p.a) === "assistant" && trustById.get(p.b) === "assistant");
+  // No assistant-trust near-dup to rank → skip the whole journal read (perf).
+  if (eligible.length === 0) return [];
 
+  const retrieval = await computeNoteRetrievalCounts(somaHome);
   const churn = (id: string): number => {
     const c = retrieval.get(id);
     return c === undefined ? 0 : c.recalled + c.verified;
@@ -603,10 +612,10 @@ export async function planConsolidation(paths: SomaPaths, options: SomaMemoryCon
   const durable = await collectDurableNotes(somaHome);
   const staleMarks = await planStaleMarks(durable.notes, somaHome, now);
   const similarPairs = planSimilarPairs(durable.notes);
-  // #428 — gate/prefer the auto-merge subset on the #425 retrieval signal (one
-  // streaming pass over the journal, reused here rather than re-deriving it).
-  const retrievalCounts = await computeNoteRetrievalCounts(somaHome);
-  const autoMergePairs = planAutoMergePairs(similarPairs, durable.notes, retrievalCounts);
+  // #428 — the assistant-trust auto-merge subset, ordered low-value-churn-first
+  // by the #425 retrieval signal. The O(events) journal read happens INSIDE
+  // only when an eligible pair exists (perf: no eligible pair → no scan).
+  const autoMergePairs = await planAutoMergePairs(somaHome, similarPairs, durable.notes);
   // State GC deletes protected state, so it only runs under the explicit --gc-state
   // override (CONTEXT.md: protected data needs a deliberate destructive flag).
   const stateGc = options.gcState === true ? await planStateGc(paths, now) : [];

--- a/src/memory-consolidate.ts
+++ b/src/memory-consolidate.ts
@@ -733,7 +733,10 @@ export async function applyConsolidationPlan(
   const autoMerged: SomaMemoryAutoMergePlan[] = [];
   for (const pair of plan.autoMergePairs) {
     const result = await mergeAndCloseAssistantPair(somaHome, now, substrate, pair.keepId, pair.dropId);
-    if (result !== undefined) autoMerged.push(pair);
+    // Report what was ACTUALLY applied (from `result`, reloaded fresh at apply
+    // time), not the planned pair — so a TOCTOU-adjusted apply is reflected
+    // faithfully. Absent a race these are identical to `pair`.
+    if (result !== undefined) autoMerged.push({ keepId: result.keptNote.id, dropId: result.closedId, score: pair.score });
   }
 
   // A stale mark skipped by a TOCTOU swap was NOT applied — drop it so

--- a/src/memory-journal.ts
+++ b/src/memory-journal.ts
@@ -1,0 +1,258 @@
+import { constants as fsConstants } from "node:fs";
+import { open } from "node:fs/promises";
+import { createInterface } from "node:readline/promises";
+import { somaMemoryEventsPath } from "./memory";
+import type { SomaMemoryEvent, SomaMemoryRetrievalQuality } from "./types";
+
+/**
+ * The NEUTRAL journal read-model. A single place that reads the append-only
+ * `memory.recall`/`memory.verify`/(#427)`memory.resurface` JSONL journal and
+ * derives retrieval signals from it — imported by BOTH the M7 audit
+ * (`memory-audit.ts`, the read-only health check) AND M6 consolidation
+ * (`memory-consolidate.ts`, deterministic maintenance). Neither of those two
+ * distinct paths (docs/architecture.md) may depend on the other's internals, so
+ * the shared journal-fold logic lives here, not inside the audit module.
+ *
+ * Two read-models, one streaming shape:
+ * - {@link streamJournalStats} — the #425 corpus-wide retrieval-quality metric
+ *   (recall volume, empty-recall rate, verify-follows-recall rate) plus the
+ *   coarse event-line count; consumed by the audit's retrieval-quality +
+ *   event-ratio probes.
+ * - {@link computeNoteRetrievalCounts} — the #428 PER-NOTE recall/verify tally;
+ *   consumed by M6 consolidation's auto-merge to prefer collapsing low-value
+ *   churn over actively-useful notes.
+ *
+ * Both stream the journal line-by-line through an O_NOFOLLOW-opened FileHandle
+ * (a symlinked events file fails the open with ELOOP and is treated as an empty
+ * journal — the same forgiving stance the audit takes everywhere), so memory
+ * stays O(window + counters), never O(journal).
+ */
+
+// Read WITHOUT following a final-component symlink — a symlinked events file fails
+// the open (ELOOP) and reads as an empty journal, never through the link to an
+// outside target. Exported so the audit reuses the SAME flag for its note/digest
+// reads instead of re-deriving it.
+export const NOFOLLOW_READ = fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW;
+
+// --- #425 retrieval-quality fold ----------------------------------------------
+
+/**
+ * The subsequent-event window the retrieval-quality metric searches, chronologically
+ * after a `memory.recall` event, for a `memory.verify` OR (#427) `memory.resurface`
+ * of one of its returned ids. No existing audit window applies here (the consolidate TTLs are day-based
+ * staleness thresholds for a different concern), so this is a fresh, documented
+ * default rather than a reused constant — events, not days, keep the correlation
+ * deterministic and independent of clock/timezone handling. The window is counted
+ * in PARSEABLE journal events (a malformed line is skipped, does not consume a
+ * window slot). Not yet configurable; a future slice may need to tune it once real
+ * recall volume exists.
+ */
+const RECALL_VERIFY_WINDOW_EVENTS = 50;
+
+/** The `noteIds` a `memory.recall` event recorded (its returned note ids — both
+ *  term matches and 1-hop link pulls), or `[]` if absent/malformed. */
+function recallEventNoteIds(event: SomaMemoryEvent): string[] {
+  const raw = event.metadata?.noteIds;
+  return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === "string") : [];
+}
+
+/**
+ * #427 — the second event kind that satisfies a pending recall, alongside
+ * `memory.verify`: `memory.resurface` (`memory-write.ts`'s `resurfaceMemoryNote`,
+ * the low-friction "this recalled note helped" signal). Both record the bumped
+ * note id the same way (`metadata.id`) and both count toward
+ * `verifyFollowsRecallRate` as "the recall got reinforced" — but they assert
+ * different things: `memory.resurface` asserts observed USEFULNESS, while
+ * `memory.verify` asserts a fact was RE-CONFIRMED (which can happen independently
+ * of a note actually being useful). The rate conflates the two deliberately as a
+ * reinforcement proxy, not as a pure usefulness measure; the metric name stays
+ * `verifyFollowsRecallRate` (not renamed) since it is still measuring "did a
+ * recall get reinforced", just via either turning force.
+ */
+const VERIFY_LIKE_EVENT_KINDS = new Set(["memory.verify", "memory.resurface"]);
+
+/** The note id a `memory.verify`/`memory.resurface` event bumped
+ *  (`memory-write.ts`'s verify/resurface paths both record it as
+ *  `metadata.id`), or `undefined` if the event is neither kind, or the id is
+ *  absent/malformed. */
+function verifyEventNoteId(event: SomaMemoryEvent): string | undefined {
+  if (!VERIFY_LIKE_EVENT_KINDS.has(event.kind)) return undefined;
+  const raw = event.metadata?.id;
+  return typeof raw === "string" ? raw : undefined;
+}
+
+/**
+ * The bounded, incremental retrieval-quality accumulator. Only the running counters
+ * plus a window of PENDING recalls (each a non-empty recall still inside its
+ * lookahead window) are resident — never the whole journal. A pending recall retires
+ * as soon as a matching `memory.verify` is seen (counted as followed) OR after
+ * `RECALL_VERIFY_WINDOW_EVENTS` subsequent parseable events elapse (unfollowed), so
+ * `pending.length ≤ RECALL_VERIFY_WINDOW_EVENTS` at all times.
+ */
+interface RetrievalAccumulator {
+  recallVolume: number;
+  emptyRecalls: number;
+  recallsWithResults: number;
+  verifiedFollows: number;
+  pending: { noteIds: Set<string>; remaining: number }[];
+}
+
+function newRetrievalAccumulator(): RetrievalAccumulator {
+  return { recallVolume: 0, emptyRecalls: 0, recallsWithResults: 0, verifiedFollows: 0, pending: [] };
+}
+
+/**
+ * Fold one PARSEABLE event into the accumulator, preserving the exact
+ * array-based semantics of the prior implementation: the current event is a
+ * SUBSEQUENT event for every earlier pending recall (so it decrements each window
+ * and may satisfy one via a matching verify OR #427 resurface), and only AFTER
+ * that does the event — if it is itself a recall — become pending (a recall
+ * never verifies/resurfaces itself).
+ */
+function foldRetrievalEvent(acc: RetrievalAccumulator, event: SomaMemoryEvent): void {
+  if (acc.pending.length > 0) {
+    const verifiedId = verifyEventNoteId(event);
+    const stillPending: RetrievalAccumulator["pending"][number][] = [];
+    for (const p of acc.pending) {
+      p.remaining -= 1;
+      if (verifiedId !== undefined && p.noteIds.has(verifiedId)) {
+        acc.verifiedFollows += 1; // satisfied → retire, counted as followed
+      } else if (p.remaining > 0) {
+        stillPending.push(p); // window not yet exhausted → keep watching
+      }
+      // else: window exhausted unsatisfied → retire, uncounted
+    }
+    acc.pending = stillPending;
+  }
+
+  if (event.kind === "memory.recall") {
+    acc.recallVolume += 1;
+    const noteIds = recallEventNoteIds(event);
+    if (noteIds.length === 0) {
+      acc.emptyRecalls += 1;
+    } else {
+      acc.recallsWithResults += 1;
+      acc.pending.push({ noteIds: new Set(noteIds), remaining: RECALL_VERIFY_WINDOW_EVENTS });
+    }
+  }
+}
+
+function finalizeRetrieval(acc: RetrievalAccumulator, skippedEventLines: number): SomaMemoryRetrievalQuality {
+  return {
+    recallVolume: acc.recallVolume,
+    emptyRecallRate: acc.recallVolume === 0 ? 0 : acc.emptyRecalls / acc.recallVolume,
+    verifyFollowsRecallRate: acc.recallsWithResults === 0 ? 0 : acc.verifiedFollows / acc.recallsWithResults,
+    recallsWithResults: acc.recallsWithResults,
+    verifyWindowEvents: RECALL_VERIFY_WINDOW_EVENTS,
+    skippedEventLines,
+  };
+}
+
+/**
+ * Parse one non-empty journal line into a well-formed {@link SomaMemoryEvent}, or
+ * `undefined` when it is not JSON or lacks a string `kind`/`timestamp`. The single
+ * definition of "a malformed journal line" — both read-models below skip the same
+ * shape identically.
+ */
+function parseEventLine(line: string): SomaMemoryEvent | undefined {
+  try {
+    const parsed = JSON.parse(line) as Partial<SomaMemoryEvent>;
+    if (typeof parsed.kind === "string" && typeof parsed.timestamp === "string") return parsed as SomaMemoryEvent;
+  } catch {
+    // fall through → malformed
+  }
+  return undefined;
+}
+
+/**
+ * ONE streaming pass over the JSONL journal — read line by line via an
+ * O_NOFOLLOW-opened FileHandle (a symlinked events file fails the open with ELOOP
+ * and is treated as an empty journal, same forgiving stance as the rest of the
+ * audit), so audit memory stays O(window + counters), not O(journal). Feeds BOTH:
+ * `eventLines` (non-empty lines — the coarse event-ratio count, malformed lines
+ * INCLUDED, matching the old byte-scan) and the incremental retrieval accumulator
+ * (PARSEABLE events only; a malformed line is skipped and counted). A malformed
+ * line is a non-empty line that is not JSON, or lacks a string `kind`/`timestamp`.
+ */
+export async function streamJournalStats(eventsPath: string): Promise<{ eventLines: number; retrieval: SomaMemoryRetrievalQuality }> {
+  let eventLines = 0;
+  let skippedEventLines = 0;
+  const acc = newRetrievalAccumulator();
+
+  const handle = await open(eventsPath, NOFOLLOW_READ).catch(() => undefined);
+  if (handle === undefined) {
+    // absent, symlinked (ELOOP), or otherwise unopenable → empty journal
+    return { eventLines: 0, retrieval: finalizeRetrieval(acc, 0) };
+  }
+  try {
+    const lines = createInterface({ input: handle.createReadStream({ encoding: "utf8" }), crlfDelay: Infinity });
+    for await (const line of lines) {
+      if (line.trim().length === 0) continue;
+      eventLines += 1; // event-ratio counts every non-empty line, parseable or not
+      const event = parseEventLine(line);
+      if (event === undefined) {
+        skippedEventLines += 1;
+        continue; // malformed → does not consume a retrieval window slot
+      }
+      foldRetrievalEvent(acc, event);
+    }
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+
+  return { eventLines, retrieval: finalizeRetrieval(acc, skippedEventLines) };
+}
+
+// --- #428 per-note retrieval counts (M6 auto-merge gating) --------------------
+
+/**
+ * Per-note counterpart of the #425 corpus-wide retrieval-quality signal: how
+ * many times THIS id was returned by a `memory.recall` event, and how many
+ * times it was reinforced by a `memory.verify`/(#427) `memory.resurface` event.
+ * Used by M6's #428 auto-merge to PREFER collapsing low-value churn (rarely
+ * recalled, never reinforced) over actively-useful notes when two near-dup
+ * pairs compete for the same note. This is a documented HEURISTIC — a combined
+ * count, no recency/decay weighting — rather than a true per-PAIR "was this
+ * recall useful" correlation: that would need the same recall→verify window
+ * correlation `foldRetrievalEvent` already does at the CORPUS level, and
+ * re-deriving it per-note here would be premature tuning before real recall
+ * volume exists (the #425 retrieval-quality probe documents the same
+ * young-corpus caveat). Malformed journal lines are silently skipped (not
+ * surfaced) — this is an internal gating signal, not a health probe.
+ */
+export interface SomaMemoryNoteRetrievalCount {
+  /** Times this note id appeared in a `memory.recall` event's returned ids. */
+  recalled: number;
+  /** Times this note id was bumped by `memory.verify` or `memory.resurface`. */
+  verified: number;
+}
+
+/** Stream the journal once, counting per-note recall/verify occurrences (#428). */
+export async function computeNoteRetrievalCounts(somaHome: string): Promise<Map<string, SomaMemoryNoteRetrievalCount>> {
+  const counts = new Map<string, SomaMemoryNoteRetrievalCount>();
+  const bump = (id: string, field: keyof SomaMemoryNoteRetrievalCount): void => {
+    const existing = counts.get(id) ?? { recalled: 0, verified: 0 };
+    existing[field] += 1;
+    counts.set(id, existing);
+  };
+
+  const handle = await open(somaMemoryEventsPath(somaHome), NOFOLLOW_READ).catch(() => undefined);
+  if (handle === undefined) return counts; // absent/symlinked journal → no signal, same forgiving stance as the audit
+  try {
+    const lines = createInterface({ input: handle.createReadStream({ encoding: "utf8" }), crlfDelay: Infinity });
+    for await (const line of lines) {
+      if (line.trim().length === 0) continue;
+      const event = parseEventLine(line); // malformed line → skipped, same shape as the retrieval-quality probe
+      if (event === undefined) continue;
+      if (event.kind === "memory.recall") {
+        for (const id of recallEventNoteIds(event)) bump(id, "recalled");
+        continue;
+      }
+      const verifiedId = verifyEventNoteId(event);
+      if (verifiedId !== undefined) bump(verifiedId, "verified");
+    }
+  } finally {
+    await handle.close().catch(() => undefined);
+  }
+  return counts;
+}

--- a/src/memory-write.ts
+++ b/src/memory-write.ts
@@ -12,6 +12,7 @@ import { jaccard, NEAR_DUPLICATE_JACCARD_THRESHOLD } from "./memory-corpus";
 import { SOMA_MEMORY_NOTE_TYPES, SOMA_MEMORY_TRIGGER_TRUST } from "./types";
 import type {
   SomaMemoryDuplicateCandidate,
+  SomaMemoryEvent,
   SomaMemoryNote,
   SomaMemoryNoteType,
   SomaMemoryResurfaceOptions,
@@ -771,6 +772,17 @@ function buildNewNote(options: SomaMemoryWriteOptions, now: Date): NewNote {
 }
 
 async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now: Date): Promise<SomaMemoryWriteResult> {
+  // #428: force and upsert are contradictory intents — force says "write anyway,
+  // skip the scan"; upsert says "resolve a collision via merge" (which needs the
+  // scan to run to find a target). Refused up front rather than silently letting
+  // force win, so a caller never wonders why --upsert appeared to do nothing.
+  if (options.force === true && options.upsert === true) {
+    throw new MemoryNoteError(
+      `Soma memory write: --force and --upsert are mutually exclusive (force skips the dedup scan entirely; upsert needs it to run).`,
+      "upsert",
+    );
+  }
+
   const { note, governance } = buildNewNote(options, now);
 
   // Cheap path-existence PREFLIGHT — reject an id collision before paying for
@@ -791,11 +803,26 @@ async function createNote(somaHome: string, options: SomaMemoryWriteOptions, now
     const scan = await findDuplicateCandidates(somaHome, note.body);
     unreadable = scan.unreadable;
     if (scan.candidates.length > 0) {
+      // #428 — an opt-in resolution, not a silent auto-merge: redirect to the
+      // SAME `merge` mode an explicit `--merge <id>` would use, targeting the
+      // BEST-scoring candidate (`scan.candidates` is sorted score-desc, id-asc).
+      // Governance is UNCHANGED — `mergeNote`'s own trust-rank + tier-authority
+      // checks still apply exactly as they would for a manual merge; `upsert`
+      // only automates target SELECTION, it grants no new authority. `id`/`type`
+      // are mint-only fields the merge path doesn't take; `force`/`upsert`
+      // themselves aren't merge options either; `provenance` is refused by
+      // `mergeNote` (merge always preserves the target's existing provenance) —
+      // all five are stripped before redirecting.
+      if (options.upsert === true) {
+        const target = scan.candidates[0];
+        const { id: _id, type: _type, force: _force, upsert: _upsert, provenance: _provenance, ...mergeOptions } = options;
+        return mergeNote(somaHome, { ...mergeOptions, mode: "merge", targetId: target.id }, now);
+      }
       const list = scan.candidates.map((c) => `${c.id} (${c.exact ? "exact" : c.score.toFixed(2)})`).join(", ");
       const blindSpot = unreadable.length > 0 ? ` (${unreadable.length} note(s)/dir(s) were unreadable and not checked)` : "";
       throw new MemoryNoteError(
         `Recall-first refusal: ${scan.candidates.length} similar note(s) exist — ${list}${blindSpot}. ` +
-          `Re-run with --merge <id>, --supersede <id>, or --force.`,
+          `Re-run with --merge <id>, --supersede <id>, --upsert, or --force.`,
       );
     }
   }
@@ -918,6 +945,108 @@ async function supersedeNote(somaHome: string, options: SomaMemoryWriteOptions, 
   );
 
   return { somaHome, mode: "supersede", path: newPath, note: newNote, supersededId: closed.id, event };
+}
+
+// --- M6 consolidation auto-merge (#428) ---------------------------------------
+
+/** The result of a successful {@link mergeAndCloseAssistantPair} call. */
+export interface AutoMergeApplied {
+  keptPath: string;
+  keptNote: SomaMemoryNote;
+  closedPath: string;
+  closedId: string;
+  event: SomaMemoryEvent;
+}
+
+/**
+ * The M6 counterpart of `mergeNote`, reachable ONLY from `applyConsolidationPlan`
+ * (never the public write dispatch, never the CLI): delta-merge `dropId`'s body
+ * into `keepId` — the SAME body-delta shape `mergeNote` uses — and, in the SAME
+ * atomic transaction, CLOSE `dropId` (`valid_until` set, cross-linked, never
+ * deleted). Closing `dropId` is what makes repeated consolidation runs
+ * idempotent: a closed note is already excluded from `findDuplicateCandidates`/
+ * `planSimilarPairs` (both filter on `valid_until === null`), so the SAME pair
+ * cannot be re-merged on a later run — reusing that existing exclusion instead
+ * of inventing a second "already merged" signal. This is NOT `supersede`: no new
+ * note id is minted; an EXISTING note absorbs another EXISTING note's content.
+ *
+ * Both notes are re-verified as `assistant` trust and active HERE, fresh from
+ * disk — never trusted from the caller's plan snapshot. This is the hard
+ * governance line ("never auto-merge principal-trust notes") holding even under
+ * a plan→apply TOCTOU race: a note re-authored to `principal` (or closed by
+ * another process) between planning and applying is silently SKIPPED
+ * (`undefined`), not merged — a best-effort maintenance op, not a hard failure
+ * path. Authorization is resolved through the SAME `resolveMutationGovernance`
+ * gate (#409) every other mutation uses (twice, mirroring `supersedeNote`'s
+ * two-resolution shape — merge-into-keep and close-drop each need their own
+ * resolution), and both writes go through the SAME `writeNotesAtomically` (#412)
+ * atomicity primitive — not a hand-rolled write.
+ */
+export async function mergeAndCloseAssistantPair(
+  somaHome: string,
+  now: Date,
+  substrate: SomaMemoryWriteOptions["substrate"],
+  keepId: string,
+  dropId: string,
+): Promise<AutoMergeApplied | undefined> {
+  let keep: LoadedNote;
+  let drop: LoadedNote;
+  try {
+    keep = await loadNoteById(somaHome, keepId);
+    drop = await loadNoteById(somaHome, dropId);
+  } catch {
+    return undefined; // one of the pair vanished since planning — skip, not an error
+  }
+  // Already closed (by a prior run, or a concurrent process) — skip.
+  if (keep.note.valid_until !== null || drop.note.valid_until !== null) return undefined;
+  // Re-authored since planning — the hard governance line holds even on a race.
+  if (keep.note.trust !== "assistant" || drop.note.trust !== "assistant") return undefined;
+
+  // Both sides authorize via the SAME internal capability the rest of M6 uses to
+  // mint/mutate assistant trust (SOMA_MEMORY_WRITE_TRIGGERS' documented
+  // "consolidation → assistant" path) — resolved through the SAME gate every
+  // other mutation uses, not a bespoke check.
+  const auth = { consolidationAuthority: true };
+  const mergeGovernance = resolveMutationGovernance("consolidation", keep.note, auth);
+  const closeGovernance = resolveMutationGovernance("consolidation", drop.note, auth);
+
+  const today = isoDate(now);
+  const merged: SomaMemoryNote = {
+    ...keep.note,
+    last_verified: today,
+    body: `${keep.note.body}\n\n**Update (${today}):** ${drop.note.body.trim()}`,
+    links: keep.note.links.includes(drop.note.id) ? keep.note.links : [...keep.note.links, drop.note.id],
+  };
+  const closed: SomaMemoryNote = {
+    ...drop.note,
+    valid_until: today,
+    links: drop.note.links.includes(keep.note.id) ? drop.note.links : [...drop.note.links, keep.note.id],
+  };
+
+  const event = await writeNotesAtomically(
+    somaHome,
+    now,
+    substrate,
+    "memory.consolidate.merge",
+    [
+      { path: keep.path, flag: "w", note: merged, priorRaw: keep.raw },
+      { path: drop.path, flag: "w", note: closed, priorRaw: drop.raw },
+    ],
+    {
+      summary: `Consolidation merged near-duplicate ${closed.id} into ${merged.id} (assistant trust)`,
+      artifactPaths: [keep.path, drop.path],
+      metadata: {
+        keptId: merged.id,
+        mergedId: closed.id,
+        trust: "assistant",
+        trigger: "consolidation",
+        ...mergeGovernance.eventMeta,
+        ...closeGovernance.eventMeta,
+      },
+    },
+  );
+
+  return { keptPath: keep.path, keptNote: merged, closedPath: drop.path, closedId: closed.id, event };
 }
 
 export async function writeMemoryNote(options: SomaMemoryWriteOptions): Promise<SomaMemoryWriteResult> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2491,6 +2491,18 @@ export interface SomaMemoryWriteOptions {
   targetId?: string;
   /** create only: bypass the recall-first refusal gate. */
   force?: boolean;
+  /**
+   * #428 — create only: when the recall-first refusal gate finds a near-dup
+   * (exact-hash or Jaccard ≥ 0.6), delta-merge this write's body into the
+   * BEST-scoring candidate (the existing `merge` mode) instead of refusing —
+   * an opt-in resolution, not a silent auto-merge. Governance is UNCHANGED: the
+   * redirect only picks the target automatically, `mergeNote`'s own
+   * trust-rank + tier-authority checks still apply exactly as for an explicit
+   * `--merge <id>`. Mutually exclusive with `force` (which skips the scan
+   * entirely, so there is nothing for `upsert` to react to). Ignored when no
+   * candidate is found — the write proceeds as a normal create.
+   */
+  upsert?: boolean;
 }
 
 export interface SomaMemoryWriteResult {
@@ -2779,11 +2791,29 @@ export interface SomaMemoryArchivePlan {
 /**
  * A pair of notes with high LEXICAL similarity (Jaccard token overlap), surfaced
  * for principal review — a CANDIDATE duplicate/contradiction, not a proven semantic
- * one. `score` is the token-overlap ratio; consolidation never auto-merges.
+ * one. `score` is the token-overlap ratio. This report itself is always read-only
+ * (unchanged by #428); the ELIGIBLE-for-auto-merge subset of it is a separate field,
+ * {@link SomaMemoryAutoMergePlan}.
  */
 export interface SomaMemorySimilarPair {
   a: string;
   b: string;
+  score: number;
+}
+
+/**
+ * #428 — a near-dup pair from {@link SomaMemorySimilarPair} that M6 consolidation
+ * is eligible to auto-merge: BOTH notes are `assistant` trust (never `principal` —
+ * those stay a read-only `similarPairs` entry only; never `quarantined` — unvetted
+ * content is never auto-consolidated either). `keepId` absorbs `dropId`'s body via
+ * the SAME delta-append shape the M1 `merge` mode uses; `dropId` is then CLOSED
+ * (`valid_until` set, cross-linked) — invalidated, never deleted, and never
+ * re-minted under a new id (this is NOT `supersede`). `score` is the pair's
+ * Jaccard score at plan time.
+ */
+export interface SomaMemoryAutoMergePlan {
+  keepId: string;
+  dropId: string;
   score: number;
 }
 
@@ -2801,8 +2831,14 @@ export interface SomaMemoryConsolidateResult {
   markedStale: string[];
   /** `current-work-*.json` files older than 7d to GC — only under `--gc-state`; this pass's only deletion. */
   stateGced: string[];
-  /** High-lexical-similarity note pairs listed for review (candidate duplicates/contradictions). */
+  /** High-lexical-similarity note pairs listed for review (candidate duplicates/contradictions). Read-only; never mutates anything itself. */
   similarPairs: SomaMemorySimilarPair[];
+  /**
+   * #428 — assistant-trust near-dup pairs auto-merged (planned on dry-run, applied
+   * on a real run): `keepId` absorbed `dropId`'s body and `dropId` was closed.
+   * Principal-trust pairs NEVER appear here — see {@link SomaMemoryAutoMergePlan}.
+   */
+  autoMerged: SomaMemoryAutoMergePlan[];
   /**
    * Note files surfaced for the audit and NOT acted on — either an I/O/parse failure
    * (couldn't be read/parsed) OR a safety refusal (unsafe id, malformed calendar date,
@@ -2812,9 +2848,9 @@ export interface SomaMemoryConsolidateResult {
   unreadable: string[];
   /**
    * True iff the pass has (or, on dry-run, would have) any file mutation — i.e. any
-   * of archived / markedStale / stateGced is non-empty. The single source of truth
-   * for whether the INDEX is rebuilt and a `memory.consolidate` event is emitted;
-   * the similar-pairs report is read-only and does NOT set this.
+   * of archived / markedStale / stateGced / autoMerged is non-empty. The single
+   * source of truth for whether the INDEX is rebuilt and a `memory.consolidate`
+   * event is emitted; the similar-pairs report is read-only and does NOT set this.
    */
   mutated: boolean;
   /**

--- a/test/memory-audit.test.ts
+++ b/test/memory-audit.test.ts
@@ -13,6 +13,8 @@ import {
   writeSessionDigest,
 } from "../src/index";
 import { parseMemoryArgs, runMemoryCli } from "../src/cli/memory";
+// #428: module-private, test-imported (same pattern as findDuplicateCandidates etc.).
+import { computeNoteRetrievalCounts } from "../src/memory-audit";
 
 const NOW = new Date("2026-07-04T10:00:00.000Z");
 const SESSION = "0afea4e4-967d-4a38-a855-0d12ac63c2f3";
@@ -423,6 +425,38 @@ test("retrieval-quality: a real recall(#425) followed by soma memory used (#427)
     const after = await auditMemory({ somaHome });
     expect(after.retrieval.recallsWithResults).toBe(1);
     expect(after.retrieval.verifyFollowsRecallRate).toBe(1);
+  });
+});
+
+// --- #428: per-note retrieval counts (M6 auto-merge gating) ------------------
+
+test("#428: computeNoteRetrievalCounts tallies per-note recall + verify/resurface occurrences from the journal", async () => {
+  await withTempSoma(async (somaHome) => {
+    await seedRecallEvent(somaHome, ["a", "b"]);
+    await seedRecallEvent(somaHome, ["a"]);
+    await seedVerifyEvent(somaHome, "a");
+    await seedResurfaceEvent(somaHome, "b");
+    await seedRecallEvent(somaHome, []); // empty recall — contributes to neither
+
+    const counts = await computeNoteRetrievalCounts(somaHome);
+    expect(counts.get("a")).toEqual({ recalled: 2, verified: 1 });
+    expect(counts.get("b")).toEqual({ recalled: 1, verified: 1 });
+    expect(counts.get("c")).toBeUndefined(); // never mentioned — no entry, not a zeroed one
+  });
+});
+
+test("#428: computeNoteRetrievalCounts returns an empty map when the journal is absent, and skips malformed lines", async () => {
+  await withTempSoma(async (somaHome) => {
+    const empty = await computeNoteRetrievalCounts(somaHome);
+    expect(empty.size).toBe(0);
+
+    const eventsPath = somaMemoryEventsPath(somaHome);
+    await mkdir(join(eventsPath, ".."), { recursive: true });
+    await appendFile(eventsPath, "not json\n", "utf8");
+    await seedRecallEvent(somaHome, ["a"]);
+
+    const counts = await computeNoteRetrievalCounts(somaHome);
+    expect(counts.get("a")).toEqual({ recalled: 1, verified: 0 });
   });
 });
 

--- a/test/memory-audit.test.ts
+++ b/test/memory-audit.test.ts
@@ -13,8 +13,10 @@ import {
   writeSessionDigest,
 } from "../src/index";
 import { parseMemoryArgs, runMemoryCli } from "../src/cli/memory";
-// #428: module-private, test-imported (same pattern as findDuplicateCandidates etc.).
-import { computeNoteRetrievalCounts } from "../src/memory-audit";
+// #428: computeNoteRetrievalCounts now lives in the neutral journal read-model
+// (moved out of memory-audit so M6 consolidation can reuse it without depending
+// on the audit module). Module-private, test-imported (same pattern as elsewhere).
+import { computeNoteRetrievalCounts } from "../src/memory-journal";
 
 const NOW = new Date("2026-07-04T10:00:00.000Z");
 const SESSION = "0afea4e4-967d-4a38-a855-0d12ac63c2f3";

--- a/test/memory-consolidate.test.ts
+++ b/test/memory-consolidate.test.ts
@@ -2,7 +2,7 @@ import { access, mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
-import { consolidateMemory, parseMemoryNote, serializeMemoryNote, type SomaMemoryNote } from "../src/index";
+import { appendSomaMemoryEvent, consolidateMemory, parseMemoryNote, serializeMemoryNote, type SomaMemoryNote } from "../src/index";
 import { memoryIndexPath } from "../src/memory-index";
 import { createPaths } from "../src/paths";
 // Plan/apply internals are module-private (not public index API) — import direct,
@@ -222,6 +222,201 @@ test("lexically-similar active notes are LISTED as near-duplicate pairs (no merg
   });
 });
 
+// --- #428: auto-merge assistant-trust near-dups ------------------------------
+
+test("#428: an assistant-trust near-dup pair is auto-merged — delta-merge + close, never delete", async () => {
+  await withTempSoma(async (somaHome) => {
+    const aPath = await writeNote(
+      somaHome,
+      "memory/semantic/a.md",
+      note({ id: "a", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering the message" }),
+    );
+    const bPath = await writeNote(
+      somaHome,
+      "memory/semantic/b.md",
+      note({ id: "b", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering the message now" }),
+    );
+
+    const result = await consolidateMemory({ somaHome, now: NOW });
+
+    expect(result.autoMerged).toHaveLength(1);
+    expect(result.autoMerged[0].keepId).toBe("a");
+    expect(result.autoMerged[0].dropId).toBe("b");
+    expect(result.autoMerged[0].score).toBeGreaterThanOrEqual(0.6);
+
+    const kept = parseMemoryNote(await readFile(aPath, "utf8"));
+    expect(kept.valid_until).toBeNull(); // survives, active
+    expect(kept.body).toContain("**Update");
+    expect(kept.links).toContain("b");
+
+    const dropped = parseMemoryNote(await readFile(bPath, "utf8"));
+    expect(dropped.valid_until).toBe("2026-07-04"); // closed, not deleted
+    expect(dropped.links).toContain("a");
+    expect(await exists(bPath)).toBe(true); // invalidate, never delete
+  });
+});
+
+test("#428: a principal-trust near-dup pair stays report-only — consolidation never merges or closes it", async () => {
+  await withTempSoma(async (somaHome) => {
+    const aPath = await writeNote(
+      somaHome,
+      "memory/semantic/a.md",
+      note({ id: "a", type: "semantic", trust: "principal", body: "gateway retries thrice before dead lettering the message" }),
+    );
+    const bPath = await writeNote(
+      somaHome,
+      "memory/semantic/b.md",
+      note({ id: "b", type: "semantic", trust: "principal", body: "gateway retries thrice before dead lettering the message now" }),
+    );
+
+    const result = await consolidateMemory({ somaHome, now: NOW });
+
+    expect(result.similarPairs).toHaveLength(1); // still reported for principal review
+    expect(result.autoMerged).toEqual([]); // never auto-merged
+
+    const a = parseMemoryNote(await readFile(aPath, "utf8"));
+    const b = parseMemoryNote(await readFile(bPath, "utf8"));
+    expect(a.valid_until).toBeNull();
+    expect(b.valid_until).toBeNull();
+    expect(a.body).not.toContain("**Update");
+    expect(b.body).not.toContain("**Update");
+  });
+});
+
+test("#428: a MIXED-trust pair (one principal, one assistant) is never auto-merged", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(somaHome, "memory/semantic/a.md", note({ id: "a", type: "semantic", trust: "principal", body: "gateway retries thrice before dead lettering the message" }));
+    await writeNote(
+      somaHome,
+      "memory/semantic/b.md",
+      note({ id: "b", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering the message now" }),
+    );
+
+    const result = await consolidateMemory({ somaHome, now: NOW });
+    expect(result.autoMerged).toEqual([]);
+  });
+});
+
+test("#428: a quarantined near-dup pair is excluded from auto-merge too (unvetted content is never auto-consolidated)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(
+      somaHome,
+      "memory/semantic/a.md",
+      note({ id: "a", type: "semantic", trust: "quarantined", provenance: "import", body: "gateway retries thrice before dead lettering the message" }),
+    );
+    await writeNote(
+      somaHome,
+      "memory/semantic/b.md",
+      note({ id: "b", type: "semantic", trust: "quarantined", provenance: "import", body: "gateway retries thrice before dead lettering the message now" }),
+    );
+
+    const result = await consolidateMemory({ somaHome, now: NOW });
+    expect(result.autoMerged).toEqual([]);
+  });
+});
+
+test("#428: --dry-run's auto-merge plan matches the applied result", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(
+      somaHome,
+      "memory/semantic/a.md",
+      note({ id: "a", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering the message" }),
+    );
+    await writeNote(
+      somaHome,
+      "memory/semantic/b.md",
+      note({ id: "b", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering the message now" }),
+    );
+
+    const dry = await consolidateMemory({ somaHome, now: NOW, dryRun: true });
+    expect(dry.autoMerged).toHaveLength(1);
+    expect(dry.dryRun).toBe(true);
+
+    const real = await consolidateMemory({ somaHome, now: NOW });
+    expect(dry.autoMerged).toEqual(real.autoMerged);
+  });
+});
+
+test("#428: auto-merge is idempotent — a second run does not re-merge an already-closed pair", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(
+      somaHome,
+      "memory/semantic/a.md",
+      note({ id: "a", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering the message" }),
+    );
+    await writeNote(
+      somaHome,
+      "memory/semantic/b.md",
+      note({ id: "b", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering the message now" }),
+    );
+
+    const first = await consolidateMemory({ somaHome, now: NOW });
+    expect(first.autoMerged).toHaveLength(1);
+
+    const second = await consolidateMemory({ somaHome, now: NOW });
+    expect(second.autoMerged).toEqual([]); // "b" is closed — no longer an active near-dup candidate
+  });
+});
+
+test("#428: auto-merge PREFERS low-value churn — a never-recalled note wins a shared-pair claim over a recalled+verified one", async () => {
+  await withTempSoma(async (somaHome) => {
+    // A chain: hot ~ shared ~ cold (all three pairs clear the Jaccard floor).
+    // "shared" can only be claimed by ONE merge this run — the #425 journal
+    // signal should prefer pairing it with "cold" (never recalled) over "hot"
+    // (recalled + verified).
+    await writeNote(
+      somaHome,
+      "memory/semantic/hot.md",
+      note({ id: "hot", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering hot message alpha" }),
+    );
+    await writeNote(
+      somaHome,
+      "memory/semantic/shared.md",
+      note({ id: "shared", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering hot message" }),
+    );
+    await writeNote(
+      somaHome,
+      "memory/semantic/cold.md",
+      note({ id: "cold", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering hot message beta" }),
+    );
+
+    // "hot" has journal history; "shared"/"cold" have none.
+    await appendSomaMemoryEvent(somaHome, { timestamp: NOW.toISOString(), substrate: "custom", kind: "memory.recall", summary: "recall", metadata: { noteIds: ["hot"] } });
+    await appendSomaMemoryEvent(somaHome, { timestamp: NOW.toISOString(), substrate: "custom", kind: "memory.verify", summary: "verify", metadata: { id: "hot" } });
+
+    const result = await consolidateMemory({ somaHome, now: NOW });
+
+    expect(result.autoMerged).toHaveLength(1); // the chain resolves ONE pair this run
+    const involvesShared = result.autoMerged.find((p) => p.keepId === "shared" || p.dropId === "shared");
+    expect(involvesShared).toBeDefined();
+    expect([involvesShared!.keepId, involvesShared!.dropId]).toContain("cold");
+    expect([involvesShared!.keepId, involvesShared!.dropId]).not.toContain("hot");
+    // "hot" (actively used) is left untouched this run — a future run resolves it.
+    expect(result.autoMerged.some((p) => p.keepId === "hot" || p.dropId === "hot")).toBe(false);
+  });
+});
+
+test("#428: planConsolidation's autoMergePairs is frozen too (#412 immutability)", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(
+      somaHome,
+      "memory/semantic/a.md",
+      note({ id: "a", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering the message" }),
+    );
+    await writeNote(
+      somaHome,
+      "memory/semantic/b.md",
+      note({ id: "b", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering the message now" }),
+    );
+
+    const paths = createPaths(somaHome);
+    const plan = await planConsolidation(paths, {}, NOW);
+    expect(plan.autoMergePairs.length).toBe(1);
+    expect(Object.isFrozen(plan.autoMergePairs)).toBe(true);
+    expect(() => plan.autoMergePairs.push({ keepId: "x", dropId: "y", score: 1 })).toThrow(TypeError);
+  });
+});
+
 test("unreadable note files are surfaced, never silently skipped", async () => {
   await withTempSoma(async (somaHome) => {
     await mkdir(join(somaHome, "memory/semantic"), { recursive: true });
@@ -380,6 +575,7 @@ const forgedPlan = (somaHome: string, staleMark: string, extra: Partial<Consolid
   digestsWritten: [],
   staleMarks: staleMark ? [{ path: staleMark, rel: "forged", note: note({ id: "x", type: "semantic", body: "forged mark" }) }] : [],
   similarPairs: [],
+  autoMergePairs: [],
   stateGc: [],
   unreadable: [],
   mutated: true,

--- a/test/memory-consolidate.test.ts
+++ b/test/memory-consolidate.test.ts
@@ -1,13 +1,16 @@
 import { access, mkdir, mkdtemp, readFile, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import { appendSomaMemoryEvent, consolidateMemory, parseMemoryNote, serializeMemoryNote, type SomaMemoryNote } from "../src/index";
 import { memoryIndexPath } from "../src/memory-index";
 import { createPaths } from "../src/paths";
 // Plan/apply internals are module-private (not public index API) — import direct,
 // for the #412 plan-immutability acceptance test.
 import { applyConsolidationPlan, planConsolidation, type ConsolidationPlan } from "../src/memory-consolidate";
+// The neutral journal read-model — spied on to prove the #428-R2 perf gate skips
+// the O(events) journal scan when no assistant-trust pair is eligible.
+import * as journal from "../src/memory-journal";
 
 const NOW = new Date("2026-07-04T10:00:00.000Z");
 
@@ -414,6 +417,41 @@ test("#428: planConsolidation's autoMergePairs is frozen too (#412 immutability)
     expect(plan.autoMergePairs.length).toBe(1);
     expect(Object.isFrozen(plan.autoMergePairs)).toBe(true);
     expect(() => plan.autoMergePairs.push({ keepId: "x", dropId: "y", score: 1 })).toThrow(TypeError);
+  });
+});
+
+test("#428 review R2: a principal-only near-dup pair is reported but does NOT trigger the O(events) journal scan", async () => {
+  await withTempSoma(async (somaHome) => {
+    // A near-dup pair that is REPORTED but never eligible (both principal), so
+    // there is no assistant-trust pair to rank → the journal read is skipped.
+    await writeNote(somaHome, "memory/semantic/a.md", note({ id: "a", type: "semantic", trust: "principal", body: "gateway retries thrice before dead lettering the message" }));
+    await writeNote(somaHome, "memory/semantic/b.md", note({ id: "b", type: "semantic", trust: "principal", body: "gateway retries thrice before dead lettering the message now" }));
+
+    const spy = spyOn(journal, "computeNoteRetrievalCounts");
+    try {
+      const result = await consolidateMemory({ somaHome, now: NOW });
+      expect(result.similarPairs).toHaveLength(1); // still reported for principal review
+      expect(result.autoMerged).toEqual([]);
+      expect(spy).not.toHaveBeenCalled(); // the journal scan was skipped entirely
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+test("#428 review R2 (positive control): an assistant-trust near-dup pair DOES scan the journal exactly once", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeNote(somaHome, "memory/semantic/a.md", note({ id: "a", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering the message" }));
+    await writeNote(somaHome, "memory/semantic/b.md", note({ id: "b", type: "semantic", trust: "assistant", provenance: "consolidation", body: "gateway retries thrice before dead lettering the message now" }));
+
+    const spy = spyOn(journal, "computeNoteRetrievalCounts");
+    try {
+      const result = await consolidateMemory({ somaHome, now: NOW });
+      expect(result.autoMerged).toHaveLength(1);
+      expect(spy).toHaveBeenCalledTimes(1); // eligible pair present → the scan runs
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 

--- a/test/memory-write.test.ts
+++ b/test/memory-write.test.ts
@@ -275,6 +275,106 @@ test("--force overrides the recall-first refusal", async () => {
   });
 });
 
+// --- #428: write-time upsert (near-dup → merge instead of refuse) -----------
+
+test("#428: --upsert delta-merges a write-time near-dup into the best-scoring assistant note (no second file, one memory.write.merge event)", async () => {
+  await withTempSoma(async (somaHome) => {
+    const original = await writeMemoryNote(
+      createOpts(somaHome, {
+        id: "original",
+        trigger: "consolidation",
+        consolidationAuthority: true,
+        body: "assistant fact about gateway retries and backoff",
+      }),
+    );
+    expect(original.note.trust).toBe("assistant");
+    expect(await countEvents(somaHome)).toBe(1);
+
+    const upserted = await writeMemoryNote(
+      createOpts(somaHome, {
+        id: "reworded", // ignored — the redirect targets the near-dup, no second file is minted
+        trigger: "consolidation",
+        consolidationAuthority: true,
+        upsert: true,
+        body: "assistant fact about gateway retries and backoff, now with jitter",
+      }),
+    );
+
+    expect(upserted.mode).toBe("merge");
+    expect(upserted.note.id).toBe("original");
+    expect(upserted.path).toBe(original.path);
+    expect(upserted.event.kind).toBe("memory.write.merge");
+
+    const note = await readNote(upserted.path);
+    expect(note.body).toContain("**Update");
+    expect(note.body).toContain("now with jitter");
+
+    // No second file was ever minted under the rejected id.
+    await expect(readNote(memoryNotePath(somaHome, "semantic", "reworded"))).rejects.toThrow();
+    // Exactly one create event + one merge event — no separate create landed.
+    expect(await countEvents(somaHome)).toBe(2);
+  });
+});
+
+test("#428: --upsert still enforces merge governance — a lower-trust trigger cannot inject via upsert either", async () => {
+  await withTempSoma(async (somaHome) => {
+    await writeMemoryNote(
+      createOpts(somaHome, {
+        id: "assistant-note",
+        trigger: "consolidation",
+        consolidationAuthority: true,
+        body: "assistant fact about gateway retries and backoff",
+      }),
+    );
+
+    await expect(
+      writeMemoryNote(
+        createOpts(somaHome, {
+          id: "reworded",
+          trigger: "import",
+          upsert: true,
+          body: "assistant fact about gateway retries and backoff, now with jitter",
+        }),
+      ),
+    ).rejects.toThrow(/Cannot mutate assistant-trust note/);
+    // Refused — no note was minted or merged.
+    await expect(readNote(memoryNotePath(somaHome, "semantic", "reworded"))).rejects.toThrow();
+  });
+});
+
+test("#428: --force and --upsert are mutually exclusive", async () => {
+  await withTempSoma(async (somaHome) => {
+    await expect(writeMemoryNote(createOpts(somaHome, { force: true, upsert: true }))).rejects.toThrow(
+      /--force and --upsert are mutually exclusive/,
+    );
+  });
+});
+
+test("#428: --upsert has no effect when there is no near-dup collision (falls through to a normal create)", async () => {
+  await withTempSoma(async (somaHome) => {
+    const result = await writeMemoryNote(createOpts(somaHome, { upsert: true, body: "a completely unrelated fresh fact zzz yyy xxx" }));
+    expect(result.mode).toBe("create");
+  });
+});
+
+test("CLI: --upsert is accepted on write and rejected alongside --merge/--supersede/--force", () => {
+  const parsed = parseMemoryArgs([
+    "memory", "write", "--trigger", "principal-correction", "--principal-authority",
+    "--id", "a", "--type", "semantic", "--body", "x", "--upsert",
+  ]);
+  expect(parsed.action === "write" && parsed.options.upsert).toBe(true);
+
+  expect(() =>
+    parseMemoryArgs(["memory", "write", "--trigger", "principal-correction", "--body", "x", "--merge", "t", "--upsert"]),
+  ).toThrow(/--upsert only applies to a create-mode collision/);
+  expect(() =>
+    parseMemoryArgs([
+      "memory", "write", "--trigger", "principal-correction", "--body", "x",
+      "--id", "a", "--type", "semantic", "--force", "--upsert",
+    ]),
+  ).toThrow(/--upsert and --force are mutually exclusive/);
+});
+
 test("an exact-body duplicate is refused as an exact match", async () => {
   await withTempSoma(async (somaHome) => {
     await writeMemoryNote(createOpts(somaHome, { id: "original" }));


### PR DESCRIPTION
## Summary

Turns near-duplicate *detection* into optional *consolidation*, per #428, while holding the existing trust-governance line.

**1. Write-time upsert (`src/memory-write.ts`)** — `createNote`'s recall-first refusal gate (exact-hash / Jaccard ≥ 0.6, `findDuplicateCandidates`) now accepts a new opt-in `upsert?: boolean` write option. On a collision, when `upsert: true`, the write redirects to the SAME `mergeNote` path an explicit `--merge <id>` would use, targeting the best-scoring candidate (`scan.candidates[0]`, already sorted score-desc/id-asc) instead of refusing. Governance is unchanged — `mergeNote`'s own trust-rank + tier-authority checks (`resolveMutationGovernance`, #409) still apply exactly as for a manual merge; `upsert` only automates target *selection*, it grants no new authority. `force` and `upsert` are mutually exclusive (refused at both the SDK and CLI layers) since `force` skips the scan `upsert` needs to run. New CLI flag: `soma memory write ... --upsert`.

**2. M6 consolidation auto-merge (`src/memory-consolidate.ts`, `src/memory-write.ts`)** — a new op, `planAutoMergePairs`, selects the subset of the existing (unchanged) `similarPairs` report where **both** notes are `assistant` trust. That subset is auto-merged via a new function, `mergeAndCloseAssistantPair` (`memory-write.ts`): it delta-merges the "drop" note's body into the "keep" note (the same delta-append shape `mergeNote` uses) and **closes** the drop note (`valid_until` set, cross-linked, never deleted, never re-minted under a new id — this is explicitly *not* `supersede`). Both notes are re-verified as active + `assistant` trust *fresh from disk* at apply time (not trusted from the plan snapshot) — the hard governance line holds even under a plan→apply TOCTOU race. Both writes route through `resolveMutationGovernance` (#409, twice — mirroring `supersedeNote`'s two-resolution shape) and `writeNotesAtomically` (#412, two staged writes + one `memory.consolidate.merge` event) — no hand-rolled write. `principal`-trust pairs are **never** touched — they stay exactly the pre-existing read-only `similarPairs` report. `quarantined` pairs are excluded from auto-merge too. Closing the drop note is also what makes repeated runs idempotent: a closed note already drops out of `findDuplicateCandidates`/`planSimilarPairs` (both filter `valid_until === null`), so the same pair is never re-merged — reusing that existing exclusion instead of inventing new per-note state.

**3. Metric-gated preference (#425 dependency)** — a new function `computeNoteRetrievalCounts` (`src/memory-audit.ts`) streams the journal once per consolidation plan, tallying per-note `memory.recall` occurrences and `memory.verify`/`memory.resurface` reinforcement counts. `planAutoMergePairs` orders eligible pairs **low-value-churn first** (lowest combined recall+verify count) before a greedy one-merge-per-note-per-run pass, so a rarely-useful pair is preferred for collapsing over an actively-recalled one when they compete for the same note. This is a documented **preference** (an ordering), not a hard cutoff — there's no minimum-churn threshold, since #425's signal is corpus-young and a hard gate would be premature tuning (the same caveat the #425 retrieval-quality probe already documents). It's a genuine per-note journal signal, not a fabricated proxy, and adds no new per-note schema state.

## #428 verification checklist

- [x] Write a near-dup of an existing assistant note → upsert path delta-merges into the original; no second file; one `memory.write.merge` event — `test/memory-write.test.ts`: *"#428: --upsert delta-merges a write-time near-dup into the best-scoring assistant note (no second file, one memory.write.merge event)"*.
- [x] A principal-trust near-dup pair → consolidation still only *reports* it (no mutation) — `test/memory-consolidate.test.ts`: *"#428: a principal-trust near-dup pair stays report-only — consolidation never merges or closes it"* (also covered for a mixed principal/assistant pair and a quarantined pair).
- [x] `--dry-run` PLAN lists the intended merges and equals the applied op set — `test/memory-consolidate.test.ts`: *"#428: --dry-run's auto-merge plan matches the applied result"*, plus the `#412`-style frozen-plan test *"#428: planConsolidation's autoMergePairs is frozen too"*.
- [x] An assistant near-dup pair is auto-merged by consolidation — `test/memory-consolidate.test.ts`: *"#428: an assistant-trust near-dup pair is auto-merged — delta-merge + close, never delete"*.

Also added: idempotency (a second consolidation run does not re-merge an already-closed pair), the low-value-churn preference ordering (a three-note chain test proving a never-recalled note wins a shared-pair claim over a recalled+verified one), and two direct unit tests for `computeNoteRetrievalCounts`.

## Governance / invariants held

- Every note mutation routes through the existing `resolveMutationGovernance` (#409) + `writeNotesAtomically` (#412) paths — no hand-rolled write, in either the write-time upsert redirect or the M6 auto-merge.
- `principal`-trust notes are **never** auto-merged — proven by test, and enforced twice over: (1) `planAutoMergePairs` only selects pairs where both ids resolve to `assistant` trust at plan time, and (2) `mergeAndCloseAssistantPair` independently re-verifies both notes are `assistant` trust *fresh from disk* at apply time, so even a plan→apply TOCTOU race (a note re-authored to `principal` between planning and applying) is refused, not silently merged.
- No new key-typed schema; keyed on the existing Jaccard/term overlap (`memory-corpus.ts`'s `NEAR_DUPLICATE_JACCARD_THRESHOLD`, unchanged).
- Not a replacement for `supersede` — no new note id is ever minted by the auto-merge path; an existing note absorbs another existing note's content and the absorbed note is closed in place.
- Consolidate's plan/apply purity holds **absent a TOCTOU race**: on a stable corpus `--dry-run`'s `autoMerged` (planned) equals the real run's applied `autoMerged` (proven by the stable-corpus equality test). A pair that becomes ineligible between plan and apply (e.g. a note re-authored to `principal`, or swapped) is **dropped** from the applied `autoMerged` — matching how the other consolidation ops handle TOCTOU skips; it is not an unconditional byte-equality invariant.

## Verification

- `bun run typecheck` — clean (`tsc --noEmit`, no errors).
- `bun test` — **1845 pass / 0 fail** (baseline on main 1828; +17 tests after the review-round-1 module move).
- `git diff --stat origin/main HEAD` (below) — confirms the diff is **additive**: 10 files changed, 966 insertions(+), 199 deletions(-). The 199 deletions are the #425 journal-streaming fold + `computeNoteRetrievalCounts` **moving** to the new neutral `src/memory-journal.ts` (review round 1), not removals — no epic, #425, or #427 file or test was removed.

```
 src/cli/memory.ts               |  24 ++++-
 src/index.ts                    |   1 +
 src/memory-audit.ts             |  60 ++++++++++++
 src/memory-consolidate.ts       | 139 ++++++++++++++++++++++++----
 src/memory-write.ts             | 131 +++++++++++++++++++++++++-
 src/types.ts                    |  46 +++++++++-
 test/memory-audit.test.ts       |  34 +++++++
 test/memory-consolidate.test.ts | 198 +++++++++++++++++++++++++++++++++++++++-
 test/memory-write.test.ts       | 100 ++++++++++++++++++++
 10 files changed, 966 insertions(+), 199 deletions(-)
```

## Design notes on ambiguous points

- **Which note "keeps" and which "drops" in an auto-merge pair.** `similarPairs` already sorts `[a, b]` lexicographically; the auto-merge keeps `a` and closes `b`. Arbitrary but stable and deterministic — neither note's content is objectively "better".
- **At most one auto-merge per note per consolidation run.** A 3-way near-dup chain (a~b~c) resolves one pair now and the rest on a later run (once the surviving note's tokens shift). A documented heuristic degrade rather than a full transitive-closure resolver — kept simple and deterministic, and exercised directly by the low-value-churn-preference test.
- **New event kind `memory.consolidate.merge`.** Distinguishes an M6 auto-merge-and-close (two files touched, one event) from a plain single-file `memory.write.merge` (one file touched) in the audit trail.
- **Metric gating degrades to preference, not a hard cutoff.** #425's retrieval signal is corpus-young; a hard minimum-churn threshold would be premature tuning. The implementation gates the *order* pairs are greedily claimed in, which is where "prefer low-value churn over actively-useful" actually matters (when two pairs compete for the same note).

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JzijJAY7wa47Bm4CH8Ux5



---

### Review round 1 (sage #434)
- **Layering:** `computeNoteRetrievalCounts` (+ the shared #425 journal-streaming fold) moved out of `memory-audit.ts` into a neutral `src/memory-journal.ts` read-model consumed by both audit and consolidation, so M6 no longer depends on the M7 audit module. Audit probe behaviour unchanged.
- **Perf:** `planAutoMergePairs` computes the assistant-eligible subset first and skips the O(events) journal scan when it is empty — a no-op consolidation no longer reads the journal.
