### PR TITLE
feat(algorithm): VerificationGate + PreCompact ports (refuse hollow pass; handover across compaction)

### DIFF
--- a/Plans/2026-07-07-HANDOVER-verification-gate-precompact-hook-cleanup.md
+++ b/Plans/2026-07-07-HANDOVER-verification-gate-precompact-hook-cleanup.md
@@ -1,0 +1,77 @@
+# HANDOVER — VerificationGate + PreCompact ports & PAI hook cleanup
+
+*Written 2026-07-07. Read this first when resuming. Sibling doc: `Plans/2026-07-06-HANDOVER-remove-pai-from-claude.md` (the de-PAI migration — still the source of truth for tree removal + settings.json cleanup).*
+
+## The frame
+
+**First finish line = Soma-as-a-standalone-product** (the composability epic: #381 AI-native install doc, #373 greenfield CI across adapters, #370 provenance/doctor, #371 compact skill registry — no milestone defined yet). JC's sequencing: **clean up the local installation first**, then the product work.
+
+"Clean up local installation" = finish de-PAI: retire the legacy PAI hooks, remove the 18 MB `~/.claude/PAI/` tree, and port the FEW PAI hooks that carry real value into Soma. This session did the hook triage + the first port (VerificationGate). PreCompact is the remaining port.
+
+## Git state
+
+- Branch **`feat/verification-gate-and-precompact`** (off `main`), **1 commit `41d9830`** (VerificationGate), **NOT pushed**, tree clean.
+- `main` is at `232e974` (the merged skill-projection PR #437). `~/.claude/bin/soma` symlinks to this dev tree, so `soma install` runs whatever is checked out — **stay on `main` or a rebased branch when running `soma install`**, or you'll install half-built code.
+- Prior merged work this arc: PR #437 (bundled skills project as invocable dirs — `the-algorithm`/`Memory` now real dirs in `~/.claude/skills`, applied + verified live). Open follow-up: **issue #438** (portable-skill manifest clobbers across same-substrate multi-home installs — deferred).
+
+## ✅ DONE this session: VerificationGate (ports PAI EvidenceGate)
+
+Committed on the branch (`41d9830`), **1851 tests pass, typecheck clean**. Not yet pushed / no PR.
+
+- **What**: the block-mode, record-time counterpart to #330's audit-time gate. `verifyAlgorithmCriterion` now REFUSES to record a `passed` on specification-only or rote ("done"/"verified"/…) evidence. Helper: `verificationGateViolation(status, evidence, evidenceKind)` in `src/vsa-accessors.ts`.
+- **Layer (b) already existed**: `learnGateViolations` (`src/algorithm.ts`) blocks a hollow pass from entering LEARN → completing (`:298` completeness, `:459` gate). VerificationGate (layer a) just moved the same bar to record time. JC's decisions: **Block**, layers **a + b**, name **VerificationGate**.
+- **Reconstruction opt-out**: `verifyAlgorithmCriterion(..., enforceGate=true)`. The VSA→run sync (`src/algorithm-vsa-sync.ts`, two call sites) passes `false` — it reconstructs already-declared `[x]` state (bare checkboxes carry no probe kind); synced hollow passes are still caught by the audit-time LEARN gate. The strictness belongs on the ASSERTION surface, not on mirroring on-disk state.
+- **Escape hatches**: `evidenceKind: "probed"|"tested"`, or `status: "deferred-probe"`. The CLI already accepts `--evidence-kind`.
+- **Tests touched**: `algorithm-verification-evidence.test.ts` (2 new negative tests: spec-only + rote refused at record time; the old "grandfathered" / "blocks advance to LEARN" tests rewritten to the record-time contract), plus probe kinds added to agent-verify setups in `algorithm.test.ts`, `lifecycle.test.ts`, `cli.test.ts`.
+- **Open question for JC**: I did NOT port EvidenceGate's fuller rote-text matching — Soma's structured `evidenceKind` is the real discriminator, so the gate leans on that + a bare-word blocklist only. Flag if the fuller text matching is wanted.
+- ⚠️ **Debugging gotcha for next session**: a test named `records per-hop substrate provenance for Algorithm mutations` exists in BOTH `algorithm.test.ts` AND `algorithm-meta-reflection.test.ts`. When the full suite reports it failing, check `algorithm.test.ts` FIRST — a same-named test in another file makes "run it alone → passes" misleading. Also: single-line `grep "verifyAlgorithmCriterion.*passed"` MISSES multi-line calls; use `grep -A6`.
+
+## ⏭️ NEXT: PreCompact port (the remaining port — NOT started)
+
+Task: port PAI's `PreCompact.hook.ts` (auto handover-on-compaction) into a Soma-owned claude-code hook. **JC's decision: emit + PERSIST** (his words: "the output gets cleared before the user has a chance to read it, so a persistence into the next section would be good"). This effectively realizes part of the deferred **M5b** (SessionEnd digest).
+
+**Source hook** (read for the output format): `~/.claude/hooks/PreCompact.hook.ts` — reads PAI `MEMORY/STATE/current-work*.json` (gone in Soma) + the active ISA, emits a `# Pre-Compaction Handover` markdown to stdout (Active Work / ISA Summary / Files Modified / Key Decisions / Working Directory / Session ID). Non-blocking, PreCompact event.
+
+**Soma side (grounded this session):**
+- Data source: **`buildSomaStartupContext()`** at `src/lifecycle.ts:199` already assembles work-state (`SomaStartupContext` has a `context: string`). Reuse it rather than re-derive.
+- Existing claude-code hook assets to mirror: `src/adapters/claude-code/{mode-classifier-hook.mjs, policy-guard-hook.mjs, hook-runner.mjs}`; install wiring `installClaudeCodeSomaHooks` in `src/adapters/claude-code/hooks.ts`; config JSON pattern; marker-guarded `settings.json` patch. The de-PAI pass REMOVED the `PreCompact` event from `settings.json` — **re-add it as Soma-owned**.
+
+**Design decisions to make while building:**
+1. **Where to persist** so it survives into the post-compaction section: a Soma episodic digest (ties to M5b — needs the digest-authorship model JC deferred) OR a simpler durable `last-handover` file that the next `UserPromptSubmit` (`soma-claude-code-hook.mjs`) or session-start re-injects. Recommend the simpler file first; wire M5b episodic later.
+2. **Re-surface mechanism**: claude-code compaction does NOT re-run session-start, so emitting alone isn't enough (that's JC's exact complaint). The persisted handover must be re-injected by the per-prompt hook (`soma-claude-code-hook.mjs`, UserPromptSubmit) reading the durable file. Design this loop explicitly.
+3. Substrate scope: PreCompact is claude-code-specific (other substrates have no compaction event) — a claude-code adapter hook, fine.
+
+**Build the same way as VerificationGate**: verification-first, tests, then commit on this branch. Then push both + PR (the skill-projection arc went via PR + Sage review — see below).
+
+## PAI hook cleanup ledger (decided with JC this session)
+
+The `~/.claude/hooks/` triage is DONE. Full analysis in this session's transcript. Disposition:
+
+**PORT into Soma:** EvidenceGate → VerificationGate ✅ DONE. PreCompact → ⏭️ TODO (above).
+
+**KEEP (not PAI):** `ACR.hook.ts` (JC's recall), the 4 `Cortex*.hook.ts` symlinks, `ContextReduction.hook.sh` (RTK auto-rewrite), `PrePushSmokeTest.hook.ts` (JC's), and **caduceus** = `SkillNudgeInject.hook.ts` + `handlers/SkillNudge.ts` + `lib/skill-stats-log` (JC's experiment; ⚠️ currently UNWIRED by the de-PAI pass — re-wire if JC wants it firing).
+
+**RETIRE** (move to `~/.claude/hooks/_retired-2026-07/`, don't delete yet):
+- *Soma-covered:* PromptGuard, SecurityPipeline, ContentScanner, ContainmentGuard (→ `soma-policy-guard`), ModeClassifier (→ `soma-mode-classifier`), LoadContext (→ projection + `soma-claude-code-hook`).
+- *Flinch (JC retracted the experiment completely):* FlinchDetect, FlinchReview — **and delete the Soma `flinch` skill** (`~/.soma/skills/flinch`).
+- *Voice (JC won't port):* VoiceCompletion.
+- *Cruft:* FileChangeTracker, SkillEnforcer, SkillGuard, SkillLoadLogger, LastResponseCache, KittyEnvPersist, SetQuestionTab, QuestionAnswered.
+- *PAI-infra:* KVSync, UpdateCounts, AgentInvocation, StopFailureHandler, IntegrityCheck, DocIntegrity.
+
+⚠️ **5 retire-list hooks still `import` from `../PAI/…`** (ContainmentGuard, FlinchDetect, FlinchReview, IntegrityCheck, VoiceCompletion) — they hard-break when the PAI tree is removed. They're unwired so it's inert, but retire them WITH the tree removal. (ContainmentGuard's pattern list was already emptied in the migration — a no-op today.)
+
+## Then: finish de-PAI (from the 2026-07-06 handover)
+
+1. **Clear `settings.json` PAI residue** (`autoMode`/`daidentity`/`spinnerTipsOverride` + the 1 live ref INTO the PAI tree) — this is the safety blocker for removing the tree. ⚠️ `settings.json` is GITIGNORED; back it up first (a `settings.json.backup-preSkillInstall` already exists from this session).
+2. **Retire the ~19 hook FILES** → `_retired-2026-07/` (per the ledger above), after confirming no KEPT hook imports from `hooks/lib/` shared by PAI.
+3. **Remove the 18 MB `~/.claude/PAI/` tree** — backup-copy first (not git-reversible for ignored paths), grep-confirm zero refs, then delete. The symbolic "PAI is gone" moment.
+4. Migrate the kept `CLAUDE.md` guidance (completion guard / MODES) into `~/.soma` (#5 in the old handover); decide #403 (per-prompt recall as ACR's Soma-native successor).
+
+## PR / review workflow (how the last arc landed)
+
+The skill-projection PR (#437) went: push branch → `gh pr create` (use `--body-file`, NOT an inline `$(cat <<EOF)` subshell — the runtime policy blocks that as `env-egress`) → **`sage review the-metafactory/soma#<N> --substrate <pi|codex> --post --emit-verdict-block`** (runs the botanical reviewer on a pi.dev or Codex LLM substrate; posts to the PR). Sage tends NOT to converge to `approve` (it surfaces fresh nits each round, even regresses) — so triage its findings (verify each; several were false alarms / misreads / pre-existing) and, once the real ones are fixed, the repo's `REVIEW_REQUIRED` ruleset needs an admin-override merge (`gh pr merge <N> --squash --admin --delete-branch`) since Sage's verdict posts as a COMMENT, not an approval. JC authorized admin-merge when Sage won't approve.
+
+## Verify before declaring done
+
+- `bun run typecheck` + `bun test` (full suite ~1851 pass; the 5000ms failures are environmental timeout flakes under parallel load — re-run or run the file alone to confirm).
+- For anything touching `~/.claude` (installs, hook removal): back up gitignored `settings.json`, keep the 117 native skill dirs intact, keep `settings.json` at 0 PAI / 8 soma hooks, and don't pass `--claude-md` (leaves the de-PAI'd CLAUDE.md alone).

--- a/Plans/2026-07-07-HANDOVER-verification-gate-precompact-hook-cleanup.md
+++ b/Plans/2026-07-07-HANDOVER-verification-gate-precompact-hook-cleanup.md
@@ -2,6 +2,8 @@
 
 *Written 2026-07-07. Read this first when resuming. Sibling doc: `Plans/2026-07-06-HANDOVER-remove-pai-from-claude.md` (the de-PAI migration — still the source of truth for tree removal + settings.json cleanup).*
 
+> **STATUS UPDATE (later same day):** BOTH ports are now DONE. VerificationGate (`41d9830`) + PreCompact (`7735ca2`) are committed on `feat/verification-gate-and-precompact` and **pushed** — bundled in **PR #439**. The "PreCompact — NOT started" and "1 commit, not pushed" statements below are the point-in-time framing from when this doc was written; they are superseded. Remaining work = land #439 (Sage review → admin-merge), then finish de-PAI (settings.json residue → retire hook files → remove the 18 MB PAI tree).
+
 ## The frame
 
 **First finish line = Soma-as-a-standalone-product** (the composability epic: #381 AI-native install doc, #373 greenfield CI across adapters, #370 provenance/doctor, #371 compact skill registry — no milestone defined yet). JC's sequencing: **clean up the local installation first**, then the product work.

--- a/src/adapters/claude-code/hooks.ts
+++ b/src/adapters/claude-code/hooks.ts
@@ -14,7 +14,7 @@ import { isClaudeCodeInstallOptions } from "./install-options";
  */
 export function claudeCodeHookEnabled(
   options: unknown,
-  hook: "modeClassifier" | "policyGuard",
+  hook: "modeClassifier" | "policyGuard" | "preCompact",
 ): boolean {
   if (!isClaudeCodeInstallOptions(options)) return true;
   return options[hook] !== false;
@@ -26,6 +26,8 @@ export const SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH = "hooks/soma/soma-mode-c
 export const SOMA_CLAUDE_MODE_CLASSIFIER_CONFIG_RELATIVE_PATH = "hooks/soma/soma-mode-classifier.config.json";
 export const SOMA_CLAUDE_POLICY_GUARD_RELATIVE_PATH = "hooks/soma/soma-policy-guard.mjs";
 export const SOMA_CLAUDE_POLICY_GUARD_CONFIG_RELATIVE_PATH = "hooks/soma/soma-policy-guard.config.json";
+export const SOMA_CLAUDE_PRECOMPACT_RELATIVE_PATH = "hooks/soma/soma-precompact.mjs";
+export const SOMA_CLAUDE_PRECOMPACT_CONFIG_RELATIVE_PATH = "hooks/soma/soma-precompact.config.json";
 // PreToolUse matcher for the fail-closed enforcement guard: every tool whose
 // input can carry a dangerous command, an outbound exfiltration, or a
 // credential-path read/write that the runtime policy must inspect.
@@ -231,6 +233,81 @@ function removeSomaPolicyGuardFromSettings(settings: JsonObject, substrateHome: 
   const preTool = removeCommandsFromSettingsEvent(settings, "PreToolUse", commands);
   const prompt = removeCommandsFromSettingsEvent(settings, "UserPromptSubmit", commands);
   return preTool || prompt;
+}
+
+// PreCompact handover hook: ONE asset dispatched by argv into two events —
+// `capture` on PreCompact (persist the handover) and `resurface` on
+// UserPromptSubmit (re-inject it once after compaction). The action suffix is
+// part of the command string so idempotent append + clean removal see both.
+function legacySomaPreCompactCommand(substrateHome: string, action: string): string {
+  return `${shellQuote(resolve(substrateHome, SOMA_CLAUDE_PRECOMPACT_RELATIVE_PATH))} ${action}`;
+}
+
+function somaPreCompactCommand(substrateHome: string, bunPath: string, action: string): string {
+  return `${shellQuote(bunPath)} ${shellQuote(resolve(substrateHome, SOMA_CLAUDE_PRECOMPACT_RELATIVE_PATH))} ${action}`;
+}
+
+function somaPreCompactCommands(substrateHome: string, bunPath: string): Set<string> {
+  return new Set(
+    ["capture", "resurface"].flatMap((action) => [
+      somaPreCompactCommand(substrateHome, bunPath, action),
+      legacySomaPreCompactCommand(substrateHome, action),
+    ]),
+  );
+}
+
+function somaPreCompactEntry(substrateHome: string, bunPath: string, action: string, timeout: number): JsonObject {
+  return {
+    type: "command",
+    command: somaPreCompactCommand(substrateHome, bunPath, action),
+    timeout,
+  };
+}
+
+function appendSomaPreCompactHookGroups(settings: JsonObject, substrateHome: string, bunPath: string): boolean {
+  const knownCommands = somaPreCompactCommands(substrateHome, bunPath);
+  const capture = appendCommandHookGroup(settings, {
+    event: "PreCompact",
+    description: "Soma: Capture a pre-compaction handover of active work-state",
+    entry: somaPreCompactEntry(substrateHome, bunPath, "capture", 30),
+    knownCommands,
+  });
+  const resurface = appendCommandHookGroup(settings, {
+    event: "UserPromptSubmit",
+    description: "Soma: Resurface the pre-compaction handover after compaction",
+    entry: somaPreCompactEntry(substrateHome, bunPath, "resurface", 15),
+    knownCommands,
+  });
+  return capture || resurface;
+}
+
+// Like installedPolicyGuardCommands: collect every command in the two events
+// that references the handover script regardless of the bun path it was
+// recorded with, so uninstall is robust to a drifted bun path.
+function installedPreCompactCommands(settings: JsonObject, substrateHome: string): Set<string> {
+  const scriptPath = resolve(substrateHome, SOMA_CLAUDE_PRECOMPACT_RELATIVE_PATH);
+  const found = new Set<string>();
+  if (!isObject(settings.hooks)) return found;
+  for (const event of ["PreCompact", "UserPromptSubmit"]) {
+    const groups = settings.hooks[event];
+    if (!Array.isArray(groups)) continue;
+    for (const group of groups) {
+      for (const command of groupCommands(group)) {
+        if (command.includes(scriptPath)) found.add(command);
+      }
+    }
+  }
+  return found;
+}
+
+function removeSomaPreCompactFromSettings(settings: JsonObject, substrateHome: string, bunPath: string): boolean {
+  const commands = new Set([
+    ...somaPreCompactCommands(substrateHome, bunPath),
+    ...installedPreCompactCommands(settings, substrateHome),
+  ]);
+  const preCompact = removeCommandsFromSettingsEvent(settings, "PreCompact", commands);
+  const prompt = removeCommandsFromSettingsEvent(settings, "UserPromptSubmit", commands);
+  return preCompact || prompt;
 }
 
 function appendCommandHookGroup(
@@ -498,6 +575,22 @@ export async function unpatchClaudeCodePolicyGuardSettings(substrateHome: string
   return writeJsonIfChanged(settingsPath, settings, before);
 }
 
+export async function patchClaudeCodePreCompactSettings(substrateHome: string, bunPath = resolveBunExecutable()): Promise<string[]> {
+  const settingsPath = resolve(substrateHome, SOMA_CLAUDE_SETTINGS_RELATIVE_PATH);
+  const { before, settings } = await readSettingsWithRaw(settingsPath);
+  const changed = appendSomaPreCompactHookGroups(settings, substrateHome, bunPath);
+  if (!changed && before.trim().length > 0) return [];
+  return writeJsonIfChanged(settingsPath, settings, before);
+}
+
+export async function unpatchClaudeCodePreCompactSettings(substrateHome: string, bunPath = resolveBunExecutable()): Promise<string[]> {
+  const settingsPath = resolve(substrateHome, SOMA_CLAUDE_SETTINGS_RELATIVE_PATH);
+  const { before, settings } = await readSettingsWithRaw(settingsPath);
+  if (before.trim().length === 0) return [];
+  if (!removeSomaPreCompactFromSettings(settings, substrateHome, bunPath)) return [];
+  return writeJsonIfChanged(settingsPath, settings, before);
+}
+
 export async function unpatchClaudeCodeSomaHookSettings(substrateHome: string, bunPath = resolveBunExecutable()): Promise<string[]> {
   const settingsPath = resolve(substrateHome, SOMA_CLAUDE_SETTINGS_RELATIVE_PATH);
   const { before, settings } = await readSettingsWithRaw(settingsPath);
@@ -546,7 +639,10 @@ export async function installClaudeCodeSomaHooks(context: {
   const policyGuardFiles = claudeCodeHookEnabled(context.options, "policyGuard")
     ? await installClaudeCodePolicyGuardHook(context, config, bunPath)
     : [];
-  return Array.from(new Set([hookPath, configPath, ...settingsFiles, ...modeClassifierFiles, ...policyGuardFiles]));
+  const preCompactFiles = claudeCodeHookEnabled(context.options, "preCompact")
+    ? await installClaudeCodePreCompactHook(context, config, bunPath)
+    : [];
+  return Array.from(new Set([hookPath, configPath, ...settingsFiles, ...modeClassifierFiles, ...policyGuardFiles, ...preCompactFiles]));
 }
 
 async function installClaudeCodePolicyGuardHook(
@@ -564,6 +660,24 @@ async function installClaudeCodePolicyGuardHook(
     config,
   });
   const settingsFiles = await patchClaudeCodePolicyGuardSettings(context.substrateHome, bunPath);
+  return [hookPath, configPath, ...settingsFiles];
+}
+
+async function installClaudeCodePreCompactHook(
+  context: { somaHome: string; somaRepoPath: string; substrateHome: string },
+  config: { somaHome: string; trustedSomaRepo: string; bunPath: string },
+  bunPath: string,
+): Promise<string[]> {
+  const hookPath = resolve(context.substrateHome, SOMA_CLAUDE_PRECOMPACT_RELATIVE_PATH);
+  const configPath = resolve(context.substrateHome, SOMA_CLAUDE_PRECOMPACT_CONFIG_RELATIVE_PATH);
+
+  await installClaudeCodeHookAsset({
+    hookPath,
+    configPath,
+    source: renderClaudeCodePreCompactHook(),
+    config,
+  });
+  const settingsFiles = await patchClaudeCodePreCompactSettings(context.substrateHome, bunPath);
   return [hookPath, configPath, ...settingsFiles];
 }
 
@@ -602,6 +716,7 @@ export async function removeClaudeCodeSomaHookFiles(substrateHome: string): Prom
   const installedBunPath = await readInstalledClaudeCodeHookBunPath(substrateHome);
   const installedModeClassifierBunPath = await readInstalledClaudeCodeModeClassifierBunPath(substrateHome);
   const installedPolicyGuardBunPath = await readInstalledClaudeCodePolicyGuardBunPath(substrateHome);
+  const installedPreCompactBunPath = await readInstalledClaudeCodePreCompactBunPath(substrateHome);
   for (const relativePath of [
     SOMA_CLAUDE_HOOK_RELATIVE_PATH,
     SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH,
@@ -609,6 +724,8 @@ export async function removeClaudeCodeSomaHookFiles(substrateHome: string): Prom
     SOMA_CLAUDE_MODE_CLASSIFIER_CONFIG_RELATIVE_PATH,
     SOMA_CLAUDE_POLICY_GUARD_RELATIVE_PATH,
     SOMA_CLAUDE_POLICY_GUARD_CONFIG_RELATIVE_PATH,
+    SOMA_CLAUDE_PRECOMPACT_RELATIVE_PATH,
+    SOMA_CLAUDE_PRECOMPACT_CONFIG_RELATIVE_PATH,
   ]) {
     const target = resolve(substrateHome, relativePath);
     const exists = await stat(target).then(
@@ -629,6 +746,7 @@ export async function removeClaudeCodeSomaHookFiles(substrateHome: string): Prom
   removed.push(...(await unpatchClaudeCodeSomaHookSettings(substrateHome, installedBunPath)));
   removed.push(...(await unpatchClaudeCodeModeClassifierSettings(substrateHome, installedModeClassifierBunPath ?? installedBunPath)));
   removed.push(...(await unpatchClaudeCodePolicyGuardSettings(substrateHome, installedPolicyGuardBunPath ?? installedBunPath)));
+  removed.push(...(await unpatchClaudeCodePreCompactSettings(substrateHome, installedPreCompactBunPath ?? installedBunPath)));
   return Array.from(new Set(removed));
 }
 
@@ -642,6 +760,10 @@ async function readInstalledClaudeCodePolicyGuardBunPath(substrateHome: string):
 
 async function readInstalledClaudeCodeModeClassifierBunPath(substrateHome: string): Promise<string | undefined> {
   return readInstalledClaudeCodeHookConfigBunPath(substrateHome, SOMA_CLAUDE_MODE_CLASSIFIER_CONFIG_RELATIVE_PATH);
+}
+
+async function readInstalledClaudeCodePreCompactBunPath(substrateHome: string): Promise<string | undefined> {
+  return readInstalledClaudeCodeHookConfigBunPath(substrateHome, SOMA_CLAUDE_PRECOMPACT_CONFIG_RELATIVE_PATH);
 }
 
 async function readInstalledClaudeCodeHookConfigBunPath(substrateHome: string, relativePath: string): Promise<string | undefined> {
@@ -676,4 +798,8 @@ function renderClaudeCodeModeClassifierHook(): string {
 
 function renderClaudeCodePolicyGuardHook(): string {
   return readFileSync(new URL("./policy-guard-hook.mjs", import.meta.url), "utf8");
+}
+
+function renderClaudeCodePreCompactHook(): string {
+  return readFileSync(new URL("./precompact-hook.mjs", import.meta.url), "utf8");
 }

--- a/src/adapters/claude-code/install-options.ts
+++ b/src/adapters/claude-code/install-options.ts
@@ -3,6 +3,8 @@ import type { SomaInstallOptions } from "../../types";
 export interface ClaudeCodeInstallOptions extends SomaInstallOptions {
   modeClassifier?: boolean;
   policyGuard?: boolean;
+  /** Compaction-survival handover hook (PreCompact capture + UserPromptSubmit resurface). */
+  preCompact?: boolean;
   /** soma#368: generate ~/.claude/CLAUDE.md as a projection (overlay-preserving). */
   claudeMd?: boolean;
 }

--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -10,6 +10,8 @@ import {
   SOMA_CLAUDE_MODE_CLASSIFIER_RELATIVE_PATH,
   SOMA_CLAUDE_POLICY_GUARD_CONFIG_RELATIVE_PATH,
   SOMA_CLAUDE_POLICY_GUARD_RELATIVE_PATH,
+  SOMA_CLAUDE_PRECOMPACT_CONFIG_RELATIVE_PATH,
+  SOMA_CLAUDE_PRECOMPACT_RELATIVE_PATH,
   claudeCodeHookEnabled,
   installClaudeCodeSomaHooks,
   removeClaudeCodeSomaHookFiles,
@@ -38,6 +40,9 @@ export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
       : []),
     ...(claudeCodeHookEnabled(options, "policyGuard")
       ? [SOMA_CLAUDE_POLICY_GUARD_RELATIVE_PATH, SOMA_CLAUDE_POLICY_GUARD_CONFIG_RELATIVE_PATH]
+      : []),
+    ...(claudeCodeHookEnabled(options, "preCompact")
+      ? [SOMA_CLAUDE_PRECOMPACT_RELATIVE_PATH, SOMA_CLAUDE_PRECOMPACT_CONFIG_RELATIVE_PATH]
       : []),
     ...(isClaudeCodeInstallOptions(options) && options.claudeMd === true
       ? [CLAUDE_CODE_CLAUDE_MD_RELATIVE_PATH]

--- a/src/adapters/claude-code/precompact-hook.mjs
+++ b/src/adapters/claude-code/precompact-hook.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env bun
+/**
+ * Soma PreCompact handover hook (Claude Code).
+ *
+ * Claude Code compresses the conversation mid-session and does NOT re-run
+ * SessionStart afterward, so live work-state (active Algorithm runs) is lost
+ * across the boundary. This hook is the persist+resurface pair that carries it:
+ *
+ *   argv "capture"   — wired to the PreCompact event. Snapshots the startup
+ *                      context into a durable, session-scoped file AND echoes it
+ *                      to stdout.
+ *   argv "resurface" — wired to UserPromptSubmit. On the first prompt after a
+ *                      compaction it re-injects that file as additionalContext,
+ *                      then the CLI consumes it so it fires exactly once.
+ *
+ * Fail-open: Soma continuity must never block normal Claude Code use.
+ */
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function hookDir() {
+  return dirname(fileURLToPath(import.meta.url));
+}
+
+function readConfig() {
+  try {
+    return JSON.parse(readFileSync(join(hookDir(), "soma-precompact.config.json"), "utf8"));
+  } catch (error) {
+    return { error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function readHookInput() {
+  try {
+    const raw = readFileSync(0, "utf8");
+    if (raw.trim().length === 0) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function nonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function runSoma(config, args, timeout) {
+  return spawnSync(config.bunPath, ["src/cli.ts", ...args], {
+    cwd: config.trustedSomaRepo,
+    encoding: "utf8",
+    timeout,
+    env: process.env,
+  });
+}
+
+function baseArgs(config, action) {
+  return ["precompact", action, "--soma-home", config.somaHome, "--substrate", "claude-code"];
+}
+
+function withSession(args, input) {
+  const id = nonEmptyString(input.session_id);
+  if (id) args.push("--session-id", id);
+  return args;
+}
+
+// PreCompact: persist the handover (the CLI writes the durable file) and echo it
+// to stdout. Non-blocking — exit 0 regardless.
+function capture(config, input) {
+  const args = withSession(baseArgs(config, "capture"), input);
+  const cwd = nonEmptyString(input.cwd);
+  if (cwd) args.push("--cwd", cwd);
+  const result = runSoma(config, args, 20000);
+  const handover = typeof result.stdout === "string" ? result.stdout.trim() : "";
+  if (handover.length > 0) console.log(handover);
+  process.exit(0);
+}
+
+// UserPromptSubmit: resurface the persisted handover once. The CLI consumes the
+// file, so this injects additionalContext only on the first prompt after a
+// compaction and stays silent otherwise.
+function resurface(config, input) {
+  const result = runSoma(config, withSession(baseArgs(config, "resurface"), input), 8000);
+  const handover = result.status === 0 && typeof result.stdout === "string" ? result.stdout.trim() : "";
+  if (handover.length === 0) emitContinue();
+  emitAndExit({
+    continue: true,
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: handover,
+    },
+  });
+}
+
+function emitContinue() {
+  emitAndExit({ continue: true });
+}
+
+function emitAndExit(payload) {
+  console.log(JSON.stringify(payload));
+  process.exit(0);
+}
+
+function main() {
+  const action = process.argv[2];
+  const config = readConfig();
+  if (config.error || typeof config.bunPath !== "string" || typeof config.trustedSomaRepo !== "string" || typeof config.somaHome !== "string") {
+    // Fail-open: a broken config must not block the prompt or the compaction.
+    if (action === "resurface") emitContinue();
+    process.exit(0);
+  }
+  const input = readHookInput();
+  if (action === "capture") capture(config, input);
+  else if (action === "resurface") resurface(config, input);
+  else process.exit(0);
+}
+
+main();

--- a/src/adapters/claude-code/precompact-hook.mjs
+++ b/src/adapters/claude-code/precompact-hook.mjs
@@ -16,7 +16,7 @@
  * Fail-open: Soma continuity must never block normal Claude Code use.
  */
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -67,31 +67,54 @@ function withSession(args, input) {
 }
 
 // PreCompact: persist the handover (the CLI writes the durable file) and echo it
-// to stdout. Non-blocking — exit 0 regardless.
+// to stdout. Non-blocking — exit 0 regardless, even if the spawn fails.
 function capture(config, input) {
-  const args = withSession(baseArgs(config, "capture"), input);
-  const cwd = nonEmptyString(input.cwd);
-  if (cwd) args.push("--cwd", cwd);
-  const result = runSoma(config, args, 20000);
-  const handover = typeof result.stdout === "string" ? result.stdout.trim() : "";
-  if (handover.length > 0) console.log(handover);
+  try {
+    const args = withSession(baseArgs(config, "capture"), input);
+    const cwd = nonEmptyString(input.cwd);
+    if (cwd) args.push("--cwd", cwd);
+    const result = runSoma(config, args, 20000);
+    const handover = typeof result.stdout === "string" ? result.stdout.trim() : "";
+    if (handover.length > 0) console.log(handover);
+  } catch {
+    // Non-blocking: a failed capture must not interfere with compaction.
+  }
   process.exit(0);
+}
+
+// The durable handover path the CLI would read — a mirror of preCompactHandoverPath
+// in src/cli/precompact.ts, kept in sync (same sanitize + filename template) so the
+// hook can skip the CLI spawn when no handover is pending. A drift only costs a
+// missed fast-path, never correctness: the CLI remains the authoritative reader.
+function handoverPath(config, input) {
+  const id = nonEmptyString(input.session_id);
+  const name = id ? `precompact-handover-${id.replace(/[^A-Za-z0-9_-]/g, "_")}.md` : "precompact-handover.md";
+  return join(config.somaHome, "memory/STATE", name);
 }
 
 // UserPromptSubmit: resurface the persisted handover once. The CLI consumes the
 // file, so this injects additionalContext only on the first prompt after a
-// compaction and stays silent otherwise.
+// compaction and stays silent otherwise. Fail-open on any error.
 function resurface(config, input) {
-  const result = runSoma(config, withSession(baseArgs(config, "resurface"), input), 8000);
-  const handover = result.status === 0 && typeof result.stdout === "string" ? result.stdout.trim() : "";
-  if (handover.length === 0) emitContinue();
-  emitAndExit({
-    continue: true,
-    hookSpecificOutput: {
-      hookEventName: "UserPromptSubmit",
-      additionalContext: handover,
-    },
-  });
+  try {
+    // Hot-path guard: this hook fires on EVERY prompt. Only pay the Bun/TS CLI
+    // startup on the rare prompt where a handover file actually exists (once per
+    // compaction); otherwise return immediately.
+    if (!existsSync(handoverPath(config, input))) emitContinue();
+    const result = runSoma(config, withSession(baseArgs(config, "resurface"), input), 8000);
+    const handover = result.status === 0 && typeof result.stdout === "string" ? result.stdout.trim() : "";
+    if (handover.length === 0) emitContinue();
+    emitAndExit({
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: handover,
+      },
+    });
+  } catch {
+    // Fail-open: Soma continuity must never block a prompt.
+    emitContinue();
+  }
 }
 
 function emitContinue() {

--- a/src/algorithm-vsa-sync.ts
+++ b/src/algorithm-vsa-sync.ts
@@ -341,6 +341,7 @@ function reconcileCriteria(
       timestamp,
       { substrate },
       vsaCriterion.evidenceKind,
+      false, // reconstruction, not a fresh assertion — VerificationGate does not apply (layer b still audits)
     );
   }
 
@@ -357,7 +358,7 @@ function reconcileCriteria(
     const evidence = goal ? `synced from VSA progress: ${goal}` : `synced from VSA progress: ${vsaCriterion.text}`;
     // A pass fabricated to match a frontmatter progress counter is specification
     // grade only — it must not clear the LEARN integrity gate as if probed.
-    next = verifyAlgorithmCriterion(next, vsaCriterion.id, "passed", evidence, timestamp, { substrate }, "specified");
+    next = verifyAlgorithmCriterion(next, vsaCriterion.id, "passed", evidence, timestamp, { substrate }, "specified", false);
     runCriteria = getCriteria(next.vsa);
     completed = runCriteria.filter(isClosedCriterion).length;
   }

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -382,7 +382,7 @@ export function verifyAlgorithmCriterion(
   provenance?: Pick<AlgorithmProvenanceInput, "substrate">,
   evidenceKind?: Checkpoint["evidenceKind"],
   // VerificationGate opt-out for the RECONSTRUCTION surface. The gate fires on
-  // fresh agent/CLI assertions (default); the VSA→run sync passes false because
+  // fresh assistant/CLI assertions (default); the VSA→run sync passes false because
   // it reconstructs already-DECLARED state from existing VSA markdown (a bare
   // `[x]` legitimately carries no probe kind). Synced hollow passes remain
   // caught by the audit-time LEARN gate (layer b) — the strictness belongs on

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -28,6 +28,7 @@ import {
   isHollowPass,
   progressFromCriteria,
   updateCriterionWithResult,
+  verificationGateViolation,
   verifiedFromCriteria,
 } from "./vsa-accessors";
 
@@ -380,8 +381,25 @@ export function verifyAlgorithmCriterion(
   timestamp?: string,
   provenance?: Pick<AlgorithmProvenanceInput, "substrate">,
   evidenceKind?: Checkpoint["evidenceKind"],
+  // VerificationGate opt-out for the RECONSTRUCTION surface. The gate fires on
+  // fresh agent/CLI assertions (default); the VSA→run sync passes false because
+  // it reconstructs already-DECLARED state from existing VSA markdown (a bare
+  // `[x]` legitimately carries no probe kind). Synced hollow passes remain
+  // caught by the audit-time LEARN gate (layer b) — the strictness belongs on
+  // the assertion surface, not on mirroring on-disk state.
+  enforceGate = true,
 ): AlgorithmRun {
   assertNonEmpty(evidence, "verification evidence");
+
+  // VerificationGate (layer a) — fail-fast at record time. #330's LEARN gate
+  // (assertGate → learnGateViolations) already blocks a hollow pass from
+  // COMPLETING; this refuses to RECORD a `passed` on spec-only/rote evidence so
+  // the caller is corrected immediately, not at the finish line. Escape hatches:
+  // evidenceKind "probed"/"tested", or status "deferred-probe".
+  const gateViolation = enforceGate ? verificationGateViolation(status, evidence, evidenceKind) : null;
+  if (gateViolation) {
+    throw new Error(`VerificationGate: cannot mark ${criterionId} passed — ${gateViolation.message}.`);
+  }
 
   const { isa: vsaWithSection, criteria: updatedCriteria } = updateCriterionWithResult(
     run.vsa,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -113,6 +113,12 @@ import {
   runToolCli,
   type ParsedToolArgs,
 } from "./cli/tools";
+import {
+  PRECOMPACT_COMMAND_HELP,
+  parsePreCompactArgs,
+  runPreCompactCli,
+  type ParsedPreCompactArgs,
+} from "./cli/precompact";
 
 export { SomaCliError } from "./cli/errors";
 
@@ -153,6 +159,7 @@ type ParsedArgs =
   | ParsedFeedbackArgs
   | ParsedResultArgs
   | ParsedPolicyArgs
+  | ParsedPreCompactArgs
   | ParsedWritebackArgs
   | ParsedVsaArgs
   | ParsedSnapshotCommandArgs
@@ -179,6 +186,7 @@ const TOP_LEVEL_COMMANDS = [
   "migrate",
   "opinion",
   "policy",
+  "precompact",
   "project-skill",
   "relationship",
   "reproject",
@@ -206,6 +214,7 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
   policy: POLICY_COMMAND_HELP,
   writeback: WRITEBACK_COMMAND_HELP,
   lifecycle: LIFECYCLE_COMMAND_HELP,
+  precompact: PRECOMPACT_COMMAND_HELP,
   install: SUBSTRATE_LIFECYCLE_COMMAND_HELP.install,
   uninstall: SUBSTRATE_LIFECYCLE_COMMAND_HELP.uninstall,
   reproject: SUBSTRATE_LIFECYCLE_COMMAND_HELP.reproject,
@@ -291,6 +300,10 @@ function parseArgs(args: string[]): ParsedArgs {
 
   if (args[0] === "policy") {
     return parsePolicyArgs(args);
+  }
+
+  if (args[0] === "precompact") {
+    return parsePreCompactArgs(args);
   }
 
   if (args[0] === "writeback") {
@@ -477,6 +490,10 @@ export async function runSomaCli(args: string[]): Promise<string> {
 
   if (parsed.command === "lifecycle") {
     return runLifecycleCli(parsed);
+  }
+
+  if (parsed.command === "precompact") {
+    return runPreCompactCli(parsed);
   }
 
   if (parsed.command === "doctor" || parsed.command === "init" || parsed.command === "adopt") {

--- a/src/cli/precompact.ts
+++ b/src/cli/precompact.ts
@@ -1,0 +1,139 @@
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { buildSomaStartupContext, resolveSomaHome } from "../lifecycle";
+import { isEnoent } from "../fs-errors";
+import type { SomaLifecycleOptions } from "../types";
+import { readOption } from "./parse-utils";
+import { parseSubstrate } from "./substrate";
+
+/**
+ * `soma precompact` — the compaction-survival handover for substrates (notably
+ * Claude Code) whose context window is compressed mid-session.
+ *
+ * `capture` (fired on the substrate's pre-compaction event) snapshots the
+ * live work-state — active Algorithm runs, recent learning — into a durable,
+ * session-scoped file AND prints it to stdout (some substrates surface the
+ * hook's stdout directly). `resurface` (fired on the next user prompt after
+ * compaction) prints that file once and consumes it, re-injecting the handover
+ * into the compacted context. Compaction does not re-run SessionStart, so the
+ * persist+resurface pair is what carries work-state across the boundary.
+ */
+
+export interface ParsedPreCompactArgs {
+  command: "precompact";
+  action: "capture" | "resurface";
+  options: SomaLifecycleOptions;
+}
+
+const PRECOMPACT_USAGE =
+  "Usage: soma precompact <capture|resurface> [--home-dir <dir>] [--soma-home <dir>] [--substrate <id>] [--session-id <id>] [--cwd <dir>]";
+
+export const PRECOMPACT_COMMAND_HELP: { usage: string; subcommands: Record<ParsedPreCompactArgs["action"], string> } = {
+  usage: PRECOMPACT_USAGE,
+  subcommands: {
+    capture: PRECOMPACT_USAGE,
+    resurface: PRECOMPACT_USAGE,
+  },
+};
+
+export function parsePreCompactArgs(args: string[]): ParsedPreCompactArgs {
+  const [command, action, ...rest] = args;
+
+  if (command !== "precompact" || (action !== "capture" && action !== "resurface")) {
+    throw new Error(PRECOMPACT_COMMAND_HELP.usage);
+  }
+
+  const options: SomaLifecycleOptions = {};
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--substrate":
+        options.substrate = parseSubstrate(readOption(rest, index, arg));
+        index += 1;
+        break;
+      case "--session-id":
+        options.sessionId = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--cwd":
+        options.cwd = readOption(rest, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return { command: "precompact", action, options };
+}
+
+// Session ids come from the substrate (Claude Code sends a UUID). Restrict to a
+// filename-safe alphabet so a hostile/odd id can never escape memory/STATE.
+function sanitizeSessionId(sessionId: string): string {
+  return sessionId.replace(/[^A-Za-z0-9_-]/g, "_");
+}
+
+export function preCompactHandoverPath(somaHome: string, sessionId?: string): string {
+  const scoped = sessionId !== undefined && sessionId.trim().length > 0;
+  const name = scoped ? `precompact-handover-${sanitizeSessionId(sessionId)}.md` : "precompact-handover.md";
+  return join(somaHome, "memory/STATE", name);
+}
+
+function renderHandover(input: { context: string; timestamp: string; sessionId?: string; cwd?: string }): string {
+  const header = [
+    "# Pre-Compaction Handover",
+    `*Captured: ${input.timestamp}*`,
+    input.sessionId ? `Session: ${input.sessionId}` : undefined,
+    input.cwd ? `Working directory: \`${input.cwd}\`` : undefined,
+    "",
+    input.context,
+  ].filter((line): line is string => line !== undefined);
+  return `${header.join("\n")}\n`;
+}
+
+async function runCapture(options: SomaLifecycleOptions): Promise<string> {
+  const startup = await buildSomaStartupContext(options);
+  const handover = renderHandover({
+    context: startup.context,
+    timestamp: startup.timestamp,
+    sessionId: startup.sessionId,
+    cwd: options.cwd,
+  });
+  const path = preCompactHandoverPath(startup.somaHome, startup.sessionId);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, handover, "utf8");
+  // stdout is the emit surface — printed AND persisted (JC: the pre-compaction
+  // output is cleared before it can be read, so persistence is what survives).
+  return handover.trimEnd();
+}
+
+async function runResurface(options: SomaLifecycleOptions): Promise<string> {
+  const somaHome = resolveSomaHome(options);
+  const path = preCompactHandoverPath(somaHome, options.sessionId);
+  const content = await readFile(path, "utf8").catch((error: unknown) => {
+    if (isEnoent(error)) return undefined;
+    throw error;
+  });
+  if (content === undefined) return "";
+  // Consume-once: delete after reading so the handover is re-injected exactly
+  // on the first prompt after compaction, not on every subsequent prompt.
+  await rm(path, { force: true });
+  return content.trimEnd();
+}
+
+export async function runPreCompactCli(parsed: ParsedPreCompactArgs): Promise<string> {
+  if (parsed.action === "capture") {
+    return runCapture(parsed.options);
+  }
+  return runResurface(parsed.options);
+}

--- a/src/cli/precompact.ts
+++ b/src/cli/precompact.ts
@@ -89,12 +89,27 @@ export function preCompactHandoverPath(somaHome: string, sessionId?: string): st
   return join(somaHome, "memory/STATE", name);
 }
 
+// The handover is re-injected into the model's context after compaction, so
+// hook-provided fields (cwd, session id) are an injection surface: a workspace
+// path or session id carrying backticks/newlines/control chars could break out
+// of its markdown line and inject instructions. Neutralize to a single line —
+// strip backticks and any C0 control char + DEL, keep ordinary path characters.
+// (Char loop, not a regex, to sidestep character-class range pitfalls.)
+function sanitizeInline(value: string): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    out += ch === "`" || code < 0x20 || code === 0x7f ? " " : ch;
+  }
+  return out.trim();
+}
+
 function renderHandover(input: { context: string; timestamp: string; sessionId?: string; cwd?: string }): string {
   const header = [
     "# Pre-Compaction Handover",
     `*Captured: ${input.timestamp}*`,
-    input.sessionId ? `Session: ${input.sessionId}` : undefined,
-    input.cwd ? `Working directory: \`${input.cwd}\`` : undefined,
+    input.sessionId ? `Session: ${sanitizeInline(input.sessionId)}` : undefined,
+    input.cwd ? `Working directory: \`${sanitizeInline(input.cwd)}\`` : undefined,
     "",
     input.context,
   ].filter((line): line is string => line !== undefined);

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -31,7 +31,7 @@ import type {
 
 const execFileAsync = promisify(execFile);
 
-function resolveSomaHome(options: SomaLifecycleOptions = {}): string {
+export function resolveSomaHome(options: SomaLifecycleOptions = {}): string {
   const home = resolve(options.homeDir ?? homedir());
   return resolve(options.somaHome ?? join(home, ".soma"));
 }

--- a/src/vsa-accessors.ts
+++ b/src/vsa-accessors.ts
@@ -198,6 +198,43 @@ export function defaultEvidenceKind(
   return kind ?? (status === "passed" ? "specified" : undefined);
 }
 
+/**
+ * VerificationGate (ported from PAI `EvidenceGate`, Ladder EX-00004): the
+ * block-mode, record-time counterpart to #330's audit-time LEARN gate. #330
+ * lets a hollow pass be RECORDED and only blocks it from COMPLETING; this
+ * refuses to record a `passed` on specification-only or rote evidence in the
+ * first place, so the caller learns immediately instead of at the finish line.
+ *
+ * Returns a violation (reason + message) when `status === "passed"` and the
+ * evidence is either rote ("done"/"verified"/…) or specification-only (no
+ * `probed`/`tested` kind declared); otherwise null. Escape hatches, same as the
+ * LEARN gate: declare a real probe (`evidenceKind: "probed"|"tested"`) or record
+ * `status: "deferred-probe"`. Non-`passed` statuses never violate.
+ */
+const ROTE_EVIDENCE = /^(?:done|verified|checked|confirmed|ok(?:ay)?|yes|pass(?:ed)?|complete[d]?|works?|looks?\s*good|good|fine)\.?$/i;
+
+export function verificationGateViolation(
+  status: CriterionStatus,
+  evidence: string,
+  evidenceKind: EvidenceKind | undefined,
+): { reason: "rote_evidence" | "specification_only"; message: string } | null {
+  if (status !== "passed") return null;
+  const cleaned = evidence.trim().replace(/^evidence:\s*/i, "").trim();
+  if (ROTE_EVIDENCE.test(cleaned)) {
+    return {
+      reason: "rote_evidence",
+      message: `rote evidence rejected (${JSON.stringify(cleaned)}) — describe what you actually observed (a command + its output, a file:line, a probe result)`,
+    };
+  }
+  if (defaultEvidenceKind(evidenceKind, status) === "specified") {
+    return {
+      reason: "specification_only",
+      message: `specification-only evidence — declare a real probe (evidenceKind "probed" or "tested") or record status "deferred-probe"`,
+    };
+  }
+  return null;
+}
+
 export function updateCriterion(
   isa: VerificationStateArtifact,
   criterionId: string,

--- a/test/algorithm-verification-evidence.test.ts
+++ b/test/algorithm-verification-evidence.test.ts
@@ -63,18 +63,22 @@ test("evidence kind round-trips through VSA markdown serialization", () => {
   expect(reparsed?.evidenceKind).toBe("tested");
 });
 
-test("a passed criterion verified only as 'specified' blocks advance to LEARN", () => {
-  let run = toVerify();
-  run = verifyAlgorithmCriterion(run, "C1", "passed", "the design says it returns 200", "2026-06-22T10:10:00.000Z", undefined, "specified");
-  let thrown: unknown;
-  try {
-    advanceAlgorithmRun(run, "2026-06-22T10:11:00.000Z");
-  } catch (error) {
-    thrown = error;
-  }
-  expect(thrown).toBeInstanceOf(Error);
-  expect((thrown as Error).message).toMatch(/C1/);
-  expect((thrown as Error).message).toMatch(/probe|specified|deferred/i);
+test("VerificationGate refuses recording a specification-only pass at record time", () => {
+  const run = toVerify();
+  // Layer (a): #330's LEARN gate blocked a hollow pass from COMPLETING; the
+  // VerificationGate refuses to RECORD it in the first place — fail-fast.
+  expect(() =>
+    verifyAlgorithmCriterion(run, "C1", "passed", "the design says it returns 200", "2026-06-22T10:10:00.000Z", undefined, "specified"),
+  ).toThrow(/VerificationGate.*C1.*(probe|specified|deferred)/is);
+});
+
+test("VerificationGate refuses recording a rote pass even with a probed kind", () => {
+  const run = toVerify();
+  // The rote-text guard (ported from EvidenceGate) fires regardless of the
+  // caller-asserted kind: "done" is never real evidence.
+  expect(() =>
+    verifyAlgorithmCriterion(run, "C1", "passed", "done", "2026-06-22T10:10:00.000Z", undefined, "probed"),
+  ).toThrow(/VerificationGate.*rote/is);
 });
 
 test("a probed pass advances to LEARN", () => {
@@ -95,10 +99,14 @@ test("deferred-probe is an honest resolved state accepted by the LEARN gate", ()
   expect(getRunPhase(run)).toBe("learn");
 });
 
-test("legacy passed verification without an evidence kind is grandfathered", () => {
-  let run = toVerify();
-  // old call signature: no evidenceKind -> undefined, not 'specified'
-  run = verifyAlgorithmCriterion(run, "C1", "passed", "verified", "2026-06-22T10:10:00.000Z");
-  run = advanceAlgorithmRun(run, "2026-06-22T10:11:00.000Z");
-  expect(getRunPhase(run)).toBe("learn");
+test("VerificationGate refuses a passed record with no probe kind (grandfathering removed for new records)", () => {
+  const run = toVerify();
+  // #330 grandfathered an undefined kind at the LEARN gate (isHollowPass only
+  // flags an EXPLICIT `specified`). The VerificationGate closes that at record
+  // time: a new `passed` with no probe kind resolves to specification-only and
+  // is refused. (Loaded legacy runs are still tolerated by the lenient LEARN
+  // gate — the strictness lives on the record path, not on old on-disk state.)
+  expect(() =>
+    verifyAlgorithmCriterion(run, "C1", "passed", "the endpoint should return 200 per the spec", "2026-06-22T10:10:00.000Z"),
+  ).toThrow(/VerificationGate.*specification/is);
 });

--- a/test/algorithm.test.ts
+++ b/test/algorithm.test.ts
@@ -221,7 +221,7 @@ test("enforces Algorithm phase gates", () => {
   expect(getRunPhase(run)).toBe("verify");
 
   expect(() => advanceAlgorithmRun(run)).toThrow("criterion");
-  run = verifyAlgorithmCriterion(run, "C1", "passed", "Test asserted gate failures and success path.", "2026-05-14T10:10:00.000Z");
+  run = verifyAlgorithmCriterion(run, "C1", "passed", "Test asserted gate failures and success path.", "2026-05-14T10:10:00.000Z", undefined, "tested");
   run = advanceAlgorithmRun(run, "2026-05-14T10:11:00.000Z");
   expect(getRunPhase(run)).toBe("learn");
 
@@ -949,6 +949,7 @@ test("records per-hop substrate provenance for Algorithm mutations", () => {
     "Codex verified the criterion.",
     "2026-05-14T10:02:00.000Z",
     { substrate: "codex" },
+    "tested",
   );
   run = recordAlgorithmLearning(run, "Pi.dev captured the lesson.", "2026-05-14T10:03:00.000Z", {
     substrate: "pi-dev",

--- a/test/claude-code-install.test.ts
+++ b/test/claude-code-install.test.ts
@@ -160,6 +160,9 @@ test("AC-2: planSomaForClaudeCodeInstall lists every file written", () => {
     "/tmp/test-home/.claude/hooks/soma/soma-mode-classifier.config.json",
     "/tmp/test-home/.claude/hooks/soma/soma-policy-guard.mjs",
     "/tmp/test-home/.claude/hooks/soma/soma-policy-guard.config.json",
+    // PreCompact handover hook is also default-on.
+    "/tmp/test-home/.claude/hooks/soma/soma-precompact.mjs",
+    "/tmp/test-home/.claude/hooks/soma/soma-precompact.config.json",
   ]);
 });
 
@@ -245,8 +248,8 @@ test("issue #236: claude-code install wires Soma-owned hooks without overwriting
     // Opt out of the soma#369 default-on fleet: this test targets the base
     // lifecycle hook wiring + user-hook preservation. Default-on fleet has its
     // own coverage below.
-    await installSomaForClaudeCode({ homeDir, modeClassifier: false, policyGuard: false });
-    await installSomaForClaudeCode({ homeDir, modeClassifier: false, policyGuard: false });
+    await installSomaForClaudeCode({ homeDir, modeClassifier: false, policyGuard: false, preCompact: false });
+    await installSomaForClaudeCode({ homeDir, modeClassifier: false, policyGuard: false, preCompact: false });
 
     const hookInfo = await stat(join(homeDir, ".claude/hooks/soma/soma-claude-code-hook.mjs"));
     expect((hookInfo.mode & 0o100) !== 0).toBe(true);

--- a/test/claude-code-precompact.test.ts
+++ b/test/claude-code-precompact.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Claude Code PreCompact handover hook.
+ *
+ * One asset (`soma-precompact.mjs`) dispatched by argv into two events:
+ *   - `capture` on PreCompact persists the handover + echoes it, and
+ *   - `resurface` on UserPromptSubmit re-injects it once then consumes it.
+ *
+ * Compaction does not re-run SessionStart, so this persist+resurface pair is
+ * what carries active work-state across the compression boundary.
+ */
+import { mkdtemp, readFile, rm, stat, writeFile, mkdir } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "bun:test";
+import {
+  bootstrapSomaHome,
+  createAlgorithmRun,
+  installSomaForClaudeCode,
+  planSomaForClaudeCodeInstall,
+  uninstallSomaForClaudeCode,
+  writeAlgorithmRun,
+} from "../src/index";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const HOOK_REL = ".claude/hooks/soma/soma-precompact.mjs";
+const CONFIG_REL = ".claude/hooks/soma/soma-precompact.config.json";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-precompact-hook-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+function readJson<T>(path: string): Promise<T> {
+  return readFile(path, "utf8").then((content) => JSON.parse(content) as T);
+}
+
+function countHookCommandsContaining(settings: { hooks?: Record<string, unknown[]> }, text: string): number {
+  return Object.values(settings.hooks ?? {})
+    .flatMap((groups) =>
+      groups.flatMap((group) => {
+        if (!group || typeof group !== "object" || !("hooks" in group) || !Array.isArray((group as { hooks: unknown[] }).hooks)) return [];
+        return (group as { hooks: { command?: string }[] }).hooks.map((hook) => hook.command ?? "");
+      }),
+    )
+    .filter((command) => command.includes(text)).length;
+}
+
+async function pointConfigAt(homeDir: string, somaHome: string): Promise<void> {
+  await writeFile(
+    join(homeDir, CONFIG_REL),
+    JSON.stringify({ somaHome, trustedSomaRepo: REPO_ROOT, bunPath: process.execPath }),
+    "utf8",
+  );
+}
+
+function runHook(homeDir: string, action: string, input: object): { status: number | null; stdout: string } {
+  const result = spawnSync(process.execPath, [join(homeDir, HOOK_REL), action], {
+    input: JSON.stringify(input),
+    encoding: "utf8",
+  });
+  return { status: result.status, stdout: result.stdout };
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  return stat(path).then(() => true, () => false);
+}
+
+test("precompact hook files are default-on in the plan, opt-out excludes them", () => {
+  const plan = planSomaForClaudeCodeInstall({ homeDir: "/tmp/test-home" });
+  expect(plan.substrateFiles).toContain("/tmp/test-home/.claude/hooks/soma/soma-precompact.mjs");
+  expect(plan.substrateFiles).toContain("/tmp/test-home/.claude/hooks/soma/soma-precompact.config.json");
+
+  const planOff = planSomaForClaudeCodeInstall({ homeDir: "/tmp/test-home", preCompact: false });
+  expect(planOff.substrateFiles).not.toContain("/tmp/test-home/.claude/hooks/soma/soma-precompact.mjs");
+});
+
+test("install is idempotent and patches PreCompact + UserPromptSubmit once each", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir, preCompact: true });
+    await installSomaForClaudeCode({ homeDir, preCompact: true });
+
+    const hookInfo = await stat(join(homeDir, HOOK_REL));
+    expect((hookInfo.mode & 0o100) !== 0).toBe(true); // executable
+
+    const settings = await readJson<{ hooks: Record<string, unknown[]> }>(join(homeDir, ".claude/settings.json"));
+    expect(countHookCommandsContaining(settings, "soma-precompact.mjs")).toBe(2);
+    const preCompact = JSON.stringify(settings.hooks.PreCompact ?? []);
+    expect(preCompact).toContain("soma-precompact.mjs");
+    expect(preCompact).toContain("capture");
+    const prompt = JSON.stringify(settings.hooks.UserPromptSubmit ?? []);
+    expect(prompt).toContain("soma-precompact.mjs");
+    expect(prompt).toContain("resurface");
+  });
+});
+
+test("capture hook persists a handover file and echoes it to stdout", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir, preCompact: true });
+    const somaHome = join(homeDir, ".soma");
+    await bootstrapSomaHome({ homeDir });
+    await writeAlgorithmRun(
+      createAlgorithmRun({
+        id: "hook-active-run",
+        timestamp: "2026-07-07T10:00:00.000Z",
+        prompt: "Survive compaction",
+        intent: "Expose active work across compaction.",
+        currentState: "No handover.",
+        goal: "Handover lists active runs.",
+        criteria: [{ id: "C1", text: "Active run appears." }],
+      }),
+      { homeDir },
+    );
+    await pointConfigAt(homeDir, somaHome);
+
+    const out = runHook(homeDir, "capture", { session_id: "sess-1", cwd: "/work" });
+    expect(out.status).toBe(0);
+    expect(out.stdout).toContain("# Pre-Compaction Handover");
+    expect(out.stdout).toContain("hook-active-run");
+
+    const handoverPath = join(somaHome, "memory/STATE", "precompact-handover-sess-1.md");
+    expect(await fileExists(handoverPath)).toBe(true);
+    expect(await readFile(handoverPath, "utf8")).toContain("hook-active-run");
+  });
+});
+
+test("resurface hook re-injects the persisted handover once as additionalContext, then consumes it", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir, preCompact: true });
+    const somaHome = join(homeDir, ".soma");
+    await pointConfigAt(homeDir, somaHome);
+
+    // Simulate a prior compaction having persisted a handover for this session.
+    const handoverPath = join(somaHome, "memory/STATE", "precompact-handover-sess-2.md");
+    await mkdir(dirname(handoverPath), { recursive: true });
+    await writeFile(handoverPath, "# Pre-Compaction Handover\nActive: hook-active-run\n", "utf8");
+
+    const first = runHook(homeDir, "resurface", { hook_event_name: "UserPromptSubmit", session_id: "sess-2" });
+    expect(first.status).toBe(0);
+    const parsed = JSON.parse(first.stdout);
+    expect(parsed.continue).toBe(true);
+    expect(parsed.hookSpecificOutput.hookEventName).toBe("UserPromptSubmit");
+    expect(parsed.hookSpecificOutput.additionalContext).toContain("hook-active-run");
+    expect(await fileExists(handoverPath)).toBe(false); // consumed
+
+    // Second prompt: nothing to resurface — continue with no injected context.
+    const second = runHook(homeDir, "resurface", { hook_event_name: "UserPromptSubmit", session_id: "sess-2" });
+    const secondParsed = JSON.parse(second.stdout);
+    expect(secondParsed.continue).toBe(true);
+    expect(secondParsed.hookSpecificOutput).toBeUndefined();
+  });
+});
+
+test("resurface fails open (continue, no context) when the config is missing", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir, preCompact: true });
+    await rm(join(homeDir, CONFIG_REL));
+
+    const out = runHook(homeDir, "resurface", { hook_event_name: "UserPromptSubmit", session_id: "sess-3" });
+    expect(out.status).toBe(0);
+    expect(JSON.parse(out.stdout).continue).toBe(true);
+  });
+});
+
+test("uninstall removes the precompact settings entries even if the bun path drifted", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir, preCompact: true });
+    const settingsPath = join(homeDir, ".claude/settings.json");
+
+    const raw = await readFile(settingsPath, "utf8");
+    await writeFile(settingsPath, raw.replaceAll(process.execPath, "/some/other/bun"), "utf8");
+    expect(countHookCommandsContaining(await readJson(settingsPath), "soma-precompact.mjs")).toBe(2);
+
+    await uninstallSomaForClaudeCode({ homeDir });
+
+    const after = await readJson<{ hooks?: Record<string, unknown[]> }>(settingsPath);
+    expect(countHookCommandsContaining(after, "soma-precompact.mjs")).toBe(0);
+    expect(await fileExists(join(homeDir, HOOK_REL))).toBe(false);
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -752,6 +752,8 @@ test("cli records substrate provenance and surfaces touched-by summary", async (
       "passed",
       "--evidence",
       "Codex verified the criterion.",
+      "--evidence-kind",
+      "probed",
     ]);
     await runSomaCli([
       "algorithm",
@@ -1697,6 +1699,8 @@ test("cli promotes Algorithm run memory", async () => {
       "passed",
       "--evidence",
       "Promotion file criteria verified.",
+      "--evidence-kind",
+      "probed",
     ]);
     const output = await runSomaCli([
       "memory",

--- a/test/lifecycle.test.ts
+++ b/test/lifecycle.test.ts
@@ -62,7 +62,7 @@ function completeRun() {
   run = advanceAlgorithmRun(run, "2026-05-14T10:07:00.000Z");
   run = updateAlgorithmPlanStep(run, "P1", "done", "Learning capture exists.", "2026-05-14T10:08:00.000Z");
   run = advanceAlgorithmRun(run, "2026-05-14T10:09:00.000Z");
-  run = verifyAlgorithmCriterion(run, "C1", "passed", "Learning file was written.", "2026-05-14T10:10:00.000Z");
+  run = verifyAlgorithmCriterion(run, "C1", "passed", "Learning file was written.", "2026-05-14T10:10:00.000Z", undefined, "tested");
   run = advanceAlgorithmRun(run, "2026-05-14T10:11:00.000Z");
   run = recordAlgorithmLearning(run, "Lifecycle should capture completed runs once.", "2026-05-14T10:12:00.000Z");
   run = recordAlgorithmMetaReflection(

--- a/test/precompact-cli.test.ts
+++ b/test/precompact-cli.test.ts
@@ -144,3 +144,22 @@ test("a session id with path-hostile characters is sanitized into the filename",
 test("parsePreCompactArgs rejects an unknown action", () => {
   expect(() => parsePreCompactArgs(["precompact", "bogus"])).toThrow(/capture\|resurface/);
 });
+
+test("capture neutralizes a hostile cwd so it cannot break out of its markdown line", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    const somaHome = join(homeDir, ".soma");
+
+    // A workspace path with a backtick + newline would, unsanitized, close the
+    // code span and inject a heading into the resurfaced prompt context.
+    const parsed = parsePreCompactArgs(["precompact", "capture", "--soma-home", somaHome, "--session-id", "s"]);
+    parsed.options.cwd = "/tmp/evil`\n## Injected heading";
+    const handover = await runPreCompactCli(parsed);
+
+    // The payload backtick is gone (no break-out) …
+    expect(handover).not.toContain("evil`");
+    // … and the newline is collapsed, so nothing lands at line-start.
+    expect(handover).not.toContain("\n## Injected heading");
+    expect(handover).toContain("Working directory: `/tmp/evil");
+  });
+});

--- a/test/precompact-cli.test.ts
+++ b/test/precompact-cli.test.ts
@@ -1,0 +1,146 @@
+/**
+ * `soma precompact` — the compaction-survival handover CLI.
+ *
+ * `capture` snapshots live work-state (active Algorithm runs) into a durable,
+ * session-scoped file AND returns it for stdout emit. `resurface` returns that
+ * file once and consumes it, so the handover re-injects exactly on the first
+ * prompt after compaction and never again.
+ */
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { bootstrapSomaHome, createAlgorithmRun, writeAlgorithmRun } from "../src/index";
+import { parsePreCompactArgs, preCompactHandoverPath, runPreCompactCli } from "../src/cli/precompact";
+import { isEnoent } from "../src/fs-errors";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-precompact-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  return stat(path).then(
+    () => true,
+    (error: unknown) => {
+      if (isEnoent(error)) return false;
+      throw error;
+    },
+  );
+}
+
+async function seedActiveRun(homeDir: string): Promise<void> {
+  await writeAlgorithmRun(
+    createAlgorithmRun({
+      id: "active-precompact-run",
+      timestamp: "2026-07-07T10:00:00.000Z",
+      prompt: "Do compaction-surviving work",
+      intent: "Expose active work across compaction.",
+      currentState: "No handover.",
+      goal: "Handover lists active runs.",
+      criteria: [{ id: "C1", text: "Active run appears." }],
+    }),
+    { homeDir },
+  );
+}
+
+test("capture writes a session-scoped handover file from the startup context and returns it for stdout", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    await seedActiveRun(homeDir);
+    const somaHome = join(homeDir, ".soma");
+
+    const parsed = parsePreCompactArgs([
+      "precompact",
+      "capture",
+      "--soma-home",
+      somaHome,
+      "--substrate",
+      "claude-code",
+      "--session-id",
+      "sess-abc",
+      "--cwd",
+      "/work/dir",
+    ]);
+    const emitted = await runPreCompactCli(parsed);
+
+    // Emitted to stdout (the "emit" half) …
+    expect(emitted).toContain("# Pre-Compaction Handover");
+    expect(emitted).toContain("Session: sess-abc");
+    expect(emitted).toContain("Working directory: `/work/dir`");
+    expect(emitted).toContain("# Soma Startup Context");
+    expect(emitted).toContain("active-precompact-run");
+
+    // … and persisted (the "persist" half) to the session-scoped path.
+    const path = preCompactHandoverPath(somaHome, "sess-abc");
+    expect(path).toBe(join(somaHome, "memory/STATE", "precompact-handover-sess-abc.md"));
+    expect(await readFile(path, "utf8")).toContain("active-precompact-run");
+  });
+});
+
+test("resurface prints the handover once then consumes (deletes) it", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    await seedActiveRun(homeDir);
+    const somaHome = join(homeDir, ".soma");
+
+    await runPreCompactCli(
+      parsePreCompactArgs(["precompact", "capture", "--soma-home", somaHome, "--session-id", "sess-xyz"]),
+    );
+    const path = preCompactHandoverPath(somaHome, "sess-xyz");
+    expect(await fileExists(path)).toBe(true);
+
+    const first = await runPreCompactCli(
+      parsePreCompactArgs(["precompact", "resurface", "--soma-home", somaHome, "--session-id", "sess-xyz"]),
+    );
+    expect(first).toContain("# Pre-Compaction Handover");
+    expect(first).toContain("active-precompact-run");
+    expect(await fileExists(path)).toBe(false); // consumed
+
+    const second = await runPreCompactCli(
+      parsePreCompactArgs(["precompact", "resurface", "--soma-home", somaHome, "--session-id", "sess-xyz"]),
+    );
+    expect(second).toBe("");
+  });
+});
+
+test("resurface returns empty when there is no handover file (no compaction happened)", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    const somaHome = join(homeDir, ".soma");
+    const out = await runPreCompactCli(
+      parsePreCompactArgs(["precompact", "resurface", "--soma-home", somaHome, "--session-id", "never-captured"]),
+    );
+    expect(out).toBe("");
+  });
+});
+
+test("capture/resurface round-trip without a session id uses the unscoped path", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+    await seedActiveRun(homeDir);
+    const somaHome = join(homeDir, ".soma");
+
+    await runPreCompactCli(parsePreCompactArgs(["precompact", "capture", "--soma-home", somaHome]));
+    const path = preCompactHandoverPath(somaHome);
+    expect(path).toBe(join(somaHome, "memory/STATE", "precompact-handover.md"));
+    expect(await fileExists(path)).toBe(true);
+
+    const out = await runPreCompactCli(parsePreCompactArgs(["precompact", "resurface", "--soma-home", somaHome]));
+    expect(out).toContain("# Pre-Compaction Handover");
+    expect(await fileExists(path)).toBe(false);
+  });
+});
+
+test("a session id with path-hostile characters is sanitized into the filename", () => {
+  const path = preCompactHandoverPath("/home/.soma", "../../etc/passwd");
+  expect(path).toBe("/home/.soma/memory/STATE/precompact-handover-______etc_passwd.md");
+});
+
+test("parsePreCompactArgs rejects an unknown action", () => {
+  expect(() => parsePreCompactArgs(["precompact", "bogus"])).toThrow(/capture\|resurface/);
+});


### PR DESCRIPTION
## What

Two block-mode, record-time ports of valuable PAI hooks into Soma-owned mechanisms — the "clean up local installation" step toward soma-as-a-standalone-product. Both refuse to let hollow/lossy state slip through silently.

### 1. VerificationGate — refuse recording a hollow pass (`41d9830`, ports PAI EvidenceGate)

The block-mode, record-time counterpart to the audit-time gate. `verifyAlgorithmCriterion` now **refuses** to record a `passed` on specification-only or rote (`"done"`/`"verified"`/…) evidence.

- Layer (a): new `verificationGateViolation(status, evidence, evidenceKind)` in `vsa-accessors.ts` — the assertion surface.
- Layer (b) already existed: `learnGateViolations` blocks a hollow pass from completing via LEARN.
- Escape hatches: `evidenceKind: "probed" | "tested"`, or `status: "deferred-probe"`.
- Reconstruction opt-out: the VSA→run sync passes `enforceGate=false` — mirroring already-declared `[x]` state is not a fresh assertion; synced hollow passes are still caught by the audit-time LEARN gate.
- Leans on structured `evidenceKind` + a bare-word blocklist as the discriminator (not PAI's fuller rote-text matching — `evidenceKind` is the real signal).

### 2. PreCompact — emit + persist a handover across compaction (`7735ca2`, ports PAI PreCompact)

Claude Code compresses the conversation mid-session and does **not** re-run SessionStart afterward, and the lifecycle runner spawns detached with stdio ignored — so live work-state (active Algorithm runs) is lost across the boundary. This ports PAI's auto handover-on-compaction as a **persist + resurface** pair, one asset dispatched by argv into two events:

- `soma precompact capture` (PreCompact event) — snapshots `buildSomaStartupContext` into a durable, session-scoped file (`memory/STATE/precompact-handover-<id>.md`) **and** echoes it to stdout.
- `soma precompact resurface` (UserPromptSubmit) — on the first prompt after a compaction, re-injects the file as `additionalContext` then consumes it, so it fires exactly once.

Default-on with a `preCompact` opt-out gate; bun-path-drift-robust uninstall. Exported `resolveSomaHome` so resurface stays cheap (no startup-context build on every prompt).

## Why

First finish line = soma-as-a-standalone-product; JC's sequencing is "clean up the local installation first" = finish de-PAI by porting the few PAI hooks that carry real value and retiring the rest. These are those ports.

## Verification

- `bun run typecheck` clean (`tsc --noEmit`, 0 errors).
- `bun test` — **1863 pass / 0 fail** (+12 new: `precompact-cli.test.ts`, `claude-code-precompact.test.ts`).
- Live end-to-end probe against a real `~/.soma`: capture emitted a handover listing actual active runs, persisted it, resurfaced once, and consumed the file.

## Not in this PR

- Installing the PreCompact hook into the live `~/.claude` (touches gitignored `settings.json`) — a deliberate post-merge step.
- Retiring the legacy PAI hook files + removing the 18 MB `~/.claude/PAI/` tree — the next de-PAI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
