### PR TITLE
feat(work-graph): declare operator posture, and say so in the receipt

### DIFF
--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -345,6 +345,20 @@ reaction on that specific comment ID — or a principal-authored comment, which
 wins when amending — verified via the API author field. A materially amended
 proposal is re-posted and needs fresh ratification (the replay-rebind lesson).
 
+**Selecting the ratifier.** A 👎 from the root node's author suppresses
+ratification outright. Otherwise any 👍 from someone other than the proposer
+ratifies — the root author's if present, else the first by author order.
+
+A proposer's own 👍 ratifies in exactly one case: soma-home declares
+`singleOperator` (`policy/graph-posture.json`, read by `soma policy posture`).
+That declaration is **per home, not per repo** — the claim is about who sits at
+this machine, and it does not change with the repository a map lives in — and it
+is *declared* rather than derived because the condition is not observable. Two
+derivations were tried and both failed: graph-root authorship is self-conferred
+(`findGraphRoot` returns the node itself when it has no parent), and a single
+reachable credential describes every solo-token contributor. Absent, unparsable,
+or `false` ⇒ the self-👍 ratifies nothing and the close refuses.
+
 #### Deriving `attestation` (#502)
 
 `attestation` is **derived at close time, never configured**. There is no flag,
@@ -372,7 +386,14 @@ ratified this* — not merely that two logins appear. All four must hold:
    authorization question. Root unreachable, or root authored by the acting
    agent identity → `unverified`.
 
-Any conjunct failing yields `unverified`. `attestation` is a **label, not a
+Any conjunct failing yields `unverified` — with one named exception. Where
+soma-home declares one operator, the backend can attest, and the sole operator
+ratified their own proposal on their own map, the receipt reads
+**`self-attested`**. That is a third state, not a softening of the second:
+`unverified` means *we do not know who approved this*, and conflates a reachable
+second credential, a wrong ratifier, and no ratification at all. A declared solo
+close is none of those — it is known exactly, and weaker than `verified` in a way
+the label states. It never becomes `verified` by any route. `attestation` is a **label, not a
 gate**: `close` proceeds either way. Refusing on `unverified` would deadlock
 the bootstrap — the nodes that establish credential separation are themselves
 `approve`-class, so they could never close.

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -57,6 +57,11 @@ import {
   type ProbeRegistry,
 } from "../work-graph-probe-registry";
 import { allProbesPassed, runCommand, runProbes as defaultRunProbes } from "../work-graph-probes";
+import {
+  declaresSingleOperator,
+  loadGraphPosture as defaultLoadGraphPosture,
+  type GraphPosture,
+} from "../work-graph-posture";
 import { SomaCliError } from "./errors";
 import { readOption } from "./parse-utils";
 
@@ -401,6 +406,12 @@ export interface GraphCliDeps {
    * never per invocation.
    */
   loadProbeRegistry: (repo: string) => Promise<ProbeRegistry>;
+  /**
+   * Whether soma-home declares one operator on this machine (§3.2). Per home,
+   * not per repo — the claim is about who sits here, and that does not change
+   * with the repository a map lives in.
+   */
+  loadGraphPosture: () => Promise<GraphPosture>;
   runProbes: (probes: readonly Probe[], registry: ProbeRegistry) => Promise<ProbeResult[]>;
   checkConfinement: () => Promise<ConfinementResult>;
   /**
@@ -472,6 +483,7 @@ function defaultDeps(): GraphCliDeps {
     resolveRepo: resolveGraphRepo,
     resolveIdentity: async () => await gh(["api", "user", "--jq", ".login"]),
     loadProbeRegistry: async (repo) => await defaultLoadProbeRegistry({ repo }),
+    loadGraphPosture: async () => await defaultLoadGraphPosture(),
     runProbes: async (probes, registry) => await defaultRunProbes(probes, { registry }),
     checkConfinement: async () =>
       await defaultCheckConfinement({
@@ -654,6 +666,8 @@ export function selectRatification(
   reactions: readonly Reaction[],
   proposalAuthor: string,
   rootAuthor: string | undefined,
+  /** Set only from the soma-home declaration; never derived (see work-graph-posture.ts). */
+  singleOperatorDeclared = false,
 ): { kind: "reaction"; id: string; author: string } | undefined {
   if (
     rootAuthor !== undefined &&
@@ -662,13 +676,24 @@ export function selectRatification(
     return undefined;
   }
 
-  const approvals = reactions
-    .filter((reaction) => reaction.content === "+1" && reaction.author !== proposalAuthor)
-    .sort((left, right) => (left.author < right.author ? -1 : left.author > right.author ? 1 : 0));
+  const byAuthor = (left: Reaction, right: Reaction): number =>
+    left.author < right.author ? -1 : left.author > right.author ? 1 : 0;
+  const thumbsUp = reactions.filter((reaction) => reaction.content === "+1");
 
-  if (approvals.length === 0) return undefined;
-  const preferred = approvals.find((reaction) => reaction.author === rootAuthor) ?? approvals[0];
-  return { kind: "reaction", id: preferred.id, author: preferred.author };
+  const approvals = thumbsUp.filter((reaction) => reaction.author !== proposalAuthor).sort(byAuthor);
+  if (approvals.length > 0) {
+    const preferred = approvals.find((reaction) => reaction.author === rootAuthor) ?? approvals[0];
+    return { kind: "reaction", id: preferred.id, author: preferred.author };
+  }
+
+  // Last resort, and only on a machine that DECLARED one operator. Absent the
+  // declaration this returns nothing and the close refuses — the correct answer
+  // everywhere else, because a proposer thumbing their own work is not a second
+  // human looking at it.
+  if (!singleOperatorDeclared) return undefined;
+  const selfApproval = thumbsUp.filter((reaction) => reaction.author === proposalAuthor).sort(byAuthor).at(0);
+  if (selfApproval === undefined) return undefined;
+  return { kind: "reaction", id: selfApproval.id, author: selfApproval.author };
 }
 
 async function runClose(
@@ -780,6 +805,11 @@ async function runClose(
 
   const root = await findGraphRoot(ref, async (nodeRef) => await graph.readNode(nodeRef));
 
+  // Read before the ratification path: whether this machine declares one
+  // operator decides whether a self-👍 counts, and it feeds the receipt.
+  const posture = await deps.loadGraphPosture();
+  const singleOperator = declaresSingleOperator(posture);
+
   let proposal: { commentId: string; author: string } | undefined;
   let ratification: { kind: "reaction" | "comment"; id: string; author: string } | undefined;
 
@@ -798,7 +828,7 @@ async function runClose(
     const proposalRef: CommentRef = await graph.readComment({ id: commentId, nodeId: ref.id });
     proposal = { commentId: proposalRef.id, author: proposalRef.author ?? "" };
     const reactions = await graph.readCommentReactions(proposalRef);
-    ratification = selectRatification(reactions, proposal.author, root?.author);
+    ratification = selectRatification(reactions, proposal.author, root?.author, singleOperator);
     if (ratification !== undefined) {
       evidence.push({
         kind: "approved",
@@ -816,6 +846,7 @@ async function runClose(
     ...(proposal === undefined ? {} : { proposal }),
     ...(ratification === undefined ? {} : { ratification }),
     ...(root === undefined ? {} : { root }),
+    singleOperatorDeclared: singleOperator,
   });
 
   const receipt: CloseReceipt = {

--- a/src/cli/policy.ts
+++ b/src/cli/policy.ts
@@ -11,6 +11,7 @@ import type {
   SomaPolicyCheckResult,
 } from "../types";
 import { loadProbeRegistry, type ProbeRegistry } from "../work-graph-probe-registry";
+import { loadGraphPosture, renderStarterPosture, type GraphPosture } from "../work-graph-posture";
 import { resolveGraphRepo } from "./graph";
 import { readOption } from "./parse-utils";
 import { parseSubstrate } from "./substrate";
@@ -58,7 +59,15 @@ export interface ParsedPolicyProbesArgs {
   json: boolean;
 }
 
+export interface ParsedPolicyPostureArgs {
+  command: "policy";
+  action: "posture";
+  options: { homeDir?: string; somaHome?: string };
+  json: boolean;
+}
+
 export type ParsedPolicyArgs =
+  | ParsedPolicyPostureArgs
   | ParsedPolicyCheckArgs
   | ParsedPolicyScanArgs
   | ParsedPolicyPromoteArgs
@@ -76,11 +85,12 @@ const POLICY_INSPECT_USAGE =
   "Usage: soma policy inspect --surface <prompt|tool_call|permission_request|config_change|governance_event> [--prompt <text>|--prompt-env <name>] [--tool-name <name> --tool-input-env <name>] [--permission-request-env <name>] [--config-change-env <name>] [--substrate <id>] [--record <all|deny|none>] [--json]";
 const POLICY_GUARD_USAGE =
   "Usage: soma policy guard --substrate <id> --tool-name <name> --tool-input-env <name> [--cwd <dir>] [--soma-home <dir>] [--home-dir <dir>] [--private-root <dir>]… [--record <all|deny|none>] [--json]";
+const POLICY_POSTURE_USAGE = "Usage: soma policy posture [--soma-home <dir>] [--home-dir <dir>] [--json]";
 const POLICY_PROBES_USAGE =
   "Usage: soma policy probes [--repo <owner/name>] [--soma-home <dir>] [--home-dir <dir>] [--json]";
 
 export const POLICY_COMMAND_HELP: { usage: string; subcommands: Record<ParsedPolicyArgs["action"], string> } = {
-  usage: [POLICY_CHECK_USAGE, POLICY_SCAN_USAGE, POLICY_PROMOTE_USAGE, POLICY_INSPECT_USAGE, POLICY_GUARD_USAGE, POLICY_PROBES_USAGE].join("\n"),
+  usage: [POLICY_CHECK_USAGE, POLICY_SCAN_USAGE, POLICY_PROMOTE_USAGE, POLICY_INSPECT_USAGE, POLICY_GUARD_USAGE, POLICY_PROBES_USAGE, POLICY_POSTURE_USAGE].join("\n"),
   subcommands: {
     check: POLICY_CHECK_USAGE,
     scan: POLICY_SCAN_USAGE,
@@ -88,6 +98,7 @@ export const POLICY_COMMAND_HELP: { usage: string; subcommands: Record<ParsedPol
     inspect: POLICY_INSPECT_USAGE,
     guard: POLICY_GUARD_USAGE,
     probes: POLICY_PROBES_USAGE,
+    posture: POLICY_POSTURE_USAGE,
   },
 };
 
@@ -103,6 +114,7 @@ export function parsePolicyArgs(args: string[]): ParsedPolicyArgs {
   if (action === "inspect") return parsePolicyInspectArgs(command, action, rest);
   if (action === "guard") return parsePolicyGuardArgs(command, action, rest);
   if (action === "probes") return parsePolicyProbesArgs(command, action, rest);
+  if (action === "posture") return parsePolicyPostureArgs(command, action, rest);
   if (action !== "check") throw new Error(POLICY_COMMAND_HELP.usage);
 
   const options: Partial<SomaPolicyCheckOptions> = {};
@@ -313,7 +325,39 @@ function parsePolicyProbesArgs(command: "policy", action: "probes", rest: string
   return { command, action, options, json };
 }
 
+function parsePolicyPostureArgs(command: "policy", action: "posture", rest: string[]): ParsedPolicyPostureArgs {
+  const options: ParsedPolicyPostureArgs["options"] = {};
+  let json = false;
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index];
+    switch (arg) {
+      case "--home-dir":
+        options.homeDir = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--soma-home":
+        options.somaHome = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--json":
+        json = true;
+        break;
+      default:
+        throw new Error(POLICY_POSTURE_USAGE);
+    }
+  }
+  return { command, action, options, json };
+}
+
 export async function runPolicyCli(parsed: ParsedPolicyArgs): Promise<string> {
+  if (parsed.action === "posture") {
+    const posture = await loadGraphPosture({
+      ...(parsed.options.homeDir === undefined ? {} : { homeDir: parsed.options.homeDir }),
+      ...(parsed.options.somaHome === undefined ? {} : { somaHome: parsed.options.somaHome }),
+    });
+    return parsed.json ? `${JSON.stringify(posture, null, 2)}\n` : formatGraphPosture(posture);
+  }
+
   if (parsed.action === "probes") {
     const repo = parsed.options.repo ?? (await resolveGraphRepo());
     const registry = await loadProbeRegistry({
@@ -373,6 +417,39 @@ export async function runPolicyCli(parsed: ParsedPolicyArgs): Promise<string> {
  * fail-closed: the adopter edits the document. A `soma policy probes --allow`
  * would hand the agent a verb for widening the list that constrains it.
  */
+/**
+ * Read-only, like `policy probes` and for the same reason: declaring one operator
+ * loosens a gate, so §4 keeps the write in the adopter's hand. Soma ships no verb
+ * that writes this file.
+ */
+function formatGraphPosture(posture: GraphPosture): string {
+  const header = ["Soma work-graph operator posture", `path: ${posture.path}`];
+  if (posture.status === "absent") {
+    return [
+      ...header,
+      "status: absent — this machine declares nothing",
+      "",
+      "A HITL node cannot close where the proposer is the only account available to",
+      "ratify: `soma graph close` refuses, because a self-👍 is not a second human.",
+      "If one person operates this machine, declare it by creating that file:",
+      "",
+      renderStarterPosture(),
+    ].join("\n");
+  }
+  if (posture.status === "invalid") {
+    return [...header, "status: invalid", `reason: it ${posture.reason}`, "", "Nothing is declared until the document parses."].join("\n");
+  }
+  return [
+    ...header,
+    `status: declared`,
+    `singleOperator: ${posture.singleOperator}`,
+    "",
+    posture.singleOperator
+      ? "The sole operator's own 👍 ratifies their proposal, and such a close is recorded\n`self-attested` — never `verified`."
+      : "Declared multi-operator: a self-👍 ratifies nothing, exactly as if undeclared.",
+  ].join("\n");
+}
+
 function formatProbeRegistry(registry: ProbeRegistry): string {
   const header = [
     "Soma probe registry (DD-16 Amendment A)",

--- a/src/index.ts
+++ b/src/index.ts
@@ -741,6 +741,18 @@ export {
   type ProbeRunnerOptions,
 } from "./work-graph-probes";
 export {
+  declaresSingleOperator,
+  graphPosturePath,
+  loadGraphPosture,
+  parseGraphPosture,
+  renderStarterPosture,
+  GRAPH_POSTURE_RELATIVE_PATH,
+  GRAPH_POSTURE_VERSION,
+  type GraphPosture,
+  type GraphPostureHomeOptions,
+  type LoadGraphPostureOptions,
+} from "./work-graph-posture";
+export {
   authorizeProbe,
   isProbeRefusal,
   loadProbeRegistry,

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -93,12 +93,26 @@ body text. A 👎 from the graph root's author suppresses ratification outright.
 
 Two things the runtime does **not** do here, both of which are yours to hold:
 
-- **Any non-proposer's 👍 closes the node.** The ratifier is preferred to be the
-  graph root's author, but the fallback is the first other reaction — so on a
-  public tracker a stranger's thumb produces `approved` evidence and the node
-  closes. Only the `attestation` label records that it was not the right human.
-  Read root-author approval as the *thing you must obtain*, not as a condition
-  the verb enforces.
+- **Any non-proposer's 👍 closes the node.** The graph root's author is
+  preferred, but the fallback is the first other reaction — so on a public
+  tracker a stranger's thumb produces `approved` evidence and the node closes.
+  Only the `attestation` label records that it was not the right human. Read
+  root-author approval as the *thing you must obtain*, not as a condition the
+  verb enforces.
+- **A self-👍 ratifies only where soma-home declares one operator.** On a
+  machine run by one person the agent posts the proposal under their login, so
+  no second account exists to ratify and the close would refuse forever. That is
+  a gate, and §3.2 says attestation is a label — so the adopter declares the
+  posture once, in `~/.soma/policy/graph-posture.json`, and their own 👍 then
+  ratifies. Read it with `soma policy posture`; soma ships no verb that writes
+  it, because declaring it loosens a gate (§4).
+
+  Such a close is recorded **`self-attested`** — never `verified`, and
+  deliberately not `unverified` either: `unverified` means *we do not know who
+  approved this*, and here it is known exactly. Undeclared, the refusal stands
+  and **there is no hand override**: closing a node past a refusal by other means
+  produces a receipt that claims a ratification the graph never saw.
+
 - **Ratification binds to a comment id, not to its text.** Nothing hashes the
   proposal body, so a proposal that is ratified and *then edited* still closes
   on that 👍. "A materially amended proposal is re-posted and needs fresh

--- a/src/work-graph-attestation.ts
+++ b/src/work-graph-attestation.ts
@@ -135,6 +135,12 @@ export interface AttestationInputs {
   proposal?: { commentId: string; author: string };
   ratification?: { kind: "reaction" | "comment"; id: string; author: string };
   root?: { nodeId: string; author: string };
+  /**
+   * True when soma-home declares this machine has one operator
+   * (`policy/graph-posture.json`). Never derived — see `work-graph-posture.ts`
+   * for why the two attempts to derive it failed.
+   */
+  singleOperatorDeclared?: boolean;
 }
 
 export interface AttestationOutcome {
@@ -207,7 +213,38 @@ export function deriveAttestation(inputs: AttestationInputs): AttestationOutcome
     ...(reasons.length === 0 ? {} : { reasons }),
   };
 
-  return { attestation: reasons.length === 0 ? "verified" : "unverified", facts };
+  if (reasons.length === 0) return { attestation: "verified", facts };
+
+  // A declared single-operator machine, where that operator ratified their own
+  // proposal on their own map, is a *known* state rather than an unknown one.
+  // `unverified` conflates "a second credential was reachable", "the wrong
+  // person approved" and "nobody approved at all" — none of which happened here,
+  // and reporting them alike loses the distinction a reader needs.
+  //
+  // Stated as what must hold, not as "which reasons are absent". Two of the
+  // reasons above are *expected* on such a machine and must not disqualify it:
+  // the operator's own keyring is reachable (there is no second human whose
+  // credential conjunct 2 could be protecting against), and the operator authored
+  // the map (there is nobody else to have authored it). Keying on their absence
+  // would mean this label never fires on the deployment it exists for.
+  //
+  // What must still hold is everything that would signal a *different* failure:
+  // a backend that can attest at all, a proposal that exists, a ratification
+  // that exists, and a ratifier who is both the proposer and the map's owner —
+  // i.e. the declared operator, not a passer-by.
+  //
+  // This never becomes `verified` by any route. One person approving their own
+  // work is a weaker claim than §3.2's four conjuncts, and the label says so.
+  const selfAttested =
+    inputs.singleOperatorDeclared === true &&
+    inputs.backendCapability === "verifiable" &&
+    proposer !== undefined &&
+    ratifier !== undefined &&
+    proposer === ratifier &&
+    ratifier === root?.author;
+  if (selfAttested) return { attestation: "self-attested", facts };
+
+  return { attestation: "unverified", facts };
 }
 
 /**

--- a/src/work-graph-posture.ts
+++ b/src/work-graph-posture.ts
@@ -1,0 +1,129 @@
+/**
+ * Operator posture — the one fact about a deployment the runtime cannot derive.
+ *
+ * §3.2's HITL close wants a 👍 from someone other than the proposal's author. On
+ * a deployment operated by one person there is nobody else: `soma graph close
+ * --propose` posts under their login, so every reaction available to them is a
+ * self-ratification, and the node cannot close at all. That turns `attestation`
+ * into a *gate* when §3.2 is explicit that it is a label.
+ *
+ * Two attempts to derive the condition failed review, and their failures are the
+ * reason this file exists:
+ *
+ *   - **graph-root authorship** — self-conferred. `findGraphRoot` returns the
+ *     node itself when it has no parent, so anyone who opens a parentless node
+ *     holds the role.
+ *   - **one reachable credential** — universal. Any contributor running a single
+ *     personal token looks identical to a solo adopter, so it cannot tell one
+ *     operator from one of fifty.
+ *
+ * "Am I the only person working here?" is a property of the *deployment*. Nothing
+ * observable distinguishes it, so it is declared — by the adopter, once, in
+ * soma-home, in the probe registry's shape and for the same reasons (§1 clause 5:
+ * enforcement out of the agent's reach; §4: loosening is identity-bound and
+ * fail-closed).
+ *
+ * **Per home, not per repo.** The claim is about who sits at this machine, and
+ * that does not change because a map lives in a different repository. The probe
+ * registry is repo-scoped because a *command* is only safe in context; an
+ * operator is not a property of context.
+ *
+ * Absent, unparsable, or unreadable ⇒ **not declared**. A close on such a machine
+ * refuses exactly as it does today.
+ */
+
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+/** Where the declaration sits inside soma-home. */
+export const GRAPH_POSTURE_RELATIVE_PATH = "policy/graph-posture.json";
+
+/** Only version this binary understands; an unknown one refuses rather than guessing. */
+export const GRAPH_POSTURE_VERSION = 1;
+
+export type GraphPosture =
+  | { status: "declared"; path: string; singleOperator: boolean }
+  | { status: "absent"; path: string }
+  | { status: "invalid"; path: string; reason: string };
+
+export interface GraphPostureHomeOptions {
+  homeDir?: string;
+  somaHome?: string;
+}
+
+export interface LoadGraphPostureOptions extends GraphPostureHomeOptions {
+  /** Resolves to `undefined` when the document does not exist. Injected for tests. */
+  readFile?: (path: string) => Promise<string | undefined>;
+}
+
+export function graphPosturePath(options: GraphPostureHomeOptions = {}): string {
+  const home = resolve(options.homeDir ?? homedir());
+  const somaHome = resolve(options.somaHome ?? join(home, ".soma"));
+  return join(somaHome, GRAPH_POSTURE_RELATIVE_PATH);
+}
+
+async function defaultReadFile(path: string): Promise<string | undefined> {
+  const file = Bun.file(path);
+  return (await file.exists()) ? await file.text() : undefined;
+}
+
+/** Never throws: an unreadable declaration is `invalid`, which does not declare anything. */
+export async function loadGraphPosture(options: LoadGraphPostureOptions = {}): Promise<GraphPosture> {
+  const path = graphPosturePath(options);
+  const read = options.readFile ?? defaultReadFile;
+
+  let raw: string | undefined;
+  try {
+    raw = await read(path);
+  } catch (error) {
+    return { status: "invalid", path, reason: `could not be read: ${describe(error)}` };
+  }
+
+  if (raw === undefined) return { status: "absent", path };
+  return parseGraphPosture(path, raw);
+}
+
+export function parseGraphPosture(path: string, raw: string): GraphPosture {
+  const invalid = (reason: string): GraphPosture => ({ status: "invalid", path, reason });
+
+  let document: unknown;
+  try {
+    document = JSON.parse(raw) as unknown;
+  } catch (error) {
+    return invalid(`is not valid JSON: ${describe(error)}`);
+  }
+  if (typeof document !== "object" || document === null || Array.isArray(document)) {
+    return invalid("must be a JSON object");
+  }
+
+  const record = document as Record<string, unknown>;
+  const unknownKeys = Object.keys(record).filter((key) => key !== "version" && key !== "singleOperator");
+  if (unknownKeys.length > 0) {
+    return invalid(`has unknown key(s): ${unknownKeys.join(", ")} — expected only "version" and "singleOperator"`);
+  }
+  if (record.version !== GRAPH_POSTURE_VERSION) {
+    return invalid(`must declare "version": ${GRAPH_POSTURE_VERSION} (found ${JSON.stringify(record.version)})`);
+  }
+  if (typeof record.singleOperator !== "boolean") {
+    return invalid(`"singleOperator" must be true or false`);
+  }
+
+  return { status: "declared", path, singleOperator: record.singleOperator };
+}
+
+/**
+ * Does this machine declare one operator? Everything except an explicit `true`
+ * answers no — absence is not a claim.
+ */
+export function declaresSingleOperator(posture: GraphPosture | undefined): boolean {
+  return posture?.status === "declared" && posture.singleOperator;
+}
+
+/** The document to write, for a refusal message that is copy-pasteable. */
+export function renderStarterPosture(): string {
+  return [`{`, `  "version": ${GRAPH_POSTURE_VERSION},`, `  "singleOperator": true`, `}`].join("\n");
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -204,7 +204,24 @@ export interface CloseEvidence {
   pointer?: string;
 }
 
-export type AttestationState = "verified" | "unverified";
+/**
+ * What a receipt claims about who approved it.
+ *
+ * - `verified` — all four conjuncts of §3.2 held: a human the agent cannot
+ *   impersonate ratified this.
+ * - `self-attested` — the machine **declares one operator**
+ *   (`policy/graph-posture.json`) and the proposer ratified their own proposal.
+ *   Distinct from `unverified` on purpose: `unverified` means *we do not know
+ *   who approved this*, and here we know exactly — the sole operator did, and
+ *   said so in advance. It is a weaker claim than `verified` and a more precise
+ *   one than `unverified`, and it never becomes `verified` by any route.
+ * - `unverified` — anything else: a reachable second credential, the wrong
+ *   ratifier, no ratification at all.
+ *
+ * None of the three is a gate. `close` proceeds on all of them (§3.2), and the
+ * receipt carries the facts either way.
+ */
+export type AttestationState = "verified" | "self-attested" | "unverified";
 
 /** Backend capability (§2.5): CAN receipts be independently attested here? Necessary, never sufficient. */
 export type AttestationCapability = "verifiable" | "unverified";

--- a/test/work-graph-posture.test.ts
+++ b/test/work-graph-posture.test.ts
@@ -1,0 +1,179 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parsePolicyArgs, runPolicyCli } from "../src/cli/policy";
+import { selectRatification } from "../src/cli/graph";
+import {
+  declaresSingleOperator,
+  deriveAttestation,
+  graphPosturePath,
+  loadGraphPosture,
+  parseGraphPosture,
+  GRAPH_POSTURE_RELATIVE_PATH,
+  type GraphPosture,
+  type Reaction,
+} from "../src/index";
+
+const PATH = "/home/.soma/policy/graph-posture.json";
+
+function declared(singleOperator: boolean): GraphPosture {
+  return { status: "declared", path: PATH, singleOperator };
+}
+
+// ---------------------------------------------------------------------------
+// The declaration
+// ---------------------------------------------------------------------------
+
+test("only an explicit singleOperator:true declares anything", () => {
+  expect(declaresSingleOperator(declared(true))).toBe(true);
+  expect(declaresSingleOperator(declared(false))).toBe(false);
+  // Absence is not a claim, and neither is a broken document.
+  expect(declaresSingleOperator({ status: "absent", path: PATH })).toBe(false);
+  expect(declaresSingleOperator({ status: "invalid", path: PATH, reason: "is not valid JSON" })).toBe(false);
+  expect(declaresSingleOperator(undefined)).toBe(false);
+});
+
+test("a malformed declaration declares nothing and says why", () => {
+  const reason = (raw: string): string => {
+    const parsed = parseGraphPosture(PATH, raw);
+    if (parsed.status !== "invalid") throw new Error(`expected invalid, got ${parsed.status}`);
+    return parsed.reason;
+  };
+  expect(reason("{")).toContain("not valid JSON");
+  expect(reason("[]")).toContain("must be a JSON object");
+  expect(reason(JSON.stringify({ version: 2, singleOperator: true }))).toContain(`"version": 1`);
+  expect(reason(JSON.stringify({ version: 1 }))).toContain("must be true or false");
+  expect(reason(JSON.stringify({ version: 1, singleOperator: "yes" }))).toContain("must be true or false");
+  expect(reason(JSON.stringify({ version: 1, singleOperator: true, allow: 1 }))).toContain("unknown key");
+});
+
+test("the declaration is per home, and read from soma-home", async () => {
+  const home = await mkdtemp(join(tmpdir(), "soma-posture-"));
+  await mkdir(join(home, ".soma", "policy"), { recursive: true });
+  const path = join(home, ".soma", GRAPH_POSTURE_RELATIVE_PATH);
+  expect(graphPosturePath({ homeDir: home })).toBe(path);
+
+  // No repo argument anywhere: posture is about who sits at this machine.
+  expect((await loadGraphPosture({ homeDir: home })).status).toBe("absent");
+
+  await writeFile(path, JSON.stringify({ version: 1, singleOperator: true }), "utf8");
+  expect(declaresSingleOperator(await loadGraphPosture({ homeDir: home }))).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// What it unlocks, and what it does not
+// ---------------------------------------------------------------------------
+
+test("a self-👍 ratifies only where one operator is declared", () => {
+  const own: Reaction[] = [{ id: "r1", content: "+1", author: "jcfischer" }];
+
+  // Undeclared: refused, which is why #499 needed a hand override.
+  expect(selectRatification(own, "jcfischer", "jcfischer")).toBeUndefined();
+  expect(selectRatification(own, "jcfischer", "jcfischer", false)).toBeUndefined();
+  // Declared: it ratifies.
+  expect(selectRatification(own, "jcfischer", "jcfischer", true)?.author).toBe("jcfischer");
+});
+
+test("the declaration never outranks a second credential", () => {
+  // Even on a declared single-operator machine, a real other account wins — the
+  // fallback is last resort, not preference.
+  const both: Reaction[] = [
+    { id: "r1", content: "+1", author: "jcfischer" },
+    { id: "r2", content: "+1", author: "someone-else" },
+  ];
+  expect(selectRatification(both, "jcfischer", "jcfischer", true)?.author).toBe("someone-else");
+
+  // And a 👎 from the root author still suppresses everything.
+  expect(
+    selectRatification(
+      [
+        { id: "r1", content: "+1", author: "jcfischer" },
+        { id: "r2", content: "-1", author: "jcfischer" },
+      ],
+      "jcfischer",
+      "jcfischer",
+      true,
+    ),
+  ).toBeUndefined();
+});
+
+// ---------------------------------------------------------------------------
+// The receipt
+// ---------------------------------------------------------------------------
+
+const SOLO = {
+  backendCapability: "verifiable" as const,
+  actingIdentity: "jcfischer",
+  confinement: {
+    checked: true,
+    // The operator's own keyring — expected here, and not a second human.
+    reachableIdentities: ["jcfischer", "keychain:gh:github.com"],
+    at: "2026-08-06T00:00:00.000Z",
+    probes: [],
+  },
+  proposal: { commentId: "c1", author: "jcfischer" },
+  ratification: { kind: "reaction" as const, id: "r1", author: "jcfischer" },
+  root: { nodeId: "495", author: "jcfischer" },
+};
+
+test("a declared solo close is self-attested, not unverified", () => {
+  const declaredOutcome = deriveAttestation({ ...SOLO, singleOperatorDeclared: true });
+  expect(declaredOutcome.attestation).toBe("self-attested");
+  // The facts are unchanged — the label is more precise, nothing is hidden.
+  expect(declaredOutcome.facts.reasons?.join(" ")).toContain("share an author");
+
+  // Identical inputs without the declaration stay unverified.
+  expect(deriveAttestation({ ...SOLO, singleOperatorDeclared: false }).attestation).toBe("unverified");
+});
+
+test("self-attested never covers a different failure", () => {
+  const withDeclaration = (overrides: Partial<typeof SOLO>): string =>
+    deriveAttestation({ ...SOLO, ...overrides, singleOperatorDeclared: true }).attestation;
+
+  // A stranger ratified — that is the wrong person, not a solo close.
+  expect(withDeclaration({ ratification: { kind: "reaction", id: "r1", author: "passer-by" } })).toBe("unverified");
+  // Ratifier is not the map's owner.
+  expect(withDeclaration({ root: { nodeId: "495", author: "someone-else" } })).toBe("unverified");
+  // Backend cannot attest at all.
+  expect(
+    deriveAttestation({ ...SOLO, backendCapability: "unverified", singleOperatorDeclared: true }).attestation,
+  ).toBe("unverified");
+});
+
+test("self-attested is never reachable from a clean four-conjunct close", () => {
+  // A genuinely verified close stays verified — the declaration cannot downgrade
+  // it, and nothing upgrades a solo close to verified.
+  const clean = deriveAttestation({
+    backendCapability: "verifiable",
+    actingIdentity: "ivy-agent",
+    confinement: { checked: true, reachableIdentities: ["ivy-agent"], at: SOLO.confinement.at, probes: [] },
+    proposal: { commentId: "c1", author: "ivy-agent" },
+    ratification: { kind: "reaction", id: "r1", author: "jcfischer" },
+    root: { nodeId: "495", author: "jcfischer" },
+    singleOperatorDeclared: true,
+  });
+  expect(clean.attestation).toBe("verified");
+});
+
+// ---------------------------------------------------------------------------
+// The read verb
+// ---------------------------------------------------------------------------
+
+test("`soma policy posture` shows the declaration and how to make one", async () => {
+  const home = await mkdtemp(join(tmpdir(), "soma-posture-cli-"));
+  await mkdir(join(home, ".soma", "policy"), { recursive: true });
+  const path = join(home, ".soma", GRAPH_POSTURE_RELATIVE_PATH);
+  const show = async (): Promise<string> =>
+    await runPolicyCli(parsePolicyArgs(["policy", "posture", "--home-dir", home]));
+
+  const absent = await show();
+  expect(absent).toContain("status: absent");
+  expect(absent).toContain(`"singleOperator": true`);
+
+  await writeFile(path, JSON.stringify({ version: 1, singleOperator: true }), "utf8");
+  const listed = await show();
+  expect(listed).toContain("status: declared");
+  expect(listed).toContain("self-attested");
+  expect(listed).toContain("never `verified`");
+});


### PR DESCRIPTION
Closes the deadlock that forced a hand override on
[#499](https://github.com/the-metafactory/soma/issues/499).

On a machine run by one person, `soma graph close --propose` posts under their
login, so no second account exists to ratify and a HITL node can **never** close.
That makes `attestation` a *gate* when §3.2 is explicit that it is a label.

## Declared, because it is not derivable

Two derivations were tried on
[#532](https://github.com/the-metafactory/soma/pull/532) and both failed review:

- **graph-root authorship** — self-conferred. `findGraphRoot` returns the node
  itself when it has no parent, so anyone who opens a parentless node holds the
  role.
- **one reachable credential** — universal. Any contributor running a single
  personal token looks identical to a solo adopter.

"Am I the only person working here" is a property of the *deployment*, and
nothing observable distinguishes it. So the adopter states it once:
`~/.soma/policy/graph-posture.json`, in the probe registry's shape and for the
same reasons — soma-home keeps it out of the agent's reach (§1 clause 5), and
`soma policy posture` only **reads** it, because declaring it loosens a gate
(§4). Absent, unparsable, or `false` ⇒ declares nothing, and the close refuses
exactly as before.

**Per home, not per repo.** The claim is about who sits at this machine and does
not change with the repository a map lives in. (The probe registry is repo-scoped
because a *command* is only safe in context; an operator is not.)

## A third receipt state, not a softened second

A declared solo close records **`self-attested`**.

`unverified` means *we do not know who approved this* — it conflates a reachable
second credential, a wrong ratifier, and no ratification at all. A declared solo
close is none of those: it is known exactly. `self-attested` is weaker than
`verified` and more precise than `unverified`, and is reachable from neither —
nothing upgrades it, and a clean four-conjunct close is unaffected.

### The rule is stated positively, and that matters

The first draft keyed on "the shared-author reason is the *only* one left". That
would have meant the label **never fires on the deployment it exists for**,
because two of the reasons are *expected* there: the operator's own keyring is
reachable, and the operator authored the map. So it is stated as what must hold —
a backend that can attest, a proposal, a ratification, and a ratifier who is both
the proposer and the map's owner.

## The hand override is gone from doctrine

#499 was closed past a refusal by hand, with the refusal recorded on the node.
`closing.md` now says plainly that closing past a refusal produces a receipt
claiming a ratification the graph never saw. That override should be the last.

## Verification

- `bun test` — 2226 pass / 0 fail. `bunx tsc --noEmit` — clean. eslint clean on
  the changed files.
- Nine unit tests: parsing and per-home resolution; only an explicit `true`
  declares anything; a self-👍 ratifies **only** when declared; it never outranks
  a real second credential; the root author's 👎 still suppresses everything;
  `self-attested` covers no other failure mode (stranger ratifier, wrong root
  author, non-attesting backend all stay `unverified`); and a genuinely verified
  close stays `verified`.
- **Walked live on this deployment** against scratch root #546 → node #547:
  declared the posture, `--propose`, self-👍, close. Result:
  `attestation: self-attested`. The same sequence refused on #499 before this
  branch. Both scratch issues closed.

## Known limits, carried forward

- The declaration is only as trustworthy as soma-home is unreachable from the
  agent — #511's invariant, the same base the probe registry rests on.
- `self-attested` asserts that one declared operator approved their own work. It
  is not evidence a second human looked, and does not pretend to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
