### PR TITLE
test(memory): lock codex SessionStart memory-reproject parity

### DIFF
--- a/test/memory-projection-reproject.test.ts
+++ b/test/memory-projection-reproject.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/p
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { expect, test } from "bun:test";
-import { bootstrapSomaHome, reprojectSubstrateMemoryProjection, serializeMemoryNote, type SomaMemoryNote } from "../src/index";
+import { bootstrapSomaHome, reprojectSubstrateMemoryProjection, runSomaLifecycleSessionStart, serializeMemoryNote, type SomaMemoryNote } from "../src/index";
 import { memoryIndexPath } from "../src/memory-index";
 import { memoryNotePath, type WritableType } from "../src/memory-write";
 
@@ -134,33 +134,34 @@ test("reprojectSubstrateMemoryProjection no-ops (but still reindexes) for a Subs
   });
 });
 
-test("reprojectSubstrateMemoryProjection projects codex's own memory file (substrate parity)", async () => {
+test("a codex session start reprojects codex's own memory file (substrate parity)", async () => {
   await withTempHome(async (homeDir) => {
     const { somaHome } = await bootstrapSomaHome({ homeDir });
     await seed(somaHome, note({ id: "fact", body: "the gateway retries thrice", trust: "principal" }));
 
-    // codex's session-start hook runs `soma lifecycle session-start --substrate
-    // codex`, so it rides the same substrate-neutral reproject as claude-code —
-    // to codex's OWN path (memories/soma/memory-index.md, the verbatim index).
-    const result = await reprojectSubstrateMemoryProjection({ substrate: "codex", homeDir });
+    // Exercise the ACTUAL session-start handler the codex hook drives — its
+    // hook (codex-hook-entry.mjs) just spawns `soma lifecycle session-start
+    // --substrate codex`, i.e. this function — so codex rides the same
+    // substrate-neutral reproject to its OWN path (the verbatim index).
+    await runSomaLifecycleSessionStart({ substrate: "codex", homeDir });
 
-    expect(result.projected).toBe(join(homeDir, ".codex", "memories", "soma", "memory-index.md"));
-    const content = await readFile(expectProjected(result.projected), "utf8");
-    expect(content).toContain("fact —");
-    // A codex reproject never touches claude-code's memory file.
+    const codexMemory = join(homeDir, ".codex", "memories", "soma", "memory-index.md");
+    expect(await readFile(codexMemory, "utf8")).toContain("fact —");
+    // A codex session start never touches claude-code's memory file.
     await expect(stat(join(homeDir, ".claude", "rules", "soma", "MEMORY.md"))).rejects.toThrow();
   });
 });
 
-test("reprojectSubstrateMemoryProjection no-ops for a registered substrate with no memory file (cursor)", async () => {
+test("reprojectSubstrateMemoryProjection no-ops for registered substrates with no memory file (cursor/grok/pi-dev)", async () => {
   await withTempHome(async (homeDir) => {
     const { somaHome } = await bootstrapSomaHome({ homeDir });
     await seed(somaHome, note({ id: "fact", body: "x", trust: "principal" }));
-    // cursor HAS an install spec (unlike "custom") but projects no memory file,
-    // so the content match finds nothing → projected null, index still (re)built.
-    // grok and pi-dev are the same shape today.
-    const result = await reprojectSubstrateMemoryProjection({ substrate: "cursor", homeDir });
-    expect(result.reindexed).toBe(true);
-    expect(result.projected).toBeNull();
+    // These HAVE an install spec (unlike "custom") but project no memory file,
+    // so the content match finds nothing → projected null (the index itself is
+    // still (re)built, so reindexing is unaffected).
+    for (const substrate of ["cursor", "grok", "pi-dev"] as const) {
+      const result = await reprojectSubstrateMemoryProjection({ substrate, homeDir });
+      expect(result.projected).toBeNull();
+    }
   });
 });

--- a/test/memory-projection-reproject.test.ts
+++ b/test/memory-projection-reproject.test.ts
@@ -134,10 +134,18 @@ test("reprojectSubstrateMemoryProjection no-ops (but still reindexes) for a Subs
   });
 });
 
-test("a codex session start reprojects codex's own memory file (substrate parity)", async () => {
+test("a codex session start reprojects codex's own memory file and leaves claude-code's untouched", async () => {
   await withTempHome(async (homeDir) => {
     const { somaHome } = await bootstrapSomaHome({ homeDir });
     await seed(somaHome, note({ id: "fact", body: "the gateway retries thrice", trust: "principal" }));
+
+    // Pre-existing claude-code memory file with a sentinel — a codex session
+    // start must leave it byte-for-byte unchanged (memory reproject is scoped to
+    // the ACTIVE substrate, so it must not write another substrate's file).
+    const claudeMemory = join(homeDir, ".claude", "rules", "soma", "MEMORY.md");
+    await mkdir(dirname(claudeMemory), { recursive: true });
+    const sentinel = "SENTINEL — claude-code owned\n";
+    await writeFile(claudeMemory, sentinel, "utf8");
 
     // Exercise the ACTUAL session-start handler the codex hook drives — its
     // hook (codex-hook-entry.mjs) just spawns `soma lifecycle session-start
@@ -147,8 +155,8 @@ test("a codex session start reprojects codex's own memory file (substrate parity
 
     const codexMemory = join(homeDir, ".codex", "memories", "soma", "memory-index.md");
     expect(await readFile(codexMemory, "utf8")).toContain("fact —");
-    // A codex session start never touches claude-code's memory file.
-    await expect(stat(join(homeDir, ".claude", "rules", "soma", "MEMORY.md"))).rejects.toThrow();
+    // The pre-existing claude-code file is untouched — not just "absent".
+    expect(await readFile(claudeMemory, "utf8")).toBe(sentinel);
   });
 });
 

--- a/test/memory-projection-reproject.test.ts
+++ b/test/memory-projection-reproject.test.ts
@@ -133,3 +133,34 @@ test("reprojectSubstrateMemoryProjection no-ops (but still reindexes) for a Subs
     expect(result.projected).toBeNull();
   });
 });
+
+test("reprojectSubstrateMemoryProjection projects codex's own memory file (substrate parity)", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    await seed(somaHome, note({ id: "fact", body: "the gateway retries thrice", trust: "principal" }));
+
+    // codex's session-start hook runs `soma lifecycle session-start --substrate
+    // codex`, so it rides the same substrate-neutral reproject as claude-code —
+    // to codex's OWN path (memories/soma/memory-index.md, the verbatim index).
+    const result = await reprojectSubstrateMemoryProjection({ substrate: "codex", homeDir });
+
+    expect(result.projected).toBe(join(homeDir, ".codex", "memories", "soma", "memory-index.md"));
+    const content = await readFile(expectProjected(result.projected), "utf8");
+    expect(content).toContain("fact —");
+    // A codex reproject never touches claude-code's memory file.
+    await expect(stat(join(homeDir, ".claude", "rules", "soma", "MEMORY.md"))).rejects.toThrow();
+  });
+});
+
+test("reprojectSubstrateMemoryProjection no-ops for a registered substrate with no memory file (cursor)", async () => {
+  await withTempHome(async (homeDir) => {
+    const { somaHome } = await bootstrapSomaHome({ homeDir });
+    await seed(somaHome, note({ id: "fact", body: "x", trust: "principal" }));
+    // cursor HAS an install spec (unlike "custom") but projects no memory file,
+    // so the content match finds nothing → projected null, index still (re)built.
+    // grok and pi-dev are the same shape today.
+    const result = await reprojectSubstrateMemoryProjection({ substrate: "cursor", homeDir });
+    expect(result.reindexed).toBe(true);
+    expect(result.projected).toBeNull();
+  });
+});


### PR DESCRIPTION
## Context

Follow-up to #443 (M8 SessionStart smart memory reprojection): do the other substrates get the same behaviour?

## Finding — no production change needed

The M8 reproject is **substrate-neutral** (`reprojectSubstrateMemoryProjection`) and runs inside `runSomaLifecycleSessionStart`. So any substrate whose session-start hook invokes `soma lifecycle session-start --substrate <id>` inherited it automatically when #443 merged.

| Substrate | Memory file | session-start hook | Reproject on session start | How established |
|---|---|---|---|---|
| claude-code | yes | yes | yes | shipped + tested in **#443** (not re-tested here) |
| **codex** | yes (verbatim index) | yes (`--substrate codex`) | **yes** | **test in this PR** (drives `runSomaLifecycleSessionStart({substrate:"codex"})`) |
| cursor | none | — | no-op (`projected: null`) | **test in this PR** |
| grok | none | yes | no-op (`projected: null`) | **test in this PR** |
| pi-dev | none | yes | no-op (`projected: null`) | **test in this PR** |
| anthropic-cowork | yes | none — "no verified hook surface" | not possible | adapter inspection (`anthropic-cowork.ts:96`); NOT exercised here |

## What this PR proves (test-only)

- **codex parity**: a codex session start (via the real `runSomaLifecycleSessionStart` handler its hook spawns) writes codex's own `memories/soma/memory-index.md` with the verbatim index, and leaves a pre-existing claude-code `MEMORY.md` byte-for-byte untouched.
- **no-op for registered substrates with no memory file**: cursor, grok, and pi-dev each return `projected: null` (distinct code path from the existing `custom`/no-install-spec case).

Rows not covered by this diff's tests: claude-code (proven in #443) and anthropic-cowork (a substrate limitation read off the adapter, not a runtime path this PR can exercise).

## Verification

- `tsc --noEmit`: clean.
- `bun test`: **1891 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)