### PR TITLE
feat(skills): skillsLoading on the adapter spec; stubs for eager loaders (#542)

### DIFF
--- a/src/adapters/anthropic-cowork/install.ts
+++ b/src/adapters/anthropic-cowork/install.ts
@@ -93,6 +93,7 @@ export const anthropicCoworkInstallSpec: SubstrateInstallSpec<"anthropic-cowork"
   defaultHome: ANTHROPIC_COWORK_DEFAULT_HOME,
   homeFiles: ANTHROPIC_COWORK_HOME_FILE_PATHS,
   skillsLoaderDir: skillsLoaderUnder(ANTHROPIC_COWORK_SKILLS_ROOT_PATH),
+  skillsLoading: "on-demand",
   vsaSkillProjection: {
     destinationDir: (substrateHome) => resolve(substrateHome, "skills", "VSA"),
   },

--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -58,6 +58,7 @@ export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
       : []),
   ],
   skillsLoaderDir: skillsLoaderUnder(),
+  skillsLoading: "on-demand",
   vsaSkillProjection: {
     destinationDir: vsaSkillUnder(),
     // soma#329: before reprojecting VSA, prune a sibling renamed-away "ISA" skill

--- a/src/adapters/codex/install.ts
+++ b/src/adapters/codex/install.ts
@@ -68,6 +68,7 @@ export const codexInstallSpec: SubstrateInstallSpec<"codex"> = {
   // Owned (Soma-exclusive) dir — see ownedSubtrees JSDoc. (hooks/ + skills/ are shared.)
   ownedSubtrees: ["memories/soma"],
   skillsLoaderDir: skillsLoaderUnder(),
+  skillsLoading: "on-demand",
   vsaSkillProjection: {
     destinationDir: vsaSkillUnder(),
     // soma#329: before reprojecting VSA, prune a sibling renamed-away "ISA" skill

--- a/src/adapters/cursor/install.ts
+++ b/src/adapters/cursor/install.ts
@@ -57,6 +57,7 @@ export const cursorInstallSpec: SubstrateInstallSpec<"cursor"> = {
   // obsoleteHomeFiles for TELOS.md/ACTIVE_ISA.md under .cursor/rules/soma.
   ownedSubtrees: [".cursor/rules/soma"],
   skillsLoaderDir: skillsLoaderUnder(".cursor/rules/soma"),
+  skillsLoading: "on-demand",
   vsaSkillProjection: {
     destinationDir: vsaSkillUnder(".cursor/rules/soma"),
   },

--- a/src/adapters/grok/install.ts
+++ b/src/adapters/grok/install.ts
@@ -185,6 +185,7 @@ export const grokInstallSpec: SubstrateInstallSpec<"grok"> = {
   // runtime and does not block.
   validator: validateGrokInstallRuntime,
   skillsLoaderDir: skillsLoaderUnder(),
+  skillsLoading: "on-demand",
   vsaSkillProjection: {
     // Lands the versioned VSA skill at `~/.grok/skills/VSA` (same shape
     // as Codex's `vsaSkillUnder()` → `~/.codex/skills/VSA`).

--- a/src/adapters/pi-dev/install.ts
+++ b/src/adapters/pi-dev/install.ts
@@ -42,6 +42,7 @@ export const piDevInstallSpec: SubstrateInstallSpec<"pi-dev"> = {
   // Owned (Soma-exclusive) dir — see ownedSubtrees JSDoc. (agent/extensions + agent/skills shared.)
   ownedSubtrees: ["agent/soma"],
   skillsLoaderDir: skillsLoaderUnder("agent"),
+  skillsLoading: "eager",
   vsaSkillProjection: {
     destinationDir: piDevVsaSkillDestinationDir,
     skillNameOverride: PI_DEV_VSA_SKILL_ID,

--- a/src/adapters/shared/index.ts
+++ b/src/adapters/shared/index.ts
@@ -32,6 +32,10 @@ export {
 // from ./skill-registry directly).
 export { renderSkillRegistryEntry } from "./skill-registry";
 
+// The eager-loader stub renderer (soma#542). Distinct from the registry entry
+// above: that one renders a catalog LINE, this one renders a whole SKILL.md.
+export { isSkillStub, renderSkillStub, SKILL_STUB_MARKER, type SkillStubOptions } from "./skill-stub";
+
 /**
  * The portable skills a home projection should emit files for. `skills.md`
  * (renderSkills) still lists every skill, but the VSA skill is excluded here:

--- a/src/adapters/shared/skill-stub.ts
+++ b/src/adapters/shared/skill-stub.ts
@@ -1,0 +1,65 @@
+import { PROVENANCE_MARKER } from "./provenance";
+
+/**
+ * soma#542 — the frontmatter-only skill stub projected into an *eager* skill
+ * loader.
+ *
+ * A substrate whose loader reads every projected `SKILL.md` at session start
+ * (`skillsLoading: "eager"`) cannot be handed the real body by symlink: N links
+ * cost N bodies of context before the first turn (~200K tokens across the
+ * current 114-skill home). It gets this instead — the skill's own frontmatter,
+ * so the loader can still list and route the skill, plus a pointer to the body
+ * under the Soma registry for the substrate to read once the skill is actually
+ * selected.
+ *
+ * The provenance comment sits AFTER the frontmatter, not before it. YAML
+ * frontmatter is only frontmatter when it is the first thing in the file, so the
+ * usual leading `withProvenance` header would make the stub unparseable by the
+ * very loader it is written for.
+ *
+ * No timestamp, same as {@link provenanceHeader}: reprojecting twice with
+ * unchanged sources must produce byte-identical output, which is also what lets
+ * `ensureSkillStub` report `unchanged` instead of rewriting every stub on every
+ * install.
+ */
+
+/**
+ * Identifies a Soma-generated stub. Reprojection may replace a directory
+ * carrying this marker in place; a directory without it is user data and is
+ * guarded by `force`, exactly as a non-symlink is in `ensureSymlink`.
+ */
+export const SKILL_STUB_MARKER = "soma:skill-stub";
+
+export interface SkillStubOptions {
+  /** Verbatim frontmatter of the source SKILL.md, without its `---` fences. */
+  frontmatter: string;
+  /** Absolute path to the real SKILL.md under the Soma skill registry. */
+  bodyPath: string;
+  /** Substrate this stub is projected for; named in the provenance line. */
+  substrate: string;
+}
+
+export function renderSkillStub(options: SkillStubOptions): string {
+  return [
+    "---",
+    options.frontmatter,
+    "---",
+    "",
+    `<!-- ${PROVENANCE_MARKER} (${SKILL_STUB_MARKER}, soma install ${options.substrate}). ` +
+      "Source of truth: ~/.soma. Do not edit by hand. -->",
+    "",
+    "## Body not loaded",
+    "",
+    `Full instructions: \`${options.bodyPath}\``,
+    "",
+    "Read that file before acting on this skill. This projection carries",
+    "frontmatter only, so the loader can list and route the skill without",
+    "holding its body in context (soma#542).",
+    "",
+  ].join("\n");
+}
+
+/** True when `content` is a Soma-generated skill stub. */
+export function isSkillStub(content: string): boolean {
+  return content.includes(SKILL_STUB_MARKER);
+}

--- a/src/cli/skill-projection-cli.ts
+++ b/src/cli/skill-projection-cli.ts
@@ -152,7 +152,13 @@ function formatPlan(verb: string, plan: SkillProjectionPlan, marker: string): st
     `skill: ${plan.skill}`,
     "",
     "Links:",
-    ...plan.links.map((link) => `- ${link.scope === "registry" ? "registry" : link.substrate} ${marker} ${link.path}`),
+    ...plan.links.map(
+      (link) =>
+        `- ${link.scope === "registry" ? "registry" : link.substrate} ${marker} ${link.path}` +
+        // Name the shape only when it is not the symlink default, so existing
+        // on-demand output is unchanged (soma#542).
+        (link.kind === "stub" ? " (stub: frontmatter only)" : ""),
+    ),
     "",
     `Catalog refresh: ${plan.catalogRefresh.join(", ")}`,
     "",

--- a/src/install-spec.ts
+++ b/src/install-spec.ts
@@ -42,6 +42,25 @@ export function skillsLoaderUnder(...pathSegments: string[]): (substrateHome: st
   return (substrateHome) => resolve(substrateHome, ...pathSegments, "skills");
 }
 
+/**
+ * How a substrate's skill loader pulls a projected skill into model context.
+ *
+ * - `on-demand` — the loader keeps a skill's body out of context until the skill
+ *   is invoked (Claude Code's Skill tool; Codex's route-time load). Bodies are
+ *   projected as symlinks: the loader reads the real file only when it needs it.
+ * - `eager` — the loader reads every projected `SKILL.md` at session start.
+ *   Symlinking N bodies there costs N bodies of context before the first turn
+ *   (~200K tokens across the current 114-skill home), so projection writes a
+ *   frontmatter-only stub instead and the substrate resolves the body on trigger.
+ *
+ * soma#542: this is a property of the substrate's *loader*, not of any skill,
+ * which is why it lives on the adapter spec and not in skill frontmatter. A
+ * `scope`-style field per skill would encode one substrate's limitation into
+ * every portable skill file, and would need re-curating whenever a substrate
+ * changed its loader.
+ */
+export type SkillsLoadingMode = "on-demand" | "eager";
+
 export type InstallValidator = (substrateRoot: string) => Promise<void>;
 
 export interface UninstallContext {
@@ -105,6 +124,13 @@ export interface SubstrateInstallSpec<S extends InstallSubstrate = InstallSubstr
    * does not derive loader paths from the VSA skill destination.
    */
   skillsLoaderDir(substrateHome: string): string;
+  /**
+   * Whether this substrate's loader keeps skill bodies out of context until a
+   * skill is invoked. Drives how `project-skill` materialises a skill into
+   * {@link SubstrateInstallSpec.skillsLoaderDir}: `on-demand` symlinks the body,
+   * `eager` writes a frontmatter-only stub pointing at it (soma#542).
+   */
+  skillsLoading: SkillsLoadingMode;
   validator?: InstallValidator;
   lifecycleProjection?: LifecycleProjectionSpec;
   postProjection?: readonly InstallPostProjectionStep[];

--- a/src/skill-frontmatter.ts
+++ b/src/skill-frontmatter.ts
@@ -3,6 +3,16 @@ export const SKILL_MD = "SKILL.md";
 const NAME_KEY = /^name:\s*(.+?)\s*$/m;
 const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---(?=\r?\n|$)/;
 
+/**
+ * The leading YAML frontmatter of a SKILL.md, WITHOUT its `---` fences, or
+ * undefined when the file has none. Shares {@link FRONTMATTER} with
+ * `rewriteSkillNameFrontmatter` so the fence format has a single definition
+ * (soma#542 added the second reader).
+ */
+export function extractSkillFrontmatter(content: string): string | undefined {
+  return FRONTMATTER.exec(content)?.[1];
+}
+
 export function rewriteSkillNameFrontmatter(relPath: string, content: string, skillName?: string): string {
   if (!skillName || relPath !== SKILL_MD) return content;
   const frontmatter = FRONTMATTER.exec(content);

--- a/src/skill-projection.ts
+++ b/src/skill-projection.ts
@@ -1,11 +1,12 @@
-import { lstat, mkdir, readFile, readlink, rm, stat, symlink } from "node:fs/promises";
+import { lstat, mkdir, readFile, readlink, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
-import { renderSkills, stripProvenance } from "./adapters/shared";
+import { isSkillStub, renderSkills, renderSkillStub, stripProvenance } from "./adapters/shared";
 import { buildSubstrateHomeProjection } from "./home-projection";
 import type { InstallSubstrate } from "./install-spec";
 import { installSpecFor } from "./install-spec-registry";
 import { writeProjection } from "./projection";
+import { extractSkillFrontmatter, SKILL_MD } from "./skill-frontmatter";
 import { loadSomaHome } from "./soma-home";
 import type { ProjectionInput, SomaHomeProjectionOptions } from "./types";
 
@@ -58,7 +59,19 @@ export interface UnprojectSkillOptions {
   force?: boolean;
 }
 
-export type SkillLinkStatus = "linked" | "unchanged" | "replaced" | "removed" | "absent" | "preserved";
+/**
+ * `stubbed` is the eager-loader counterpart of `linked` (soma#542): the slot was
+ * created, but as a generated frontmatter-only dir rather than a symlink to the
+ * body. `replaced`/`unchanged` carry the same meaning for both shapes.
+ */
+export type SkillLinkStatus =
+  | "linked"
+  | "stubbed"
+  | "unchanged"
+  | "replaced"
+  | "removed"
+  | "absent"
+  | "preserved";
 
 export interface SkillLink {
   scope: "registry" | "substrate";
@@ -84,7 +97,19 @@ export interface SkillProjectionResult extends LinkedSkillResult {
 export interface SkillProjectionPlan {
   skill: string;
   skillDir: string;
-  links: { scope: "registry" | "substrate"; substrate?: InstallSubstrate; path: string; target: string }[];
+  links: {
+    scope: "registry" | "substrate";
+    substrate?: InstallSubstrate;
+    path: string;
+    target: string;
+    /**
+     * What apply will actually write at `path` (soma#542). The registry slot is
+     * always a symlink; a substrate slot follows its adapter's `skillsLoading`.
+     * Carried in the plan so a dry run cannot claim a link where apply writes a
+     * stub.
+     */
+    kind: "symlink" | "stub";
+  }[];
   catalogRefresh: InstallSubstrate[];
 }
 
@@ -200,6 +225,67 @@ async function ensureSymlink(
 }
 
 /**
+ * Materialise a skill into an EAGER substrate's loader slot as a generated
+ * frontmatter-only stub instead of a symlink (soma#542).
+ *
+ * A symlink cannot be a partial view of its target, so an eager loader — one
+ * that reads every projected SKILL.md at session start — would pull the whole
+ * body into context. The stub carries the frontmatter (so the loader still lists
+ * and routes the skill) plus a pointer to the body under the Soma registry.
+ *
+ * The data-loss guard matches {@link ensureSymlink}, one shape down: a stub IS a
+ * real directory, so "not a symlink" can no longer stand in for "not ours".
+ * Ownership is decided by the stub marker instead — a dir whose SKILL.md carries
+ * it is a previous projection and is replaced; anything else is user data and
+ * needs `force`.
+ */
+async function ensureSkillStub(
+  stubDir: string,
+  skillDir: string,
+  substrate: InstallSubstrate,
+  force: boolean,
+): Promise<"stubbed" | "unchanged" | "replaced"> {
+  const bodyPath = join(skillDir, SKILL_MD);
+  const frontmatter = extractSkillFrontmatter(await readFile(bodyPath, "utf8"));
+  if (frontmatter === undefined) {
+    throw new SkillProjectionError(
+      `Cannot stub ${skillDir} for ${substrate}: ${SKILL_MD} has no YAML frontmatter to project.`,
+    );
+  }
+  const stub = renderSkillStub({ frontmatter, bodyPath, substrate });
+  const stubPath = join(stubDir, SKILL_MD);
+
+  let existed = false;
+  try {
+    const entry = await lstat(stubDir);
+    existed = true;
+    // A symlink in the slot is ours to replace, same rule as ensureSymlink — it
+    // is what an on-demand projection of this same skill would have left here.
+    if (!entry.isSymbolicLink()) {
+      const current = await readFile(stubPath, "utf8").catch(() => undefined);
+      if (current !== undefined && isSkillStub(current)) {
+        // Ours. Byte-identical means the source frontmatter has not moved, so
+        // reprojection is a no-op rather than a rewrite.
+        if (current === stub) return "unchanged";
+      } else if (!force) {
+        throw new SkillProjectionError(
+          `Refusing to replace non-stub path at ${stubDir} (not a Soma-generated skill stub). ` +
+            `Pass force to overwrite it.`,
+        );
+      }
+    }
+    await rm(stubDir, { recursive: true, force: true });
+  } catch (error) {
+    if (error instanceof SkillProjectionError) throw error;
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  await mkdir(stubDir, { recursive: true });
+  await writeFile(stubPath, stub, "utf8");
+  return existed ? "replaced" : "stubbed";
+}
+
+/**
  * Find the catalog file (SKILLS.md) within a substrate bundle without hard-coding
  * its per-substrate path: it is the file whose content equals `renderSkills(input)`.
  * Header-tolerant so it still matches when an adapter wraps the file in a
@@ -291,9 +377,16 @@ async function linkSkill(
       links.push({ scope: "registry", path: slots.registry, target: skillDir, status });
     }
 
-    // 2. Loader symlink in each substrate.
+    // 2. Loader entry in each substrate. An on-demand loader gets a symlink to
+    //    the body; an eager one gets a generated frontmatter-only stub, because
+    //    linking there would put every body in context at session start
+    //    (soma#542). Rollback below treats both shapes identically — the created
+    //    path is removed either way.
     for (const { substrate, path } of slots.substrates) {
-      const status = await ensureSymlink(path, skillDir, force);
+      const status =
+        installSpecFor(substrate).skillsLoading === "eager"
+          ? await ensureSkillStub(path, skillDir, substrate, force)
+          : await ensureSymlink(path, skillDir, force);
       if (status !== "unchanged") created.push(path);
       links.push({ scope: "substrate", substrate, path, target: skillDir, status });
     }
@@ -346,10 +439,13 @@ export async function planProjectSkill(options: ProjectSkillOptions): Promise<Sk
   const slots = skillSlots(name, somaHome, options.substrates, options);
   const links: SkillProjectionPlan["links"] = [];
   if (dirname(skillDir) !== resolve(registrySkillsDir(somaHome))) {
-    links.push({ scope: "registry", path: slots.registry, target: skillDir });
+    links.push({ scope: "registry", path: slots.registry, target: skillDir, kind: "symlink" });
   }
   for (const { substrate, path } of slots.substrates) {
-    links.push({ scope: "substrate", substrate, path, target: skillDir });
+    // Same branch apply takes in linkSkill, so plan and apply cannot disagree
+    // on the shape written into a substrate slot.
+    const kind = installSpecFor(substrate).skillsLoading === "eager" ? "stub" : "symlink";
+    links.push({ scope: "substrate", substrate, path, target: skillDir, kind });
   }
 
   return { skill: name, skillDir, links, catalogRefresh: [...options.substrates] };
@@ -391,13 +487,16 @@ export async function planUnprojectSkill(options: UnprojectSkillOptions): Promis
 
   const links: SkillProjectionPlan["links"] = [];
   for (const { substrate, path } of slots.substrates) {
-    links.push({ scope: "substrate", substrate, path, target: "" });
+    // `kind` describes the shape occupying the slot, which on unproject is the
+    // shape this substrate projects (soma#542).
+    const kind = installSpecFor(substrate).skillsLoading === "eager" ? "stub" : "symlink";
+    links.push({ scope: "substrate", substrate, path, target: "", kind });
   }
   // List the registry only when it would actually be removed — a symlink Soma
   // owns, or (with --force) a real dir. An authored real dir left intact must
   // not appear as a removal.
   if (await registryWouldBeRemoved(slots.registry, force)) {
-    links.push({ scope: "registry", path: slots.registry, target: "" });
+    links.push({ scope: "registry", path: slots.registry, target: "", kind: "symlink" });
   }
 
   return { skill: name, skillDir, links, catalogRefresh: [...options.substrates] };
@@ -458,10 +557,16 @@ async function removeLink(linkPath: string, force: boolean): Promise<"removed" |
     return "absent";
   }
   if (!stat.isSymbolicLink() && !force) {
-    // A real dir we did not create (not our symlink) — don't recurse-delete it.
-    throw new SkillProjectionError(
-      `Refusing to remove non-symlink path at ${linkPath} (not a Soma-created symlink). Pass force to override.`,
-    );
+    // A real dir. On an eager substrate that is how Soma projects a skill, so
+    // check the stub marker before refusing (soma#542) — otherwise unproject
+    // would demand --force to remove a directory Soma itself just generated.
+    const stub = await readFile(join(linkPath, SKILL_MD), "utf8").catch(() => undefined);
+    if (stub === undefined || !isSkillStub(stub)) {
+      // A real dir we did not create — don't recurse-delete it.
+      throw new SkillProjectionError(
+        `Refusing to remove non-symlink path at ${linkPath} (not a Soma-created symlink or stub). Pass force to override.`,
+      );
+    }
   }
   await rm(linkPath, { recursive: true, force: true });
   return "removed";

--- a/src/skill-projection.ts
+++ b/src/skill-projection.ts
@@ -238,15 +238,24 @@ async function ensureSymlink(
  * Ownership is decided by the stub marker instead — a dir whose SKILL.md carries
  * it is a previous projection and is replaced; anything else is user data and
  * needs `force`.
+ *
+ * The pointer names the REGISTRY slot (`~/.soma/skills/<name>/SKILL.md`), not
+ * `skillDir`. A skill may be projected from anywhere — an arc pack, a repo
+ * checkout — and the substrate's own reader refuses paths outside the Soma home
+ * (pi-dev's `soma_context action=source_file` guards on `SOMA_HOME`), so a
+ * pointer at the raw source would be unresolvable by the very tool that has to
+ * follow it. The registry symlink created in step 1 of `linkSkill` is what makes
+ * that path valid.
  */
 async function ensureSkillStub(
   stubDir: string,
   skillDir: string,
+  registryDir: string,
   substrate: InstallSubstrate,
   force: boolean,
 ): Promise<"stubbed" | "unchanged" | "replaced"> {
-  const bodyPath = join(skillDir, SKILL_MD);
-  const frontmatter = extractSkillFrontmatter(await readFile(bodyPath, "utf8"));
+  const bodyPath = join(registryDir, SKILL_MD);
+  const frontmatter = extractSkillFrontmatter(await readFile(join(skillDir, SKILL_MD), "utf8"));
   if (frontmatter === undefined) {
     throw new SkillProjectionError(
       `Cannot stub ${skillDir} for ${substrate}: ${SKILL_MD} has no YAML frontmatter to project.`,
@@ -385,7 +394,7 @@ async function linkSkill(
     for (const { substrate, path } of slots.substrates) {
       const status =
         installSpecFor(substrate).skillsLoading === "eager"
-          ? await ensureSkillStub(path, skillDir, substrate, force)
+          ? await ensureSkillStub(path, skillDir, slots.registry, substrate, force)
           : await ensureSymlink(path, skillDir, force);
       if (status !== "unchanged") created.push(path);
       links.push({ scope: "substrate", substrate, path, target: skillDir, status });

--- a/test/skill-projection.test.ts
+++ b/test/skill-projection.test.ts
@@ -357,8 +357,11 @@ describe("eager skill loading (soma#542)", () => {
       const stub = await readFile(join(stubDir, "SKILL.md"), "utf8");
       // Frontmatter survives verbatim, so the loader can still list and route it.
       expect(stub.startsWith("---\nname: MyTool\ndescription: \"A test skill.\"\n---")).toBe(true);
-      // ...and the body is a pointer, not the body.
-      expect(stub).toContain(resolve(skillDir, "SKILL.md"));
+      // ...and the body is a pointer, not the body. It names the REGISTRY slot,
+      // not the source dir: a substrate reader refuses paths outside the Soma
+      // home, and the source may be projected from anywhere.
+      expect(stub).toContain(join(homeDir, ".soma", "skills", "MyTool", "SKILL.md"));
+      expect(stub).not.toContain(resolve(skillDir, "SKILL.md"));
       expect(stub).toContain("soma:skill-stub");
       expect(stub).not.toContain("# MyTool");
 

--- a/test/skill-projection.test.ts
+++ b/test/skill-projection.test.ts
@@ -335,3 +335,139 @@ describe("soma install --skills", () => {
     });
   });
 });
+
+/**
+ * soma#542 — eager substrates get a generated frontmatter-only stub instead of a
+ * symlink, because their loader reads every projected SKILL.md at session start.
+ * pi-dev is the only eager adapter today; claude-code stands in for on-demand.
+ */
+describe("eager skill loading (soma#542)", () => {
+  const piLoader = (homeDir: string, name: string) => join(homeDir, ".pi", "agent", "skills", name);
+
+  test("writes a frontmatter-only stub, not a symlink, into an eager loader", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+
+      const result = await projectSkill({ skillDir, substrates: ["pi-dev"], homeDir });
+
+      const stubDir = piLoader(homeDir, "MyTool");
+      expect((await lstat(stubDir)).isSymbolicLink()).toBe(false);
+      expect((await lstat(stubDir)).isDirectory()).toBe(true);
+
+      const stub = await readFile(join(stubDir, "SKILL.md"), "utf8");
+      // Frontmatter survives verbatim, so the loader can still list and route it.
+      expect(stub.startsWith("---\nname: MyTool\ndescription: \"A test skill.\"\n---")).toBe(true);
+      // ...and the body is a pointer, not the body.
+      expect(stub).toContain(resolve(skillDir, "SKILL.md"));
+      expect(stub).toContain("soma:skill-stub");
+      expect(stub).not.toContain("# MyTool");
+
+      expect(result.links.find((link) => link.substrate === "pi-dev")?.status).toBe("stubbed");
+    });
+  });
+
+  test("the registry slot stays a symlink to the real body", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      await projectSkill({ skillDir, substrates: ["pi-dev"], homeDir });
+
+      const registry = join(homeDir, ".soma", "skills", "MyTool");
+      expect((await lstat(registry)).isSymbolicLink()).toBe(true);
+      expect(await readlinkAbs(registry)).toBe(resolve(skillDir));
+    });
+  });
+
+  test("an on-demand substrate still gets a symlink in the same run", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+
+      await projectSkill({ skillDir, substrates: ["claude-code", "pi-dev"], homeDir });
+
+      expect((await lstat(join(homeDir, ".claude", "skills", "MyTool"))).isSymbolicLink()).toBe(true);
+      expect((await lstat(piLoader(homeDir, "MyTool"))).isSymbolicLink()).toBe(false);
+    });
+  });
+
+  test("reprojection is byte-idempotent and reports unchanged", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      await projectSkill({ skillDir, substrates: ["pi-dev"], homeDir });
+      const first = await readFile(join(piLoader(homeDir, "MyTool"), "SKILL.md"), "utf8");
+
+      const again = await projectSkill({ skillDir, substrates: ["pi-dev"], homeDir });
+
+      expect(again.links.find((link) => link.substrate === "pi-dev")?.status).toBe("unchanged");
+      expect(await readFile(join(piLoader(homeDir, "MyTool"), "SKILL.md"), "utf8")).toBe(first);
+    });
+  });
+
+  test("replaces its own stub when the source frontmatter changes", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      await projectSkill({ skillDir, substrates: ["pi-dev"], homeDir });
+
+      await writeFile(
+        join(skillDir, "SKILL.md"),
+        `---\nname: MyTool\ndescription: "Now with triggers."\n---\n\n# MyTool\n`,
+        "utf8",
+      );
+      const again = await projectSkill({ skillDir, substrates: ["pi-dev"], homeDir });
+
+      expect(again.links.find((link) => link.substrate === "pi-dev")?.status).toBe("replaced");
+      expect(await readFile(join(piLoader(homeDir, "MyTool"), "SKILL.md"), "utf8")).toContain("Now with triggers.");
+    });
+  });
+
+  test("refuses to overwrite a real non-stub dir without force, and overwrites with it", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      const stubDir = piLoader(homeDir, "MyTool");
+      await mkdir(stubDir, { recursive: true });
+      await writeFile(join(stubDir, "SKILL.md"), "---\nname: MyTool\n---\n\nHand-authored.\n", "utf8");
+
+      await expect(projectSkill({ skillDir, substrates: ["pi-dev"], homeDir })).rejects.toThrow(
+        /not a Soma-generated skill stub/,
+      );
+      expect(await readFile(join(stubDir, "SKILL.md"), "utf8")).toContain("Hand-authored.");
+
+      await projectSkill({ skillDir, substrates: ["pi-dev"], homeDir, force: true });
+      expect(await readFile(join(stubDir, "SKILL.md"), "utf8")).toContain("soma:skill-stub");
+    });
+  });
+
+  test("unproject removes a Soma stub without --force", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      await projectSkill({ skillDir, substrates: ["pi-dev"], homeDir });
+
+      const result = await unprojectSkill({ skill: "MyTool", substrates: ["pi-dev"], homeDir });
+
+      expect(result.links.find((link) => link.substrate === "pi-dev")?.status).toBe("removed");
+      await expect(lstat(piLoader(homeDir, "MyTool"))).rejects.toThrow();
+    });
+  });
+
+  test("unproject still refuses a real dir that is not a Soma stub", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+      await projectSkill({ skillDir, substrates: ["pi-dev"], homeDir });
+      await writeFile(join(piLoader(homeDir, "MyTool"), "SKILL.md"), "---\nname: MyTool\n---\n\nMine now.\n", "utf8");
+
+      await expect(unprojectSkill({ skill: "MyTool", substrates: ["pi-dev"], homeDir })).rejects.toThrow(
+        /not a Soma-created symlink or stub/,
+      );
+    });
+  });
+
+  test("the plan names the shape apply will write", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "MyTool");
+
+      const plan = await planProjectSkill({ skillDir, substrates: ["claude-code", "pi-dev"], homeDir });
+
+      expect(plan.links.find((link) => link.substrate === "pi-dev")?.kind).toBe("stub");
+      expect(plan.links.find((link) => link.substrate === "claude-code")?.kind).toBe("symlink");
+      expect(plan.links.find((link) => link.scope === "registry")?.kind).toBe("symlink");
+    });
+  });
+});


### PR DESCRIPTION
Implements #542. Design and rationale in `docs/progressive-skill-loading.md`
DD-A and DD-B (#545, which should land first — this PR's commit message points
at it).

## Problem

A substrate whose skill loader reads every projected `SKILL.md` at session start
pays the whole corpus before the first turn — **~200K tokens** across the current
114-skill home. Claude Code does not pay it (its Skill tool loads bodies on
demand). pi-dev does. Same registry, same symlinks, different loader — and Soma
had no way to express which behaviour a substrate has.

## Change

`SkillsLoadingMode` on `SubstrateInstallSpec`, beside the `skillsLoaderDir` it
already owns:

```ts
export type SkillsLoadingMode = "on-demand" | "eager";
```

| Substrate | Value | Loader slot |
| --- | --- | --- |
| claude-code, codex, cursor, grok, anthropic-cowork | `on-demand` | symlink to the body (unchanged) |
| pi-dev | `eager` | generated frontmatter-only stub |

A stub is a directory holding a `SKILL.md` with the source frontmatter verbatim,
a provenance marker, and a pointer to the real body under `~/.soma/skills/`. The
loader can still list and route the skill; the body arrives only when the
substrate resolves the pointer.

Nothing changes for on-demand substrates, and no skill file changes at all.

## Three things that were easy to get wrong

**Provenance goes after the frontmatter.** YAML frontmatter is only frontmatter
when it is the first thing in the file, so the usual leading `withProvenance`
header would have made every stub unparseable by the exact loader it is written
for.

**A stub is a real directory, so `!isSymbolicLink()` no longer means "not
ours".** `ensureSymlink`'s data-loss guard rests on that equivalence. Ownership
is decided by the stub marker instead: a directory carrying it is a previous
projection and is replaced; anything else is user data and still needs `force`.

**`removeLink` needed the same rule.** Without it, `unproject-skill` would have
demanded `--force` to delete a directory Soma itself had just generated — a
regression this PR would otherwise have shipped. Covered by a test.

Plans carry `kind: "symlink" | "stub"` from the same branch apply takes, so a dry
run cannot claim a link where apply writes a stub.

## Tests

9 new cases in `test/skill-projection.test.ts`: stub shape and content, registry
slot still a symlink, mixed on-demand/eager run, byte-idempotent reprojection
reporting `unchanged`, replacement when source frontmatter changes, the
force/no-force guard both ways, unproject removing its own stub without
`--force`, unproject still refusing a non-stub directory, and plan/apply
agreement on `kind`.

## Verification

- `bun run typecheck` — clean.
- `bun test` — **2226 pass, 0 fail** across 146 files.
- `bun run lint` — 52 errors, all pre-existing on `main`. Two flagged files are
  also touched here (`adapters/anthropic-cowork/install.ts`,
  `adapters/grok/install.ts`), but the errors sit at lines 80 and 135–148 while
  the insertions are single lines at 96 and 188. No changed line is flagged.

## Out of scope

Per DD-D/DD-E and #542's scope section: the router, `soma-skill.json`, and the
pi-dev side of trigger-time promotion — which must deliver the body as a **tool
result, never a system-prompt edit** (DD-C), or promotion costs more than it
saves by invalidating the cached prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
