### PR TITLE
fix(install): key portable-skill manifest per substrate home (#438)

### DIFF
--- a/src/adapters/grok/install-manifest.ts
+++ b/src/adapters/grok/install-manifest.ts
@@ -11,8 +11,10 @@ import {
 /**
  * Grok's portable-skill install manifest is the shared
  * `portable-skill-manifest` mechanism bound to the `grok` substrate: schema
- * `soma-grok-install-manifest-v1`, stored at `<somaHome>/projections/grok/`.
- * These thin wrappers preserve the grok-named API its adapter/doctor/tests
+ * `soma-grok-install-manifest-v1`, stored at `<somaHome>/projections/grok/
+ * <substrateHomeHash>/` (soma#438: keyed per substrate home so two `.grok`
+ * homes installed from one soma home don't share a manifest). These thin
+ * wrappers preserve the grok-named API its adapter/doctor/tests
  * already import; the byte output is identical to the shared helper with
  * `substrate: "grok"`. See `../shared/portable-skill-manifest.ts` for the
  * full contract (SHARED skills dir → manifest-tracked round-trip).
@@ -21,8 +23,8 @@ export const GROK_INSTALL_MANIFEST_SCHEMA = portableSkillManifestSchema("grok");
 
 export type GrokInstallManifest = PortableSkillManifest;
 
-export function grokInstallManifestPath(somaHome: string): string {
-  return portableSkillManifestPath(somaHome, "grok");
+export function grokInstallManifestPath(somaHome: string, substrateHome: string): string {
+  return portableSkillManifestPath(somaHome, "grok", substrateHome);
 }
 
 export function writeGrokInstallManifest(options: {
@@ -33,8 +35,8 @@ export function writeGrokInstallManifest(options: {
   return writePortableSkillManifest({ ...options, substrate: "grok" });
 }
 
-export function readGrokInstallManifest(somaHome: string): Promise<GrokInstallManifest | null> {
-  return readPortableSkillManifest(somaHome, "grok");
+export function readGrokInstallManifest(somaHome: string, substrateHome: string): Promise<GrokInstallManifest | null> {
+  return readPortableSkillManifest(somaHome, "grok", substrateHome);
 }
 
 export function reconcileGrokPortableSkillProjection(options: {

--- a/src/adapters/shared/portable-skill-manifest.ts
+++ b/src/adapters/shared/portable-skill-manifest.ts
@@ -18,7 +18,11 @@ export type PortableSkillManifestSubstrate = "grok" | "claude-code";
  * static uninstall `remove` list cannot name them and the owned-subtree
  * reconcile cannot own their dir. Install records what it wrote — paths plus
  * content hashes — in a manifest on the SOMA side (`<somaHome>/projections/
- * <substrate>/`), and uninstall consumes it to round-trip the portable skills.
+ * <substrate>/<substrateHomeHash>/`), and uninstall consumes it to round-trip
+ * the portable skills. The path is keyed by a short hash of the resolved
+ * substrate home (soma#438) so two homes of the same substrate installed
+ * from one soma home get independent manifests instead of silently sharing
+ * (and clobbering) one.
  *
  * The manifest lives outside the substrate home on purpose: every Soma-owned
  * directory under the substrate home is itself removed during uninstall, and
@@ -42,8 +46,23 @@ export interface PortableSkillManifest {
   files: { path: string; sha256: string }[];
 }
 
-export function portableSkillManifestPath(somaHome: string, substrate: PortableSkillManifestSubstrate): string {
-  return join(somaHome, "projections", substrate, "install-manifest.json");
+/**
+ * A stable short hash of the RESOLVED substrate home, used to scope the
+ * manifest path per home (soma#438): two homes of the same substrate
+ * installed from one soma home (e.g. `--substrate-home ~/.claude` and
+ * `--substrate-home ~/claude-fresh`) must not share one manifest file, or
+ * uninstalling one silently orphans the other's projected skill dirs.
+ */
+function substrateHomeSegment(substrateHome: string): string {
+  return createHash("sha256").update(resolve(substrateHome), "utf8").digest("hex").slice(0, 12);
+}
+
+export function portableSkillManifestPath(
+  somaHome: string,
+  substrate: PortableSkillManifestSubstrate,
+  substrateHome: string,
+): string {
+  return join(somaHome, "projections", substrate, substrateHomeSegment(substrateHome), "install-manifest.json");
 }
 
 function contentHash(content: string): string {
@@ -63,7 +82,7 @@ export async function writePortableSkillManifest(options: {
     // bundle content here equals hashing the on-disk bytes.
     files: options.files.map((file) => ({ path: file.path, sha256: contentHash(file.content) })),
   };
-  const path = portableSkillManifestPath(options.somaHome, options.substrate);
+  const path = portableSkillManifestPath(options.somaHome, options.substrate, options.substrateHome);
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
   return path;
@@ -99,10 +118,11 @@ function isInsideRoot(root: string, target: string): boolean {
 export async function readPortableSkillManifest(
   somaHome: string,
   substrate: PortableSkillManifestSubstrate,
+  substrateHome: string,
 ): Promise<PortableSkillManifest | null> {
   let raw: string;
   try {
-    raw = await readFile(portableSkillManifestPath(somaHome, substrate), "utf8");
+    raw = await readFile(portableSkillManifestPath(somaHome, substrate, substrateHome), "utf8");
   } catch (error) {
     if (isEnoent(error)) return null;
     throw error;
@@ -173,7 +193,7 @@ export async function reconcilePortableSkillProjection(options: {
   substrateHome: string;
   currentPaths: readonly string[];
 }): Promise<string[]> {
-  const manifest = await readPortableSkillManifest(options.somaHome, options.substrate);
+  const manifest = await readPortableSkillManifest(options.somaHome, options.substrate, options.substrateHome);
   if (manifest === null) return [];
   const substrateHome = resolve(options.substrateHome);
   if (resolve(manifest.substrateHome) !== substrateHome) return [];
@@ -202,13 +222,13 @@ export async function removePortableSkillProjection(options: {
   substrate: PortableSkillManifestSubstrate;
   substrateHome: string;
 }): Promise<string[]> {
-  const manifest = await readPortableSkillManifest(options.somaHome, options.substrate);
+  const manifest = await readPortableSkillManifest(options.somaHome, options.substrate, options.substrateHome);
   if (manifest === null) return [];
   const substrateHome = resolve(options.substrateHome);
   if (resolve(manifest.substrateHome) !== substrateHome) return [];
 
   const removed = await removeListedProjectionFiles(substrateHome, manifest.files);
-  const manifestPath = portableSkillManifestPath(options.somaHome, options.substrate);
+  const manifestPath = portableSkillManifestPath(options.somaHome, options.substrate, options.substrateHome);
   await rm(manifestPath, { force: true });
   removed.push(manifestPath);
   return removed;

--- a/test/grok-install.test.ts
+++ b/test/grok-install.test.ts
@@ -120,8 +120,9 @@ test("grok install records the bundled portable skills in the install manifest",
     const { somaHome } = await bootstrapSomaHome({ homeDir });
 
     await installSomaForGrok({ homeDir });
+    const grokHome = join(homeDir, ".grok");
 
-    const manifest = JSON.parse(await readFile(grokInstallManifestPath(somaHome), "utf8"));
+    const manifest = JSON.parse(await readFile(grokInstallManifestPath(somaHome, grokHome), "utf8"));
     expect(manifest.schema).toBe(GROK_INSTALL_MANIFEST_SCHEMA);
     expect(resolve(manifest.substrateHome)).toBe(resolve(join(homeDir, ".grok")));
     // Only bundled portable skills project (the loop is scoped to src/skills).
@@ -140,7 +141,7 @@ test("grok install records the bundled portable skills in the install manifest",
 
     // Idempotent: a reinstall records byte-identical manifest entries.
     await installSomaForGrok({ homeDir });
-    const rerecorded = JSON.parse(await readFile(grokInstallManifestPath(somaHome), "utf8"));
+    const rerecorded = JSON.parse(await readFile(grokInstallManifestPath(somaHome, grokHome), "utf8"));
     expect(rerecorded.files).toEqual(manifest.files);
   });
 });

--- a/test/grok-uninstall.test.ts
+++ b/test/grok-uninstall.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { bootstrapSomaHome, installSomaForGrok, uninstallSomaForGrok, projectGrok } from "../src/index";
 import { GROK_INSTALL_MANIFEST_SCHEMA, grokInstallManifestPath } from "../src/adapters/grok/install-manifest";
 import {
@@ -170,13 +170,13 @@ test("grok uninstall round-trips the bundled portable skills via the install man
 
     // Unedited managed files round-trip via the manifest; the manifest is consumed.
     expect(removed).toContain(normalize(join(grokHome, "skills/Memory/Workflows/Recall.md")));
-    expect(removed).toContain(normalize(grokInstallManifestPath(somaHome)));
+    expect(removed).toContain(normalize(grokInstallManifestPath(somaHome, grokHome)));
     // The Workflows subdir emptied out and was pruned...
     expect(await pathGone(join(grokHome, "skills", "Memory", "Workflows"))).toBe(true);
     // ...but the user edit + user-added file survive, keeping the Memory dir.
     expect(await readFile(join(grokHome, "skills", "Memory", "SKILL.md"), "utf8")).toBe("hand-tuned\n");
     expect(await readFile(join(grokHome, "skills", "Memory", "extra.md"), "utf8")).toBe("User-added.\n");
-    expect(await pathGone(grokInstallManifestPath(somaHome))).toBe(true);
+    expect(await pathGone(grokInstallManifestPath(somaHome, grokHome))).toBe(true);
   });
 });
 
@@ -186,8 +186,11 @@ test("grok uninstall ignores a manifest recorded for a different substrate home"
     const grokHome = join(homeDir, ".grok");
     await mkdir(join(grokHome, "skills", "notes"), { recursive: true });
     await writeFile(join(grokHome, "skills", "notes", "SKILL.md"), "User skill.\n", "utf8");
-    const manifestPath = grokInstallManifestPath(somaHome);
-    await mkdir(join(somaHome, "projections", "grok"), { recursive: true });
+    // Written at the path keyed by the REAL grok home (so uninstall finds it),
+    // but the in-file `substrateHome` names a different home — the
+    // defense-in-depth guard this test exercises.
+    const manifestPath = grokInstallManifestPath(somaHome, grokHome);
+    await mkdir(dirname(manifestPath), { recursive: true });
     await writeFile(
       manifestPath,
       `${JSON.stringify({
@@ -214,9 +217,10 @@ test("grok uninstall skips manifest paths that escape the substrate home", async
     await mkdir(grokHome, { recursive: true });
     const outside = join(homeDir, "outside.md");
     await writeFile(outside, "Do not touch.\n", "utf8");
-    await mkdir(join(somaHome, "projections", "grok"), { recursive: true });
+    const manifestPath = grokInstallManifestPath(somaHome, grokHome);
+    await mkdir(dirname(manifestPath), { recursive: true });
     await writeFile(
-      grokInstallManifestPath(somaHome),
+      manifestPath,
       `${JSON.stringify({
         schema: GROK_INSTALL_MANIFEST_SCHEMA,
         substrateHome: resolve(grokHome),
@@ -229,7 +233,7 @@ test("grok uninstall skips manifest paths that escape the substrate home", async
 
     expect(await readFile(outside, "utf8")).toBe("Do not touch.\n");
     // The matching-home manifest is consumed even though its entries were rejected.
-    expect(result.removed.map(normalize)).toContain(normalize(grokInstallManifestPath(somaHome)));
+    expect(result.removed.map(normalize)).toContain(normalize(manifestPath));
   });
 });
 

--- a/test/portable-skill-manifest.test.ts
+++ b/test/portable-skill-manifest.test.ts
@@ -1,7 +1,8 @@
 import { expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import {
   portableSkillManifestPath,
   portableSkillManifestSchema,
@@ -10,6 +11,10 @@ import {
   removePortableSkillProjection,
   writePortableSkillManifest,
 } from "../src/adapters/shared/portable-skill-manifest";
+
+function substrateHomeSegment(substrateHome: string): string {
+  return createHash("sha256").update(resolve(substrateHome), "utf8").digest("hex").slice(0, 12);
+}
 
 async function withDirs(fn: (somaHome: string, substrateHome: string) => Promise<void>): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), "soma-psm-"));
@@ -34,10 +39,17 @@ async function project(substrateHome: string, files: { path: string; content: st
   }
 }
 
-test("schema and path are substrate-scoped and byte-stable for grok", () => {
+test("schema and path are substrate-scoped, per-substrate-home, and byte-stable for grok", () => {
   expect(portableSkillManifestSchema("grok")).toBe("soma-grok-install-manifest-v1");
   expect(portableSkillManifestSchema("claude-code")).toBe("soma-claude-code-install-manifest-v1");
-  expect(portableSkillManifestPath("/home/.soma", "grok")).toBe("/home/.soma/projections/grok/install-manifest.json");
+  const hash = substrateHomeSegment("/home/.grok");
+  expect(portableSkillManifestPath("/home/.soma", "grok", "/home/.grok")).toBe(
+    `/home/.soma/projections/grok/${hash}/install-manifest.json`,
+  );
+  // Two different substrate homes get two different manifest paths.
+  expect(portableSkillManifestPath("/home/.soma", "grok", "/home/.grok")).not.toBe(
+    portableSkillManifestPath("/home/.soma", "grok", "/home/other-grok"),
+  );
 });
 
 test("write records path + content hash; read round-trips; a foreign schema reads as null", async () => {
@@ -46,11 +58,11 @@ test("write records path + content hash; read round-trips; a foreign schema read
     await project(substrateHome, files);
     await writePortableSkillManifest({ somaHome, substrate: "claude-code", substrateHome, files });
 
-    const manifest = await readPortableSkillManifest(somaHome, "claude-code");
+    const manifest = await readPortableSkillManifest(somaHome, "claude-code", substrateHome);
     expect(manifest?.schema).toBe("soma-claude-code-install-manifest-v1");
     expect(manifest?.files.map((f) => f.path)).toEqual(["skills/Memory/SKILL.md"]);
     // Same manifest bytes, read under a DIFFERENT substrate → schema mismatch → null.
-    expect(await readPortableSkillManifest(somaHome, "grok")).toBeNull();
+    expect(await readPortableSkillManifest(somaHome, "grok", substrateHome)).toBeNull();
   });
 });
 
@@ -69,7 +81,7 @@ test("remove deletes recorded files, prunes emptied dirs, consumes the manifest"
     expect(removed).toContain(resolve(substrateHome, "skills/Memory/Workflows/Recall.md"));
     expect(await gone(join(substrateHome, "skills/Memory"))).toBe(true);
     // The manifest is consumed so a second uninstall is a no-op.
-    expect(await gone(portableSkillManifestPath(somaHome, "claude-code"))).toBe(true);
+    expect(await gone(portableSkillManifestPath(somaHome, "claude-code", substrateHome))).toBe(true);
     expect(await removePortableSkillProjection({ somaHome, substrate: "claude-code", substrateHome })).toEqual([]);
   });
 });
@@ -97,17 +109,30 @@ test("remove preserves user-edited files and user-added files (and keeps their d
   });
 });
 
-test("remove ignores a manifest describing a different substrate home", async () => {
+test("remove ignores a manifest describing a different substrate home (defense-in-depth in-file guard)", async () => {
   await withDirs(async (somaHome, substrateHome) => {
     const files = [{ path: "skills/Memory/SKILL.md", content: "a\n" }];
     await project(substrateHome, files);
-    await writePortableSkillManifest({ somaHome, substrate: "grok", substrateHome: "/some/other/home", files });
+    // Manifest lives at the path keyed by the REAL substrate home (so remove
+    // finds it), but its in-file `substrateHome` field names a different home
+    // — the tampered/stale-content case the in-file guard defends against.
+    const path = portableSkillManifestPath(somaHome, "grok", substrateHome);
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(
+      path,
+      `${JSON.stringify({
+        schema: "soma-grok-install-manifest-v1",
+        substrateHome: "/some/other/home",
+        files: [{ path: files[0].path, sha256: createHash("sha256").update(files[0].content, "utf8").digest("hex") }],
+      })}\n`,
+      "utf8",
+    );
 
     const removed = await removePortableSkillProjection({ somaHome, substrate: "grok", substrateHome });
     expect(removed).toEqual([]);
     // Neither the file nor the (foreign-home) manifest is touched.
     expect(await gone(join(substrateHome, "skills/Memory/SKILL.md"))).toBe(false);
-    expect(await gone(portableSkillManifestPath(somaHome, "grok"))).toBe(false);
+    expect(await gone(path)).toBe(false);
   });
 });
 
@@ -133,6 +158,50 @@ test("reconcile removes only files the current projection dropped, keeping the m
     expect(removed).toContain(resolve(substrateHome, "skills/Gone/SKILL.md"));
     expect(await gone(join(substrateHome, "skills/Gone"))).toBe(true);
     expect(await gone(join(substrateHome, "skills/Memory/SKILL.md"))).toBe(false);
-    expect(await gone(portableSkillManifestPath(somaHome, "claude-code"))).toBe(false);
+    expect(await gone(portableSkillManifestPath(somaHome, "claude-code", substrateHome))).toBe(false);
   });
+});
+
+test("two substrate homes of the same substrate, installed from one soma home, get independent manifests (#438)", async () => {
+  const root = await mkdtemp(join(tmpdir(), "soma-psm-multi-home-"));
+  try {
+    const somaHome = join(root, ".soma");
+    const substrateHomeA = join(root, "home-a", ".claude");
+    const substrateHomeB = join(root, "home-b", ".claude");
+    await mkdir(somaHome, { recursive: true });
+    await mkdir(substrateHomeA, { recursive: true });
+    await mkdir(substrateHomeB, { recursive: true });
+
+    const filesA = [{ path: "skills/Memory/SKILL.md", content: "home-a memory\n" }];
+    const filesB = [{ path: "skills/Memory/SKILL.md", content: "home-b memory\n" }];
+    await project(substrateHomeA, filesA);
+    await project(substrateHomeB, filesB);
+    await writePortableSkillManifest({ somaHome, substrate: "claude-code", substrateHome: substrateHomeA, files: filesA });
+    await writePortableSkillManifest({ somaHome, substrate: "claude-code", substrateHome: substrateHomeB, files: filesB });
+
+    const pathA = portableSkillManifestPath(somaHome, "claude-code", substrateHomeA);
+    const pathB = portableSkillManifestPath(somaHome, "claude-code", substrateHomeB);
+    expect(pathA).not.toBe(pathB);
+    expect(await gone(pathA)).toBe(false);
+    expect(await gone(pathB)).toBe(false);
+
+    // Uninstalling home A only consumes home A's manifest and round-trips
+    // only home A's projected skill dir; home B's manifest and skill dir
+    // are untouched.
+    const removed = await removePortableSkillProjection({ somaHome, substrate: "claude-code", substrateHome: substrateHomeA });
+
+    expect(removed).toContain(resolve(substrateHomeA, "skills/Memory/SKILL.md"));
+    expect(await gone(join(substrateHomeA, "skills/Memory"))).toBe(true);
+    expect(await gone(pathA)).toBe(true);
+
+    // Home B is fully intact — the regression this test guards against is
+    // home A's uninstall reading home B's (last-written-wins) manifest and
+    // orphaning or deleting home B's projected files.
+    expect(await gone(pathB)).toBe(false);
+    expect(await readFile(join(substrateHomeB, "skills/Memory/SKILL.md"), "utf8")).toBe("home-b memory\n");
+    const manifestB = await readPortableSkillManifest(somaHome, "claude-code", substrateHomeB);
+    expect(manifestB?.files.map((f) => f.path)).toEqual(["skills/Memory/SKILL.md"]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/test/portable-skill-manifest.test.ts
+++ b/test/portable-skill-manifest.test.ts
@@ -61,7 +61,8 @@ test("write records path + content hash; read round-trips; a foreign schema read
     const manifest = await readPortableSkillManifest(somaHome, "claude-code", substrateHome);
     expect(manifest?.schema).toBe("soma-claude-code-install-manifest-v1");
     expect(manifest?.files.map((f) => f.path)).toEqual(["skills/Memory/SKILL.md"]);
-    // Same manifest bytes, read under a DIFFERENT substrate → schema mismatch → null.
+    // The claude-code manifest lives under projections/claude-code/<hash>/; reading
+    // the same home as "grok" looks under a different per-substrate path → no file → null.
     expect(await readPortableSkillManifest(somaHome, "grok", substrateHome)).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes #438.

## Bug

The portable-skill install manifest was keyed `(somaHome, substrate)` — `<somaHome>/projections/<substrate>/install-manifest.json` — ignoring `substrateHome`. Two homes of the SAME substrate installed from ONE soma home (`soma install claude-code --substrate-home ~/.claude` and `... --substrate-home ~/claude-fresh`) clobbered one manifest (last write wins). Uninstalling the first then read a manifest whose in-file `substrateHome` guard rejected it as foreign → the first home's projected skill dirs were silently orphaned.

## Fix

Key the manifest per resolved substrate home:
`<somaHome>/projections/<substrate>/<sha256(resolve(substrateHome)).slice(0,12)>/install-manifest.json`

- `src/adapters/shared/portable-skill-manifest.ts`: new `substrateHomeSegment(substrateHome)`; `portableSkillManifestPath` and `readPortableSkillManifest` take `substrateHome`; internal write/reconcile/remove thread it. The in-file `substrateHome` diff-guard stays as defense-in-depth (now genuinely a *second* line, not the only one).
- `src/adapters/grok/install-manifest.ts`: `grokInstallManifestPath`/`readGrokInstallManifest` take `substrateHome`. `home-projection.ts` / `claude-code/install.ts` / `grok/install.ts` already passed `substrateHome` in their options — no changes needed there.

## Tests

- NEW regression (#438): install claude-code to two `--substrate-home` dirs from one soma home → distinct manifest paths; uninstall home A leaves home B's manifest AND projected skill dirs intact.
- Rewrote 3 existing tests that (under the new scheme) would have passed via "manifest not found" instead of exercising the in-file mismatch / path-escape guards — they now write the manifest at the correct per-home path so the guard is genuinely tested.

## Upgrade note (not fully harmless)

All reads now use the per-home path, so the old flat manifest is no longer consumed. Concretely: for an install made **before** this change, an `uninstall` right after upgrading will **not** round-trip those skills — they stay projected-but-untracked — until a `soma install`/reproject regenerates the manifest at the new per-home path (which re-tracks them). So after upgrading, **reinstall/reproject before relying on uninstall** for a pre-fix install. Install/uninstall are verified not to crash on a leftover old-format manifest. No automatic migration is built (per #438's scope — the multi-home scenario is mostly disposable `--substrate-home` test homes).

- `tsc --noEmit`: clean. `bun test`: **1921 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
