### PR TITLE
fix(migrate): reserve profile/purpose.md so migrate/import don't clobber curation (#441)

### DIFF
--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -1,4 +1,3 @@
-import { relative } from "node:path";
 import {
   importAlgorithm,
   importPaiDocs,
@@ -9,6 +8,7 @@ import {
   planPaiImport,
   planPaiPackImport,
 } from "../index";
+import { formatReservedSkipLine } from "../pai-importer";
 import type {
   AlgorithmImportOptions,
   AlgorithmImportPlan,
@@ -232,15 +232,11 @@ function formatSimpleImportResult(title: string, dirEntries: string[], files: st
 // soma#441 — per-run reserved-skip detail lives only in this ephemeral
 // CLI summary, not in any on-disk/byte-compared surface (mirrors the
 // memory phase's "written N / unchanged M" precedent in
-// `formatPaiMigrationResult`).
+// `formatPaiMigrationResult`). Line shape is single-sourced via
+// `formatReservedSkipLine` so this and the migrate summary can't drift.
 function formatSkippedReservedLines(somaHome: string, skippedReserved: string[] | undefined): string[] {
   if (!skippedReserved || skippedReserved.length === 0) return [];
-  return [
-    "",
-    ...skippedReserved.map(
-      (path) => `skipped reserved (curated): ${relative(somaHome, path)} — re-run with --overwrite-reserved to replace`,
-    ),
-  ];
+  return ["", ...skippedReserved.map((path) => formatReservedSkipLine(somaHome, path))];
 }
 
 function formatPaiImportResult(result: PaiImportResult): string {

--- a/src/cli/import.ts
+++ b/src/cli/import.ts
@@ -1,3 +1,4 @@
+import { relative } from "node:path";
 import {
   importAlgorithm,
   importPaiDocs,
@@ -57,7 +58,7 @@ export type ParsedImportArgs =
 export const IMPORT_COMMAND_HELP: { usage: string; subcommands: Record<ImportSource, string> } = {
   usage: "Usage: soma import <pai|algorithm|pai-pack|pai-docs> ...",
   subcommands: {
-    pai: "Usage: soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>]",
+    pai: "Usage: soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--overwrite-reserved]",
     algorithm: "Usage: soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
     "pai-pack": "Usage: soma import pai-pack [--dry-run] [--apply] [--home-dir <dir>] --pai-pack-dir <dir> [--soma-home <dir>] [--skill-name <name>] [--overwrite] [--include-unrecognized]",
     "pai-docs": "Usage: soma import pai-docs [--dry-run] [--apply] [--home-dir <dir>] --pai-source-dir <dir> [--soma-home <dir>]",
@@ -71,7 +72,7 @@ export function parseImportArgs(args: string[]): ParsedImportArgs {
     throw new Error(
       [
         "Usage:",
-        "  soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>]",
+        "  soma import pai [--dry-run] [--apply] [--home-dir <dir>] [--claude-home <dir>] [--soma-home <dir>] [--overwrite-reserved]",
         "  soma import algorithm [--dry-run] [--apply] [--home-dir <dir>] [--pai-algorithm-dir <dir>] [--soma-home <dir>]",
         "  soma import pai-pack [--dry-run] [--apply] [--home-dir <dir>] --pai-pack-dir <dir> [--soma-home <dir>] [--skill-name <name>] [--overwrite] [--include-unrecognized]",
         "  soma import pai-docs [--dry-run] [--apply] [--home-dir <dir>] --pai-source-dir <dir> [--soma-home <dir>]",
@@ -158,6 +159,15 @@ export function parseImportArgs(args: string[]): ParsedImportArgs {
         options.somaHome = readOption(rest, index, arg);
         index += 1;
         break;
+      case "--overwrite-reserved":
+        // soma#441 — mirrors `soma migrate pai`'s reserved-target
+        // protection. Only meaningful for `soma import pai`, whose
+        // identity importer reserves `profile/purpose.md`.
+        if (source !== "pai") {
+          throw new Error("--overwrite-reserved is only valid for soma import pai.");
+        }
+        options.overwriteReserved = true;
+        break;
       default:
         throw new Error(`Unknown option: ${arg}`);
     }
@@ -219,8 +229,25 @@ function formatSimpleImportResult(title: string, dirEntries: string[], files: st
   ].join("\n");
 }
 
+// soma#441 — per-run reserved-skip detail lives only in this ephemeral
+// CLI summary, not in any on-disk/byte-compared surface (mirrors the
+// memory phase's "written N / unchanged M" precedent in
+// `formatPaiMigrationResult`).
+function formatSkippedReservedLines(somaHome: string, skippedReserved: string[] | undefined): string[] {
+  if (!skippedReserved || skippedReserved.length === 0) return [];
+  return [
+    "",
+    ...skippedReserved.map(
+      (path) => `skipped reserved (curated): ${relative(somaHome, path)} — re-run with --overwrite-reserved to replace`,
+    ),
+  ];
+}
+
 function formatPaiImportResult(result: PaiImportResult): string {
-  return formatSimpleImportResult("Soma PAI import applied", [`claudeHome: ${result.claudeHome}`, `somaHome: ${result.somaHome}`], result.files);
+  return [
+    formatSimpleImportResult("Soma PAI import applied", [`claudeHome: ${result.claudeHome}`, `somaHome: ${result.somaHome}`], result.files),
+    ...formatSkippedReservedLines(result.somaHome, result.skippedReserved),
+  ].join("\n");
 }
 
 function formatAlgorithmImportPlan(plan: AlgorithmImportPlan): string {

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,3 +1,4 @@
+import { relative } from "node:path";
 import {
   migratePai,
   planPaiMigration,
@@ -463,6 +464,14 @@ function formatPaiMigrationPlan(plan: PaiMigrationPlan, verbose = false): string
 }
 
 function formatPaiMigrationResult(result: PaiMigrationResult, verbose = false): string {
+  // soma#441 — per-run reserved-skip detail for the identity phase.
+  // Ephemeral CLI-only line, mirrors the memory phase's "written N /
+  // unchanged M" precedent immediately below — the persisted
+  // MIGRATION.md manifest reports only the stable end-state total
+  // (see `renderManifest`'s identity line), not this per-run delta.
+  const identitySkippedReservedLines = (result.identity.skippedReserved ?? []).map(
+    (path) => `  - identity skipped reserved (curated): ${relative(result.somaHome, path)} — re-run with --overwrite-reserved to replace`,
+  );
   const memoryLine = result.memory === null
     ? "  - memory:   skipped"
     : result.memory.memoryDir === null
@@ -503,6 +512,7 @@ function formatPaiMigrationResult(result: PaiMigrationResult, verbose = false): 
     "",
     "Written:",
     `  - identity: ${result.identity.files.length} file(s)`,
+    ...identitySkippedReservedLines,
     result.algorithm ? `  - algorithm: ${result.algorithm.files.length} file(s)` : "  - algorithm: skipped (not present)",
     memoryLine,
     docsLine,

--- a/src/cli/migrate.ts
+++ b/src/cli/migrate.ts
@@ -1,4 +1,3 @@
-import { relative } from "node:path";
 import {
   migratePai,
   planPaiMigration,
@@ -7,6 +6,7 @@ import {
   type PaiMigrationResult,
 } from "../index";
 import { formatPackOutcomeLines } from "../pai-migration";
+import { formatReservedSkipLine } from "../pai-importer";
 import {
   countOutcomesWithMissingDependencies,
   migrateClaudeSkills,
@@ -470,7 +470,7 @@ function formatPaiMigrationResult(result: PaiMigrationResult, verbose = false): 
   // MIGRATION.md manifest reports only the stable end-state total
   // (see `renderManifest`'s identity line), not this per-run delta.
   const identitySkippedReservedLines = (result.identity.skippedReserved ?? []).map(
-    (path) => `  - identity skipped reserved (curated): ${relative(result.somaHome, path)} — re-run with --overwrite-reserved to replace`,
+    (path) => formatReservedSkipLine(result.somaHome, path, "  - identity "),
   );
   const memoryLine = result.memory === null
     ? "  - memory:   skipped"

--- a/src/pai-importer.ts
+++ b/src/pai-importer.ts
@@ -1,8 +1,17 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import type { ImportSourceCheck, PaiImportOptions, PaiImportPlan, PaiImportResult } from "./types";
+
+// soma#441 — single-sourced formatter for the reserved-skip CLI line so
+// `soma import pai` and `soma migrate pai` can't drift on wording. The
+// `prefix` argument carries each command's own bullet/label shape (e.g.
+// `"  - identity "` for the migrate summary); the reserved-noun suffix
+// stays identical.
+export function formatReservedSkipLine(somaHome: string, target: string, prefix = ""): string {
+  return `${prefix}skipped reserved (curated): ${relative(somaHome, target)} — re-run with --overwrite-reserved to replace`;
+}
 
 type PaiSourceRole = "principal" | "assistant" | "mission" | "goals" | "strategies" | "beliefs";
 

--- a/src/pai-importer.ts
+++ b/src/pai-importer.ts
@@ -36,6 +36,14 @@ const PROFILE_TARGETS = {
   purpose: "profile/purpose.md",
 } as const;
 
+// soma#441 — `profile/purpose.md` is the one identity target that
+// diverges from its source once a principal hand-curates it (it's
+// the compartment `src/soma-home.ts` reads to build every substrate's
+// projected Purpose). `principal.md` / `assistant.md` stay
+// deterministic distillations of their PAI sources and are always
+// (re)written — only `purpose.md` is reserved.
+const RESERVED_IDENTITY_TARGETS: ReadonlySet<string> = new Set([PROFILE_TARGETS.purpose]);
+
 function resolveHomes(options: PaiImportOptions = {}): { claudeHome: string; somaHome: string } {
   const home = resolve(options.homeDir ?? homedir());
 
@@ -314,9 +322,22 @@ export async function importPaiIdentity(options: PaiImportOptions = {}): Promise
   }
 
   const written: string[] = [];
+  const skippedReserved: string[] = [];
 
   for (const [relativePath, content] of files) {
     const target = join(homes.somaHome, relativePath);
+
+    // soma#441 — a reserved target that already exists on disk is
+    // presumed hand-curated (or at least previously landed); leave it
+    // untouched unless the principal explicitly opts in via
+    // `overwriteReserved`. The content is still computed above (so a
+    // fresh-target write further down stays byte-identical to before
+    // this fix) — only the write itself is gated.
+    if (RESERVED_IDENTITY_TARGETS.has(relativePath) && existsSync(target) && options.overwriteReserved !== true) {
+      skippedReserved.push(target);
+      continue;
+    }
+
     await mkdir(dirname(target), { recursive: true });
     await writeFile(target, `${content}\n`, "utf8");
     written.push(target);
@@ -326,5 +347,6 @@ export async function importPaiIdentity(options: PaiImportOptions = {}): Promise
     claudeHome: homes.claudeHome,
     somaHome: homes.somaHome,
     files: written,
+    skippedReserved,
   };
 }

--- a/src/pai-importer.ts
+++ b/src/pai-importer.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import type { ImportSourceCheck, PaiImportOptions, PaiImportPlan, PaiImportResult } from "./types";
@@ -8,9 +8,11 @@ import type { ImportSourceCheck, PaiImportOptions, PaiImportPlan, PaiImportResul
 // `soma import pai` and `soma migrate pai` can't drift on wording. The
 // `prefix` argument carries each command's own bullet/label shape (e.g.
 // `"  - identity "` for the migrate summary); the reserved-noun suffix
-// stays identical.
+// stays identical. Says `(exists)`, NOT `(curated)`: the skip is gated
+// on the target already being a regular file on disk, which is all we
+// actually detect — it may be hand-curated or a prior generated run.
 export function formatReservedSkipLine(somaHome: string, target: string, prefix = ""): string {
-  return `${prefix}skipped reserved (curated): ${relative(somaHome, target)} — re-run with --overwrite-reserved to replace`;
+  return `${prefix}skipped reserved (exists): ${relative(somaHome, target)} — re-run with --overwrite-reserved to replace`;
 }
 
 type PaiSourceRole = "principal" | "assistant" | "mission" | "goals" | "strategies" | "beliefs";
@@ -52,6 +54,33 @@ const PROFILE_TARGETS = {
 // deterministic distillations of their PAI sources and are always
 // (re)written — only `purpose.md` is reserved.
 const RESERVED_IDENTITY_TARGETS: ReadonlySet<string> = new Set([PROFILE_TARGETS.purpose]);
+
+// soma#441 — classify a reserved target's on-disk state before deciding
+// to reserve-skip. We only skip when the path resolves to a regular
+// FILE (that's the "already landed / possibly curated" case worth
+// preserving). An absent target is a first run → write normally. A
+// target that exists but is NOT a regular file (directory, socket, …)
+// is a broken filesystem state: skipping it would report success while
+// leaving an unusable target, so we surface it loud instead. `stat`
+// (not `lstat`) so a symlink pointing at a real file is treated as the
+// file it resolves to.
+async function reservedTargetState(target: string): Promise<"absent" | "file"> {
+  let stats;
+  try {
+    stats = await stat(target);
+  } catch (error) {
+    if (typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT") {
+      return "absent";
+    }
+    // Any other stat failure (EACCES, ELOOP on a broken symlink cycle, …)
+    // must surface — a silent miss could clobber or mis-skip the target.
+    throw error;
+  }
+  if (!stats.isFile()) {
+    throw new Error(`reserved target ${target} exists but is not a regular file`);
+  }
+  return "file";
+}
 
 function resolveHomes(options: PaiImportOptions = {}): { claudeHome: string; somaHome: string } {
   const home = resolve(options.homeDir ?? homedir());
@@ -336,15 +365,19 @@ export async function importPaiIdentity(options: PaiImportOptions = {}): Promise
   for (const [relativePath, content] of files) {
     const target = join(homes.somaHome, relativePath);
 
-    // soma#441 — a reserved target that already exists on disk is
-    // presumed hand-curated (or at least previously landed); leave it
-    // untouched unless the principal explicitly opts in via
-    // `overwriteReserved`. The content is still computed above (so a
-    // fresh-target write further down stays byte-identical to before
-    // this fix) — only the write itself is gated.
-    if (RESERVED_IDENTITY_TARGETS.has(relativePath) && existsSync(target) && options.overwriteReserved !== true) {
-      skippedReserved.push(target);
-      continue;
+    // soma#441 — a reserved target that already exists on disk as a
+    // regular file is left untouched unless the principal explicitly
+    // opts in via `overwriteReserved`, so a landed (possibly curated)
+    // purpose.md survives repeated imports. The content is still
+    // computed above (so a fresh-target write further down stays
+    // byte-identical to before this fix) — only the write is gated.
+    // `reservedTargetState` throws if the target exists but is not a
+    // regular file, rather than skipping and reporting a false success.
+    if (RESERVED_IDENTITY_TARGETS.has(relativePath) && options.overwriteReserved !== true) {
+      if ((await reservedTargetState(target)) === "file") {
+        skippedReserved.push(target);
+        continue;
+      }
     }
 
     await mkdir(dirname(target), { recursive: true });

--- a/src/pai-migration.ts
+++ b/src/pai-migration.ts
@@ -1764,7 +1764,11 @@ function renderManifest(result: ManifestInputs): string {
     `Last migrated at: ${result.lastMigratedAt}`,
     "",
     "## Categories",
-    `- identity: ${result.identity.files.length} files`,
+    // soma#441 — total identity target count (written + reserved-skipped)
+    // is an end-state fact and stays stable across reruns; per-run
+    // written/skipped deltas live in the result object, not on disk
+    // (matches the memory-phase comment below).
+    `- identity: ${result.identity.files.length + (result.identity.skippedReserved?.length ?? 0)} files`,
     `  - identity fingerprint: ${result.identityFingerprint}`,
     `- algorithm: ${result.algorithm ? `${result.algorithm.files.length} files` : "not present"}`,
     result.algorithm ? `  - algorithm fingerprint: ${result.algorithmFingerprint ?? "empty"}` : null,
@@ -1830,7 +1834,15 @@ interface StableManifestInputs {
 async function renderStableMigrationManifest(
   inputs: StableManifestInputs,
 ): Promise<{ manifest: string; lastMigratedAt: string }> {
-  const identityFingerprint = await fingerprintFiles(inputs.identity.files);
+  // soma#441 — fingerprint over the full identity target set (written
+  // + reserved-skipped), not just `files`. A reserved target
+  // (`profile/purpose.md`) moves from `files` to `skippedReserved`
+  // once it exists on disk, but its bytes on disk are unchanged — the
+  // union keeps this fingerprint (and the "## Categories" identity
+  // count below) an end-state fact that stays stable across a
+  // genuinely idempotent rerun, matching the memory phase's
+  // `writtenCount + skippedCount` precedent.
+  const identityFingerprint = await fingerprintFiles([...inputs.identity.files, ...(inputs.identity.skippedReserved ?? [])]);
   const algorithmFingerprint = inputs.algorithm
     ? await fingerprintFiles(inputs.algorithm.files)
     : null;
@@ -1900,7 +1912,16 @@ export async function migratePai(options: PaiMigrationOptions = {}): Promise<Pai
   const { algorithmDir, packPaths } = await discoverMigrationSources(claudeHome, options);
   const filesWritten: string[] = [];
 
-  const identity = await importPaiIdentity({ homeDir: options.homeDir, claudeHome, somaHome });
+  // soma#441 — `--overwrite-reserved` (already used by the pack phase
+  // below) also gates the identity importer's reserved
+  // `profile/purpose.md` target, so a curated purpose.md survives
+  // repeated `migrate pai` runs unless explicitly overwritten.
+  const identity = await importPaiIdentity({
+    homeDir: options.homeDir,
+    claudeHome,
+    somaHome,
+    overwriteReserved: options.overwriteReserved === true,
+  });
   filesWritten.push(...identity.files);
 
   const algorithm = algorithmDir === null

--- a/src/types.ts
+++ b/src/types.ts
@@ -731,6 +731,14 @@ export interface PaiImportOptions {
   homeDir?: string;
   claudeHome?: string;
   somaHome?: string;
+  /**
+   * soma#441 — permit overwriting reserved identity targets (currently
+   * just `profile/purpose.md`) that already exist on disk. Without
+   * this flag, an existing reserved target is left untouched on
+   * rerun so hand-curation survives repeated `migrate pai` / `import
+   * pai` runs. See `PaiImportResult.skippedReserved`.
+   */
+  overwriteReserved?: boolean;
 }
 
 export interface PaiImportPlan {
@@ -746,6 +754,12 @@ export interface PaiImportResult {
   claudeHome: string;
   somaHome: string;
   files: string[];
+  /**
+   * soma#441 — reserved identity targets (absolute paths) that already
+   * existed on disk and were left untouched because `overwriteReserved`
+   * was not set. Empty when nothing was reserved-skipped.
+   */
+  skippedReserved?: string[];
 }
 
 export interface AlgorithmImportOptions {

--- a/test/pai-importer.test.ts
+++ b/test/pai-importer.test.ts
@@ -250,7 +250,9 @@ test("#441 cli `soma import pai --apply` reports skipped reserved purpose.md and
     await writeFile(purposePath, "# Purpose\n\nHand-curated via CLI.\n", "utf8");
 
     const applied = await runSomaCli(["import", "pai", "--apply", "--home-dir", homeDir]);
-    expect(applied).toContain("skipped reserved");
+    // The marker is "(exists)", not "(curated)": the skip only detects
+    // that the target is already a regular file.
+    expect(applied).toContain("skipped reserved (exists)");
     expect(applied).toContain("profile/purpose.md");
     expect(applied).toContain("--overwrite-reserved");
     await expect(readFile(purposePath, "utf8")).resolves.toBe("# Purpose\n\nHand-curated via CLI.\n");
@@ -258,5 +260,19 @@ test("#441 cli `soma import pai --apply` reports skipped reserved purpose.md and
     const overwritten = await runSomaCli(["import", "pai", "--apply", "--home-dir", homeDir, "--overwrite-reserved"]);
     expect(overwritten).not.toContain("skipped reserved");
     await expect(readFile(purposePath, "utf8")).resolves.not.toContain("Hand-curated via CLI.");
+  });
+});
+
+test("#441 a directory at the reserved purpose target throws instead of silently skipping", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+
+    // A directory where the reserved file belongs is a broken
+    // filesystem state — the importer must surface it, not report a
+    // false success by "skipping" it.
+    const purposePath = join(homeDir, ".soma/profile/purpose.md");
+    await mkdir(purposePath, { recursive: true });
+
+    await expect(importPaiIdentity({ homeDir })).rejects.toThrow("is not a regular file");
   });
 });

--- a/test/pai-importer.test.ts
+++ b/test/pai-importer.test.ts
@@ -187,3 +187,76 @@ test("cli dry-runs and applies the PAI importer", async () => {
     await expect(readFile(join(homeDir, ".soma/profile/assistant.md"), "utf8")).resolves.toContain("Name: Ivy");
   });
 });
+
+// ---- soma#441 — profile/purpose.md is a reserved identity target ----
+
+test("#441 re-import leaves a curated purpose.md byte-unchanged and reports it as skipped-reserved", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    await importPaiIdentity({ homeDir });
+
+    const purposePath = join(homeDir, ".soma/profile/purpose.md");
+    const curated = "# Purpose\n\nHand-curated mission that must survive re-import.\n";
+    await writeFile(purposePath, curated, "utf8");
+
+    const second = await importPaiIdentity({ homeDir });
+
+    expect(await readFile(purposePath, "utf8")).toBe(curated);
+    expect(second.skippedReserved ?? []).toContain(purposePath);
+    expect(second.files).not.toContain(purposePath);
+    // principal.md / assistant.md are deterministic distillations and
+    // must still be (re)written on every run.
+    expect(second.files).toContain(join(homeDir, ".soma/profile/principal.md"));
+    expect(second.files).toContain(join(homeDir, ".soma/profile/assistant.md"));
+  });
+});
+
+test("#441 overwriteReserved: true replaces an existing curated purpose.md", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    await importPaiIdentity({ homeDir });
+
+    const purposePath = join(homeDir, ".soma/profile/purpose.md");
+    await writeFile(purposePath, "# Purpose\n\nHand-curated, about to be overwritten.\n", "utf8");
+
+    const second = await importPaiIdentity({ homeDir, overwriteReserved: true });
+
+    expect(second.files).toContain(purposePath);
+    expect(second.skippedReserved ?? []).not.toContain(purposePath);
+    const rewritten = await readFile(purposePath, "utf8");
+    expect(rewritten).not.toContain("Hand-curated, about to be overwritten.");
+  });
+});
+
+test("#441 first run (no existing purpose.md) creates it and does not report it as skipped", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+
+    const result = await importPaiIdentity({ homeDir });
+    const purposePath = join(homeDir, ".soma/profile/purpose.md");
+
+    expect(result.files).toContain(purposePath);
+    expect(result.skippedReserved ?? []).toEqual([]);
+    await expect(readFile(purposePath, "utf8")).resolves.toContain("Build useful test systems without leaking publisher context.");
+  });
+});
+
+test("#441 cli `soma import pai --apply` reports skipped reserved purpose.md and accepts --overwrite-reserved", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    await runSomaCli(["import", "pai", "--apply", "--home-dir", homeDir]);
+
+    const purposePath = join(homeDir, ".soma/profile/purpose.md");
+    await writeFile(purposePath, "# Purpose\n\nHand-curated via CLI.\n", "utf8");
+
+    const applied = await runSomaCli(["import", "pai", "--apply", "--home-dir", homeDir]);
+    expect(applied).toContain("skipped reserved");
+    expect(applied).toContain("profile/purpose.md");
+    expect(applied).toContain("--overwrite-reserved");
+    await expect(readFile(purposePath, "utf8")).resolves.toBe("# Purpose\n\nHand-curated via CLI.\n");
+
+    const overwritten = await runSomaCli(["import", "pai", "--apply", "--home-dir", homeDir, "--overwrite-reserved"]);
+    expect(overwritten).not.toContain("skipped reserved");
+    await expect(readFile(purposePath, "utf8")).resolves.not.toContain("Hand-curated via CLI.");
+  });
+});

--- a/test/pai-migration-issue-441.test.ts
+++ b/test/pai-migration-issue-441.test.ts
@@ -11,17 +11,21 @@
  * `assistant.md` stay deterministic distillations and are always
  * (re)written.
  *
- * The manifest body (`MIGRATION.md`) must stay byte-stable across a
- * genuinely idempotent rerun (established invariant — see
- * `renderManifest`'s Sage r1 #28 comment). Reserved-skip is a
- * per-run split of the SAME end-state file set (written vs.
+ * The manifest body (`MIGRATION.md`) must stay byte-identical across a
+ * genuinely idempotent rerun — the existing invariant asserted by
+ * `test/pai-migration.test.ts` ("migratePai is idempotent at the file
+ * level") and `test/pai-migration-issue-90.test.ts`. Reserved-skip is
+ * a per-run split of the SAME end-state file set (written vs.
  * skipped-because-already-present), so the identity file *count* and
- * *fingerprint* in the manifest must be computed over the union of
- * `files` + `skippedReserved`, not `files` alone — otherwise the count
- * would drop from run 1 (creates purpose.md) to run 2+ (skips it),
- * breaking the existing idempotency tests. The per-run skip detail
- * lives only in the CLI's ephemeral summary output, matching the
- * memory phase's existing "written N / unchanged M" precedent.
+ * *fingerprint* in the manifest are computed over the union of `files`
+ * + `skippedReserved`, not `files` alone. Without the union, run 1
+ * (writes purpose.md → in `files`) and run 2 (skips it → in
+ * `skippedReserved`) would report different identity counts /
+ * fingerprints and the manifest would drift on an idempotent rerun.
+ * The union mirrors the memory phase's `writtenCount + skippedCount`
+ * end-state accounting (`renderStableMigrationManifest` /
+ * `renderManifest` in `src/pai-migration.ts`). The per-run skip detail
+ * lives only in the CLI's ephemeral summary output.
  */
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -30,15 +34,48 @@ import { migratePai } from "../src/pai-migration";
 import { runSomaCli } from "../src/cli";
 import { withTempHome, writePaiIdentityFixture as writePaiFixture } from "./fixtures/pai-migration-fixtures";
 
-test("#441 migratePai leaves a curated purpose.md untouched on rerun; manifest stays byte-stable", async () => {
+test("#441 migratePai manifest is byte-identical across a genuinely idempotent rerun even though run 2 reserved-skips purpose.md", async () => {
   await withTempHome(async (homeDir) => {
     await writePaiFixture(homeDir, { withAlgorithm: true });
 
+    // Run 1 creates purpose.md (in `files`). Run 2 sees it already on
+    // disk and reserved-skips it (in `skippedReserved`). No mutation
+    // between runs → the manifest body must be byte-identical. This is
+    // the direct regression guard: computing the identity count /
+    // fingerprint over `files` alone (not the union with
+    // `skippedReserved`) would drop the count by one and change the
+    // fingerprint on run 2, drifting the manifest.
     const first = await migratePai({ homeDir });
     const purposePath = join(homeDir, ".soma/profile/purpose.md");
     const firstManifest = await readFile(first.manifestPath, "utf8");
+    // Run 1 wrote purpose.md; nothing was reserved-skipped yet.
+    expect(first.identity.files).toContain(purposePath);
+    expect(first.identity.skippedReserved ?? []).not.toContain(purposePath);
 
-    // Simulate hand-curation between runs.
+    const second = await migratePai({ homeDir });
+    // Run 2 reserved-skipped the now-present purpose.md instead of writing it.
+    expect(second.identity.skippedReserved ?? []).toContain(purposePath);
+    expect(second.identity.files).not.toContain(purposePath);
+
+    // The whole manifest body — not just one line — must be byte-for-byte
+    // identical across the idempotent rerun (the `Last migrated at:`
+    // timestamp is preserved by the importer's idempotency machinery, so
+    // a direct full-body comparison is deterministic; same pattern as
+    // pai-migration-issue-90's manifest-stability assertion).
+    const secondManifest = await readFile(second.manifestPath, "utf8");
+    expect(secondManifest).toBe(firstManifest);
+  });
+});
+
+test("#441 migratePai leaves a hand-curated purpose.md byte-unchanged on rerun", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir, { withAlgorithm: true });
+
+    await migratePai({ homeDir });
+    const purposePath = join(homeDir, ".soma/profile/purpose.md");
+
+    // Simulate hand-curation between runs (content diverges from what
+    // the importer would generate).
     const curated = "# Purpose\n\nHand-curated mission, must survive rerun.\n";
     await writeFile(purposePath, curated, "utf8");
 
@@ -47,15 +84,10 @@ test("#441 migratePai leaves a curated purpose.md untouched on rerun; manifest s
     expect(await readFile(purposePath, "utf8")).toBe(curated);
     expect(second.identity.skippedReserved ?? []).toContain(purposePath);
     expect(second.identity.files).not.toContain(purposePath);
-
-    // The manifest's identity file count + fingerprint are end-state
-    // facts (written + skipped-reserved), not "what this run wrote" —
-    // so a rerun with no real content drift must not change the
-    // manifest body byte-for-byte, even though the curated file moved
-    // from `files` to `skippedReserved` between the two runs.
-    const secondManifest = await readFile(second.manifestPath, "utf8");
-    const identityLine = (text: string) => text.split("\n").find((l) => l.trim().startsWith("- identity:"));
-    expect(identityLine(secondManifest)).toBe(identityLine(firstManifest));
+    // principal.md / assistant.md are deterministic distillations and
+    // are still (re)written every run.
+    expect(second.identity.files).toContain(join(homeDir, ".soma/profile/principal.md"));
+    expect(second.identity.files).toContain(join(homeDir, ".soma/profile/assistant.md"));
   });
 });
 

--- a/test/pai-migration-issue-441.test.ts
+++ b/test/pai-migration-issue-441.test.ts
@@ -116,7 +116,8 @@ test("#441 soma migrate pai --apply reports skipped reserved purpose.md", async 
     await writeFile(purposePath, "# Purpose\n\nHand-curated via CLI migrate.\n", "utf8");
 
     const applied = await runSomaCli(["migrate", "pai", "--apply", "--home-dir", homeDir]);
-    expect(applied).toContain("skipped reserved");
+    // "(exists)", not "(curated)": the skip only detects an existing file.
+    expect(applied).toContain("skipped reserved (exists)");
     expect(applied).toContain("profile/purpose.md");
     expect(applied).toContain("--overwrite-reserved");
     await expect(readFile(purposePath, "utf8")).resolves.toContain("Hand-curated via CLI migrate.");

--- a/test/pai-migration-issue-441.test.ts
+++ b/test/pai-migration-issue-441.test.ts
@@ -1,0 +1,96 @@
+/**
+ * #441 — `soma migrate pai`'s identity importer clobbered a
+ * hand-curated `profile/purpose.md` on every rerun. `purpose.md` is
+ * the source of truth `src/soma-home.ts` reads to build every
+ * substrate's projected Purpose, so a clobber propagates a placeholder
+ * mission everywhere on the next reproject.
+ *
+ * Fix: `profile/purpose.md` is now a reserved identity target. Once it
+ * exists on disk, `migrate pai` / `import pai` leave it untouched
+ * unless `--overwrite-reserved` is passed. `principal.md` /
+ * `assistant.md` stay deterministic distillations and are always
+ * (re)written.
+ *
+ * The manifest body (`MIGRATION.md`) must stay byte-stable across a
+ * genuinely idempotent rerun (established invariant — see
+ * `renderManifest`'s Sage r1 #28 comment). Reserved-skip is a
+ * per-run split of the SAME end-state file set (written vs.
+ * skipped-because-already-present), so the identity file *count* and
+ * *fingerprint* in the manifest must be computed over the union of
+ * `files` + `skippedReserved`, not `files` alone — otherwise the count
+ * would drop from run 1 (creates purpose.md) to run 2+ (skips it),
+ * breaking the existing idempotency tests. The per-run skip detail
+ * lives only in the CLI's ephemeral summary output, matching the
+ * memory phase's existing "written N / unchanged M" precedent.
+ */
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import { migratePai } from "../src/pai-migration";
+import { runSomaCli } from "../src/cli";
+import { withTempHome, writePaiIdentityFixture as writePaiFixture } from "./fixtures/pai-migration-fixtures";
+
+test("#441 migratePai leaves a curated purpose.md untouched on rerun; manifest stays byte-stable", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir, { withAlgorithm: true });
+
+    const first = await migratePai({ homeDir });
+    const purposePath = join(homeDir, ".soma/profile/purpose.md");
+    const firstManifest = await readFile(first.manifestPath, "utf8");
+
+    // Simulate hand-curation between runs.
+    const curated = "# Purpose\n\nHand-curated mission, must survive rerun.\n";
+    await writeFile(purposePath, curated, "utf8");
+
+    const second = await migratePai({ homeDir });
+
+    expect(await readFile(purposePath, "utf8")).toBe(curated);
+    expect(second.identity.skippedReserved ?? []).toContain(purposePath);
+    expect(second.identity.files).not.toContain(purposePath);
+
+    // The manifest's identity file count + fingerprint are end-state
+    // facts (written + skipped-reserved), not "what this run wrote" —
+    // so a rerun with no real content drift must not change the
+    // manifest body byte-for-byte, even though the curated file moved
+    // from `files` to `skippedReserved` between the two runs.
+    const secondManifest = await readFile(second.manifestPath, "utf8");
+    const identityLine = (text: string) => text.split("\n").find((l) => l.trim().startsWith("- identity:"));
+    expect(identityLine(secondManifest)).toBe(identityLine(firstManifest));
+  });
+});
+
+test("#441 migratePai --overwrite-reserved replaces a curated purpose.md", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    await migratePai({ homeDir });
+
+    const purposePath = join(homeDir, ".soma/profile/purpose.md");
+    await writeFile(purposePath, "# Purpose\n\nHand-curated, about to be overwritten.\n", "utf8");
+
+    const second = await migratePai({ homeDir, overwriteReserved: true });
+
+    expect(second.identity.files).toContain(purposePath);
+    expect(second.identity.skippedReserved ?? []).not.toContain(purposePath);
+    await expect(readFile(purposePath, "utf8")).resolves.not.toContain("Hand-curated, about to be overwritten.");
+  });
+});
+
+test("#441 soma migrate pai --apply reports skipped reserved purpose.md", async () => {
+  await withTempHome(async (homeDir) => {
+    await writePaiFixture(homeDir);
+    await runSomaCli(["migrate", "pai", "--apply", "--home-dir", homeDir]);
+
+    const purposePath = join(homeDir, ".soma/profile/purpose.md");
+    await writeFile(purposePath, "# Purpose\n\nHand-curated via CLI migrate.\n", "utf8");
+
+    const applied = await runSomaCli(["migrate", "pai", "--apply", "--home-dir", homeDir]);
+    expect(applied).toContain("skipped reserved");
+    expect(applied).toContain("profile/purpose.md");
+    expect(applied).toContain("--overwrite-reserved");
+    await expect(readFile(purposePath, "utf8")).resolves.toContain("Hand-curated via CLI migrate.");
+
+    const overwritten = await runSomaCli(["migrate", "pai", "--apply", "--home-dir", homeDir, "--overwrite-reserved"]);
+    expect(overwritten).not.toContain("skipped reserved");
+    await expect(readFile(purposePath, "utf8")).resolves.not.toContain("Hand-curated via CLI migrate.");
+  });
+});


### PR DESCRIPTION
Fixes #441.

## Bug

`soma migrate pai` (and `soma import pai`) regenerated and overwrote `profile/purpose.md` on **every** run, clobbering hand-curation with a mechanical dump of the raw PAI TELOS sources. Since `src/soma-home.ts` reads `purpose.md` to build every substrate's projected Purpose, a clobber propagated a placeholder mission into every substrate on the next reproject. (`principal.md`/`assistant.md` are safe — deterministic distillations.)

## Fix

Make `profile/purpose.md` a **reserved** identity target:
- `src/pai-importer.ts`: `RESERVED_IDENTITY_TARGETS = { profile/purpose.md }`. The write loop skips a reserved target when it already `existsSync` on disk and `overwriteReserved !== true`, recording it in a new `skippedReserved` result field instead of overwriting. Content is still computed; only the write is gated. First run (absent) still creates it; `--overwrite-reserved` still replaces it.
- `src/types.ts`: `PaiImportOptions.overwriteReserved?` + `PaiImportResult.skippedReserved?`.
- Plumbing: `migrate pai` threads its existing `--overwrite-reserved` flag into the identity phase; `soma import pai` gains a matching `--overwrite-reserved` flag. Both now protect `purpose.md`.
- Reporting: both CLIs emit `skipped reserved (exists): profile/purpose.md — re-run with --overwrite-reserved to replace` when applicable (ephemeral CLI output only). The skip protects any existing file (it doesn't attempt to *detect* hand-curation), and a non-regular-file at the target throws rather than being silently treated as reserved.

## Manifest idempotency (subtle)

The persisted `MIGRATION.md` manifest has a byte-stability invariant across idempotent reruns. A naive skip would move `purpose.md` from `files` to `skippedReserved` between run 1 and run 2, changing the manifest's identity count/fingerprint. Resolved the same way the codebase already handles the memory phase: the manifest counts/fingerprints the **union** of written + skipped (a stable end-state fact); the written/skipped split lives only in ephemeral CLI output.

## Tests

8 new (TDD, RED→GREEN): rerun skips an existing `purpose.md` (byte-unchanged, in `skippedReserved` not `files`; principal/assistant still rewritten); `overwriteReserved: true` replaces it; first run creates it; a directory at the target throws; CLI reporting; migrate-level full-manifest byte-stability across a genuinely idempotent rerun.

- `tsc --noEmit`: clean. `bun test`: **1918 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
