### PR TITLE
fix(work-graph): a HITL node closes on the session's say-so

### DIFF
--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -364,10 +364,12 @@ What remains:
   reactions through the receipt and binding superseded proposals, which is
   machinery this primitive does not want.
 
-- **The receipt is unchanged.** Proposal, ratifier, root authorship, confinement
-  and `attestation` are all still recorded, so a reader can tell a ratified close
-  from an unratified one. What changed is that an unratified close is *possible*,
-  not that it is *approved*.
+- **The receipt still distinguishes the two cases.** A ratified close records the
+  proposal and ratifier; a bare one records their *absence*, in
+  `attestationFacts.reasons` ("no proposal comment recorded", "no ratification
+  found"), alongside root authorship, confinement and `attestation`. Either way a
+  reader can tell which happened. What changed is that an unratified close is
+  *possible*, not that it is *approved*.
 
 **On multi-party deployments.** The gate is removed for *every* deployment, not
 only single-operator ones, and that is deliberate rather than incidental: "how
@@ -385,10 +387,10 @@ phase-2 auditor. Justifying the removal by appealing to an auditor that does not
 exist would be the same move this change is undoing: a gate defended by a
 consumer nobody can point at.
 
-Naming this precisely matters: an earlier draft claimed the receipt carried
-"proposal, ratifier, root authorship and confinement", which is what a *ratified*
-close records. On the default path the first two are absent, and their absence —
-not their presence — is the audit signal.
+Their absence — not their presence — is the audit signal on the default path.
+Stated twice in this section on purpose: an earlier revision asserted the
+ratified-close field list as if it applied to every close, and a correction that
+is appended rather than *applied* leaves a document saying both things.
 
 That is a real trade. A team wanting closes gated on a second party's approval
 does not get that from this primitive today; they get an auditable record that

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -370,10 +370,17 @@ What remains:
 only single-operator ones, and that is deliberate rather than incidental: "how
 many people are watching" is not derivable — two attempts to derive it failed
 review (#532) — so a rule conditioned on it would be a rule conditioned on a
-guess. What a multi-party deployment gets instead is the receipt: proposal,
-ratifier, root authorship and confinement are all still recorded, so an
-unratified close is *visible* rather than *prevented*, and a reviewer or the
-phase-2 auditor can act on it after the fact.
+guess. What a multi-party deployment gets instead is a receipt that **records the
+absence**. On a bare close no proposal is read, so there is no ratifier to name —
+and `attestationFacts.reasons` says exactly that: *"no proposal comment
+recorded"*, *"no ratification found"*, alongside the root authorship and
+confinement facts. An unratified close is therefore *visible* rather than
+*prevented*, and a reviewer or the phase-2 auditor can act on it after the fact.
+
+Naming this precisely matters: an earlier draft claimed the receipt carried
+"proposal, ratifier, root authorship and confinement", which is what a *ratified*
+close records. On the default path the first two are absent, and their absence —
+not their presence — is the audit signal.
 
 That is a real trade. A team wanting closes gated on a second party's approval
 does not get that from this primitive today; they get an auditable record that

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -338,12 +338,29 @@ quality ratifies when a downstream HITL node consumes the artifact (#485).
 
 ### 3.2 HITL (`propose` / `approve`)
 
-`approved` evidence is an attestation verifiable as coming from **a credential
-the agent does not hold**. Concretely (#486): the executing bot posts the
-resolution as a **proposal comment**; the receipt is the principal's 👍
-reaction on that specific comment ID — or a principal-authored comment, which
-wins when amending — verified via the API author field. A materially amended
-proposal is re-posted and needs fresh ratification (the replay-rebind lesson).
+A HITL node **closes on the closing session's say-so**. The human in the loop is
+the person running the session; requiring a second party to ratify named no
+consumer where one person walks the map, and the rule did not verify those closes
+— it prevented them (#499 is the worked example: finished, merged, evidenced work
+that the gate refused, protecting nobody).
+
+What remains:
+
+- **The proposal flow is available, not required.** `close --propose` posts a
+  proposal and `close --proposal-comment <id>` reads its reactions, for when a
+  second opinion is genuinely wanted. Ratification is admissible evidence; its
+  absence is not a defect.
+- **An explicit refusal still stops the close.** A 👎 from the graph root's
+  author refuses it. Dropping "must be approved" is not "may close over being
+  refused".
+- **The receipt is unchanged.** Proposal, ratifier, root authorship, confinement
+  and `attestation` are all still recorded, so a reader can tell a ratified close
+  from an unratified one. What changed is that an unratified close is *possible*,
+  not that it is *approved*.
+
+Where a receipt genuinely must be attestable — a headless phase-2 tick, a
+multi-party deployment — the machinery below still derives it. It is a label on
+the record, never a gate on the close.
 
 #### Deriving `attestation` (#502)
 

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -350,17 +350,20 @@ What remains:
   proposal and `close --proposal-comment <id>` reads its reactions, for when a
   second opinion is genuinely wanted. Ratification is admissible evidence; its
   absence is not a defect.
-- **An explicit refusal stops the close — within the proposal flow.** When
-  `--proposal-comment` is supplied, a 👎 from the graph root's author on that
-  comment refuses the close, naming who refused. Dropping "must be approved" is
-  not "may close over being refused".
+- **An explicit refusal is surfaced, not enforced.** When `--proposal-comment` is
+  supplied, a 👎 from the graph root's author on that comment refuses *that*
+  close, naming who refused.
 
-  Scope, stated precisely because the earlier draft overstated it: a refusal
-  lives *on a proposal*, so a bare `close` reads no reactions and cannot be
-  refused by one. Someone who was 👎'd and then closes without the flag is not
-  stopped by the runtime. That is a real limit, and the honest one for a
-  primitive whose gate is the human running it — the alternative is hunting prior
-  comments on every close, which is the machinery this change exists to remove.
+  It is a speed bump and the spec says so rather than overselling it. Three
+  limits, all deliberate: it lives in the CLI, not in `assertClosable`, so a
+  non-CLI consumer of the seam gets none of it; a bare `close` reads no reactions
+  and cannot be refused by one; and nothing binds a new proposal to a refused
+  one, so `--propose` on an unchanged body mints a fresh comment that closes
+  cleanly. It catches the honest case — told no, closed anyway by reflex — and
+  stops nobody who means to proceed. Making it real would mean threading
+  reactions through the receipt and binding superseded proposals, which is
+  machinery this primitive does not want.
+
 - **The receipt is unchanged.** Proposal, ratifier, root authorship, confinement
   and `attestation` are all still recorded, so a reader can tell a ratified close
   from an unratified one. What changed is that an unratified close is *possible*,
@@ -375,7 +378,12 @@ absence**. On a bare close no proposal is read, so there is no ratifier to name 
 and `attestationFacts.reasons` says exactly that: *"no proposal comment
 recorded"*, *"no ratification found"*, alongside the root authorship and
 confinement facts. An unratified close is therefore *visible* rather than
-*prevented*, and a reviewer or the phase-2 auditor can act on it after the fact.
+*prevented*, and a person reading the node can act on it after the fact.
+
+The consumer named here is a **human reading the record**, deliberately — not the
+phase-2 auditor. Justifying the removal by appealing to an auditor that does not
+exist would be the same move this change is undoing: a gate defended by a
+consumer nobody can point at.
 
 Naming this precisely matters: an earlier draft claimed the receipt carried
 "proposal, ratifier, root authorship and confinement", which is what a *ratified*

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -354,12 +354,14 @@ What remains:
   supplied, a 👎 from the graph root's author on that comment refuses *that*
   close, naming who refused.
 
-  It is a speed bump and the spec says so rather than overselling it. Three
-  limits, all deliberate: it lives in the CLI, not in `assertClosable`, so a
-  non-CLI consumer of the seam gets none of it; a bare `close` reads no reactions
-  and cannot be refused by one; and nothing binds a new proposal to a refused
-  one, so `--propose` on an unchanged body mints a fresh comment that closes
-  cleanly. It catches the honest case — told no, closed anyway by reflex — and
+  It is a speed bump and the spec says so rather than overselling it. Its limits,
+  all deliberate: it lives in the CLI, not in `assertClosable`, so a non-CLI
+  consumer of the seam gets none of it; a bare `close` reads no reactions and
+  cannot be refused by one; nothing binds a new proposal to a refused one, so
+  `--propose` on an unchanged body mints a fresh comment that closes cleanly; and
+  the predicate needs the root author to resolve, so where the root walk fails
+  nothing refuses — **silently**. Not a closed list: it is a reminder, and
+  anything that treats it as a control will be disappointed somewhere else too. It catches the honest case — told no, closed anyway by reflex — and
   stops nobody who means to proceed. Making it real would mean threading
   reactions through the receipt and binding superseded proposals, which is
   machinery this primitive does not want.

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -350,17 +350,35 @@ What remains:
   proposal and `close --proposal-comment <id>` reads its reactions, for when a
   second opinion is genuinely wanted. Ratification is admissible evidence; its
   absence is not a defect.
-- **An explicit refusal still stops the close.** A 👎 from the graph root's
-  author refuses it. Dropping "must be approved" is not "may close over being
-  refused".
+- **An explicit refusal stops the close — within the proposal flow.** When
+  `--proposal-comment` is supplied, a 👎 from the graph root's author on that
+  comment refuses the close, naming who refused. Dropping "must be approved" is
+  not "may close over being refused".
+
+  Scope, stated precisely because the earlier draft overstated it: a refusal
+  lives *on a proposal*, so a bare `close` reads no reactions and cannot be
+  refused by one. Someone who was 👎'd and then closes without the flag is not
+  stopped by the runtime. That is a real limit, and the honest one for a
+  primitive whose gate is the human running it — the alternative is hunting prior
+  comments on every close, which is the machinery this change exists to remove.
 - **The receipt is unchanged.** Proposal, ratifier, root authorship, confinement
   and `attestation` are all still recorded, so a reader can tell a ratified close
   from an unratified one. What changed is that an unratified close is *possible*,
   not that it is *approved*.
 
-Where a receipt genuinely must be attestable — a headless phase-2 tick, a
-multi-party deployment — the machinery below still derives it. It is a label on
-the record, never a gate on the close.
+**On multi-party deployments.** The gate is removed for *every* deployment, not
+only single-operator ones, and that is deliberate rather than incidental: "how
+many people are watching" is not derivable — two attempts to derive it failed
+review (#532) — so a rule conditioned on it would be a rule conditioned on a
+guess. What a multi-party deployment gets instead is the receipt: proposal,
+ratifier, root authorship and confinement are all still recorded, so an
+unratified close is *visible* rather than *prevented*, and a reviewer or the
+phase-2 auditor can act on it after the fact.
+
+That is a real trade. A team wanting closes gated on a second party's approval
+does not get that from this primitive today; they get an auditable record that
+one did not happen. If such a consumer appears, the gate returns as an opt-in
+naming them — which is what §1 clause 3 asks of any gate.
 
 #### Deriving `attestation` (#502)
 

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -373,9 +373,14 @@ What remains:
 
 **On multi-party deployments.** The gate is removed for *every* deployment, not
 only single-operator ones, and that is deliberate rather than incidental: "how
-many people are watching" is not derivable — two attempts to derive it failed
-review (#532) — so a rule conditioned on it would be a rule conditioned on a
-guess. What a multi-party deployment gets instead is a receipt that **records the
+many people are watching" is not derivable, so a rule conditioned on it would be
+a rule conditioned on a guess. Two attempts were made and both failed review;
+neither survives in a merged commit, so they are cited where they actually live:
+**graph-root authorship** (self-conferred — `findGraphRoot` returns the node
+itself when it has no parent) and **one reachable credential** (universal — true
+of any solo-token contributor), both on branch `feat/self-ratification` at
+`b8acfe4`, with the reasoning in the closing comment of
+[#548](https://github.com/the-metafactory/soma/pull/548). What a multi-party deployment gets instead is a receipt that **records the
 absence**. On a bare close no proposal is read, so there is no ratifier to name —
 and `attestationFacts.reasons` says exactly that: *"no proposal comment
 recorded"*, *"no ratification found"*, alongside the root authorship and

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -350,59 +350,24 @@ What remains:
   proposal and `close --proposal-comment <id>` reads its reactions, for when a
   second opinion is genuinely wanted. Ratification is admissible evidence; its
   absence is not a defect.
-- **An explicit refusal is surfaced, not enforced.** When `--proposal-comment` is
-  supplied, a 👎 from the graph root's author on that comment refuses *that*
-  close, naming who refused.
+- **An explicit refusal is surfaced, not enforced.** With `--proposal-comment`, a
+  👎 from the graph root's author on that comment refuses that close, naming who
+  refused.
 
-  It is a speed bump and the spec says so rather than overselling it. Its limits,
-  all deliberate: it lives in the CLI, not in `assertClosable`, so a non-CLI
-  consumer of the seam gets none of it; a bare `close` reads no reactions and
-  cannot be refused by one; nothing binds a new proposal to a refused one, so
-  `--propose` on an unchanged body mints a fresh comment that closes cleanly; and
-  the predicate needs the root author to resolve, so where the root walk fails
-  nothing refuses — **silently**. Not a closed list: it is a reminder, and
-  anything that treats it as a control will be disappointed somewhere else too. It catches the honest case — told no, closed anyway by reflex — and
-  stops nobody who means to proceed. Making it real would mean threading
-  reactions through the receipt and binding superseded proposals, which is
-  machinery this primitive does not want.
+  A reminder, not a control, and its limits are not a closed list: it lives in
+  the CLI rather than `assertClosable`, so a non-CLI consumer of the seam gets
+  none of it; a bare `close` reads no reactions; nothing binds a new proposal to
+  a refused one; and it needs the root author to resolve, so where the root walk
+  fails nothing refuses, silently.
 
-- **The receipt still distinguishes the two cases.** A ratified close records the
-  proposal and ratifier; a bare one records their *absence*, in
+- **The receipt distinguishes the two cases.** A ratified close records the
+  proposal and ratifier; a bare one records their absence in
   `attestationFacts.reasons` ("no proposal comment recorded", "no ratification
-  found"), alongside root authorship, confinement and `attestation`. Either way a
-  reader can tell which happened. What changed is that an unratified close is
-  *possible*, not that it is *approved*.
+  found"), alongside root authorship, confinement and `attestation`.
 
-**On multi-party deployments.** The gate is removed for *every* deployment, not
-only single-operator ones, and that is deliberate rather than incidental: "how
-many people are watching" is not derivable, so a rule conditioned on it would be
-a rule conditioned on a guess. Two attempts were made and both failed review;
-neither survives in a merged commit, so they are cited where they actually live:
-**graph-root authorship** (self-conferred — `findGraphRoot` returns the node
-itself when it has no parent) and **one reachable credential** (universal — true
-of any solo-token contributor), both on branch `feat/self-ratification` at
-`b8acfe4`, with the reasoning in the closing comment of
-[#548](https://github.com/the-metafactory/soma/pull/548). What a multi-party deployment gets instead is a receipt that **records the
-absence**. On a bare close no proposal is read, so there is no ratifier to name —
-and `attestationFacts.reasons` says exactly that: *"no proposal comment
-recorded"*, *"no ratification found"*, alongside the root authorship and
-confinement facts. An unratified close is therefore *visible* rather than
-*prevented*, and a person reading the node can act on it after the fact.
-
-The consumer named here is a **human reading the record**, deliberately — not the
-phase-2 auditor. Justifying the removal by appealing to an auditor that does not
-exist would be the same move this change is undoing: a gate defended by a
-consumer nobody can point at.
-
-Their absence — not their presence — is the audit signal on the default path.
-Stated twice in this section on purpose: an earlier revision asserted the
-ratified-close field list as if it applied to every close, and a correction that
-is appended rather than *applied* leaves a document saying both things.
-
-That is a real trade. A team wanting closes gated on a second party's approval
-does not get that from this primitive today; they get an auditable record that
-one did not happen. If such a consumer appears, the gate returns as an opt-in
-naming them — which is what §1 clause 3 asks of any gate.
+The removal is unconditional — it is not scoped to single-operator deployments.
+A deployment wanting closes gated on a second party's approval does not get that
+from this primitive; it gets a record of whether one happened.
 
 #### Deriving `attestation` (#502)
 

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -786,8 +786,15 @@ async function runClose(
   // A proposal comment is optional now: a HITL node closes on the session's
   // say-so (§3.2). When one IS supplied, its reactions still carry weight —
   // a ratification as admissible evidence, and a root-author 👎 as a refusal.
+  //
+  // Keyed on the comment id alone, deliberately. `assertClosable` no longer
+  // distinguishes `propose` from `approve` from anything else non-`auto`, so a
+  // CLI-side autonomy test would be the only place in the system still drawing a
+  // line the core does not — a distinction living in one consumer is worse than
+  // no distinction at all. Supplying a proposal on an `auto` node is unusual
+  // rather than wrong: its reactions are read on the same terms.
   const commentId = parsed.options.proposalComment;
-  if (state.node.autonomy !== "auto" && commentId !== undefined) {
+  if (commentId !== undefined) {
     const proposalRef: CommentRef = await graph.readComment({ id: commentId, nodeId: ref.id });
     proposal = { commentId: proposalRef.id, author: proposalRef.author ?? "" };
     const reactions = await graph.readCommentReactions(proposalRef);

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -792,10 +792,15 @@ async function runClose(
     proposal = { commentId: proposalRef.id, author: proposalRef.author ?? "" };
     const reactions = await graph.readCommentReactions(proposalRef);
 
-    // Ratification is no longer required, but an explicit refusal is still
-    // honoured. Dropping "you must be approved" must not become "you may ignore
-    // being refused" — a 👎 from the map's owner is the one reaction that
-    // unambiguously means *no*, and it is cheap to respect.
+    // Ratification is no longer required; an explicit refusal is still surfaced.
+    //
+    // Deliberately a speed bump, not a control, and it lives here in the CLI
+    // rather than in `assertClosable` because it is not a contract rule. It
+    // catches the honest case — you were told no and closed anyway by reflex —
+    // and it stops nobody who means to proceed: a fresh `--propose` mints a new
+    // comment with no reactions, and passing that id closes cleanly. Binding
+    // proposals to superseded ones, or threading reactions through the receipt
+    // so the core could enforce it, is machinery this primitive does not want.
     const vetoed = reactions.some(
       (reaction) => reaction.content === "-1" && root?.author !== undefined && reaction.author === root.author,
     );
@@ -803,7 +808,7 @@ async function runClose(
       throw new SomaCliError(
         [
           `Node ${ref.id} was refused: ${root?.author ?? "the graph root's author"} left a 👎 on proposal comment ${proposal.commentId}.`,
-          `Address it and post a new proposal rather than closing over the refusal.`,
+          `Nothing here can stop you closing anyway — this is a reminder, not a gate.`,
         ].join("\n"),
         1,
       );

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -783,18 +783,11 @@ async function runClose(
   let proposal: { commentId: string; author: string } | undefined;
   let ratification: { kind: "reaction" | "comment"; id: string; author: string } | undefined;
 
-  if (state.node.autonomy !== "auto") {
-    const commentId = parsed.options.proposalComment;
-    if (commentId === undefined) {
-      throw new SomaCliError(
-        [
-          `Node ${ref.id} is ${state.node.autonomy}-class: it closes on a ratified proposal, not on a self-report (§3.2).`,
-          `Post one with:  soma graph close ${ref.id} --propose --body-file <path>`,
-          `Then close with: soma graph close ${ref.id} --proposal-comment <id>`,
-        ].join("\n"),
-        1,
-      );
-    }
+  // A proposal comment is optional now: a HITL node closes on the session's
+  // say-so (§3.2). When one IS supplied, its reactions still carry weight —
+  // a ratification as admissible evidence, and a root-author 👎 as a refusal.
+  const commentId = parsed.options.proposalComment;
+  if (state.node.autonomy !== "auto" && commentId !== undefined) {
     const proposalRef: CommentRef = await graph.readComment({ id: commentId, nodeId: ref.id });
     proposal = { commentId: proposalRef.id, author: proposalRef.author ?? "" };
     const reactions = await graph.readCommentReactions(proposalRef);

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -798,6 +798,24 @@ async function runClose(
     const proposalRef: CommentRef = await graph.readComment({ id: commentId, nodeId: ref.id });
     proposal = { commentId: proposalRef.id, author: proposalRef.author ?? "" };
     const reactions = await graph.readCommentReactions(proposalRef);
+
+    // Ratification is no longer required, but an explicit refusal is still
+    // honoured. Dropping "you must be approved" must not become "you may ignore
+    // being refused" — a 👎 from the map's owner is the one reaction that
+    // unambiguously means *no*, and it is cheap to respect.
+    const vetoed = reactions.some(
+      (reaction) => reaction.content === "-1" && root?.author !== undefined && reaction.author === root.author,
+    );
+    if (vetoed) {
+      throw new SomaCliError(
+        [
+          `Node ${ref.id} was refused: ${root?.author ?? "the graph root's author"} left a 👎 on proposal comment ${proposal.commentId}.`,
+          `Address it and post a new proposal rather than closing over the refusal.`,
+        ].join("\n"),
+        1,
+      );
+    }
+
     ratification = selectRatification(reactions, proposal.author, root?.author);
     if (ratification !== undefined) {
       evidence.push({

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -101,10 +101,14 @@ It is a tool, not a toll. An earlier version required that 👍 before any
 the map: there was nobody else to ratify, so the rule did not verify closes, it
 prevented them.
 
-**One reaction still stops a close.** A 👎 from the graph root's author is an
-explicit refusal, and the close refuses with it — dropping "you must be approved"
-does not mean "you may close over being refused". Address it and post a new
-proposal.
+**One reaction still stops a close — if you use the flow.** A 👎 from the graph
+root's author on a proposal refuses the close when you pass
+`--proposal-comment`: dropping "you must be approved" does not mean "you may
+close over being refused". Address it and post a new proposal.
+
+A bare `close` reads no reactions, so it cannot be refused by one. That is not a
+loophole to use — if someone 👎'd your proposal, closing around it produces a
+receipt that records no refusal ever happened.
 
 Two things worth knowing when you do use the proposal flow:
 

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -102,7 +102,9 @@ the map: there was nobody else to ratify, so the rule did not verify closes, it
 prevented them.
 
 **A 👎 is surfaced, not enforced.** If you pass `--proposal-comment` and the
-graph root's author left a 👎 on it, the close refuses and names them. Treat it
+graph root's author left a 👎 on it, the close refuses and names them — provided
+the root author could be resolved at all. Where the root walk fails, no reaction
+matches and nothing refuses, silently. Treat it
 as a reminder: it catches you closing by reflex after being told no, and it stops
 nothing else. A bare `close` reads no reactions at all, and re-proposing produces
 a fresh comment that closes cleanly — nothing binds it to the refused one.

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -101,14 +101,15 @@ It is a tool, not a toll. An earlier version required that 👍 before any
 the map: there was nobody else to ratify, so the rule did not verify closes, it
 prevented them.
 
-**One reaction still stops a close — if you use the flow.** A 👎 from the graph
-root's author on a proposal refuses the close when you pass
-`--proposal-comment`: dropping "you must be approved" does not mean "you may
-close over being refused". Address it and post a new proposal.
+**A 👎 is surfaced, not enforced.** If you pass `--proposal-comment` and the
+graph root's author left a 👎 on it, the close refuses and names them. Treat it
+as a reminder: it catches you closing by reflex after being told no, and it stops
+nothing else. A bare `close` reads no reactions at all, and re-proposing produces
+a fresh comment that closes cleanly — nothing binds it to the refused one.
 
-A bare `close` reads no reactions, so it cannot be refused by one. That is not a
-loophole to use — if someone 👎'd your proposal, closing around it produces a
-receipt that records no refusal ever happened.
+So the honest reading is that being refused is *recorded*, not *prevented*. If
+you close around a 👎, the receipt shows a close with no refusal in it, and the
+person who said no finds out by reading the node.
 
 Two things worth knowing when you do use the proposal flow:
 

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -103,11 +103,12 @@ prevented them.
 
 **A 👎 is surfaced, not enforced.** If you pass `--proposal-comment` and the
 graph root's author left a 👎 on it, the close refuses and names them — provided
-the root author could be resolved at all. Where the root walk fails, no reaction
-matches and nothing refuses, silently. Treat it
-as a reminder: it catches you closing by reflex after being told no, and it stops
-nothing else. A bare `close` reads no reactions at all, and re-proposing produces
-a fresh comment that closes cleanly — nothing binds it to the refused one.
+the root author resolves at all; where the root walk fails, nothing refuses and
+nobody is named.
+
+Treat it as a reminder: it catches you closing by reflex after being told no, and
+stops nothing else. A bare `close` reads no reactions, and re-proposing produces a
+fresh comment that closes cleanly — nothing binds it to the refused one.
 
 So the honest reading is that being refused is *recorded*, not *prevented*. If
 you close around a 👎, the receipt shows a close with no refusal in it, and the

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -80,30 +80,40 @@ downstream HITL node consumes the artifact.
 
 ## HITL close (`propose` / `approve`)
 
-Two phases, one verb:
+A HITL node **closes when you close it**. There is no ratification requirement:
+you are the human in the loop, and you are present.
+
+```bash
+soma graph close <id>
+```
+
+The two-phase flow remains for when a second opinion is actually wanted — a
+decision you want someone else to sign off, or a record of who agreed:
 
 ```bash
 soma graph close <id> --propose --body-file <path>   # posts the proposal, closes nothing
-#  … the principal reacts 👍 on that comment …
+#  … someone reacts 👍 on that comment …
 soma graph close <id> --proposal-comment <comment-id>
 ```
 
-The receipt is the ratification, read from the API's author field — never from
-body text. A 👎 from the graph root's author suppresses ratification outright.
+It is a tool, not a toll. An earlier version required that 👍 before any
+`approve`-class node could close, which named no consumer when one person walks
+the map: there was nobody else to ratify, so the rule did not verify closes, it
+prevented them.
 
-Two things the runtime does **not** do here, both of which are yours to hold:
+**One reaction still stops a close.** A 👎 from the graph root's author is an
+explicit refusal, and the close refuses with it — dropping "you must be approved"
+does not mean "you may close over being refused". Address it and post a new
+proposal.
 
-- **Any non-proposer's 👍 closes the node.** The ratifier is preferred to be the
-  graph root's author, but the fallback is the first other reaction — so on a
-  public tracker a stranger's thumb produces `approved` evidence and the node
-  closes. Only the `attestation` label records that it was not the right human.
-  Read root-author approval as the *thing you must obtain*, not as a condition
-  the verb enforces.
+Two things worth knowing when you do use the proposal flow:
+
+- **Any non-proposer's 👍 is taken as the ratification**, root author preferred.
+  On a public tracker that includes a stranger's. Only `attestation` records
+  that it was not the right human.
 - **Ratification binds to a comment id, not to its text.** Nothing hashes the
-  proposal body, so a proposal that is ratified and *then edited* still closes
-  on that 👍. "A materially amended proposal is re-posted and needs fresh
-  ratification" is doctrine you follow, not a property the runtime checks: if
-  the resolution changes materially, post a new comment and get a new 👍.
+  proposal body, so a proposal that is ratified and *then edited* still closes on
+  that 👍. If the resolution changes materially, post a new comment.
 
 ## Attestation
 

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -633,34 +633,11 @@ export function assertClosable(node: WorkGraphNode, receipt: CloseReceipt): void
   // Evidence is required of `auto` nodes only, and there it costs nothing: the
   // `probed` entry is derived from probes that already ran and passed.
   //
-  // HITL nodes close on the session's say-so. Requiring a ratified proposal here
-  // was the original rule, and it was wrong for what this primitive is: a way to
-  // structure work whose route is unclear, walked by a human who is *present*.
-  // A gate naming no consumer is ceremony (§1 clause 3), and where one person
-  // walks a map the ratification gate named none — nobody else could ratify, so
-  // it did not verify the close, it only prevented it. #499 is the worked
-  // example: finished, merged, evidenced work that the gate refused, protecting
-  // no one.
-  //
-  // The removal is UNCONDITIONAL, not scoped to single-operator deployments, and
-  // that is the deliberate part. "How many people are watching" is not derivable
-  // — two attempts to derive it failed review — so conditioning the gate on it
-  // would condition it on a guess. A multi-party deployment instead gets a
-  // receipt that RECORDS THE ABSENCE: on a bare close no proposal is read, so
-  // there is no ratifier to name, and `attestationFacts.reasons` says exactly
-  // that — "no proposal comment recorded", "no ratification found". Their
-  // absence is the audit signal, not their presence. An unratified close is
-  // therefore visible rather than prevented, and a person reading the node can
-  // act on it. If a consumer appears who needs it gated, it returns as an
-  // opt-in naming them.
-  //
-  // The receipt still records everything it recorded before — proposal, ratifier,
-  // root authorship, confinement, `attestation`. Nothing is hidden; a reader can
-  // still tell a ratified close from an unratified one. What changed is that an
-  // unratified close is now *possible*, not *approved*.
-  //
-  // The two-phase `--propose` flow remains for when a second opinion is wanted.
-  // It is a tool, no longer a toll.
+  // HITL nodes close on the session's say-so, unconditionally — not scoped to
+  // single-operator deployments. The receipt still distinguishes the two cases:
+  // a bare close records the absence of a proposal and ratification in
+  // `attestationFacts.reasons`, so an unratified close is visible rather than
+  // prevented. See §3.2.
   if (node.autonomy !== "auto") return;
 
   const admissible = agentExternalEvidenceKinds(node.autonomy);

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -630,6 +630,27 @@ export function assertClosable(node: WorkGraphNode, receipt: CloseReceipt): void
     }
   }
 
+  // Evidence is required of `auto` nodes only, and there it costs nothing: the
+  // `probed` entry is derived from probes that already ran and passed.
+  //
+  // HITL nodes close on the session's say-so. Requiring a ratified proposal here
+  // was the original rule, and it was wrong for what this primitive is: a way to
+  // structure work whose route is unclear, walked by a human who is *present*.
+  // A gate naming no consumer is ceremony (§1 clause 3), and on a
+  // single-operator deployment the ratification gate named none — there was
+  // nobody else to ratify, so it did not verify the close, it only prevented it.
+  // #499 is the worked example: a finished, merged, evidenced piece of work that
+  // the gate refused, and the refusal protected no one.
+  //
+  // The receipt still records everything it recorded before — proposal, ratifier,
+  // root authorship, confinement, `attestation`. Nothing is hidden; a reader can
+  // still tell a ratified close from an unratified one. What changed is that an
+  // unratified close is now *possible*, not *approved*.
+  //
+  // The two-phase `--propose` flow remains for when a second opinion is wanted.
+  // It is a tool, no longer a toll.
+  if (node.autonomy !== "auto") return;
+
   const admissible = agentExternalEvidenceKinds(node.autonomy);
   const external = receipt.evidence.filter(
     (entry) => admissible.includes(entry.kind) && entry.summary.trim().length > 0 && (entry.pointer ?? "").trim().length > 0,

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -645,10 +645,14 @@ export function assertClosable(node: WorkGraphNode, receipt: CloseReceipt): void
   // The removal is UNCONDITIONAL, not scoped to single-operator deployments, and
   // that is the deliberate part. "How many people are watching" is not derivable
   // — two attempts to derive it failed review — so conditioning the gate on it
-  // would condition it on a guess. A multi-party deployment instead gets the
-  // receipt: proposal, ratifier, root authorship and confinement are all still
-  // recorded, so an unratified close is visible rather than prevented. If a
-  // consumer appears who needs it gated, it returns as an opt-in naming them.
+  // would condition it on a guess. A multi-party deployment instead gets a
+  // receipt that RECORDS THE ABSENCE: on a bare close no proposal is read, so
+  // there is no ratifier to name, and `attestationFacts.reasons` says exactly
+  // that — "no proposal comment recorded", "no ratification found". Their
+  // absence is the audit signal, not their presence. An unratified close is
+  // therefore visible rather than prevented, and a person reading the node can
+  // act on it. If a consumer appears who needs it gated, it returns as an
+  // opt-in naming them.
   //
   // The receipt still records everything it recorded before — proposal, ratifier,
   // root authorship, confinement, `attestation`. Nothing is hidden; a reader can

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -636,11 +636,19 @@ export function assertClosable(node: WorkGraphNode, receipt: CloseReceipt): void
   // HITL nodes close on the session's say-so. Requiring a ratified proposal here
   // was the original rule, and it was wrong for what this primitive is: a way to
   // structure work whose route is unclear, walked by a human who is *present*.
-  // A gate naming no consumer is ceremony (§1 clause 3), and on a
-  // single-operator deployment the ratification gate named none — there was
-  // nobody else to ratify, so it did not verify the close, it only prevented it.
-  // #499 is the worked example: a finished, merged, evidenced piece of work that
-  // the gate refused, and the refusal protected no one.
+  // A gate naming no consumer is ceremony (§1 clause 3), and where one person
+  // walks a map the ratification gate named none — nobody else could ratify, so
+  // it did not verify the close, it only prevented it. #499 is the worked
+  // example: finished, merged, evidenced work that the gate refused, protecting
+  // no one.
+  //
+  // The removal is UNCONDITIONAL, not scoped to single-operator deployments, and
+  // that is the deliberate part. "How many people are watching" is not derivable
+  // — two attempts to derive it failed review — so conditioning the gate on it
+  // would condition it on a guess. A multi-party deployment instead gets the
+  // receipt: proposal, ratifier, root authorship and confinement are all still
+  // recorded, so an unratified close is visible rather than prevented. If a
+  // consumer appears who needs it gated, it returns as an opt-in naming them.
   //
   // The receipt still records everything it recorded before — proposal, ratifier,
   // root authorship, confinement, `attestation`. Nothing is hidden; a reader can

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -390,9 +390,15 @@ test("a bare `close` on a HITL node works — no proposal, no ratification", asy
 
   expect(store.closed).toHaveLength(1);
   expect(output).toContain("Closed node 530");
-  // No proposal was read, so the receipt names none — and says so honestly.
-  expect(store.closed[0].receipt.attestation).toBe("unverified");
-  expect(store.closed[0].receipt.attestationFacts?.proposal).toBeUndefined();
+  // No proposal was read, so the receipt names none — and RECORDS THE ABSENCE.
+  // That record is the whole after-the-fact audit story for a multi-party
+  // deployment, so it is pinned here rather than left to prose.
+  const receipt = store.closed[0].receipt;
+  expect(receipt.attestation).toBe("unverified");
+  expect(receipt.attestationFacts?.proposal).toBeUndefined();
+  const reasons = receipt.attestationFacts?.reasons?.join(" ") ?? "";
+  expect(reasons).toContain("no proposal comment recorded");
+  expect(reasons).toContain("no ratification found");
 });
 
 test("--propose posts the proposal comment and closes nothing", async () => {

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -486,6 +486,26 @@ test("a 👎 from the root author blocks ratification, so the close is refused",
   expect(store.closed).toHaveLength(0);
 });
 
+test("the veto is one close deep — a fresh proposal carries no refusal", async () => {
+  // Pins a documented LIMIT rather than a guarantee. The docs call the veto a
+  // speed bump and say re-proposing closes cleanly; that claim is executable
+  // here so it cannot quietly become false in either direction.
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
+
+  await run(["graph", "close", "530", "--propose", "--body", "x", "--repo", REPO], store);
+  store.reactions.set("c1", [{ id: "r1", content: "-1", author: "jcfischer" }]);
+  expect(await failure(["graph", "close", "530", "--proposal-comment", "c1", "--repo", REPO], store)).toContain(
+    "was refused",
+  );
+
+  // Re-propose: a new comment id, no reactions on it, and the close proceeds.
+  await run(["graph", "close", "530", "--propose", "--body", "x", "--repo", REPO], store);
+  await run(["graph", "close", "530", "--proposal-comment", "c2", "--repo", REPO], store);
+  expect(store.closed).toHaveLength(1);
+});
+
 test("without a 👎, a HITL node closes on the session's say-so", async () => {
   const store = new FakeStore()
     .seed("495", { node: autoNode("495"), author: "jcfischer" })

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -378,15 +378,21 @@ test("an auto receipt is honestly unverified — no human ratified it", async ()
   expect(receipt.attestationFacts?.reasons?.join(" ")).toContain("no ratification found");
 });
 
-test("a HITL node refuses to close on a self-report and says how to propose", async () => {
+test("a bare `close` on a HITL node works — no proposal, no ratification", async () => {
+  // The exact command closing.md documents, and the exact shape #499 was stuck
+  // in. Relaxing `assertClosable` alone did not fix it: this CLI branch still
+  // refused, which is the layer #499 actually hit.
   const store = new FakeStore()
     .seed("495", { node: autoNode("495"), author: "jcfischer" })
     .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
 
-  const message = await failure(["graph", "close", "530", "--repo", REPO], store);
-  expect(message).toContain("closes on a ratified proposal");
-  expect(message).toContain("--propose");
-  expect(store.closed).toHaveLength(0);
+  const output = await run(["graph", "close", "530", "--repo", REPO], store);
+
+  expect(store.closed).toHaveLength(1);
+  expect(output).toContain("Closed node 530");
+  // No proposal was read, so the receipt names none — and says so honestly.
+  expect(store.closed[0].receipt.attestation).toBe("unverified");
+  expect(store.closed[0].receipt.attestationFacts?.proposal).toBeUndefined();
 });
 
 test("--propose posts the proposal comment and closes nothing", async () => {

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -486,6 +486,33 @@ test("a 👎 from the root author blocks ratification, so the close is refused",
   expect(store.closed).toHaveLength(0);
 });
 
+test("a proposal comment on an auto node is read on the same terms", async () => {
+  // Keying the block on the comment id alone (rather than on autonomy) made
+  // `--proposal-comment` take effect for `auto` nodes too. That is a real
+  // behaviour change and it is pinned here rather than asserted in a comment:
+  // a root-author 👎 refuses an auto close, because an explicit human "no"
+  // should not depend on the node's class.
+  const store = autoGraph();
+  await run(["graph", "close", "520", "--propose", "--body", "x", "--repo", REPO], store);
+  store.reactions.set("c1", [{ id: "r1", content: "-1", author: "jcfischer" }]);
+
+  expect(await failure(["graph", "close", "520", "--proposal-comment", "c1", "--repo", REPO], store)).toContain(
+    "was refused",
+  );
+  expect(store.closed).toHaveLength(0);
+
+  // And with a ratification instead, the auto close proceeds — its probe-derived
+  // evidence is what gates it, with the approval recorded alongside.
+  const ratified = autoGraph();
+  await run(["graph", "close", "520", "--propose", "--body", "x", "--repo", REPO], ratified);
+  ratified.reactions.set("c1", [{ id: "r1", content: "+1", author: "jcfischer" }]);
+  await run(["graph", "close", "520", "--proposal-comment", "c1", "--repo", REPO], ratified);
+
+  expect(ratified.closed).toHaveLength(1);
+  expect(ratified.closed[0].receipt.evidence.some((e) => e.kind === "approved")).toBe(true);
+  expect(ratified.closed[0].receipt.evidence.some((e) => e.kind === "probed")).toBe(true);
+});
+
 test("the veto is one close deep — a fresh proposal carries no refusal", async () => {
   // Pins a documented LIMIT rather than a guarantee. The docs call the veto a
   // speed bump and say re-proposing closes cleanly; that claim is executable

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -464,9 +464,28 @@ test("a 👎 from the root author blocks ratification, so the close is refused",
     { id: "r2", content: "+1", author: "mellanon" },
   ]);
 
+  // Ratification is no longer required, but an explicit refusal is still
+  // honoured: dropping "you must be approved" must not become "you may ignore
+  // being refused". A 👎 from the map's owner is the one reaction that
+  // unambiguously means no — even with a second account's 👍 present.
   const message = await failure(["graph", "close", "530", "--proposal-comment", "c1", "--repo", REPO], store);
-  expect(message).toContain("needs at least one approved evidence");
+  expect(message).toContain("was refused");
+  expect(message).toContain("jcfischer");
   expect(store.closed).toHaveLength(0);
+});
+
+test("without a 👎, a HITL node closes on the session's say-so", async () => {
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
+
+  await run(["graph", "close", "530", "--propose", "--body", "x", "--repo", REPO], store);
+  // No reactions at all — the #499 case, which used to be unclosable.
+  await run(["graph", "close", "530", "--proposal-comment", "c1", "--repo", REPO], store);
+
+  expect(store.closed).toHaveLength(1);
+  // The receipt still records what it always did; the label is unchanged.
+  expect(store.closed[0].receipt.attestation).toBe("unverified");
 });
 
 test("selectRatification prefers the root author and ignores the proposer's own reaction", () => {

--- a/test/work-graph.test.ts
+++ b/test/work-graph.test.ts
@@ -199,17 +199,27 @@ test("an auto node closes on probed evidence with a pointer and every probe pass
   expect(() => { assertClosable(AUTO_NODE, receipt()); }).not.toThrow();
 });
 
-test("a HITL node needs approved evidence — probed evidence is not a ratification", () => {
+test("a HITL node closes without a ratification — the human walking it is present", () => {
+  // The original rule required `approved` evidence here. It named no consumer on
+  // a single-operator deployment: there was nobody else to ratify, so it did not
+  // verify the close, it only prevented it (#499). Dropped deliberately.
   const hitl: WorkGraphNode = { id: "511", title: "credential confinement", autonomy: "approve", checkpointId: "cp-511" };
-  const probedOnly = receipt({ checkpointId: "cp-511", probeResults: [] });
-  expect(codeOf(() => { assertClosable(hitl, probedOnly); })).toBe("close-refused");
+  expect(() => { assertClosable(hitl, receipt({ checkpointId: "cp-511", probeResults: [] })); }).not.toThrow();
 
+  // A ratification is still admissible when one exists — it is a tool, not a toll.
   const ratified = receipt({
     checkpointId: "cp-511",
     probeResults: [],
     evidence: [{ kind: "approved", summary: "👍 by jcfischer", pointer: "https://example.test/#issuecomment-1" }],
   });
   expect(() => { assertClosable(hitl, ratified); }).not.toThrow();
+});
+
+test("an auto node still needs evidence its probes actually produced", () => {
+  // The gate that survives: machine-checkable, free (the entry is derived from
+  // probes that ran), and it names a real consumer — nobody watched this close.
+  const bare = receipt({ evidence: [] });
+  expect(codeOf(() => { assertClosable(AUTO_NODE, bare); })).toBe("close-refused");
 });
 
 test("an unverified attestation still closes — gating on it would deadlock the bootstrap", () => {


### PR DESCRIPTION
`assertClosable` no longer requires ratified evidence on `approve`/`propose`
nodes. A HITL node closes when the closing session closes it.

## Why

The rule named no consumer (§1 clause 3). Where one person walks a map there is
nobody else to ratify, so requiring a second party's 👍 did not verify those
closes — it prevented them.
[#499](https://github.com/the-metafactory/soma/issues/499) is the worked example:
finished, merged, evidenced work that the gate refused, closed by hand with the
refusal recorded on the node.

## What changes

- **HITL nodes close on the session's say-so.** `--proposal-comment` is optional.
- **`--proposal-comment` is keyed on the flag, not on autonomy class**, so it
  takes effect on `auto` nodes too: a root-author 👎 refuses an `auto` close, and
  a ratification is recorded alongside the probe evidence that gates it.
- **`auto` nodes are unchanged** — they still need evidence, derived from probes
  that ran and passed.
- **Probes and the registry gate are untouched.**
- **A 👎 from the root author is surfaced** when `--proposal-comment` is
  supplied: a reminder, not a control. Its limits are documented and not a closed
  list — CLI-level only, absent on a bare close, not bound across proposals, and
  silent when the root author does not resolve.

## Verification

- `bun test` — 2221 pass / 0 fail. `bunx tsc --noEmit` — clean. CI green.
- Tests assert the new rule rather than around it: a HITL node closes with no
  ratification; an `auto` node without derived evidence still refuses; a
  root-author 👎 refuses even with a second account's 👍 present; the #499 shape
  (proposal posted, no reactions) now closes, recording `attestation: unverified`
  with "no proposal comment recorded" / "no ratification found"; the veto's
  one-close depth is pinned; and the `auto` + `--proposal-comment` behaviour is
  pinned in both directions.

## Review history

Seven sage rounds. The code came through unchanged; every round after the first
found defects in the **prose** — a citation pointing at a document arguing the
opposite of its claim, a "three limits, all deliberate" list that was neither, an
assertion about `auto` nodes standing in for a test. The final commit removes the
rationale rather than defending it further: −85 lines of argument, +28 of
description, no behaviour or test changed.

One objection is recorded rather than resolved: sage holds that #496's existing
`ivy-agent` authorship separation means the deadlock could be dissolved by
finishing the credential split (#510's remaining half) instead of removing the
gate. That is a real alternative and remains open — it is a decision about what
this primitive is for, not a defect in this diff.

## Supersedes

[#548](https://github.com/the-metafactory/soma/pull/548) (operator posture),
closed unmerged; `feat/graph-posture` and `feat/self-ratification` kept for
reference. Map nodes #500 and #511 were ruled out of scope for losing their
consumer with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
