### PR TITLE
feat(lifecycle): projection self-repair at session start (#460)

### DIFF
--- a/src/adapters/claude-code/hooks.ts
+++ b/src/adapters/claude-code/hooks.ts
@@ -1059,8 +1059,14 @@ function renderClaudeCodeFeedbackCaptureHook(): string {
 // (backslash FIRST so we don't double-escape the escapes we add) so the shell
 // reads them literally. A function replacer also avoids `$`-pattern corruption
 // from String.replace's special `$&`/`$1` handling on the replacement side.
+let statusLineTemplateCache: string | undefined;
+
 export function renderClaudeCodeStatusLineScript(somaHome: string): string {
-  const source = readFileSync(new URL("./statusline.sh", import.meta.url), "utf8");
+  // Cache the static template: this renderer is called on the SessionStart
+  // projection self-repair path (#460) as a drift oracle, so avoid a blocking
+  // fs read on every healthy session start. The asset never changes at runtime.
+  statusLineTemplateCache ??= readFileSync(new URL("./statusline.sh", import.meta.url), "utf8");
+  const source = statusLineTemplateCache;
   const escaped = somaHome.replace(/[\\"$`]/g, "\\$&");
   const rendered = source.replace("__SOMA_HOME__", () => escaped);
   if (rendered === source) throw new Error("Claude Code status line asset is missing the SOMA_HOME placeholder.");

--- a/src/adapters/claude-code/hooks.ts
+++ b/src/adapters/claude-code/hooks.ts
@@ -1059,7 +1059,7 @@ function renderClaudeCodeFeedbackCaptureHook(): string {
 // (backslash FIRST so we don't double-escape the escapes we add) so the shell
 // reads them literally. A function replacer also avoids `$`-pattern corruption
 // from String.replace's special `$&`/`$1` handling on the replacement side.
-function renderClaudeCodeStatusLineScript(somaHome: string): string {
+export function renderClaudeCodeStatusLineScript(somaHome: string): string {
   const source = readFileSync(new URL("./statusline.sh", import.meta.url), "utf8");
   const escaped = somaHome.replace(/[\\"$`]/g, "\\$&");
   const rendered = source.replace("__SOMA_HOME__", () => escaped);

--- a/src/adapters/claude-code/projection-self-repair.ts
+++ b/src/adapters/claude-code/projection-self-repair.ts
@@ -1,4 +1,7 @@
+import { homedir } from "node:os";
 import { resolve } from "node:path";
+import { installSpecFor } from "../../install-spec-registry";
+import { registerProjectionRepairProvider } from "../../lifecycle";
 import { SOMA_CLAUDE_STATUSLINE_RELATIVE_PATH, renderClaudeCodeStatusLineScript } from "./hooks";
 import type { ProjectedArtifact } from "../../projection-self-repair";
 
@@ -29,3 +32,14 @@ export function claudeCodeProjectionRepairArtifacts(input: {
     },
   ];
 }
+
+/**
+ * Register claude-code's projection self-repair provider (soma#460). The core
+ * SessionStart step looks this up by substrate, so core imports no adapter (the
+ * same dependency inversion as the SessionEnd transcript handler). Loaded for
+ * its side effect via `src/cli/lifecycle.ts`.
+ */
+registerProjectionRepairProvider("claude-code", ({ homeDir, somaHome }) => {
+  const substrateHome = resolve(homeDir ?? homedir(), installSpecFor("claude-code").defaultHome);
+  return { substrateHome, artifacts: claudeCodeProjectionRepairArtifacts({ substrateHome, somaHome }) };
+});

--- a/src/adapters/claude-code/projection-self-repair.ts
+++ b/src/adapters/claude-code/projection-self-repair.ts
@@ -1,0 +1,31 @@
+import { resolve } from "node:path";
+import { SOMA_CLAUDE_STATUSLINE_RELATIVE_PATH, renderClaudeCodeStatusLineScript } from "./hooks";
+import type { ProjectedArtifact } from "../../projection-self-repair";
+
+/**
+ * Claude Code's projection self-repair surface (soma#460): the projected
+ * artifacts worth a session-start repair sweep.
+ *
+ * Only the statusline qualifies today. It is the ONE claude-code projection the
+ * substrate execs DIRECTLY via its shebang (`settings.json` `statusLine.command`
+ * = the script path), so a lost exec bit silently collapses the status line —
+ * exactly the fragility class this feature targets. It is also a pure function
+ * of `somaHome` (the value is baked in at projection time with no timestamp), so
+ * a fresh render is a sound checksum oracle for drift.
+ *
+ * The other soma hooks are bun-invoked (`bunPath <script>`), so their exec bit
+ * is irrelevant, and they carry machine-specific config (bunPath), making them
+ * poor drift oracles — out of scope for this slice.
+ */
+export function claudeCodeProjectionRepairArtifacts(input: {
+  substrateHome: string;
+  somaHome: string;
+}): ProjectedArtifact[] {
+  return [
+    {
+      path: resolve(input.substrateHome, SOMA_CLAUDE_STATUSLINE_RELATIVE_PATH),
+      directExec: true,
+      expected: renderClaudeCodeStatusLineScript(input.somaHome),
+    },
+  ];
+}

--- a/src/cli/lifecycle.ts
+++ b/src/cli/lifecycle.ts
@@ -12,6 +12,9 @@ import { parseSubstrate } from "./substrate";
 // imports the adapter). Side-effect import; the symbol itself is not used here.
 import "../adapters/claude-code/session-digest";
 import "../adapters/codex/session-digest";
+// Registers claude-code's projection self-repair provider (soma#460) — same
+// dependency inversion; core looks it up by substrate and never imports it.
+import "../adapters/claude-code/projection-self-repair";
 
 export interface ParsedLifecycleArgs {
   command: "lifecycle";

--- a/src/index.ts
+++ b/src/index.ts
@@ -493,6 +493,14 @@ export {
   runSomaLifecycleSessionStart,
   writeAlgorithmWorkIndex,
 } from "./lifecycle";
+export { repairProjectedArtifacts } from "./projection-self-repair";
+export type {
+  ProjectedArtifact,
+  ProjectionRepairFinding,
+  ProjectionRepairFindingKind,
+  ProjectionRepairResult,
+} from "./projection-self-repair";
+export { claudeCodeProjectionRepairArtifacts } from "./adapters/claude-code/projection-self-repair";
 export { captureSomaFeedback, classifySomaFeedback, maybeSomaFeedbackPrompt } from "./feedback";
 export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from "./memory";
 export { MemoryNoteError, parseMemoryNote, serializeMemoryNote } from "./memory-note";

--- a/src/index.ts
+++ b/src/index.ts
@@ -500,7 +500,6 @@ export type {
   ProjectionRepairFindingKind,
   ProjectionRepairResult,
 } from "./projection-self-repair";
-export { claudeCodeProjectionRepairArtifacts } from "./adapters/claude-code/projection-self-repair";
 export { captureSomaFeedback, classifySomaFeedback, maybeSomaFeedbackPrompt } from "./feedback";
 export { appendSomaMemoryEvent, searchSomaMemory, somaMemoryEventsPath } from "./memory";
 export { MemoryNoteError, parseMemoryNote, serializeMemoryNote } from "./memory-note";

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -7,9 +7,7 @@ import { listAlgorithmRunSummaries, listAlgorithmRuns, readAlgorithmRunById, wri
 import { appendAlgorithmProvenance } from "./algorithm-provenance";
 import { appendSomaMemoryEvent } from "./memory";
 import { reprojectSubstrateMemoryProjection } from "./memory-projection-reproject";
-import { repairProjectedArtifacts } from "./projection-self-repair";
-import { claudeCodeProjectionRepairArtifacts } from "./adapters/claude-code/projection-self-repair";
-import { installSpecFor } from "./install-spec-registry";
+import { repairProjectedArtifacts, type ProjectedArtifact } from "./projection-self-repair";
 import { loadSomaProfile } from "./soma-home";
 import { normalizeSomaWorkRegistryArtifacts, upsertSomaCurrentWorkPointer } from "./work-registry";
 import { SECTION_NAME_MAP, getCriteria, getGoal } from "./vsa-accessors";
@@ -406,18 +404,17 @@ export async function runSomaLifecycleSessionStart(options: SomaLifecycleOptions
   // #460: deterministic projection self-repair. Additive, best-effort, and
   // non-blocking like the memory reproject above: restore a lost exec bit on a
   // direct-exec projected script (containment-guarded to the substrate home)
-  // and REPORT content drift vs a fresh render. Only claude-code has a repair
-  // surface today; other substrates yield an empty artifact list and no-op. A
+  // and REPORT content drift vs a fresh render. The provider is looked up by
+  // substrate (dependency-inverted; core imports no adapter); a substrate with
+  // no registered provider no-ops. Only claude-code registers one today. A
   // clean projection emits no event; anything healed/found/refused — or a
   // failure — logs one observability event, never halting the session.
   let projectionRepairFiles: string[] = [];
   try {
-    if (startup.substrate === "claude-code") {
-      const substrateHome = resolve(options.homeDir ?? homedir(), installSpecFor("claude-code").defaultHome);
-      const repair = await repairProjectedArtifacts({
-        substrateHome,
-        artifacts: claudeCodeProjectionRepairArtifacts({ substrateHome, somaHome: startup.somaHome }),
-      });
+    const repairProvider = projectionRepairProviders.get(startup.substrate);
+    if (repairProvider) {
+      const { substrateHome, artifacts } = repairProvider({ homeDir: options.homeDir, somaHome: startup.somaHome });
+      const repair = await repairProjectedArtifacts({ substrateHome, artifacts });
       projectionRepairFiles = repair.healed;
       if (repair.healed.length > 0 || repair.drifted.length > 0 || repair.skipped.length > 0) {
         await appendSomaMemoryEvent(startup.somaHome, {
@@ -826,6 +823,25 @@ const sessionEndTranscriptHandlers = new Map<SubstrateId, SessionEndTranscriptHa
 /** Register a substrate's SessionEnd transcript-digest fallback (see the type doc). */
 export function registerSessionEndTranscriptHandler(substrate: SubstrateId, handler: SessionEndTranscriptHandler): void {
   sessionEndTranscriptHandlers.set(substrate, handler);
+}
+
+/**
+ * A substrate-registered projection self-repair provider (soma#460). Same
+ * dependency INVERSION as the transcript handler above: core owns the neutral
+ * SessionStart repair step and looks the provider up by substrate, so core never
+ * imports an adapter. The provider resolves its own substrate home and returns
+ * the artifact descriptors to repair.
+ */
+export type ProjectionRepairProvider = (input: {
+  homeDir?: string;
+  somaHome: string;
+}) => { substrateHome: string; artifacts: readonly ProjectedArtifact[] };
+
+const projectionRepairProviders = new Map<SubstrateId, ProjectionRepairProvider>();
+
+/** Register a substrate's projection self-repair provider (see the type doc). */
+export function registerProjectionRepairProvider(substrate: SubstrateId, provider: ProjectionRepairProvider): void {
+  projectionRepairProviders.set(substrate, provider);
 }
 
 export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions = {}): Promise<SomaLifecycleResult> {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -401,52 +401,11 @@ export async function runSomaLifecycleSessionStart(options: SomaLifecycleOptions
     });
   }
 
-  // #460: deterministic projection self-repair. Additive, best-effort, and
-  // non-blocking like the memory reproject above: restore a lost exec bit on a
-  // direct-exec projected script (containment-guarded to the substrate home)
-  // and REPORT content drift vs a fresh render. The provider is looked up by
-  // substrate (dependency-inverted; core imports no adapter); a substrate with
-  // no registered provider no-ops. Only claude-code registers one today. A
-  // clean projection emits no event; anything healed/found/refused — or a
-  // failure — logs one observability event, never halting the session.
-  let projectionRepairFiles: string[] = [];
-  try {
-    const repairProvider = projectionRepairProviders.get(startup.substrate);
-    if (repairProvider) {
-      const { substrateHome, artifacts } = repairProvider({ homeDir: options.homeDir, somaHome: startup.somaHome });
-      const repair = await repairProjectedArtifacts({ substrateHome, artifacts });
-      projectionRepairFiles = repair.healed;
-      if (repair.healed.length > 0 || repair.drifted.length > 0 || repair.skipped.length > 0) {
-        await appendSomaMemoryEvent(startup.somaHome, {
-          substrate: startup.substrate,
-          kind: "lifecycle.session_start.projection-repair",
-          summary:
-            `Projection self-repair: ${repair.healed.length} exec-bit restored, ` +
-            `${repair.drifted.length} drifted, ${repair.skipped.length} refused.`,
-          timestamp: startup.timestamp,
-          metadata: {
-            sessionId: startup.sessionId,
-            substrate: startup.substrate,
-            healed: repair.healed,
-            drifted: repair.drifted,
-            skipped: repair.skipped,
-          },
-        });
-      }
-    }
-  } catch (error: unknown) {
-    await appendSomaMemoryEvent(startup.somaHome, {
-      substrate: startup.substrate,
-      kind: "lifecycle.session_start.projection-repair-failed",
-      summary: "Session started; projection self-repair failed.",
-      timestamp: startup.timestamp,
-      metadata: {
-        sessionId: startup.sessionId,
-        substrate: startup.substrate,
-        error: lifecycleErrorMessage(error, startup.somaHome, options.homeDir),
-      },
-    });
-  }
+  // #460: deterministic projection self-repair — best-effort, non-blocking, and
+  // dependency-inverted (looked up by substrate; core imports no adapter). All of
+  // it, including failure reporting, is guarded inside the helper so it can never
+  // halt session start. See repairProjectionAtSessionStart.
+  const projectionRepairFiles = await repairProjectionAtSessionStart(startup, options);
 
   await appendSomaMemoryEvent(startup.somaHome, {
     substrate: startup.substrate,
@@ -842,6 +801,62 @@ const projectionRepairProviders = new Map<SubstrateId, ProjectionRepairProvider>
 /** Register a substrate's projection self-repair provider (see the type doc). */
 export function registerProjectionRepairProvider(substrate: SubstrateId, provider: ProjectionRepairProvider): void {
   projectionRepairProviders.set(substrate, provider);
+}
+
+/**
+ * The #460 projection self-repair step, extracted from runSomaLifecycleSessionStart.
+ * Best-effort and non-blocking: look up the substrate's repair provider
+ * (dependency-inverted; core imports no adapter), repair, and return the healed
+ * file list. EVERY event write — including the failure report — is guarded, so a
+ * throwing append can never halt session start.
+ */
+async function repairProjectionAtSessionStart(
+  startup: SomaStartupContext,
+  options: SomaLifecycleOptions,
+): Promise<string[]> {
+  const repairProvider = projectionRepairProviders.get(startup.substrate);
+  if (!repairProvider) return [];
+  try {
+    const { substrateHome, artifacts } = repairProvider({ homeDir: options.homeDir, somaHome: startup.somaHome });
+    const repair = await repairProjectedArtifacts({ substrateHome, artifacts });
+    if (repair.healed.length > 0 || repair.drifted.length > 0 || repair.skipped.length > 0) {
+      await appendSomaMemoryEvent(startup.somaHome, {
+        substrate: startup.substrate,
+        kind: "lifecycle.session_start.projection-repair",
+        summary:
+          `Projection self-repair: ${repair.healed.length} exec-bit restored, ` +
+          `${repair.drifted.length} drifted, ${repair.skipped.length} refused.`,
+        timestamp: startup.timestamp,
+        metadata: {
+          sessionId: startup.sessionId,
+          substrate: startup.substrate,
+          healed: repair.healed,
+          drifted: repair.drifted,
+          skipped: repair.skipped,
+        },
+      });
+    }
+    return repair.healed;
+  } catch (error: unknown) {
+    // Report the failure — but GUARD the report itself. If the event write throws,
+    // swallow it: even failure reporting must never halt session start.
+    try {
+      await appendSomaMemoryEvent(startup.somaHome, {
+        substrate: startup.substrate,
+        kind: "lifecycle.session_start.projection-repair-failed",
+        summary: "Session started; projection self-repair failed.",
+        timestamp: startup.timestamp,
+        metadata: {
+          sessionId: startup.sessionId,
+          substrate: startup.substrate,
+          error: lifecycleErrorMessage(error, startup.somaHome, options.homeDir),
+        },
+      });
+    } catch {
+      // best-effort: never halt the session.
+    }
+    return [];
+  }
 }
 
 export async function runSomaLifecycleSessionEnd(options: SomaLifecycleOptions = {}): Promise<SomaLifecycleResult> {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -7,6 +7,9 @@ import { listAlgorithmRunSummaries, listAlgorithmRuns, readAlgorithmRunById, wri
 import { appendAlgorithmProvenance } from "./algorithm-provenance";
 import { appendSomaMemoryEvent } from "./memory";
 import { reprojectSubstrateMemoryProjection } from "./memory-projection-reproject";
+import { repairProjectedArtifacts } from "./projection-self-repair";
+import { claudeCodeProjectionRepairArtifacts } from "./adapters/claude-code/projection-self-repair";
+import { installSpecFor } from "./install-spec-registry";
 import { loadSomaProfile } from "./soma-home";
 import { normalizeSomaWorkRegistryArtifacts, upsertSomaCurrentWorkPointer } from "./work-registry";
 import { SECTION_NAME_MAP, getCriteria, getGoal } from "./vsa-accessors";
@@ -400,6 +403,54 @@ export async function runSomaLifecycleSessionStart(options: SomaLifecycleOptions
     });
   }
 
+  // #460: deterministic projection self-repair. Additive, best-effort, and
+  // non-blocking like the memory reproject above: restore a lost exec bit on a
+  // direct-exec projected script (containment-guarded to the substrate home)
+  // and REPORT content drift vs a fresh render. Only claude-code has a repair
+  // surface today; other substrates yield an empty artifact list and no-op. A
+  // clean projection emits no event; anything healed/found/refused — or a
+  // failure — logs one observability event, never halting the session.
+  let projectionRepairFiles: string[] = [];
+  try {
+    if (startup.substrate === "claude-code") {
+      const substrateHome = resolve(options.homeDir ?? homedir(), installSpecFor("claude-code").defaultHome);
+      const repair = await repairProjectedArtifacts({
+        substrateHome,
+        artifacts: claudeCodeProjectionRepairArtifacts({ substrateHome, somaHome: startup.somaHome }),
+      });
+      projectionRepairFiles = repair.healed;
+      if (repair.healed.length > 0 || repair.drifted.length > 0 || repair.skipped.length > 0) {
+        await appendSomaMemoryEvent(startup.somaHome, {
+          substrate: startup.substrate,
+          kind: "lifecycle.session_start.projection-repair",
+          summary:
+            `Projection self-repair: ${repair.healed.length} exec-bit restored, ` +
+            `${repair.drifted.length} drifted, ${repair.skipped.length} refused.`,
+          timestamp: startup.timestamp,
+          metadata: {
+            sessionId: startup.sessionId,
+            substrate: startup.substrate,
+            healed: repair.healed,
+            drifted: repair.drifted,
+            skipped: repair.skipped,
+          },
+        });
+      }
+    }
+  } catch (error: unknown) {
+    await appendSomaMemoryEvent(startup.somaHome, {
+      substrate: startup.substrate,
+      kind: "lifecycle.session_start.projection-repair-failed",
+      summary: "Session started; projection self-repair failed.",
+      timestamp: startup.timestamp,
+      metadata: {
+        sessionId: startup.sessionId,
+        substrate: startup.substrate,
+        error: lifecycleErrorMessage(error, startup.somaHome, options.homeDir),
+      },
+    });
+  }
+
   await appendSomaMemoryEvent(startup.somaHome, {
     substrate: startup.substrate,
     kind: "lifecycle.session_start",
@@ -416,7 +467,7 @@ export async function runSomaLifecycleSessionStart(options: SomaLifecycleOptions
     event: "session_start",
     somaHome: startup.somaHome,
     timestamp: startup.timestamp,
-    files: Array.from(new Set([...registryFiles, eventsPath, ...(memoryProjectedFile ? [memoryProjectedFile] : [])])),
+    files: Array.from(new Set([...registryFiles, eventsPath, ...(memoryProjectedFile ? [memoryProjectedFile] : []), ...projectionRepairFiles])),
     context: startup.context,
     activeVsa: active === null ? null : { slug: active.slug, phase: active.isa.frontmatter.phase },
   };

--- a/src/projection-self-repair.ts
+++ b/src/projection-self-repair.ts
@@ -111,11 +111,12 @@ export async function repairProjectedArtifacts(input: {
 
     if (artifact.directExec) {
       // Operate on an opened HANDLE (fstat + fchmod), not the pathname, so the
-      // mode change binds to the exact inode we containment-checked — a symlink
-      // swapped in after the realpath check cannot redirect the chmod. O_NOFOLLOW
-      // additionally refuses a final-component symlink substituted post-realpath
-      // (real's final component is an already-resolved non-symlink), closing the
-      // check→mutate race.
+      // mode change binds to the inode we open here rather than re-resolving the
+      // path at chmod time. O_NOFOLLOW refuses a final-component symlink
+      // substituted after the realpath check. This NARROWS the check→mutate race
+      // (it does not fully close it — a parent-component swap between realpath and
+      // open would need per-component openat(2), out of scope for a single-user
+      // substrate home); the realpath containment check above is the primary guard.
       let handle;
       try {
         handle = await open(real, constants.O_RDONLY | constants.O_NOFOLLOW);

--- a/src/projection-self-repair.ts
+++ b/src/projection-self-repair.ts
@@ -1,0 +1,140 @@
+import { createHash } from "node:crypto";
+import { chmod, readFile, realpath, stat } from "node:fs/promises";
+import { isInsidePath } from "./path-utils";
+
+/**
+ * Deterministic (no-LLM, no-network) self-repair for projected substrate
+ * artifacts (soma#460). Portable core: it operates on an explicit list of
+ * artifact descriptors so it holds no substrate knowledge — each substrate
+ * adapter supplies its own descriptors (see
+ * `adapters/claude-code/projection-self-repair.ts`).
+ *
+ * Two passes, both confined to the substrate home:
+ *
+ * 1. exec-bit restore — a projected script the substrate execs directly via
+ *    its shebang silently breaks if it loses its exec bit (a Write recreates a
+ *    file 0644). Re-add the execute bit. CONTAINMENT-GUARDED: an artifact whose
+ *    real path escapes the substrate home (e.g. a symlink pointing outside) is
+ *    refused, never chmod'd.
+ * 2. drift report — flag an artifact whose on-disk bytes no longer match a
+ *    fresh render, by checksum. Reported only; nothing is rewritten here.
+ *
+ * A healthy projection produces an empty result (no healed/drifted/skipped, no
+ * findings).
+ */
+
+/** A projected artifact the self-repair pass can heal (exec bit) and drift-check. */
+export interface ProjectedArtifact {
+  /** Absolute path of the projected file under the substrate home. */
+  path: string;
+  /**
+   * True when the substrate execs the file directly via its shebang (a script
+   * registered as a command), so a lost exec bit silently breaks it. False for
+   * bun-invoked hooks, whose exec bit the runtime ignores.
+   */
+  directExec: boolean;
+  /**
+   * Fresh in-memory render of the file's expected bytes, when the artifact is a
+   * pure function of its projection inputs. Present ⇒ eligible for drift
+   * detection; absent ⇒ exec-bit repair only.
+   */
+  expected?: string;
+}
+
+export type ProjectionRepairFindingKind = "exec-bit-restored" | "content-drift" | "containment-skip";
+
+export interface ProjectionRepairFinding {
+  kind: ProjectionRepairFindingKind;
+  severity: "info" | "warning";
+  path: string;
+  message: string;
+}
+
+export interface ProjectionRepairResult {
+  /** Paths whose exec bit was restored (files modified). */
+  healed: string[];
+  /** Paths whose on-disk bytes drifted from the fresh render (reported, not changed). */
+  drifted: string[];
+  /** Paths refused because they resolve outside the substrate home (never touched). */
+  skipped: string[];
+  findings: ProjectionRepairFinding[];
+}
+
+const OWNER_EXEC = 0o100;
+const ALL_EXEC = 0o111;
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+export async function repairProjectedArtifacts(input: {
+  substrateHome: string;
+  artifacts: readonly ProjectedArtifact[];
+}): Promise<ProjectionRepairResult> {
+  const result: ProjectionRepairResult = { healed: [], drifted: [], skipped: [], findings: [] };
+  if (input.artifacts.length === 0) return result;
+
+  // Containment root: the REAL path of the substrate home (symlinks resolved on
+  // both sides so the isInsidePath check compares real inodes, not link names).
+  // A home that does not resolve (never installed) means there is nothing to
+  // repair.
+  let root: string;
+  try {
+    root = await realpath(input.substrateHome);
+  } catch {
+    return result;
+  }
+
+  for (const artifact of input.artifacts) {
+    let real: string;
+    try {
+      real = await realpath(artifact.path);
+    } catch {
+      // Missing artifact (ENOENT) — a not-installed/removed projection is the
+      // doctor's concern, not self-repair's. Skip silently.
+      continue;
+    }
+    // Refuse anything that resolves outside the substrate home. realpath has
+    // already followed every symlink, so a link inside the home pointing out is
+    // caught here BEFORE any chmod could touch the escaped target.
+    if (!isInsidePath(real, root)) {
+      result.skipped.push(artifact.path);
+      result.findings.push({
+        kind: "containment-skip",
+        severity: "warning",
+        path: artifact.path,
+        message: `Projected artifact resolves outside the substrate home; refused: ${artifact.path}.`,
+      });
+      continue;
+    }
+
+    if (artifact.directExec) {
+      const info = await stat(real);
+      if ((info.mode & OWNER_EXEC) === 0) {
+        await chmod(real, info.mode | ALL_EXEC);
+        result.healed.push(artifact.path);
+        result.findings.push({
+          kind: "exec-bit-restored",
+          severity: "info",
+          path: artifact.path,
+          message: `Restored the exec bit on a direct-exec projected script: ${artifact.path}.`,
+        });
+      }
+    }
+
+    if (artifact.expected !== undefined) {
+      const onDisk = await readFile(real, "utf8");
+      if (sha256(onDisk) !== sha256(artifact.expected)) {
+        result.drifted.push(artifact.path);
+        result.findings.push({
+          kind: "content-drift",
+          severity: "warning",
+          path: artifact.path,
+          message: `Projected artifact drifted from its fresh render: ${artifact.path}. Run \`soma reproject\` to restore.`,
+        });
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/projection-self-repair.ts
+++ b/src/projection-self-repair.ts
@@ -17,7 +17,7 @@ import { isInsidePath } from "./path-utils";
  *    real path escapes the substrate home (e.g. a symlink pointing outside) is
  *    refused, never chmod'd.
  * 2. drift report — flag an artifact whose on-disk bytes no longer match a
- *    fresh render, by checksum. Reported only; nothing is rewritten here.
+ *    fresh projection, by checksum. Reported only; nothing is rewritten here.
  *
  * A healthy projection produces an empty result (no healed/drifted/skipped, no
  * findings).
@@ -34,7 +34,7 @@ export interface ProjectedArtifact {
    */
   directExec: boolean;
   /**
-   * Fresh in-memory render of the file's expected bytes, when the artifact is a
+   * Fresh in-memory projection of the file's expected bytes, when the artifact is a
    * pure function of its projection inputs. Present ⇒ eligible for drift
    * detection; absent ⇒ exec-bit repair only.
    */
@@ -53,7 +53,7 @@ export interface ProjectionRepairFinding {
 export interface ProjectionRepairResult {
   /** Paths whose exec bit was restored (files modified). */
   healed: string[];
-  /** Paths whose on-disk bytes drifted from the fresh render (reported, not changed). */
+  /** Paths whose on-disk bytes drifted from the fresh projection (reported, not changed). */
   drifted: string[];
   /** Paths refused because they resolve outside the substrate home (never touched). */
   skipped: string[];
@@ -130,7 +130,7 @@ export async function repairProjectedArtifacts(input: {
           kind: "content-drift",
           severity: "warning",
           path: artifact.path,
-          message: `Projected artifact drifted from its fresh render: ${artifact.path}. Run \`soma reproject\` to restore.`,
+          message: `Projected artifact drifted from its fresh projection: ${artifact.path}. Run \`soma reproject\` to restore.`,
         });
       }
     }

--- a/src/projection-self-repair.ts
+++ b/src/projection-self-repair.ts
@@ -1,5 +1,6 @@
+import { constants } from "node:fs";
 import { createHash } from "node:crypto";
-import { chmod, readFile, realpath, stat } from "node:fs/promises";
+import { open, readFile, realpath } from "node:fs/promises";
 import { isInsidePath } from "./path-utils";
 
 /**
@@ -109,16 +110,33 @@ export async function repairProjectedArtifacts(input: {
     }
 
     if (artifact.directExec) {
-      const info = await stat(real);
-      if ((info.mode & OWNER_EXEC) === 0) {
-        await chmod(real, info.mode | ALL_EXEC);
-        result.healed.push(artifact.path);
-        result.findings.push({
-          kind: "exec-bit-restored",
-          severity: "info",
-          path: artifact.path,
-          message: `Restored the exec bit on a direct-exec projected script: ${artifact.path}.`,
-        });
+      // Operate on an opened HANDLE (fstat + fchmod), not the pathname, so the
+      // mode change binds to the exact inode we containment-checked — a symlink
+      // swapped in after the realpath check cannot redirect the chmod. O_NOFOLLOW
+      // additionally refuses a final-component symlink substituted post-realpath
+      // (real's final component is an already-resolved non-symlink), closing the
+      // check→mutate race.
+      let handle;
+      try {
+        handle = await open(real, constants.O_RDONLY | constants.O_NOFOLLOW);
+      } catch {
+        // Vanished or replaced by a symlink between realpath and open — refuse.
+        continue;
+      }
+      try {
+        const info = await handle.stat();
+        if ((info.mode & OWNER_EXEC) === 0) {
+          await handle.chmod(info.mode | ALL_EXEC);
+          result.healed.push(artifact.path);
+          result.findings.push({
+            kind: "exec-bit-restored",
+            severity: "info",
+            path: artifact.path,
+            message: `Restored the exec bit on a direct-exec projected script: ${artifact.path}.`,
+          });
+        }
+      } finally {
+        await handle.close();
       }
     }
 

--- a/test/projection-self-repair.test.ts
+++ b/test/projection-self-repair.test.ts
@@ -31,6 +31,20 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
   }
 }
 
+interface MemoryEvent {
+  kind: string;
+  metadata: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/** Parse the Soma memory event log written under a temp home. */
+async function readMemoryEvents(homeDir: string): Promise<MemoryEvent[]> {
+  return (await readFile(join(homeDir, ".soma/memory/STATE/events.jsonl"), "utf8"))
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as MemoryEvent);
+}
+
 function claudeArtifacts(homeDir: string): { substrateHome: string; artifacts: ReturnType<typeof claudeCodeProjectionRepairArtifacts> } {
   const substrateHome = join(homeDir, ".claude");
   return {
@@ -129,10 +143,7 @@ test("session start heals a chmod-644'd statusline and logs an observability eve
     expect((await stat(scriptPath)).mode & 0o111).not.toBe(0);
     expect(start.files).toContain(scriptPath);
 
-    const events = (await readFile(join(homeDir, ".soma/memory/STATE/events.jsonl"), "utf8"))
-      .trim()
-      .split("\n")
-      .map((line) => JSON.parse(line));
+    const events = await readMemoryEvents(homeDir);
     const repair = events.find((event) => event.kind === "lifecycle.session_start.projection-repair");
     expect(repair).toBeDefined();
     expect(repair?.metadata.healed).toContain(scriptPath);
@@ -151,10 +162,7 @@ test("session start emits no projection-repair event when the projection is heal
       timestamp: "2026-07-13T10:00:00.000Z",
     });
 
-    const events = (await readFile(join(homeDir, ".soma/memory/STATE/events.jsonl"), "utf8"))
-      .trim()
-      .split("\n")
-      .map((line) => JSON.parse(line));
+    const events = await readMemoryEvents(homeDir);
     expect(events.some((event) => event.kind.startsWith("lifecycle.session_start.projection-repair"))).toBe(false);
   });
 });

--- a/test/projection-self-repair.test.ts
+++ b/test/projection-self-repair.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Projection self-repair (soma#460).
+ *
+ * A deterministic SessionStart pass that (1) restores the exec bit on a
+ * projected direct-exec script that lost it, containment-guarded to the
+ * substrate home, and (2) reports content drift vs a fresh render. These tests
+ * exercise the portable core against the claude-code reference surface (the
+ * statusline — the one projection Claude Code execs directly via its shebang).
+ */
+import { chmod, mkdir, mkdtemp, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "bun:test";
+import {
+  claudeCodeProjectionRepairArtifacts,
+  installSomaForClaudeCode,
+  repairProjectedArtifacts,
+  runSomaLifecycleSessionStart,
+} from "../src/index";
+
+const STATUSLINE_REL = ".claude/hooks/soma/soma-statusline.sh";
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-proj-repair-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+function claudeArtifacts(homeDir: string): { substrateHome: string; artifacts: ReturnType<typeof claudeCodeProjectionRepairArtifacts> } {
+  const substrateHome = join(homeDir, ".claude");
+  return {
+    substrateHome,
+    artifacts: claudeCodeProjectionRepairArtifacts({ substrateHome, somaHome: join(homeDir, ".soma") }),
+  };
+}
+
+test("restores the exec bit on a projected direct-exec script that lost it", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir });
+    const scriptPath = join(homeDir, STATUSLINE_REL);
+    await chmod(scriptPath, 0o644);
+    expect((await stat(scriptPath)).mode & 0o100).toBe(0);
+
+    const { substrateHome, artifacts } = claudeArtifacts(homeDir);
+    const result = await repairProjectedArtifacts({ substrateHome, artifacts });
+
+    expect(result.healed).toEqual([scriptPath]);
+    expect((await stat(scriptPath)).mode & 0o111).not.toBe(0);
+    expect(result.findings.some((f) => f.kind === "exec-bit-restored" && f.path === scriptPath)).toBe(true);
+    // Only the mode changed — the bytes still match the fresh render.
+    expect(result.drifted).toEqual([]);
+  });
+});
+
+test("refuses to follow a symlink that escapes the substrate home", async () => {
+  await withTempHome(async (homeDir) => {
+    const substrateHome = join(homeDir, ".claude");
+    const hookDir = join(substrateHome, "hooks/soma");
+    await mkdir(hookDir, { recursive: true });
+
+    // A real script OUTSIDE the substrate home, non-executable.
+    const outsideScript = join(homeDir, "outside", "evil.sh");
+    await mkdir(join(homeDir, "outside"), { recursive: true });
+    await writeFile(outsideScript, "#!/bin/sh\n", { mode: 0o644 });
+    await chmod(outsideScript, 0o644);
+
+    // The projected path is a symlink into the escaped target.
+    const linkPath = join(hookDir, "soma-statusline.sh");
+    await symlink(outsideScript, linkPath);
+
+    const result = await repairProjectedArtifacts({
+      substrateHome,
+      artifacts: [{ path: linkPath, directExec: true, expected: "#!/bin/sh\n" }],
+    });
+
+    expect(result.skipped).toEqual([linkPath]);
+    expect(result.healed).toEqual([]);
+    expect(result.drifted).toEqual([]);
+    // The escaped target was never chmod'd — still 0644, not executable.
+    expect((await stat(outsideScript)).mode & 0o111).toBe(0);
+    expect(result.findings.some((f) => f.kind === "containment-skip")).toBe(true);
+  });
+});
+
+test("no-op on a healthy projection: nothing healed, drifted, or refused", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir });
+    const { substrateHome, artifacts } = claudeArtifacts(homeDir);
+    const result = await repairProjectedArtifacts({ substrateHome, artifacts });
+    expect(result).toEqual({ healed: [], drifted: [], skipped: [], findings: [] });
+  });
+});
+
+test("reports drift for a hand-edited projected file", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir });
+    const scriptPath = join(homeDir, STATUSLINE_REL);
+    const original = await readFile(scriptPath, "utf8");
+    await writeFile(scriptPath, `${original}\n# hand-edited\n`, { mode: 0o755 });
+
+    const { substrateHome, artifacts } = claudeArtifacts(homeDir);
+    const result = await repairProjectedArtifacts({ substrateHome, artifacts });
+
+    expect(result.drifted).toEqual([scriptPath]);
+    expect(result.findings.some((f) => f.kind === "content-drift" && f.path === scriptPath)).toBe(true);
+    // Still executable — only the content changed, not the mode.
+    expect(result.healed).toEqual([]);
+  });
+});
+
+test("session start heals a chmod-644'd statusline and logs an observability event", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir });
+    const scriptPath = join(homeDir, STATUSLINE_REL);
+    await chmod(scriptPath, 0o644);
+
+    const start = await runSomaLifecycleSessionStart({
+      homeDir,
+      substrate: "claude-code",
+      sessionId: "session-projection-repair",
+      timestamp: "2026-07-13T10:00:00.000Z",
+    });
+
+    expect((await stat(scriptPath)).mode & 0o111).not.toBe(0);
+    expect(start.files).toContain(scriptPath);
+
+    const events = (await readFile(join(homeDir, ".soma/memory/STATE/events.jsonl"), "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    const repair = events.find((event) => event.kind === "lifecycle.session_start.projection-repair");
+    expect(repair).toBeDefined();
+    expect(repair?.metadata.healed).toContain(scriptPath);
+    expect(events.some((event) => event.kind === "lifecycle.session_start")).toBe(true);
+  });
+});
+
+test("session start emits no projection-repair event when the projection is healthy", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForClaudeCode({ homeDir });
+
+    await runSomaLifecycleSessionStart({
+      homeDir,
+      substrate: "claude-code",
+      sessionId: "session-healthy",
+      timestamp: "2026-07-13T10:00:00.000Z",
+    });
+
+    const events = (await readFile(join(homeDir, ".soma/memory/STATE/events.jsonl"), "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(events.some((event) => event.kind.startsWith("lifecycle.session_start.projection-repair"))).toBe(false);
+  });
+});

--- a/test/projection-self-repair.test.ts
+++ b/test/projection-self-repair.test.ts
@@ -12,11 +12,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "bun:test";
 import {
-  claudeCodeProjectionRepairArtifacts,
   installSomaForClaudeCode,
   repairProjectedArtifacts,
   runSomaLifecycleSessionStart,
 } from "../src/index";
+// Direct adapter import (not re-exported from the root — it's an adapter-internal
+// descriptor): also loads the module's registerProjectionRepairProvider side effect.
+import { claudeCodeProjectionRepairArtifacts } from "../src/adapters/claude-code/projection-self-repair";
 
 const STATUSLINE_REL = ".claude/hooks/soma/soma-statusline.sh";
 

--- a/test/projection-self-repair.test.ts
+++ b/test/projection-self-repair.test.ts
@@ -3,7 +3,7 @@
  *
  * A deterministic SessionStart pass that (1) restores the exec bit on a
  * projected direct-exec script that lost it, containment-guarded to the
- * substrate home, and (2) reports content drift vs a fresh render. These tests
+ * substrate home, and (2) reports content drift vs a fresh projection. These tests
  * exercise the portable core against the claude-code reference surface (the
  * statusline — the one projection Claude Code execs directly via its shebang).
  */
@@ -50,7 +50,7 @@ test("restores the exec bit on a projected direct-exec script that lost it", asy
     expect(result.healed).toEqual([scriptPath]);
     expect((await stat(scriptPath)).mode & 0o111).not.toBe(0);
     expect(result.findings.some((f) => f.kind === "exec-bit-restored" && f.path === scriptPath)).toBe(true);
-    // Only the mode changed — the bytes still match the fresh render.
+    // Only the mode changed — the bytes still match the fresh projection.
     expect(result.drifted).toEqual([]);
   });
 });


### PR DESCRIPTION
## What (Closes #460)

A deterministic (no-LLM, no-network) **projection self-repair** pass, run best-effort at SessionStart. Two passes over an explicit artifact list, confined to the substrate home:

1. **exec-bit restore** — a projected script the substrate execs via its shebang silently breaks if it loses its exec bit (a `Write` recreates a file 0644). Re-add it.
2. **drift report** — flag a projected artifact whose on-disk bytes drifted from a fresh render (checksum). Reported, not auto-rewritten.

## Why

soma projects hooks/statusline/rules into each substrate; they can silently break (lost exec bit, drift after upgrade) with no detection or repair — `soma doctor` detects some drift but has no fix path. This is the class of fragility behind the jq/statusline incident (#457): a degraded projection nobody noticed.

## Design

- **Portable core** `src/projection-self-repair.ts` — `repairProjectedArtifacts({ substrateHome, artifacts })`; holds no substrate knowledge.
- **Containment-guarded** — `realpath` resolves symlinks on both the home and each artifact before an `isInsidePath` (existing helper) check, so an artifact escaping the home is refused **before** any `chmod`; `chmod` targets the resolved real path.
- **Thin claude-code surface** `src/adapters/claude-code/projection-self-repair.ts` — supplies the statusline descriptor (the one claude-code projection that is direct-exec *and* a pure function of `somaHome`, so its fresh render is a sound drift oracle). The `.mjs` hooks are bun-invoked (exec bit irrelevant) and carry machine-specific config, so they're excluded.
- **Wired into `runSomaLifecycleSessionStart`** as an additive, non-blocking step (same soft shape as the memory-reproject step); emits a `lifecycle.session_start.projection-repair` event only when it heals/drifts/refuses.

## Verify

`tsc --noEmit` clean; `bun test` **2055 pass / 0 fail**; new `test/projection-self-repair.test.ts` **6 pass** (exec-bit restore, symlink-escape containment, healthy no-op, hand-edit drift, + 2 SessionStart wiring tests); eslint clean on changed files.

## Deferred (follow-ups)

- Stretch "degraded-capability when a runtime dep is missing" (the jq case) — needs a dependency-probe model; left out of this slice.
- Drift coverage for the bun-invoked hooks (needs machine-specific config excluded from the checksum).
- The optional `PostToolUse(Write|Edit)` trigger — only the SessionStart pass is wired, per the plan's acceptance.

Part of the self-improvement plan (`Plans/2026-07-13-...`). Refs #459 #457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
