### PR TITLE
docs(skills): loading mode belongs to the install spec, not skill frontmatter (#542)

### DIFF
--- a/docs/progressive-skill-loading.md
+++ b/docs/progressive-skill-loading.md
@@ -133,8 +133,14 @@ optional workspace overlays. It is safe to project into substrate homes because
 it is small and descriptive.
 
 The registry is **the** stub contract. Substrates consume it; they do not define
-their own. Its entry shape is owned by `renderSkillRegistryEntry()` and its size
-is bounded by `SKILL_REGISTRY_LINE_BUDGET`.
+their own. Its entry shape is owned by `renderSkillRegistryEntry()`.
+
+`SKILL_REGISTRY_LINE_BUDGET` (300) is a **design target, not a runtime cap**.
+`renderSkills()` emits every skill, so the real catalog can cross it as skills
+accumulate; the constant is asserted in `test/skill-registry.test.ts` against
+synthetic fixtures, not against the shipped catalog. It measured ~122 lines at
+~104 skills and 201 lines at 114, so the budget needs watching rather than
+assuming.
 
 ### Skill Loader
 
@@ -163,11 +169,11 @@ loads bodies on demand — its session receives the registry plus a name and
 description listing, not 18,644 lines. Pi does not. Same registry, same
 symlinks, different loader. Nothing about any skill changed.
 
-Add one field to the install spec, beside the loader root it already owns
-(`src/install-spec.ts:107`, soma#356):
+Add one field to `SubstrateInstallSpec` (`src/install-spec.ts:79`), beside the
+loader root it already owns (`:107`, soma#356):
 
 ```ts
-interface InstallSpec {
+interface SubstrateInstallSpec<S extends InstallSubstrate = InstallSubstrate> {
   skillsLoaderDir(substrateHome: string): string;
   skillsLoading: "on-demand" | "eager";   // NEW
 }
@@ -190,10 +196,24 @@ Bodies project as symlinks today (`ensureSymlink()`, `skill-projection.ts:163`):
 one body in `~/.soma/skills/<name>`, N loader entries. A symlink cannot be a
 partial view of its target.
 
-So for `skillsLoading: "eager"`, the adapter must **generate** a stub file into
-the loader dir instead of linking. The stub is rendered from the same source as
-the registry entry, so the two can never drift. The registry entry already
-carries the resolve path, so trigger-time promotion has its target.
+So for `skillsLoading: "eager"`, projection must **generate** a stub into the
+loader dir instead of linking.
+
+A stub is a **directory**, not a catalog line. An eager substrate's loader scans
+`skillsLoaderDir(home)/<name>/` and reads `SKILL.md` from inside it — pi-dev
+resolves that to `~/.pi/agent/skills/<name>/` (`skillsLoaderUnder("agent")`,
+`src/adapters/pi-dev/install.ts:44`). So the stub is:
+
+```text
+<skillsLoaderDir>/<name>/SKILL.md   frontmatter only + a pointer to the body
+```
+
+The pointer resolves to the registry path `~/.soma/skills/<name>/SKILL.md`, which
+is what trigger-time promotion reads.
+
+Stub and registry entry are two renderers over the same `SomaSkill` frontmatter,
+so they cannot drift on content — but they are not the same artifact, and
+`renderSkillRegistryEntry()` is not the stub renderer.
 
 This is the concrete form of the original spec's "substrates without native file
 loading" rule. It moves from prose to a typed adapter obligation.
@@ -308,7 +328,7 @@ router and ship first.
 1. **Deduplicate the kernel projection.** Collapse `PROFILE.md` / `PURPOSE.md`
    into `CONTEXT.md`, and move `README.md` out of the loaded `rules/` path.
    ~21% of always-on context. No new types. (DD-E)
-2. **Add `skillsLoading` to `InstallSpec`.** Set every current adapter to
+2. **Add `skillsLoading` to `SubstrateInstallSpec`.** Set every current adapter to
    `on-demand` except `pi-dev`. (DD-A)
 3. **Generate stubs for eager substrates** from the registry renderer instead of
    symlinking bodies. (DD-B)

--- a/docs/progressive-skill-loading.md
+++ b/docs/progressive-skill-loading.md
@@ -1,26 +1,48 @@
 # Progressive Skill Loading
 
+**Status:** Revised spec. Registry tier shipped; router and manifest tiers unbuilt.
+**Date:** 2026-08-06
+
 Progressive skill loading keeps Soma's capability surface broad without putting
 every capability into every model context. See [CONTEXT.md](../CONTEXT.md) for
-glossary; this document uses the eager / indexed / on-demand loading tiers.
+glossary; this document uses the registry / entrypoint / reference loading tiers.
+
+This revision supersedes a Pi-specific draft (`~/work/pi/subagents/context-aware-skill-loading.md`)
+that proposed a parallel stub format. That draft is folded in here. Its core
+insight was correct and its numbers were not; both are addressed below.
 
 ## Problem
 
-PAI already selects skills and capabilities during work. The failure mode is not
-missing selection. The failure mode is that selection can happen after a large
-amount of routing doctrine, capability descriptions, and skill material has
-already entered the LLM context.
+Selection is not the failure mode. Soma already selects skills during work. The
+failure mode is that selection happens *after* routing doctrine, capability
+descriptions, and skill bodies have already entered the LLM context.
 
-That is especially costly in Claude Code, where global instructions, hooks,
-skills, commands, agents, and project context all compete for the same context
-window. A large always-loaded capability surface reduces task focus and makes
-irrelevant material more likely to influence the answer.
+Measured on this machine, 2026-08-06, against `~/.soma/skills`:
 
-Soma should preserve PAI's capability breadth while changing the loading model:
+| Quantity | Measured |
+| --- | --- |
+| Skills in the registry | 114 |
+| Total `SKILL.md` lines | 18,644 |
+| Total `SKILL.md` bytes | 799,571 |
+| Estimated tokens (soma V0 estimator, `bytes / 4`) | **~200,000** |
+| Mean skill size | 163 lines |
+| Skills over 500 lines | 3 |
+| Largest skill (`tana`) | 1,816 lines |
+| Smallest cited skill (`the-algorithm`) | 32 lines |
 
-```text
-small kernel -> skill registry -> route -> selected manifest -> selected body
-```
+A substrate that loads every body eagerly pays ~200K tokens before the first
+user turn. A substrate that loads on demand pays the registry only. Same
+registry, same files, different loader.
+
+Two corrections to the Pi draft's arithmetic, because they change the size of
+the prize by an order of magnitude:
+
+- It assumed 2,000 lines per skill. The measured mean is **163**. The corpus is
+  18,644 lines, not 234,000.
+- It cited `calendar` at "2,500+ lines". It is **358**.
+
+The problem is real. It is ~12x smaller than that draft claimed, and the fix is
+correspondingly cheaper.
 
 ## Goals
 
@@ -40,10 +62,37 @@ small kernel -> skill registry -> route -> selected manifest -> selected body
 - Requiring a vector database in the first implementation.
 - Making a substrate adapter own skill semantics.
 - Treating generated substrate projections as the source of truth.
+- Inventing a second stub format alongside the registry.
+
+## Implementation Status
+
+Grounding the spec in what is actually built, so the migration plan does not
+re-specify shipped work:
+
+| Layer | Status | Evidence |
+| --- | --- | --- |
+| Registry projection | **Shipped** | `renderSkills()`, `src/adapters/shared/index.ts:199` |
+| Registry entry format | **Shipped** | `renderSkillRegistryEntry()`, `src/adapters/shared/skill-registry.ts:173` |
+| Registry line budget | **Shipped** | `SKILL_REGISTRY_LINE_BUDGET = 300`, `skill-registry.ts:31` |
+| Trigger / anti-trigger extraction | **Shipped** | `extractUseWhenTriggers()`, `extractAntiTriggers()`, `skill-registry.ts:85,110` |
+| Catalog auto-refresh on projection | **Shipped** | `refreshSkillCatalogs()`, `src/skill-projection.ts:316` |
+| Per-substrate loader root | **Shipped** | `skillsLoaderDir()`, `src/install-spec.ts:107`, 6 adapters |
+| Body projection | **Shipped as symlink** | `ensureSymlink()`, `src/skill-projection.ts:163` |
+| `SomaSkillManifest` | **Typed, not materialized** | `src/types.ts:958`; **0** `soma-skill.json` files on disk |
+| `SkillRoute` | **Not built** | 0 occurrences in `src/` |
+| `estimatedTokens` / budget reporting | **Not built** | 0 occurrences in `src/` |
+| `defaultLoad` tiering | **Not built** | 0 occurrences in `src/` |
+
+The registry tier is done. On this machine it renders 201 lines for 114 skills,
+inside the 300-line budget, with name, short description, `triggers:`, `not:`,
+and resolve path per entry.
+
+**The stub tier the Pi draft proposed already exists.** It is the registry. Any
+new stub format would be a second, competing source of the same data.
 
 ## Architecture
 
-Progressive loading has four layers.
+Four layers, unchanged from the original spec.
 
 ```text
 Soma home
@@ -51,7 +100,7 @@ Soma home
       |
       v
 Skill registry
-  compact metadata for every skill
+  compact metadata for every skill        <- SHIPPED
       |
       v
 Skill router
@@ -74,8 +123,8 @@ The kernel is the maximum context that should be loaded by default:
 - skill registry location and loading protocol
 
 The kernel must not include full skill bodies unless the substrate has a native
-on-demand skill mechanism that guarantees those bodies are not inserted into
-the LLM context until invoked.
+on-demand skill mechanism that guarantees those bodies stay out of the LLM
+context until invoked.
 
 ### Skill Registry
 
@@ -83,300 +132,221 @@ The registry is a deterministic index built from the Soma skill home and
 optional workspace overlays. It is safe to project into substrate homes because
 it is small and descriptive.
 
-Each registry entry should contain:
-
-```ts
-interface SomaSkillManifest {
-  name: string;
-  path: string;
-  description: string;
-  triggers: string[];
-  antiTriggers: string[];
-  tags: string[];
-  phases: string[];
-  substrateSupport: string[];
-  estimatedTokens: number;
-  defaultLoad: "never" | "manifest" | "body";
-  entrypoint: string;
-  references: {
-    path: string;
-    description: string;
-    triggers: string[];
-    estimatedTokens: number;
-  }[];
-  tools: {
-    name: string;
-    description: string;
-    substrateSupport: string[];
-  }[];
-  algorithmCapability?: {
-    kind: "skill" | "inline" | "agent" | "command" | "adapter";
-    phases: string[];
-    triggerSignals: string[];
-  };
-}
-```
-
-`defaultLoad: "body"` is reserved for tiny kernel skills whose complete body is
-part of startup behavior. Most skills should be `manifest`; high-volume or
-narrow skills should be `never` until a router selects them.
-
-### Skill Router
-
-The router chooses candidate skills before their full bodies are loaded. Inputs:
-
-- current user prompt
-- active Algorithm run or active VSA
-- current workspace overlay
-- substrate id and known context budget
-- available tool surface
-- skill manifests
-
-The router returns:
-
-```ts
-interface SkillRoute {
-  selected: {
-    name: string;
-    reason: string;
-    load: "manifest" | "body" | "references";
-    referencePaths: string[];
-  }[];
-  rejected: {
-    name: string;
-    reason: string;
-  }[];
-  contextBudget: {
-    maxTokens: number;
-    estimatedKernelTokens: number;
-    estimatedSkillTokens: number;
-    remainingTokens: number;
-  };
-}
-```
-
-Selection is conservative. If the manifest is enough, the router should not load
-the body. If the skill body is needed, the loader should include only the
-entrypoint first. References and examples are loaded only when their triggers
-match the task.
+The registry is **the** stub contract. Substrates consume it; they do not define
+their own. Its entry shape is owned by `renderSkillRegistryEntry()` and its size
+is bounded by `SKILL_REGISTRY_LINE_BUDGET`.
 
 ### Skill Loader
 
-The loader materializes the selected context for the current substrate. It
-should support three load levels:
+Three load levels:
 
 | Level | Loaded content | Use when |
 | --- | --- | --- |
-| Registry | Names, descriptions, triggers, budgets | Startup and broad discovery |
-| Entrypoint | `SKILL.md` or equivalent entry file | A skill is selected for the task |
+| Registry | Names, short descriptions, triggers, anti-triggers, path | Startup and broad discovery |
+| Entrypoint | `SKILL.md` | A skill is selected for the task |
 | Reference | Specific workflow, example, or tool docs | The entrypoint routes to more detail |
 
-The loader must keep provenance. Every loaded section should be traceable to a
-source path under the Soma skill home or a workspace overlay.
-
-## Routing Algorithm
-
-The first implementation can be deterministic and file-backed:
-
-1. Build or refresh the skill registry from frontmatter and optional
-   `soma-skill.json` files.
-2. Score manifests against the prompt using trigger matches, anti-trigger
-   matches, tags, active phase, and substrate support.
-3. Apply hard gates for substrate compatibility and policy.
-4. Keep the top candidates that fit the context budget.
-5. Load only selected entrypoints.
-6. Re-score references from the selected entrypoints if more detail is needed.
-7. Record the selected skills and loaded paths in the Algorithm run or substrate
-   session state.
-
-This is intentionally simpler than semantic search. A later implementation can
-add embeddings or BM25-style indexing without changing the contract.
-
-## Adapter Behavior
-
-Adapters project the same route into substrate-native behavior.
-
-### Codex
-
-Codex should project:
-
-- the Soma kernel skill
-- the compact skill registry
-- a command or hook path for route-time loading
-- selected skill entrypoints only when a task requires them
-
-Codex rules should remain a parse-safe marker. Natural-language routing belongs
-in the projected Soma skill and memory files.
-
-### Pi.dev
-
-Pi.dev should expose progressive loading through the `soma_context` extension
-tool. The tool should support actions such as:
-
-- `skill_registry`
-- `skill_route`
-- `skill_entrypoint`
-- `skill_reference`
-
-The Pi system prompt should receive only identity/kernel context plus routing
-instructions. Detailed PAI imports and skill bodies remain tool-readable.
-
-### Claude Code
-
-Claude Code may keep native skills installed globally, but Soma should treat the
-installed skill directories as an availability mechanism, not permission to paste
-all skill text into global prompt context.
-
-The Claude projection should keep the global assistant file small: kernel,
-registry pointer, and loading protocol. Hooks can refresh the registry or record
-selected skills, but hooks must remain optional enhancements.
-
-### Cortex / Myelin
-
-In daemon mode, Cortex/Myelin should route before spawning or addressing a
-substrate session. The daemon can send a Myelin envelope containing the selected
-skill manifests and source paths, then let the substrate adapter materialize the
-right context shape.
-
-The ownership and safety contract for this runtime lives in
-[daemon-mode.md](./daemon-mode.md). Soma owns route decisions and selected
-context provenance; Myelin owns the wire protocol and envelope semantics.
-
-## Context Budget Rules
-
-- Every projection should report estimated token cost for kernel, registry, and
-  selected skills.
-- A selected skill should have a reason and a budget estimate.
-- If selected skills exceed budget, the router should prefer entrypoints over
-  references and references over examples.
-- If a task needs more skill context than the budget allows, the adapter should
-  ask the model to use a tool/read path instead of pasting the content.
-
-## State And Learning
-
-Each task should be able to record:
-
-- skill manifests considered
-- selected skills
-- loaded paths
-- rejected high-scoring skills and reasons
-- whether the selected skills were sufficient
-- lessons for trigger, anti-trigger, or budget tuning
-
-For Algorithm work, this belongs in the run's decisions, verification, and
-learning logs. Outside Algorithm work, it can be captured as append-only state
-events.
+The loader must keep provenance. Every loaded section should trace to a source
+path under the Soma skill home or a workspace overlay.
 
 ## Decisions
 
-### Skill-Owned Manifests
+### DD-A: Loading strategy is a substrate capability, not a skill property
 
-Each skill should own a `soma-skill.json` alongside `SKILL.md`. Soma should
-generate a registry from those manifests. The skill-local manifest is the source
-of truth for routing metadata; the registry is an index.
+*Tracked as soma#542 (with DD-B and DD-C).*
 
-```text
-skills/<skill>/
-  SKILL.md
-  soma-skill.json
-  references/
-  tools/
+The Pi draft put a `scope:` field in skill frontmatter. That is the wrong home.
+It would encode one substrate's loader limitation into 114 portable files.
+
+Evidence that it is substrate-shaped, not skill-shaped: Claude Code already
+loads bodies on demand — its session receives the registry plus a name and
+description listing, not 18,644 lines. Pi does not. Same registry, same
+symlinks, different loader. Nothing about any skill changed.
+
+Add one field to the install spec, beside the loader root it already owns
+(`src/install-spec.ts:107`, soma#356):
+
+```ts
+interface InstallSpec {
+  skillsLoaderDir(substrateHome: string): string;
+  skillsLoading: "on-demand" | "eager";   // NEW
+}
 ```
 
-Importers should create `soma-skill.json` during import. For imported PAI packs,
-the importer can derive the first version from pack metadata, `SKILL.md`
-frontmatter, copied reference files, and safe defaults:
+| Substrate | `skillsLoading` | Body projection |
+| --- | --- | --- |
+| claude-code | `on-demand` | symlink (today) |
+| codex | `on-demand` | symlink (today) |
+| cursor | `on-demand` | symlink (today) |
+| grok | `on-demand` | symlink (today) |
+| anthropic-cowork | `on-demand` | symlink (today) |
+| pi-dev | `eager` | **generated stub**, body resolved on trigger |
 
-- `name`: normalized skill name
-- `description`: pack or skill description
-- `triggers`: imported frontmatter triggers or conservative keyword defaults
-- `antiTriggers`: empty until curated
-- `tags`: source and pack tags such as `pai-pack`
-- `phases`: empty or inferred from known Algorithm capability metadata
-- `substrateSupport`: `["codex", "pi-dev", "claude-code", "cortex"]` unless the
-  import marks files as substrate-specific
-- `estimatedTokens`: deterministic estimate from the entrypoint and selected
-  references
-- `defaultLoad`: `manifest`
-- `entrypoint`: `SKILL.md`
-- `references`: copied reference files with descriptions when available
-- `tools`: copied portable tools when available
-- `algorithmCapability`: optional run-scoped Algorithm capability metadata when
-  the skill should be selectable inside Algorithm runs. It describes routing
-  signals, not substrate execution bindings; adapters or the registry derive
-  invocation contract and target.
+One field fixes every eager substrate at once. No change to any skill file.
 
-This is distinct from `soma-pack.json`. `soma-pack.json` records import
-provenance and file classification. `soma-skill.json` records runtime routing
-metadata.
+### DD-B: An eager substrate gets generated stubs, not symlinks
+
+Bodies project as symlinks today (`ensureSymlink()`, `skill-projection.ts:163`):
+one body in `~/.soma/skills/<name>`, N loader entries. A symlink cannot be a
+partial view of its target.
+
+So for `skillsLoading: "eager"`, the adapter must **generate** a stub file into
+the loader dir instead of linking. The stub is rendered from the same source as
+the registry entry, so the two can never drift. The registry entry already
+carries the resolve path, so trigger-time promotion has its target.
+
+This is the concrete form of the original spec's "substrates without native file
+loading" rule. It moves from prose to a typed adapter obligation.
+
+### DD-C: Promotion must not invalidate the prompt cache
+
+When an eager substrate promotes a stub to a full body mid-session, it must
+deliver the body as a **tool result**, never as an edit to the system prompt.
+
+Editing the system prompt changes the cached prefix and forces a full re-read of
+every preceding token. For a session already carrying the kernel and registry,
+that costs more than the body being loaded. This constraint is not optional and
+is not visible from the skill side, which is a second reason DD-A belongs in the
+install spec.
+
+### DD-D: Derive routing metadata from frontmatter; defer `soma-skill.json`
+
+The original spec made `soma-skill.json` the source of truth for routing
+metadata. Measured today: **0 such files exist**. The shipped
+`SomaSkillManifest` (`src/types.ts:958`) is also not that type — it carries
+`source: { kind: "pai-pack" }` and is an import-provenance artifact. It has no
+`antiTriggers`, `tags`, `phases`, `estimatedTokens`, or `defaultLoad`.
+
+Meanwhile `extractUseWhenTriggers()` and `extractAntiTriggers()` already parse
+triggers and anti-triggers out of the existing description text, and they work
+across all 114 skills today with no per-skill authoring.
+
+So: derive routing metadata from frontmatter. Introduce `soma-skill.json` only
+when a concrete routing decision needs a field that frontmatter cannot express.
+Until then it is 114 files of authoring debt for no measured gain.
+
+### DD-E: Measure Soma-owned context before gating it per skill
+
+The original spec's `scope`-style gating of kernel context (profile, memory,
+startup) is genuinely portable, because Soma owns those projections. But size it
+first. Measured at `~/.claude/rules/soma/`:
+
+| File | Lines |
+| --- | --- |
+| SKILLS.md | 201 |
+| CONTEXT.md | 62 |
+| PROFILE.md | 51 |
+| MEMORY.md | 39 |
+| README.md | 26 |
+| PURPOSE.md | 26 |
+| POLICY.md | 13 |
+| MEMORY_LAYOUT.md | 9 |
+| **Total** | **427** |
+
+The whole always-on Soma projection is 427 lines. Per-skill gating of that
+cannot repay a new metadata format across 114 skills. Defer it.
+
+Two cheaper wins are available in the same 427 lines, with no new metadata, no
+new format, and no loader change:
+
+1. **Deduplicate the identity projections.** `PROFILE.md` is 51 lines, and 41 of
+   them are byte-identical to lines already in `CONTEXT.md`. `CONTEXT.md` also
+   embeds the full Purpose block, making `PURPOSE.md` a third copy of mission,
+   goals, principles, and commitments. Three files, one payload.
+2. **Stop projecting `README.md` into loaded context.** All 26 lines describe how
+   the projection directory is generated and warn against hand-editing. That is
+   for a human reading the repo. The model reads it every session and can never
+   act on it.
+
+Together these cut roughly 90 of 427 lines — about 21% of the always-on Soma
+projection — for the cost of a projection change.
+
+### DD-F: Routing accuracy is measured, not asserted
+
+The Pi draft set a success metric of "skill trigger accuracy: 100%". Selection
+across 114 overlapping descriptions is a judgment call, and 100% is neither
+reachable nor measurable as stated.
+
+Any router lands with a labelled query set: queries that should select a skill,
+and queries that should not. Targets are stated separately, because the two
+failure modes cost differently — a miss loses a capability, a false positive
+burns budget.
 
 ### Router Placement
 
-Routing belongs in the core library. Lifecycle hooks may call the router at
-session or prompt boundaries, but the routing contract must not be owned by any
-one adapter.
+Unchanged: routing belongs in the core library. Lifecycle hooks may call the
+router at session or prompt boundaries, but the routing contract must not be
+owned by any one adapter. Adapters materialize route results into
+substrate-specific context. They do not own skill semantics.
 
-Adapters materialize route results into substrate-specific context. They do not
-own skill semantics.
+## Adapter Behavior
 
-### Substrates Without Native File Loading
+| Substrate | Shape |
+| --- | --- |
+| **Claude Code** | Already on-demand. Keep the global assistant file small: kernel, registry, loading protocol. Installed skill directories are an availability mechanism, not permission to paste all skill text into global context. |
+| **Codex** | Kernel skill, registry, and a command or hook path for route-time loading. Codex rules stay a parse-safe marker; natural-language routing lives in the projected Soma skill and memory files. |
+| **Pi.dev** | The eager case, and the one this revision unblocks. Expose loading through the `soma_context` extension tool: `skill_registry`, `skill_route`, `skill_entrypoint`, `skill_reference`. System prompt receives kernel plus registry only. Bodies stay tool-readable. |
+| **Cortex / Myelin** | In daemon mode, route before spawning or addressing a substrate session. The daemon sends an envelope with selected manifests and source paths; the adapter materializes the context shape. Ownership contract in [daemon-mode.md](./daemon-mode.md). |
 
-If a substrate cannot read selected files on demand, the adapter should
-materialize a route projection before the task starts. The projection contains
-the kernel, registry entry subset, and selected entrypoints or references. This
-preserves progressive loading even on static substrates.
+## Context Budget Rules
 
-```text
-tool-capable substrate -> read selected skill files on demand
-static substrate -> pre-materialize a selected route bundle
-daemon substrate -> route centrally, then spawn with selected context
-```
-
-### V0 Token Estimation
-
-V0 should use deterministic rough token estimates rather than provider-specific
-tokenizers:
-
-```ts
-estimatedTokens = Math.ceil(characterCount / 4);
-```
-
-The estimate only needs to support budget pressure and relative comparisons.
-Provider-specific tokenization can be added later without changing the manifest
-or route contracts.
+- Every projection reports estimated token cost for kernel, registry, and
+  selected skills.
+- Every selected skill carries a reason and a budget estimate.
+- Over budget, the router prefers entrypoints over references, and references
+  over examples.
+- If a task needs more skill context than budget allows, the adapter asks the
+  model to use a tool or read path rather than pasting content.
+- V0 token estimation stays deterministic: `Math.ceil(characterCount / 4)`.
+  Provider-specific tokenizers can land later without changing the contract.
 
 ## Migration Plan
 
-1. Add `SomaSkillManifest` and `SkillRoute` types.
-2. Add a registry builder that reads the Soma skill home and workspace overlays.
-3. Extend skill importers to emit `soma-skill.json` alongside imported
-   `SKILL.md` files.
-4. Add a deterministic router with lexical trigger scoring and budget gates.
-5. Change home projections to project registry data instead of every portable
-   skill body by default.
-6. Add adapter-specific loading surfaces for Codex, Pi.dev, Claude Code, and
-   Cortex/Myelin.
-7. Record selected skills and loaded paths in Algorithm/session state.
+Ordered by cost against measured benefit. Steps 1 and 2 are independent of the
+router and ship first.
+
+1. **Deduplicate the kernel projection.** Collapse `PROFILE.md` / `PURPOSE.md`
+   into `CONTEXT.md`, and move `README.md` out of the loaded `rules/` path.
+   ~21% of always-on context. No new types. (DD-E)
+2. **Add `skillsLoading` to `InstallSpec`.** Set every current adapter to
+   `on-demand` except `pi-dev`. (DD-A)
+3. **Generate stubs for eager substrates** from the registry renderer instead of
+   symlinking bodies. (DD-B)
+4. **Instrument.** Report kernel, registry, and body tokens per substrate
+   projection. This is the baseline every later claim is measured against, so it
+   precedes the router rather than following it.
+5. **Add the deterministic router** — lexical trigger scoring, anti-trigger
+   gates, substrate gates, budget gates — with its labelled query set. (DD-F)
+6. **Record** selected skills and loaded paths in Algorithm or session state.
+7. **Revisit `soma-skill.json` and kernel `scope` gating** only if steps 4–6
+   surface a routing decision that frontmatter cannot express. (DD-D, DD-E)
 
 ## Verification Criteria
 
-- A substrate startup projection can be generated without including full bodies
-  for unrelated skills.
+- A substrate startup projection generates without including full bodies for
+  unrelated skills.
+- An eager substrate's loader dir contains generated stubs, and the registry
+  entry resolves to the real body path.
+- Promotion of a skill body on an eager substrate does not modify the system
+  prompt.
 - A task that names or clearly triggers a skill loads that skill entrypoint.
-- A task with no matching skill keeps only the kernel and registry context.
-- Anti-triggers prevent irrelevant but lexically similar skills from loading.
+- A task with no matching skill keeps only kernel and registry context.
+- Anti-triggers prevent lexically similar but irrelevant skills from loading.
 - Loaded skill paths are recorded with provenance.
 - Context budget estimates are visible in route output.
-- Existing PAI-style capability selection still works after selected skills are
-  loaded.
+- The always-on Soma projection contains no line that appears in two projected
+  files.
+- Existing Algorithm capability selection still works after selected skills load.
 - The source of truth remains Soma home; substrate projections remain generated
   snapshots.
 
 ## Deferred Questions
 
-- Which fields should be mandatory in hand-written `soma-skill.json` files
-  versus backfilled by the registry builder?
-- How aggressively should imported triggers be inferred from source text before
-  a human curates them?
-- Which route decisions should become durable learning automatically, and which
-  should remain session-local telemetry?
+- Does any real routing decision need a field that `SKILL.md` frontmatter cannot
+  carry? Until one appears, `soma-skill.json` stays deferred.
+- How aggressively should triggers be inferred from source text before a human
+  curates them?
+- Which route decisions become durable learning automatically, and which stay
+  session-local telemetry?
+- Should eager substrates support demotion, or accept that a long session
+  converges on loading everything?


### PR DESCRIPTION
Revises `docs/progressive-skill-loading.md` against what is actually built and
measured, and folds in a superseded Pi-side draft that proposed a parallel stub
format.

Docs only — no code change. The spec change it decides is tracked as #542.

## Why

The original spec was written pre-implementation. Since then the registry tier
shipped and the router tier did not, so the document no longer described the
system it specifies. Separately, a Pi-side draft was proposing to build a second
stub format alongside the registry Soma already projects.

## What changed

**Implementation status is now grounded.** New table with `file:line` for each
layer:

- Shipped: `renderSkills()`, `renderSkillRegistryEntry()`,
  `SKILL_REGISTRY_LINE_BUDGET = 300`, trigger/anti-trigger extraction,
  `refreshSkillCatalogs()`, `skillsLoaderDir()` across 6 adapters,
  `ensureSymlink()` body projection.
- Not built: `SkillRoute`, `estimatedTokens`, `defaultLoad` — 0 occurrences in
  `src/`.
- Typed but never materialized: `SomaSkillManifest` (`src/types.ts:958`), with
  **0** `soma-skill.json` files on disk.

**Six decisions recorded (DD-A…DD-F).** The load-bearing ones:

| | Decision |
| --- | --- |
| DD-A | Loading strategy is a substrate capability. `skillsLoading: "on-demand" \| "eager"` goes on `InstallSpec` beside `skillsLoaderDir`, not as a `scope` field in 114 portable skill files. |
| DD-B | An eager substrate needs *generated* stubs, because a symlink cannot be a partial view of its target. |
| DD-C | Promotion arrives as a tool result, never a system-prompt edit, or it invalidates the prompt cache. |
| DD-D | Derive routing metadata from frontmatter; defer `soma-skill.json`. |
| DD-E | Measure kernel context before gating it per skill. |
| DD-F | Routing accuracy is measured against a labelled query set, not asserted. |

**Migration plan reordered** so instrumentation lands before the router — it is
the baseline every later claim is measured against.

## Measurements behind the revision

Taken 2026-08-06 against `~/.soma/skills` and `~/.claude/rules/soma/`:

| Quantity | Measured |
| --- | --- |
| Skills in the registry | 114 |
| Total `SKILL.md` lines | 18,644 |
| Estimated tokens (soma V0 estimator) | ~200,000 |
| Mean skill size | 163 lines |
| Rendered registry | 201 lines (budget 300) |
| Whole always-on Soma projection | 427 lines |
| `PROFILE.md` lines byte-identical to `CONTEXT.md` | 41 of 51 |

The superseded draft assumed a 2,000-line mean and a 234,000-line corpus. The
problem is real and roughly 12x smaller than it claimed, which changes what the
fix is worth.

DD-E notes a separable, shippable-today cleanup that falls out of the last two
rows: collapsing the duplicated identity projections and dropping `README.md`
from the loaded `rules/` path removes ~21% of always-on context with no new
types. Not in this PR.

## Verification

- Every `file:line` reference in the document was re-read in the same session it
  was written.
- Every quantity in the tables is a measurement, not an estimate, except the two
  labelled as `bytes / 4` V0 token estimates.

## Related

- #542 — the `skillsLoading` spec change (DD-A, DD-B, DD-C).
- #356 — introduced `skillsLoaderDir` as the adapter-owned loader root; this
  extends the same seam.
- Superseded draft `~/work/pi/subagents/context-aware-skill-loading.md` now
  carries a pointer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
