### PR TITLE
chore(release): 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.14.1] - 2026-08-02
+
+### Fixed
+- **pi-dev message-path freeze (#475, #489)** — `before_agent_start` ran two blocking
+  `spawnSync` calls on every message: a full `soma lifecycle session-start` plus
+  `soma algorithm classify`. Entering a message froze Pi.dev until both returned.
+  The message path now spawns nothing.
+
+  The larger finding: **classification never needed a subprocess.**
+  `classifyAlgorithmPrompt` is pure and synchronous — regex matching, zero I/O — so
+  the entire cost attributed to it was bun cold start (~210ms measured) spawned to
+  run a regex. The classifier is now projected into the generated extension and
+  called locally, which keeps classification correct for the *current* prompt on
+  every message including the first, with no cache and no deferral.
+
+- **`session-end` lifecycle records were being lost** — `captureSessionEnd` was
+  fire-and-forget on `session_shutdown`, so the process exited and killed the child
+  mid-write. It is now awaited with a bounded timeout.
+
+### Changed
+- **Startup context is computed once per session** and reused by `before_agent_start`
+  instead of re-running the whole session-start lifecycle per message.
+- **Work-index refreshes are deferred and coalesced** behind an in-flight guard.
+  `spawnSync` previously serialised them; an unguarded async fan-out would let a
+  tool-heavy turn race dozens of concurrent writers on `algorithm-work-index.json`.
+- **Classifier pattern set extracted to `ALGORITHM_CLASSIFIER_CONTRACT`**
+  (`src/algorithm-classifier.ts`), serialised into the projected copy by the new
+  `src/adapters/shared/algorithm-classifier-source.ts` rather than retyped — the same
+  share-the-data-generate-the-logic idiom as `feedback-helper.ts`. Classification
+  behaviour is unchanged; a behavioural-equivalence test pins the projected copy to
+  the runtime function.
+
+### Added
+- `test/pi-dev-blocking-calls.test.ts` — pins the pi-dev message path as
+  subprocess-free, alongside a transpile check of the generated extension.
+- `test/pi-dev-classifier-projection.test.ts` — drift guard comparing the projected
+  classifier against the runtime one across a branch-covering prompt corpus.
+
 ## [0.14.0] - 2026-07-26
 
 ### Added

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,6 +1,6 @@
 schema: arc/v1
 name: soma
-version: 0.14.0
+version: 0.14.1
 type: tool
 tier: community
 description: Substrate-portable Personal AI Assistant core for identity, memory, VSA, skills, learning, and adapters.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soma",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "private": true,
   "type": "module",
   "description": "Substrate-portable Personal AI Assistant core.",


### PR DESCRIPTION
Patch release covering the single change merged since `v0.14.0` ([#489](https://github.com/the-metafactory/soma/pull/489), fixes #475).

## Headline

Entering a message in Pi.dev no longer freezes. `before_agent_start` was making two blocking `spawnSync` calls per message — a full `soma lifecycle session-start` plus `soma algorithm classify`. The message path now spawns nothing.

The finding worth carrying forward: **classification never needed a subprocess.** `classifyAlgorithmPrompt` is pure and synchronous, so the entire cost attributed to it was bun cold start (~210ms measured) spawned to run a regex match. Projecting it into the generated extension also fixed a correctness bug the first attempt introduced — classification is now for the *current* prompt on every message including the first, not a cached result from the previous turn.

Also in: `session-end` lifecycle records are no longer lost to fire-and-forget at shutdown, and work-index refreshes are coalesced behind an in-flight guard instead of racing concurrent writers on `algorithm-work-index.json`.

## Version bump

| File | 0.14.0 → 0.14.1 |
|---|---|
| `package.json` | ✔ |
| `arc-manifest.yaml` | ✔ |
| `CHANGELOG.md` | new `[0.14.1]` section |

`src/version.ts` reads from `package.json`, so no third edit is needed — verified: `soma --version` reports `soma 0.14.1`, and no `0.14.0` stragglers remain outside the changelog history.

Patch rather than minor: one bug-fix commit, no public API change. `ALGORITHM_CLASSIFIER_CONTRACT` is new but is not re-exported from `src/index.ts`.

## Verification

- `bun test` — 2079 pass, 0 fail
- `bun run typecheck` — clean
- `soma --version` → `soma 0.14.1`
- The fix was confirmed working against the principal's live Pi environment before this release

## Not included

Publishing to the arc registry is a manual `workflow_dispatch` step and remains the principal's call, matching the 0.14.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)