### PR TITLE
feat(skills): compact skill registry projection under a line budget (#371)

### DIFF
--- a/src/adapters/shared/index.ts
+++ b/src/adapters/shared/index.ts
@@ -17,14 +17,10 @@ export {
   stripProvenance,
   withProvenance,
 } from "./provenance";
-export {
-  SHORT_DESCRIPTION_MAX_LENGTH,
-  SKILL_REGISTRY_LINE_BUDGET,
-  extractAntiTriggers,
-  leadClause,
-  renderSkillRegistryEntry,
-  truncateAtWordBoundary,
-} from "./skill-registry";
+// Only the entry renderer is part of the shared public surface; the parsing/
+// truncation helpers + budget constants stay module-private (tests import them
+// from ./skill-registry directly).
+export { renderSkillRegistryEntry } from "./skill-registry";
 
 /**
  * The portable skills a home projection should emit files for. `skills.md`

--- a/src/adapters/shared/index.ts
+++ b/src/adapters/shared/index.ts
@@ -3,6 +3,7 @@ import type { ProjectionInput, SomaSkill, SubstrateId } from "../../types";
 import { getCriteria, getGoal } from "../../vsa-accessors";
 import { VSA_SKILL_NAME } from "../../vsa-skill-installer";
 import { rewriteSubstrateProjectionContent } from "../../substrate-projection-rewrites";
+import { renderSkillRegistryEntry } from "./skill-registry";
 
 export { renderAlgorithmRenderingContract } from "./algorithm-rendering-contract";
 export {
@@ -16,6 +17,14 @@ export {
   stripProvenance,
   withProvenance,
 } from "./provenance";
+export {
+  SHORT_DESCRIPTION_MAX_LENGTH,
+  SKILL_REGISTRY_LINE_BUDGET,
+  extractAntiTriggers,
+  leadClause,
+  renderSkillRegistryEntry,
+  truncateAtWordBoundary,
+} from "./skill-registry";
 
 /**
  * The portable skills a home projection should emit files for. `skills.md`
@@ -174,12 +183,17 @@ export function renderMemoryLayout(input: ProjectionInput): string {
 export const SOMA_SKILLS_HEADING = "# Soma Skills";
 export const SOMA_POLICY_PROJECTION_HEADING = "# Soma Policy Projection";
 
+/**
+ * soma#371 — compact skill registry. One tight entry per skill (see
+ * `renderSkillRegistryEntry`) instead of the pre-#371 `## <name>` full-body
+ * listing, so the eager catalog stops crowding out routing signal. Skill
+ * BODIES still load on demand at invocation time (unchanged by this
+ * projection) — only this always-loaded catalog got smaller.
+ */
 export function renderSkills(input: ProjectionInput): string {
-  const skills = input.profile.skills.map((skill) =>
-    [`## ${skill.name}`, "", skill.description, "", `Path: ${skill.path}`, "", "Triggers:", formatList(skill.triggers)].join("\n"),
-  );
+  const skills = input.profile.skills.map(renderSkillRegistryEntry);
 
-  return [SOMA_SKILLS_HEADING, "", skills.length === 0 ? "No Soma skills were declared." : skills.join("\n\n")].join("\n");
+  return [SOMA_SKILLS_HEADING, "", skills.length === 0 ? "No Soma skills were declared." : skills.join("\n")].join("\n");
 }
 
 export function renderPolicyProjection(substrate: string, enforceable: string[], advisory: string[]): string {

--- a/src/adapters/shared/skill-registry.ts
+++ b/src/adapters/shared/skill-registry.ts
@@ -1,0 +1,127 @@
+import type { SomaSkill } from "../../types";
+
+/**
+ * soma#371 — the compact skill registry projection.
+ *
+ * The pre-#371 `renderSkills` emitted a `## <name>` heading, the FULL
+ * frontmatter `description`, a `Path:` line, and a `Triggers:` bullet list
+ * per skill — roughly 9 lines/skill, ~963 lines across the real ~104-skill
+ * home. That entire catalog is eager context in every session (it is not
+ * behind the Skill tool's on-demand load — only a skill's *body*
+ * (`SKILL.md`) loads on demand; the catalog that tells the router a skill
+ * exists loads every time), so its verbosity crowds out routing signal
+ * rather than helping it.
+ *
+ * This module renders one tight entry per skill instead: name, a truncated
+ * lead clause of the description, and the path on a single line, plus two
+ * OPTIONAL follow-up lines — `triggers:` (from the skill's structured
+ * `triggers` array) and `not:` (an anti-trigger clause extracted from the
+ * description's inline prose, since skills declare anti-triggers only that
+ * way today — there is no structured field for it, see soma#371's
+ * out-of-scope note about adding one).
+ */
+
+/** Enforced by `renderSkills` output — see `test/skill-registry.test.ts`. */
+export const SKILL_REGISTRY_LINE_BUDGET = 300;
+
+/** Word-boundary truncation length for the per-skill lead-clause summary. */
+export const SHORT_DESCRIPTION_MAX_LENGTH = 160;
+
+/**
+ * Markers whose presence means "the rest of this description is routing
+ * guidance the registry shows structured instead" (triggers via the
+ * `triggers` array, anti-triggers via `extractAntiTriggers` below) — so the
+ * lead-clause summary is cut before the earliest one. A bare `NOT` is
+ * deliberately NOT one of these: unlike `USE WHEN` / `NOT FOR` / `SKIP:`,
+ * plain prose uses lowercase "not" constantly, and even the uppercase
+ * shouted form ("Do NOT trigger on...") reads as a clause fragment, not a
+ * tail — truncating there would leave the lead clause ending mid-sentence
+ * on a dangling word. `extractAntiTriggers` still recognizes a bare `NOT`
+ * as an anti-trigger marker (best-effort, lower priority); this pattern
+ * only governs where the SHORT description gets cut.
+ */
+const LEAD_CLAUSE_MARKER = /\bUSE WHEN:?\s+|\bNOT FOR:?\s+|\bSKIP:\s+/;
+
+/**
+ * Anti-trigger markers, ordered so the regex engine prefers the more
+ * specific alternative when both start at the same index (`NOT FOR` is
+ * tried before the bare `NOT` it contains as a prefix). Case-sensitive on
+ * purpose: real skill descriptions shout these keywords in caps
+ * ("NOT FOR", "SKIP:", "Do NOT trigger"); ordinary prose ("does not",
+ * "cannot") is lowercase and never matches.
+ */
+const ANTI_TRIGGER_MARKER = /\bNOT FOR:?\s+|\bSKIP:\s+|\bNOT\s+/;
+
+/**
+ * Extract an anti-trigger clause from a skill's description, best-effort.
+ * Skills declare anti-triggers only as inline prose today (no structured
+ * field — see soma#371's out-of-scope note), introduced by `NOT FOR `,
+ * `SKIP: `, or a bare `NOT ` (in that priority). The clause runs from the
+ * marker to the next sentence boundary (the first `.`) or the end of the
+ * description. Returns `undefined` when no marker is present.
+ */
+export function extractAntiTriggers(description: string): string | undefined {
+  const match = ANTI_TRIGGER_MARKER.exec(description);
+  if (!match) return undefined;
+
+  const rest = description.slice(match.index);
+  const sentenceEnd = rest.indexOf(".");
+  const clause = (sentenceEnd === -1 ? rest : rest.slice(0, sentenceEnd)).trim();
+  return clause.length > 0 ? clause : undefined;
+}
+
+/**
+ * The description's lead clause: everything before the earliest
+ * `USE WHEN` / `NOT FOR` / `SKIP:` tail. Those tails are routing guidance
+ * the registry shows structured instead (triggers array / `not:` line), so
+ * repeating them in the summary would be redundant. Returns the whole
+ * description unchanged when no marker is present.
+ */
+export function leadClause(description: string): string {
+  const match = LEAD_CLAUSE_MARKER.exec(description);
+  const clause = match ? description.slice(0, match.index) : description;
+  return clause.trim();
+}
+
+/**
+ * Truncate `text` to at most `maxLength` characters, cutting on a word
+ * boundary (never mid-word) and appending an ellipsis when truncated.
+ * Text at or under the limit is returned unchanged.
+ */
+export function truncateAtWordBoundary(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+
+  const slice = text.slice(0, maxLength);
+  const lastSpace = slice.lastIndexOf(" ");
+  const cut = lastSpace > 0 ? slice.slice(0, lastSpace) : slice;
+  return `${cut.trimEnd()}…`;
+}
+
+/**
+ * Render one skill as a compact registry entry:
+ *
+ * ```
+ * - **<name>** — <short description> → <path>
+ *   triggers: <t1>, <t2>, …            ← only when skill.triggers is non-empty
+ *   not: <anti-triggers>               ← only when the description declares one
+ * ```
+ *
+ * A skill with an empty description omits the `— <lead>` segment entirely
+ * rather than rendering a dangling em dash.
+ */
+export function renderSkillRegistryEntry(skill: SomaSkill): string {
+  const lead = truncateAtWordBoundary(leadClause(skill.description), SHORT_DESCRIPTION_MAX_LENGTH);
+  const summary = lead.length > 0 ? `**${skill.name}** — ${lead}` : `**${skill.name}**`;
+  const lines = [`- ${summary} → ${skill.path}`];
+
+  if (skill.triggers.length > 0) {
+    lines.push(`  triggers: ${skill.triggers.join(", ")}`);
+  }
+
+  const antiTriggers = extractAntiTriggers(skill.description);
+  if (antiTriggers) {
+    lines.push(`  not: ${antiTriggers}`);
+  }
+
+  return lines.join("\n");
+}

--- a/src/adapters/shared/skill-registry.ts
+++ b/src/adapters/shared/skill-registry.ts
@@ -22,10 +22,11 @@ import type { SomaSkill } from "../../types";
  */
 
 /**
- * Design target for the eager registry, verified against representative fixtures
- * and the real skill tree in `test/skill-registry.test.ts`. NOT a runtime-enforced
- * cap — `renderSkills` emits every skill, so a pathologically large tree could
- * exceed it; the compact per-entry format keeps the real ~104-skill tree well under.
+ * Design target for the eager registry, asserted in `test/skill-registry.test.ts`
+ * against representative synthetic fixtures (not the shipped catalog's contents).
+ * NOT a runtime-enforced cap — `renderSkills` emits every skill, so a
+ * pathologically large tree could exceed it; the compact per-entry format keeps
+ * the real ~104-skill tree well under (measured ~122 lines; see the PR).
  */
 export const SKILL_REGISTRY_LINE_BUDGET = 300;
 
@@ -95,6 +96,9 @@ export function leadClause(description: string): string {
  */
 export function truncateAtWordBoundary(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text;
+  // Too small to hold any content plus the ellipsis — just hard-cut to the
+  // limit (never exceeds maxLength; no ellipsis, since there's no room).
+  if (maxLength <= 1) return text.slice(0, Math.max(0, maxLength));
 
   // Reserve one character for the ellipsis so the returned string (cut + "…")
   // never exceeds maxLength.

--- a/src/adapters/shared/skill-registry.ts
+++ b/src/adapters/shared/skill-registry.ts
@@ -21,7 +21,12 @@ import type { SomaSkill } from "../../types";
  * out-of-scope note about adding one).
  */
 
-/** Enforced by `renderSkills` output — see `test/skill-registry.test.ts`. */
+/**
+ * Design target for the eager registry, verified against representative fixtures
+ * and the real skill tree in `test/skill-registry.test.ts`. NOT a runtime-enforced
+ * cap — `renderSkills` emits every skill, so a pathologically large tree could
+ * exceed it; the compact per-entry format keeps the real ~104-skill tree well under.
+ */
 export const SKILL_REGISTRY_LINE_BUDGET = 300;
 
 /** Word-boundary truncation length for the per-skill lead-clause summary. */
@@ -91,7 +96,9 @@ export function leadClause(description: string): string {
 export function truncateAtWordBoundary(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text;
 
-  const slice = text.slice(0, maxLength);
+  // Reserve one character for the ellipsis so the returned string (cut + "…")
+  // never exceeds maxLength.
+  const slice = text.slice(0, maxLength - 1);
   const lastSpace = slice.lastIndexOf(" ");
   const cut = lastSpace > 0 ? slice.slice(0, lastSpace) : slice;
   return `${cut.trimEnd()}…`;

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -660,7 +660,8 @@ test("first install already converges: skills.md lists VSA and the file set matc
     // before the VSA baseline existed).
     const first = await installSomaForCodex({ homeDir });
     const afterFirst = await readFile(skillsPath, "utf8");
-    expect(afterFirst).toContain("## VSA");
+    // soma#371: compact registry entry (`- **VSA** — ...`), not a `## <name>` heading.
+    expect(afterFirst).toContain("**VSA**");
     expect(afterFirst).not.toContain("No Soma skills were declared.");
 
     // Snapshot every projected file's bytes after the first install.

--- a/test/skill-projection.test.ts
+++ b/test/skill-projection.test.ts
@@ -54,9 +54,9 @@ describe("projectSkill", () => {
       expect((await lstat(registryLink)).isSymbolicLink()).toBe(true);
       expect(await readlinkAbs(registryLink)).toBe(resolve(skillDir));
 
-      // Catalog lists it.
+      // Catalog lists it (soma#371: compact registry entry, not a `## <name>` heading).
       const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
-      expect(catalog).toContain("## MyTool");
+      expect(catalog).toContain("**MyTool**");
     });
   });
 
@@ -151,7 +151,7 @@ describe("unprojectSkill", () => {
       await expect(lstat(join(homeDir, ".soma", "skills", "MyTool"))).rejects.toThrow();
 
       const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
-      expect(catalog).not.toContain("## MyTool");
+      expect(catalog).not.toContain("**MyTool**");
     });
   });
 
@@ -248,8 +248,8 @@ describe("projectSkills (batch)", () => {
       expect((await lstat(join(homeDir, ".claude", "skills", "Beta"))).isSymbolicLink()).toBe(true);
 
       const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
-      expect(catalog).toContain("## Alpha");
-      expect(catalog).toContain("## Beta");
+      expect(catalog).toContain("**Alpha**");
+      expect(catalog).toContain("**Beta**");
     });
   });
 
@@ -267,7 +267,7 @@ describe("projectSkills (batch)", () => {
       // Ok was linked before the failure; the finally-refresh catalogued it.
       expect((await lstat(join(homeDir, ".claude", "skills", "Ok"))).isSymbolicLink()).toBe(true);
       const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
-      expect(catalog).toContain("## Ok");
+      expect(catalog).toContain("**Ok**");
     });
   });
 
@@ -290,7 +290,7 @@ describe("projectSkills (batch)", () => {
       // Registry link rolled back → Solo is neither registered nor cataloged.
       await expect(lstat(join(homeDir, ".soma", "skills", "Solo"))).rejects.toThrow();
       const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
-      expect(catalog).not.toContain("## Solo");
+      expect(catalog).not.toContain("**Solo**");
       // The user's real loader dir is untouched.
       expect((await lstat(loaderSlot)).isDirectory()).toBe(true);
     });
@@ -313,7 +313,7 @@ describe("soma install --skills", () => {
 
       expect((await lstat(join(homeDir, ".claude", "skills", "Widget"))).isSymbolicLink()).toBe(true);
       const catalog = await readFile(join(homeDir, ".claude", "rules", "soma", "SKILLS.md"), "utf8");
-      expect(catalog).toContain("## Widget");
+      expect(catalog).toContain("**Widget**");
     });
   });
 

--- a/test/skill-registry.test.ts
+++ b/test/skill-registry.test.ts
@@ -103,7 +103,7 @@ describe("truncateAtWordBoundary", () => {
   test("cuts long text on a word boundary and appends an ellipsis", () => {
     const long = "word ".repeat(60).trim(); // 299 chars
     const result = truncateAtWordBoundary(long, 160);
-    expect(result.length).toBeLessThanOrEqual(161); // 160 + ellipsis char, word-boundary cut
+    expect(result.length).toBeLessThanOrEqual(160); // ellipsis reserved: total never exceeds maxLength
     expect(result.endsWith("…")).toBe(true);
     expect(result.endsWith(" …")).toBe(false); // no trailing space before the ellipsis
   });
@@ -200,11 +200,12 @@ describe("renderSkills — compact registry projection", () => {
 });
 
 /**
- * A representative ~104-skill fixture, mirroring the real soma skill count
- * and the real mix observed in the shipped catalog: most skills declare no
- * structured `triggers` (their guidance lives only in inline `USE WHEN`
+ * A SYNTHETIC ~104-skill fixture — chosen to match the real catalog's
+ * approximate SIZE, with a deliberate (modulo-driven, not sampled) mix: most
+ * skills declare no structured `triggers` (guidance in inline `USE WHEN`
  * prose), a minority declare a real `triggers` array, and roughly a fifth
- * carry a `NOT FOR` / `SKIP:` anti-trigger clause in their description.
+ * carry a `NOT FOR` / `SKIP:` anti-trigger clause. It exercises the budget at
+ * catalog scale; it is not drawn from the shipped catalog's actual contents.
  */
 function buildRepresentativeSkillFixture(count: number): SomaSkill[] {
   const skills: SomaSkill[] = [];

--- a/test/skill-registry.test.ts
+++ b/test/skill-registry.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SKILL_REGISTRY_LINE_BUDGET,
+  extractAntiTriggers,
+  leadClause,
+  renderSkillRegistryEntry,
+  truncateAtWordBoundary,
+} from "../src/adapters/shared/skill-registry";
+import { renderSkills } from "../src/adapters/shared";
+import type { SomaSkill } from "../src/types";
+import { portableProjectionInput } from "./fixtures";
+
+/**
+ * soma#371 — the compact skill registry replaces `## <name>` full-body
+ * entries (Path/Triggers on their own lines, full descriptions) with a
+ * tight per-skill entry so the eager catalog projection stops crowding out
+ * routing signal. These tests pin the extraction helpers (pure, unit-
+ * tested per the issue's explicit ask) and the overall line budget.
+ */
+
+describe("extractAntiTriggers", () => {
+  test("extracts a NOT FOR clause up to the sentence boundary", () => {
+    const description =
+      "Headless browser automation via agent-browser. USE WHEN batch screenshots, dev server tests. " +
+      "NOT FOR deploy verification or real-Chrome UI confirmation (use Interceptor), simple single-URL fetches (use WebFetch).";
+    expect(extractAntiTriggers(description)).toBe(
+      "NOT FOR deploy verification or real-Chrome UI confirmation (use Interceptor), simple single-URL fetches (use WebFetch)",
+    );
+  });
+
+  test("extracts a SKIP: clause up to the sentence boundary", () => {
+    const description =
+      "Apify-based scraping for social media and e-commerce. USE WHEN scraping Instagram, LinkedIn. " +
+      "SKIP: X/Twitter bookmarks (use X-API skill) and progressive scraping (use BrightData).";
+    expect(extractAntiTriggers(description)).toBe(
+      "SKIP: X/Twitter bookmarks (use X-API skill) and progressive scraping (use BrightData)",
+    );
+  });
+
+  test("falls back to a bare NOT clause when NOT FOR / SKIP: are absent", () => {
+    const description =
+      "Router for spec-driven development. Loads the specflow skill when the project has a .specify/ directory. " +
+      "Do NOT trigger on bare \"spec\" without a path or an explicit command.";
+    expect(extractAntiTriggers(description)).toBe(
+      "NOT trigger on bare \"spec\" without a path or an explicit command",
+    );
+  });
+
+  test("prefers NOT FOR over a coincidental bare NOT earlier in the same clause", () => {
+    const description = "Some skill. NOT FOR ad-hoc swarms or TeamCreate (use Delegation).";
+    expect(extractAntiTriggers(description)).toBe("NOT FOR ad-hoc swarms or TeamCreate (use Delegation)");
+  });
+
+  test("returns undefined when no anti-trigger marker is present", () => {
+    expect(extractAntiTriggers("Static visual content via Flux, Nano Banana Pro, GPT-Image-1.")).toBeUndefined();
+  });
+
+  test("is case-sensitive — lowercase 'not' in ordinary prose is not a marker", () => {
+    const description = "This does not require network access and cannot be disabled.";
+    expect(extractAntiTriggers(description)).toBeUndefined();
+  });
+
+  test("returns undefined for an empty description", () => {
+    expect(extractAntiTriggers("")).toBeUndefined();
+  });
+});
+
+describe("leadClause", () => {
+  test("strips an inline USE WHEN tail", () => {
+    const description = "Multi-agent coordination via shared blackboard. USE WHEN register a project, create work items.";
+    expect(leadClause(description)).toBe("Multi-agent coordination via shared blackboard.");
+  });
+
+  test("strips an inline NOT FOR tail", () => {
+    const description = "Adversarial analysis via 32 parallel expert agents. NOT FOR pure attack on systems.";
+    expect(leadClause(description)).toBe("Adversarial analysis via 32 parallel expert agents.");
+  });
+
+  test("strips an inline SKIP: tail", () => {
+    const description = "4-tier progressive scraping. SKIP: single-URL fetches.";
+    expect(leadClause(description)).toBe("4-tier progressive scraping.");
+  });
+
+  test("does not strip a bare NOT (only USE WHEN / NOT FOR / SKIP: truncate the lead clause)", () => {
+    const description = "Router for spec-driven development. Do NOT trigger on bare \"spec\".";
+    expect(leadClause(description)).toBe(description);
+  });
+
+  test("returns the whole description when no marker is present", () => {
+    expect(leadClause("Plain description with no markers.")).toBe("Plain description with no markers.");
+  });
+
+  test("handles an empty description", () => {
+    expect(leadClause("")).toBe("");
+  });
+});
+
+describe("truncateAtWordBoundary", () => {
+  test("leaves short text untouched", () => {
+    expect(truncateAtWordBoundary("short text", 160)).toBe("short text");
+  });
+
+  test("cuts long text on a word boundary and appends an ellipsis", () => {
+    const long = "word ".repeat(60).trim(); // 299 chars
+    const result = truncateAtWordBoundary(long, 160);
+    expect(result.length).toBeLessThanOrEqual(161); // 160 + ellipsis char, word-boundary cut
+    expect(result.endsWith("…")).toBe(true);
+    expect(result.endsWith(" …")).toBe(false); // no trailing space before the ellipsis
+  });
+
+  test("never splits mid-word", () => {
+    const long = "supercalifragilisticexpialidocious ".repeat(10).trim();
+    const result = truncateAtWordBoundary(long, 20);
+    const withoutEllipsis = result.replace(/…$/, "").trim();
+    expect(long.startsWith(withoutEllipsis)).toBe(true);
+  });
+});
+
+describe("renderSkillRegistryEntry", () => {
+  function skill(overrides: Partial<SomaSkill> = {}): SomaSkill {
+    return {
+      name: "Browser",
+      path: "/Users/jc/.soma/skills/browser",
+      description: "Headless browser automation via agent-browser.",
+      triggers: [],
+      ...overrides,
+    };
+  }
+
+  test("renders name, lead description, and path on one line", () => {
+    const entry = renderSkillRegistryEntry(skill());
+    expect(entry).toBe("- **Browser** — Headless browser automation via agent-browser. → /Users/jc/.soma/skills/browser");
+  });
+
+  test("omits the triggers line when triggers is empty", () => {
+    const entry = renderSkillRegistryEntry(skill());
+    expect(entry).not.toContain("triggers:");
+  });
+
+  test("includes a triggers line, comma-joined, when triggers is non-empty", () => {
+    const entry = renderSkillRegistryEntry(skill({ triggers: ["algorithm", "ideal state", "VSA"] }));
+    expect(entry).toContain("triggers: algorithm, ideal state, VSA");
+  });
+
+  test("omits the not: line when the description carries no anti-trigger clause", () => {
+    const entry = renderSkillRegistryEntry(skill());
+    expect(entry).not.toContain("not:");
+  });
+
+  test("includes a not: line when the description carries a NOT FOR / SKIP: clause", () => {
+    const entry = renderSkillRegistryEntry(
+      skill({ description: "Headless browser automation. NOT FOR deploy verification (use Interceptor)." }),
+    );
+    expect(entry).toContain("not: NOT FOR deploy verification (use Interceptor)");
+  });
+
+  test("renders both triggers and not: lines when both are present", () => {
+    const entry = renderSkillRegistryEntry(
+      skill({
+        triggers: ["scrape", "crawl"],
+        description: "4-tier progressive scraping. NOT FOR simple public content (use WebFetch directly).",
+      }),
+    );
+    const lines = entry.split("\n");
+    expect(lines[0]).toContain("- **Browser**");
+    expect(lines).toContainEqual(expect.stringContaining("triggers: scrape, crawl"));
+    expect(lines).toContainEqual(expect.stringContaining("not: NOT FOR simple public content (use WebFetch directly)"));
+  });
+
+  test("degrades gracefully when the description is empty", () => {
+    const entry = renderSkillRegistryEntry(skill({ description: "" }));
+    expect(entry).toBe("- **Browser** → /Users/jc/.soma/skills/browser");
+  });
+});
+
+describe("renderSkills — compact registry projection", () => {
+  test("keeps the heading and still lists a single portable skill", () => {
+    const rendered = renderSkills(portableProjectionInput);
+    expect(rendered.startsWith("# Soma Skills\n\n")).toBe(true);
+    expect(rendered).toContain("- **Ledger Update**");
+    expect(rendered).toContain("triggers: ledger, status update");
+  });
+
+  test("reports 'no Soma skills' when the skill list is empty", () => {
+    const rendered = renderSkills({
+      ...portableProjectionInput,
+      profile: { ...portableProjectionInput.profile, skills: [] },
+    });
+    expect(rendered).toContain("No Soma skills were declared.");
+  });
+
+  test("no longer inlines full skill bodies — the projection is the compact registry only", () => {
+    // The old verbose format emitted a `## <name>` heading followed by a
+    // dedicated `Path:` line and a `Triggers:` bullet list. The compact
+    // format folds all three into one tight entry.
+    const rendered = renderSkills(portableProjectionInput);
+    expect(rendered).not.toContain("## Ledger Update");
+    expect(rendered).not.toContain("Path: skills/ledger-update");
+  });
+});
+
+/**
+ * A representative ~104-skill fixture, mirroring the real soma skill count
+ * and the real mix observed in the shipped catalog: most skills declare no
+ * structured `triggers` (their guidance lives only in inline `USE WHEN`
+ * prose), a minority declare a real `triggers` array, and roughly a fifth
+ * carry a `NOT FOR` / `SKIP:` anti-trigger clause in their description.
+ */
+function buildRepresentativeSkillFixture(count: number): SomaSkill[] {
+  const skills: SomaSkill[] = [];
+  for (let i = 0; i < count; i++) {
+    const hasTriggers = i % 5 === 0; // ~20%
+    const hasAntiTrigger = i % 5 === 1; // ~20%
+    const base =
+      `A moderately long description of what skill number ${i} does, written in the same discursive ` +
+      `style real skill authors use, covering the domain, the workflows it exposes, and why it exists in the first place.`;
+    const trigger = hasTriggers ? ` USE WHEN keyword-${i}, another-keyword-${i}, or a third phrase entirely.` : "";
+    const anti = hasAntiTrigger ? ` NOT FOR unrelated-case-${i} (use OtherSkill${i} instead).` : "";
+    skills.push({
+      name: `Skill${i}`,
+      path: `/Users/jc/.soma/skills/skill-${i}`,
+      description: `${base}${trigger}${anti}`,
+      triggers: hasTriggers ? [`keyword-${i}`, `another-keyword-${i}`, "a third phrase entirely"] : [],
+    });
+  }
+  return skills;
+}
+
+describe("renderSkills — line budget (soma#371)", () => {
+  test("a ~104-skill representative catalog renders within the declared line budget", () => {
+    const skills = buildRepresentativeSkillFixture(104);
+    const rendered = renderSkills({
+      ...portableProjectionInput,
+      profile: { ...portableProjectionInput.profile, skills },
+    });
+    const lineCount = rendered.split("\n").length;
+    expect(lineCount).toBeLessThanOrEqual(SKILL_REGISTRY_LINE_BUDGET);
+  });
+
+  test("every skill with triggers has a triggers: line — a missed trigger is diagnosable from the registry alone", () => {
+    const skills = buildRepresentativeSkillFixture(104);
+    const rendered = renderSkills({
+      ...portableProjectionInput,
+      profile: { ...portableProjectionInput.profile, skills },
+    });
+    for (const skill of skills) {
+      if (skill.triggers.length === 0) continue;
+      const entry = renderSkillRegistryEntry(skill);
+      expect(rendered).toContain(entry);
+      expect(entry).toContain(`triggers: ${skill.triggers.join(", ")}`);
+    }
+  });
+
+  test("a 30-skill catalog (the issue's minimum representative size) also fits the budget", () => {
+    const skills = buildRepresentativeSkillFixture(30);
+    const rendered = renderSkills({
+      ...portableProjectionInput,
+      profile: { ...portableProjectionInput.profile, skills },
+    });
+    expect(rendered.split("\n").length).toBeLessThanOrEqual(SKILL_REGISTRY_LINE_BUDGET);
+  });
+});


### PR DESCRIPTION
Fixes #371.

## Why

Every substrate projection embedded the FULL skill catalog — `renderSkills` emitted `## <name>` + full description + `Path:` + `Triggers:` per skill × ~106 skills = **962 lines / 42 KB** of eager context, crowding out routing signal. Bodies already load on demand (Skill tool / `SKILL.md` at invocation), so only the eager catalog needed compacting.

## What

New `src/adapters/shared/skill-registry.ts` — a compact entry per skill, shared across all substrates via `renderSkills`:
```
- **<name>** — <lead clause, ≤160 chars, word-boundary truncated> → <path>
  triggers: <t1>, <t2>, …          (only if non-empty)
  not: <anti-trigger clause>        (only when the description declares NOT FOR / SKIP: / NOT)
```
- **Short description**: the description's lead clause with the inline `USE WHEN` / `NOT FOR` / `SKIP:` tails stripped (shown structured instead), truncated at a word boundary.
- **Anti-triggers** (`extractAntiTriggers`, tested): case-sensitive match on the shouted convention (`NOT FOR`, `SKIP:`, `Do NOT trigger`) so it catches real declarations but never lowercase prose ("does not", "cannot"). Skills "declare" anti-triggers only as inline prose today, so this is the "where declared" source.
- Pure, unit-tested helpers: `extractAntiTriggers`, `leadClause`, `truncateAtWordBoundary`, `renderSkillRegistryEntry`.

## Budget & observability

`SKILL_REGISTRY_LINE_BUDGET = 300`, enforced by tests against a ~104-skill representative fixture and a 30-skill minimum fixture (both ≤ 300). A route-miss-observability test asserts every skill with triggers has its `triggers:` line verbatim in the registry.

**Real-world:** the live 106-skill tree renders to **122 lines / 21 KB** — an ~87% line reduction, well inside budget.

`findCatalogFile` matches the catalog by content-equality with `renderSkills`, so the format change is transparent to the symlink/refresh machinery. Updated the 6 tests that hard-coded the old `## <name>` shape.

**Out of scope (follow-up):** structured `substrate support` / `estimated tokens` per skill — needs new `SomaSkill` fields + scanner work, beyond this issue's acceptance.

- `tsc --noEmit`: clean. `bun test`: **1969 pass, 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
