### PR TITLE
fix(work-graph): a ratification is a reaction; amendment is caller discipline (#525)

### DIFF
--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -360,8 +360,10 @@ What remains:
   a refused one; and it needs the root author to resolve, so where the root walk
   fails nothing refuses, silently.
 
-- **A 👍 reaction is the only ratification (#525).** Literally that reaction:
-  `selectRatification` matches on `content === "+1"`, so no other emoji ratifies.
+- **A 👍 reaction is the only ratification (#525).** Literally that reaction —
+  matched on `+1`, so no other emoji ratifies, and (per the rule above) any
+  non-proposer's counts, with *whose* it is affecting `attestation` rather than
+  admissibility.
   This section once admitted a second form — a principal-authored *comment*,
   winning over the 👍 when amending — and the seam carried a `"comment"`
   ratification kind nothing produced. It is withdrawn, not unimplemented: with
@@ -374,9 +376,9 @@ What remains:
   guarantee**. Ratification is read from the comment id passed to
   `--proposal-comment`, so an amended proposal inherits nothing *when the new id
   is the one passed*; passing the superseded id ratifies from the superseded
-  proposal, and nothing in the runtime rejects it. Same class of limit as "a
-  fresh proposal carries no refusal" above, and it has the same root: no verb
-  binds a proposal to the one it supersedes.
+  proposal, and nothing in the runtime rejects it. Same class of limit as the
+  refusal one named above — nothing binds a new proposal to a refused one — and
+  it has the same root: no verb binds a proposal to the one it supersedes.
 
 - **The receipt distinguishes the two cases.** A ratified close records the
   proposal and ratifier; a bare one records their absence in

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -360,15 +360,23 @@ What remains:
   a refused one; and it needs the root author to resolve, so where the root walk
   fails nothing refuses, silently.
 
-- **A reaction is the only ratification (#525).** This section once admitted a
-  second form — a principal-authored *comment*, winning over the 👍 when
-  amending — and the seam carried a `"comment"` ratification kind nothing
-  produced. It is withdrawn, not unimplemented: with ratification demoted from
-  gate to label, deriving approval from free prose would let a root-author reply
-  of "hold on, not this" produce `verified` on the one field the phase-2 auditor
-  recomputes. A 👍 is a deliberate, unambiguous gesture; prose is not. The
-  amendment rule it served survives structurally — a re-posted proposal is a new
-  comment id with no reactions, so it inherits nothing.
+- **A 👍 reaction is the only ratification (#525).** Literally that reaction:
+  `selectRatification` matches on `content === "+1"`, so no other emoji ratifies.
+  This section once admitted a second form — a principal-authored *comment*,
+  winning over the 👍 when amending — and the seam carried a `"comment"`
+  ratification kind nothing produced. It is withdrawn, not unimplemented: with
+  ratification demoted from gate to label, deriving approval from free prose
+  would let a root-author reply of "hold on, not this" produce `verified` on the
+  one field the phase-2 auditor recomputes. A 👍 is a deliberate, unambiguous
+  gesture; prose is not.
+
+  The amendment rule it served is **caller discipline, not a structural
+  guarantee**. Ratification is read from the comment id passed to
+  `--proposal-comment`, so an amended proposal inherits nothing *when the new id
+  is the one passed*; passing the superseded id ratifies from the superseded
+  proposal, and nothing in the runtime rejects it. Same class of limit as "a
+  fresh proposal carries no refusal" above, and it has the same root: no verb
+  binds a proposal to the one it supersedes.
 
 - **The receipt distinguishes the two cases.** A ratified close records the
   proposal and ratifier; a bare one records their absence in

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -360,6 +360,16 @@ What remains:
   a refused one; and it needs the root author to resolve, so where the root walk
   fails nothing refuses, silently.
 
+- **A reaction is the only ratification (#525).** This section once admitted a
+  second form — a principal-authored *comment*, winning over the 👍 when
+  amending — and the seam carried a `"comment"` ratification kind nothing
+  produced. It is withdrawn, not unimplemented: with ratification demoted from
+  gate to label, deriving approval from free prose would let a root-author reply
+  of "hold on, not this" produce `verified` on the one field the phase-2 auditor
+  recomputes. A 👍 is a deliberate, unambiguous gesture; prose is not. The
+  amendment rule it served survives structurally — a re-posted proposal is a new
+  comment id with no reactions, so it inherits nothing.
+
 - **The receipt distinguishes the two cases.** A ratified close records the
   proposal and ratifier; a bare one records their absence in
   `attestationFacts.reasons` ("no proposal comment recorded", "no ratification

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -655,7 +655,7 @@ export function selectRatification(
   reactions: readonly Reaction[],
   proposalAuthor: string,
   rootAuthor: string | undefined,
-): { kind: "reaction"; id: string; author: string } | undefined {
+): Ratification | undefined {
   if (
     rootAuthor !== undefined &&
     reactions.some((reaction) => reaction.content === "-1" && reaction.author === rootAuthor)

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -41,6 +41,7 @@ import {
   type NodeState,
   type Probe,
   type ProbeResult,
+  type Ratification,
   type Reaction,
   type WorkGraphEvidenceKind,
 } from "../work-graph";
@@ -781,7 +782,7 @@ async function runClose(
   const root = await findGraphRoot(ref, async (nodeRef) => await graph.readNode(nodeRef));
 
   let proposal: { commentId: string; author: string } | undefined;
-  let ratification: { kind: "reaction"; id: string; author: string } | undefined;
+  let ratification: Ratification | undefined;
 
   // A proposal comment is optional now: a HITL node closes on the session's
   // say-so (§3.2). When one IS supplied, its reactions still carry weight —

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -781,7 +781,7 @@ async function runClose(
   const root = await findGraphRoot(ref, async (nodeRef) => await graph.readNode(nodeRef));
 
   let proposal: { commentId: string; author: string } | undefined;
-  let ratification: { kind: "reaction" | "comment"; id: string; author: string } | undefined;
+  let ratification: { kind: "reaction"; id: string; author: string } | undefined;
 
   // A proposal comment is optional now: a HITL node closes on the session's
   // say-so (§3.2). When one IS supplied, its reactions still carry weight —

--- a/src/index.ts
+++ b/src/index.ts
@@ -711,6 +711,7 @@ export {
   type Probe,
   type ProbeResult,
   type ProbeType,
+  type Ratification,
   type Reaction,
   type WorkGraphAutonomy,
   type WorkGraphErrorCode,

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -121,10 +121,13 @@ Two things worth knowing when you do use the proposal flow:
   that it was not the right human.
 - **Ratification binds to a comment id, not to its text.** Nothing hashes the
   proposal body, so a proposal that is ratified and *then edited* still closes on
-  that 👍. If the resolution changes materially, post a new comment — the new one
-  carries no reactions, so it needs fresh ratification and inherits nothing.
-- **A 👍 is the only ratification.** Replying "yes, go ahead" ratifies nothing;
-  the receipt will read *no ratification found*. An older §3.2 also admitted a
+  that 👍. If the resolution changes materially, post a new comment — and then
+  **pass the new id**. Amending is your discipline, not the runtime's: nothing
+  binds a proposal to the one it supersedes, so a close pointed at the old id
+  still ratifies from the old 👍.
+- **A 👍 is the only ratification** — that reaction specifically, matched on
+  `+1`; no other emoji counts. Replying "yes, go ahead" ratifies nothing, and the
+  receipt will read *no ratification found*. An older §3.2 also admitted a
   principal-authored comment, outranking the 👍 when amending, and #525 was to
   implement it. It was dropped instead: once ratification stopped gating a HITL
   close (#549) and became a label feeding `attestation`, reading approval out of

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -121,7 +121,15 @@ Two things worth knowing when you do use the proposal flow:
   that it was not the right human.
 - **Ratification binds to a comment id, not to its text.** Nothing hashes the
   proposal body, so a proposal that is ratified and *then edited* still closes on
-  that 👍. If the resolution changes materially, post a new comment.
+  that 👍. If the resolution changes materially, post a new comment — the new one
+  carries no reactions, so it needs fresh ratification and inherits nothing.
+- **A 👍 is the only ratification.** Replying "yes, go ahead" ratifies nothing;
+  the receipt will read *no ratification found*. An older §3.2 also admitted a
+  principal-authored comment, outranking the 👍 when amending, and #525 was to
+  implement it. It was dropped instead: once ratification stopped gating a HITL
+  close (#549) and became a label feeding `attestation`, reading approval out of
+  free prose would let a reply of "hold on, not this" derive `verified`. React,
+  don't reply.
 
 ## Attestation
 

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -114,7 +114,7 @@ So the honest reading is that being refused is *recorded*, not *prevented*. If
 you close around a 👎, the receipt shows a close with no refusal in it, and the
 person who said no finds out by reading the node.
 
-Two things worth knowing when you do use the proposal flow:
+Three things worth knowing when you do use the proposal flow:
 
 - **Any non-proposer's 👍 is taken as the ratification**, root author preferred.
   On a public tracker that includes a stranger's. Only `attestation` records
@@ -126,13 +126,14 @@ Two things worth knowing when you do use the proposal flow:
   binds a proposal to the one it supersedes, so a close pointed at the old id
   still ratifies from the old 👍.
 - **A 👍 is the only ratification** — that reaction specifically, matched on
-  `+1`; no other emoji counts. Replying "yes, go ahead" ratifies nothing, and the
-  receipt will read *no ratification found*. An older §3.2 also admitted a
-  principal-authored comment, outranking the 👍 when amending, and #525 was to
-  implement it. It was dropped instead: once ratification stopped gating a HITL
-  close (#549) and became a label feeding `attestation`, reading approval out of
-  free prose would let a reply of "hold on, not this" derive `verified`. React,
-  don't reply.
+  `+1`; no other emoji counts, and per the first bullet *whose* 👍 it is affects
+  `attestation`, not whether it ratifies. Replying "yes, go ahead" ratifies
+  nothing, and the receipt will read *no ratification found*. The HITL section of
+  the spec once admitted a principal-authored comment too, outranking the 👍 when
+  amending, and #525 was to implement it. It was dropped instead: once
+  ratification stopped gating a HITL close (#549) and became a label feeding
+  `attestation`, reading approval out of free prose would let a reply of "hold
+  on, not this" derive `verified`. React, don't reply.
 
 ## Attestation
 

--- a/src/work-graph-attestation.ts
+++ b/src/work-graph-attestation.ts
@@ -28,6 +28,7 @@ import type {
   ConfinementProbeRecord,
   NodeRef,
   NodeState,
+  Ratification,
 } from "./work-graph";
 import type { CommandOutcome, CommandRequest } from "./work-graph-probes";
 
@@ -133,8 +134,7 @@ export interface AttestationInputs {
   actingIdentity: string;
   confinement?: ConfinementResult;
   proposal?: { commentId: string; author: string };
-  /** Reactions only — see {@link AttestationFacts.ratification} for why the comment path is not here. */
-  ratification?: { kind: "reaction"; id: string; author: string };
+  ratification?: Ratification;
   root?: { nodeId: string; author: string };
 }
 

--- a/src/work-graph-attestation.ts
+++ b/src/work-graph-attestation.ts
@@ -133,7 +133,8 @@ export interface AttestationInputs {
   actingIdentity: string;
   confinement?: ConfinementResult;
   proposal?: { commentId: string; author: string };
-  ratification?: { kind: "reaction" | "comment"; id: string; author: string };
+  /** Reactions only — see {@link AttestationFacts.ratification} for why the comment path is not here. */
+  ratification?: { kind: "reaction"; id: string; author: string };
   root?: { nodeId: string; author: string };
 }
 

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -233,7 +233,17 @@ export interface AttestationFacts {
     probes?: readonly ConfinementProbeRecord[];
   };
   proposal?: { commentId: string; author: string };
-  ratification?: { kind: "reaction" | "comment"; id: string; author: string };
+  /**
+   * A reaction, and only ever a reaction (#525). The older §3.2 admitted a second
+   * kind — a principal-authored *comment*, winning over a 👍 when amending — and
+   * this union carried a `"comment"` member for it that nothing ever produced.
+   * The clause did not survive #549: ratification stopped gating a HITL close and
+   * became a label feeding `attestation`, and inferring approval from free prose
+   * would let a root-author reply of "hold on, not this" derive `verified`. A 👍
+   * is a deliberate, unambiguous gesture; prose is not. Narrowed rather than left
+   * as a member with no producer, which reads as a path the system has.
+   */
+  ratification?: { kind: "reaction"; id: string; author: string };
   root?: { nodeId: string; author: string };
   /**
    * Why the verdict came out as it did, one line per failed conjunct — empty on

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -224,6 +224,26 @@ export interface ConfinementProbeRecord {
   observed: string;
 }
 
+/**
+ * A ratification recorded on a close receipt.
+ *
+ * `kind` is deliberately a one-variant discriminant rather than an omitted
+ * field. A receipt is a published artifact re-read years later, and *how* this
+ * was ratified is part of what it records; a bare `{id, author}` would leave a
+ * future reader to infer the mechanism from an id shape. Nothing branches on it
+ * today, and nothing should need to.
+ *
+ * Named rather than spelled inline at each use: dropping the withdrawn
+ * `"comment"` member (#525) took a three-file edit, and the next shape change
+ * would have taken another.
+ */
+export interface Ratification {
+  /** A reaction, and only ever a reaction — the HITL receipts section of `docs/work-graph.md` has why (#525, #549). */
+  kind: "reaction";
+  id: string;
+  author: string;
+}
+
 export interface AttestationFacts {
   backendCapability: AttestationCapability;
   confinement?: {
@@ -233,17 +253,7 @@ export interface AttestationFacts {
     probes?: readonly ConfinementProbeRecord[];
   };
   proposal?: { commentId: string; author: string };
-  /**
-   * A reaction, and only ever a reaction — §3.2 has the argument for why the
-   * comment path was withdrawn (#525).
-   *
-   * `kind` is deliberately a one-variant discriminant rather than an omitted
-   * field. A receipt is a published artifact re-read years later, and *how* this
-   * was ratified is part of what it records; a bare `{id, author}` would leave a
-   * future reader to infer the mechanism from an id shape. Nothing branches on
-   * it today, and nothing should need to.
-   */
-  ratification?: { kind: "reaction"; id: string; author: string };
+  ratification?: Ratification;
   root?: { nodeId: string; author: string };
   /**
    * Why the verdict came out as it did, one line per failed conjunct — empty on

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -234,14 +234,14 @@ export interface AttestationFacts {
   };
   proposal?: { commentId: string; author: string };
   /**
-   * A reaction, and only ever a reaction (#525). The older §3.2 admitted a second
-   * kind — a principal-authored *comment*, winning over a 👍 when amending — and
-   * this union carried a `"comment"` member for it that nothing ever produced.
-   * The clause did not survive #549: ratification stopped gating a HITL close and
-   * became a label feeding `attestation`, and inferring approval from free prose
-   * would let a root-author reply of "hold on, not this" derive `verified`. A 👍
-   * is a deliberate, unambiguous gesture; prose is not. Narrowed rather than left
-   * as a member with no producer, which reads as a path the system has.
+   * A reaction, and only ever a reaction — §3.2 has the argument for why the
+   * comment path was withdrawn (#525).
+   *
+   * `kind` is deliberately a one-variant discriminant rather than an omitted
+   * field. A receipt is a published artifact re-read years later, and *how* this
+   * was ratified is part of what it records; a bare `{id, author}` would leave a
+   * future reader to infer the mechanism from an id shape. Nothing branches on
+   * it today, and nothing should need to.
    */
   ratification?: { kind: "reaction"; id: string; author: string };
   root?: { nodeId: string; author: string };

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -533,6 +533,33 @@ test("the veto is one close deep — a fresh proposal carries no refusal", async
   expect(store.closed).toHaveLength(1);
 });
 
+test("an amended proposal inherits no ratification — the replay-rebind invariant", async () => {
+  // §3.2's amendment rule: a materially amended proposal is re-posted and needs
+  // FRESH ratification. Today that holds structurally rather than by a rule —
+  // ratification is read from the comment id passed, and a re-`--propose` mints
+  // an id with no reactions — so it is asserted only in `closing.md` prose and
+  // nothing would catch it becoming false. #525 was going to add a rule; #549
+  // removed the gate it would have served, leaving the invariant worth pinning
+  // and the rule not worth writing. This is the pin.
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
+
+  await run(["graph", "close", "530", "--propose", "--body", "the resolution", "--repo", REPO], store);
+  store.reactions.set("c1", [{ id: "r1", content: "+1", author: "jcfischer" }]);
+
+  // The proposal is amended: a new comment, and the old 👍 stays on the old one.
+  await run(["graph", "close", "530", "--propose", "--body", "the AMENDED resolution", "--repo", REPO], store);
+  await run(["graph", "close", "530", "--proposal-comment", "c2", "--repo", REPO], store);
+
+  const receipt = store.closed[0].receipt;
+  expect(receipt.attestationFacts?.proposal?.commentId).toBe("c2");
+  expect(receipt.attestationFacts?.ratification).toBeUndefined();
+  expect(receipt.evidence.some((entry) => entry.kind === "approved")).toBe(false);
+  expect(receipt.attestation).toBe("unverified");
+  expect(receipt.attestationFacts?.reasons?.join(" ")).toContain("no ratification found");
+});
+
 test("without a 👎, a HITL node closes on the session's say-so", async () => {
   const store = new FakeStore()
     .seed("495", { node: autoNode("495"), author: "jcfischer" })

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -535,24 +535,42 @@ test("the veto is one close deep — a fresh proposal carries no refusal", async
 
 test("an amended proposal inherits no ratification — the replay-rebind invariant", async () => {
   // §3.2's amendment rule: a materially amended proposal is re-posted and needs
-  // FRESH ratification. Today that holds structurally rather than by a rule —
-  // ratification is read from the comment id passed, and a re-`--propose` mints
-  // an id with no reactions — so it is asserted only in `closing.md` prose and
-  // nothing would catch it becoming false. #525 was going to add a rule; #549
-  // removed the gate it would have served, leaving the invariant worth pinning
-  // and the rule not worth writing. This is the pin.
-  const store = new FakeStore()
-    .seed("495", { node: autoNode("495"), author: "jcfischer" })
-    .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
+  // FRESH ratification. #525 was going to enforce it; #549 removed the gate it
+  // would have served, leaving an invariant that holds by construction —
+  // ratification is read from the comment id passed — and was asserted only in
+  // `closing.md` prose.
+  //
+  // Both arms run against the SAME seeded 👍, because asserting the amended
+  // close is unratified proves nothing on its own: it follows from c2 carrying
+  // no reactions, and would read identically if the 👍 on c1 had never been
+  // admissible. Arm A establishes that this exact reaction, in this exact
+  // store, does derive a ratified `verified` receipt. Arm B then shows the
+  // amended close declining to reach it. The discrimination is between the two
+  // arms; neither carries it alone.
+  const seeded = () =>
+    new FakeStore()
+      .seed("495", { node: autoNode("495"), author: "jcfischer" })
+      .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
 
-  await run(["graph", "close", "530", "--propose", "--body", "the resolution", "--repo", REPO], store);
-  store.reactions.set("c1", [{ id: "r1", content: "+1", author: "jcfischer" }]);
+  // Arm A — the ratification is live and sufficient.
+  const ratified = seeded();
+  await run(["graph", "close", "530", "--propose", "--body", "the resolution", "--repo", REPO], ratified);
+  ratified.reactions.set("c1", [{ id: "r1", content: "+1", author: "jcfischer" }]);
+  await run(["graph", "close", "530", "--proposal-comment", "c1", "--repo", REPO], ratified);
 
-  // The proposal is amended: a new comment, and the old 👍 stays on the old one.
-  await run(["graph", "close", "530", "--propose", "--body", "the AMENDED resolution", "--repo", REPO], store);
-  await run(["graph", "close", "530", "--proposal-comment", "c2", "--repo", REPO], store);
+  expect(ratified.closed[0].receipt.attestationFacts?.ratification?.id).toBe("r1");
+  expect(ratified.closed[0].receipt.attestation).toBe("verified");
 
-  const receipt = store.closed[0].receipt;
+  // Arm B — same proposal, same 👍, then amended. The 👍 stays on c1, live and
+  // unretracted; the close against the amended comment must not reach it.
+  const amended = seeded();
+  await run(["graph", "close", "530", "--propose", "--body", "the resolution", "--repo", REPO], amended);
+  amended.reactions.set("c1", [{ id: "r1", content: "+1", author: "jcfischer" }]);
+  await run(["graph", "close", "530", "--propose", "--body", "the AMENDED resolution", "--repo", REPO], amended);
+  await run(["graph", "close", "530", "--proposal-comment", "c2", "--repo", REPO], amended);
+
+  const receipt = amended.closed[0].receipt;
+  expect(amended.reactions.get("c1")).toHaveLength(1); // still there — not consumed, not retracted
   expect(receipt.attestationFacts?.proposal?.commentId).toBe("c2");
   expect(receipt.attestationFacts?.ratification).toBeUndefined();
   expect(receipt.evidence.some((entry) => entry.kind === "approved")).toBe(false);

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -375,7 +375,9 @@ test("an auto receipt is honestly unverified — no human ratified it", async ()
 
   const receipt = store.closed[0].receipt;
   expect(receipt.attestation).toBe("unverified");
-  expect(receipt.attestationFacts?.reasons?.join(" ")).toContain("no ratification found");
+  expect(receipt.attestationFacts?.reasons ?? []).toContain(
+    "no ratification found — nothing was attested by a second credential",
+  );
 });
 
 test("a bare `close` on a HITL node works — no proposal, no ratification", async () => {
@@ -536,9 +538,10 @@ test("the veto is one close deep — a fresh proposal carries no refusal", async
 test("an amended proposal inherits no ratification — the replay-rebind invariant", async () => {
   // §3.2's amendment rule: a materially amended proposal is re-posted and needs
   // FRESH ratification. #525 was going to enforce it; #549 removed the gate it
-  // would have served, leaving an invariant that holds by construction —
-  // ratification is read from the comment id passed — and was asserted only in
-  // `closing.md` prose.
+  // would have served, so nothing enforces it now — it is CALLER DISCIPLINE, and
+  // this test pins the half the runtime does supply: ratification is read from
+  // the comment id passed, so the new proposal starts unratified. Pass the
+  // superseded id instead and the old 👍 still ratifies; nothing rejects that.
   //
   // Both arms run against the SAME seeded 👍, because asserting the amended
   // close is unratified proves nothing on its own: it follows from c2 carrying
@@ -590,6 +593,28 @@ test("without a 👎, a HITL node closes on the session's say-so", async () => {
   expect(store.closed).toHaveLength(1);
   // The receipt still records what it always did; the label is unchanged.
   expect(store.closed[0].receipt.attestation).toBe("unverified");
+});
+
+test("only 👍 ratifies — every other reaction is inert", () => {
+  // §3.2 states this as an absolute ("matched on `+1`, so no other emoji
+  // ratifies"), and until now nothing exercised it: every test seeded `+1`.
+  // A spec absolute with no probe behind it is the claim this repo keeps
+  // learning not to make.
+  const enthusiasm: Reaction[] = [
+    { id: "r1", content: "heart", author: "jcfischer" },
+    { id: "r2", content: "hooray", author: "jcfischer" },
+    { id: "r3", content: "rocket", author: "jcfischer" },
+    { id: "r4", content: "eyes", author: "jcfischer" },
+  ];
+  expect(selectRatification(enthusiasm, "ivy-agent", "jcfischer")).toBeUndefined();
+
+  // And the companion half of the same sentence: whose 👍 it is decides
+  // `attestation`, not admissibility — a non-proposer stranger still ratifies.
+  expect(selectRatification([{ id: "r5", content: "+1", author: "a-stranger" }], "ivy-agent", "jcfischer")).toEqual({
+    kind: "reaction",
+    id: "r5",
+    author: "a-stranger",
+  });
 });
 
 test("selectRatification prefers the root author and ignores the proposer's own reaction", () => {


### PR DESCRIPTION
Resolves #525.

#525 asked for §3.2's second ratification path — a principal-authored comment, outranking the 👍 when amending. **The §3.2 it quoted no longer exists**: #549 (`8ba3378`) rewrote the section and dropped the clause.

So this withdraws the path rather than leaving it unimplemented:

- **Why not build it.** With ratification demoted from gate to label, its only remaining job is feeding conjuncts 3 and 4 of the attestation derivation. Reading approval out of free prose would let a root-author reply of "hold on, not this" derive `verified` — on the one field the phase-2 close auditor recomputes. A 👍 is a deliberate, unambiguous gesture; prose is not.
- **The dead type goes, and gets a name.** `ratification.kind` was `"reaction" | "comment"` spelled inline in three modules; nothing ever produced `"comment"`. It is now a single exported `Ratification` type — dropping one member took a three-file edit, and the next shape change would have taken another.
- **Amendment is caller discipline, and the docs now say so.** An amended proposal inherits nothing *when the caller passes the new id*; passing the superseded id ratifies from the superseded proposal, and nothing in the runtime rejects it. Same root as the already-documented "nothing binds a new proposal to a refused one" — no verb binds a proposal to the one it supersedes. Earlier revisions of this PR called that a structural guarantee, which the shipped §3.2 contradicts.
- **The invariant is pinned by a two-arm test.** Arm A closes against the original proposal and asserts a ratified `verified` receipt — establishing the 👍 is admissible in that exact store. Arm B amends, closes against the new comment, and asserts the close declines to reach it, with the original reaction still present and unretracted. Deleting either seed fails the test; a single-arm version did not, because every assertion followed from the amended comment simply having no reactions.

No `listComments` seam addendum. No behaviour change beyond the type narrowing.

`bun test` 2264 pass / 0 fail **on the PR head** (`70a17b3`) · `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)