### PR TITLE
feat(work-graph): planSteps nodeId bridge — the node is the one home for a bridged step's status (#501)

### DIFF
--- a/docs/algorithm-execution-modes.md
+++ b/docs/algorithm-execution-modes.md
@@ -169,9 +169,26 @@ parallel registry. *Cross-session* effort topology is a different scope and
 belongs to the work graph (`docs/work-graph.md`): a plan step may carry an
 optional `nodeId` reference to a work-graph node and then derives its status
 from that node — one work item never has two authoritative homes. The
-work-graph spec (pre-implementation) makes this a runner obligation rather
-than an assumption: when the `nodeId` bridge lands, `updateAlgorithmPlanStep`
-must refuse a direct status write on a bridged step, and the read side
-re-derives status from the node via `GraphStore.readNode` /
-`soma graph node <id>` (see `docs/work-graph.md` §2.7, "planSteps bridge"). Until that lands, `planSteps[]` has no bridge and
-this section's within-run rule is the whole story.
+work-graph spec makes this a runner obligation rather than an assumption, and
+**the bridge is implemented** (#501): `updateAlgorithmPlanStep` refuses a direct
+status write on a bridged step, and status arrives only by re-deriving from the
+node via `GraphStore.readNode` / `soma graph node <id> --json` (see
+`docs/work-graph.md` §2.7, "planSteps bridge").
+
+The CLI surface:
+
+```bash
+soma algorithm step --id <run> --step-id <step> --node <node-id>   # bridge + derive
+soma algorithm step --id <run> --step-id <step> --sync             # re-derive
+soma algorithm step --id <run> --step-id <step> --status done       # refused when bridged
+```
+
+`--node` binds *and* derives in one act, so a step is never bridged while still
+carrying its stale hand-written status. The derived `evidence` names the node and
+the moment, because a derived status that reads like a written one is the defect
+with the gate removed. Two write paths had to be closed, not one: the per-step
+call refuses, and the VSA sync's whole-run VERIFY sweep
+(`markUnbridgedPlanStepsDone`) *skips* bridged steps — it has no single step to
+refuse for, and the `done` it writes comes from the VSA's phase alone. The
+visible cost is the honest one: an open bridged step leaves the run short of the
+VERIFY gate until its node closes.

--- a/docs/algorithm-execution-modes.md
+++ b/docs/algorithm-execution-modes.md
@@ -171,9 +171,14 @@ optional `nodeId` reference to a work-graph node and then derives its status
 from that node — one work item never has two authoritative homes. The
 work-graph spec makes this a runner obligation rather than an assumption, and
 **the bridge is implemented** (#501): `updateAlgorithmPlanStep` refuses a direct
-status write on a bridged step, and status arrives only by re-deriving from the
-node via `GraphStore.readNode` / `soma graph node <id> --json` (see
-`docs/work-graph.md` §2.7, "planSteps bridge").
+status write on a bridged step, and the intended way for status to arrive is
+re-derivation from the node via `GraphStore.readNode` /
+`soma graph node <id> --json`.
+
+Read "intended", not "only". The refusals live in the mutation helpers, not in
+the type, so a caller can still route around them deliberately —
+`docs/work-graph.md` §2.7 names each hole. What the helpers guarantee is that a
+bridged step's authority is never dropped *incidentally*.
 
 The CLI surface:
 
@@ -186,11 +191,17 @@ soma algorithm step --id <run> --step-id <step> --status done       # refused wh
 `--node` binds *and* derives in one act, so a step is never bridged while still
 carrying its stale hand-written status. The derived `evidence` names the node and
 the moment, because a derived status that reads like a written one is the defect
-with the gate removed. **Three** write paths had to be closed, not one:
-`updateAlgorithmPlanStep` refuses (and `applyAlgorithmBatch` routes through it),
-`setAlgorithmPlan` refuses a step that arrives carrying a `nodeId`, and the VSA
-sync's whole-run VERIFY sweep (`markUnbridgedPlanStepsDone`) *skips* bridged steps
-— it has no single step to refuse for, and the `done` it writes comes from the
-VSA's phase alone. The visible cost is the honest one: an open bridged step leaves
-the run short of the VERIFY gate (`advanceAlgorithmRun` requires every plan step
-`done` or `blocked`) until its node closes.
+with the gate removed. **Three** mutation helpers reach a step's status, and each
+is handled — `updateAlgorithmPlanStep` refuses (and `applyAlgorithmBatch` routes
+through it), `setAlgorithmPlan` refuses in both directions, and the VSA sync's
+whole-run VERIFY sweep (`markUnbridgedPlanStepsDone`) *skips* bridged steps, since
+it has no single step to refuse for and the `done` it writes comes from the VSA's
+phase alone. `docs/work-graph.md` §2.7 is the authority on that enumeration and on
+what it does not cover; this section does not restate it.
+
+The cost is real but **not a lock**: an open bridged step leaves the run short of
+the VERIFY gate (`advanceAlgorithmRun` requires every plan step `done` or
+`blocked`) until its node closes — and a `setAlgorithmPlan` that omits the step
+clears the gate immediately, since a removed step gates nothing. Removal is a
+deliberate act and the end state is honest, but it is not refused and leaves no
+trace that a node-backed step was dropped.

--- a/docs/algorithm-execution-modes.md
+++ b/docs/algorithm-execution-modes.md
@@ -186,9 +186,11 @@ soma algorithm step --id <run> --step-id <step> --status done       # refused wh
 `--node` binds *and* derives in one act, so a step is never bridged while still
 carrying its stale hand-written status. The derived `evidence` names the node and
 the moment, because a derived status that reads like a written one is the defect
-with the gate removed. Two write paths had to be closed, not one: the per-step
-call refuses, and the VSA sync's whole-run VERIFY sweep
-(`markUnbridgedPlanStepsDone`) *skips* bridged steps — it has no single step to
-refuse for, and the `done` it writes comes from the VSA's phase alone. The
-visible cost is the honest one: an open bridged step leaves the run short of the
-VERIFY gate until its node closes.
+with the gate removed. **Three** write paths had to be closed, not one:
+`updateAlgorithmPlanStep` refuses (and `applyAlgorithmBatch` routes through it),
+`setAlgorithmPlan` refuses a step that arrives carrying a `nodeId`, and the VSA
+sync's whole-run VERIFY sweep (`markUnbridgedPlanStepsDone`) *skips* bridged steps
+— it has no single step to refuse for, and the `done` it writes comes from the
+VSA's phase alone. The visible cost is the honest one: an open bridged step leaves
+the run short of the VERIFY gate (`advanceAlgorithmRun` requires every plan step
+`done` or `blocked`) until its node closes.

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -331,8 +331,8 @@ be precise about what that buys, because the first version of this section claim
 exhaustiveness on the strength of a hand-made list that had missed one:
 
 > The invariant is enforced at the **mutation layer, not in the type**, and the
-> mutation layer is a set of speed bumps rather than a seal. Two holes, both
-> demonstrated rather than theorised:
+> mutation layer is a set of speed bumps rather than a seal. Two holes — the
+> second demonstrated by a test, the first following from the signature:
 >
 > - `writeAlgorithmRun` is on the public barrel and takes a whole run, so a caller
 >   can construct an `AlgorithmRun` literal with a bridged step and a hand-written
@@ -366,6 +366,12 @@ step no longer claims a node backs it.
   Dropping the step from the plan entirely stays legal: the step ceases to exist,
   so nothing claims a node backs it. What is refused is the id surviving with its
   authority quietly removed.
+
+  Note what that costs, since it is easy to read this section as stricter than it
+  is: **dropping the step also clears the VERIFY gate**, because a removed step
+  gates nothing. The "open bridged step holds the run short of VERIFY" property
+  below is therefore a cost a caller can decline, not a lock — and the removal is
+  neither refused nor recorded.
 - The VSA sync's VERIFY sweep — flipped every open step to `done` from the VSA's
   phase alone. A whole-run map has no single step to refuse for, so
   `markUnbridgedPlanStepsDone` **skips** bridged steps instead of throwing.

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -330,15 +330,26 @@ three *mutation helpers* that can reach a step's status, and each is handled —
 be precise about what that buys, because the first version of this section claimed
 exhaustiveness on the strength of a hand-made list that had missed one:
 
-> The invariant is enforced at the **mutation layer, not in the type.** Nothing
-> stops a caller from constructing an `AlgorithmRun` literal with a bridged step
-> and a hand-written `done` and handing it to `writeAlgorithmRun` — which is on the
-> public barrel and takes a whole run. A list of guarded functions cannot rule that
-> out, and no count of entries makes it exhaustive; only moving `status` out of the
-> bridged step's shape could, and that is a larger change than #501.
+> The invariant is enforced at the **mutation layer, not in the type**, and the
+> mutation layer is a set of speed bumps rather than a seal. Two holes, both
+> demonstrated rather than theorised:
+>
+> - `writeAlgorithmRun` is on the public barrel and takes a whole run, so a caller
+>   can construct an `AlgorithmRun` literal with a bridged step and a hand-written
+>   `done` and persist it.
+> - `setAlgorithmPlan`'s un-bridge refusal is **per-call**. Removing the step in
+>   one call and re-adding it unbridged in the next reproduces the end state the
+>   single-call refusal rejects; nothing sees across two calls.
+>
+> Only moving `status` out of a bridged step's shape would actually close these,
+> and that is a larger change than #501.
 
-So: a bridged step's status cannot be forged *through the helpers a run is
-normally mutated by*, and the three below are those helpers.
+So the accurate claim is narrower than "one write path": a bridged step's status
+cannot be forged **incidentally**. A re-plan that happens to omit a `nodeId`, a
+VSA sweep that flushes every open step, a routine `--status done` — each is caught,
+so a step's authority is never demoted as a side effect of something else. A caller
+who sets out to un-bridge a step can still do it, and the end state is honest: the
+step no longer claims a node backs it.
 
 - `updateAlgorithmPlanStep` — the per-step write. **Refuses** on a bridged step.
   `applyAlgorithmBatch`'s `step` operation routes through it, so it is covered by

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -325,6 +325,25 @@ from the node, read via `GraphStore.readNode` (surfaced as
 `docs/algorithm-execution-modes.md` is correspondingly narrowed to "no
 parallel work registry **at the same scope**" (#484).
 
+**Implemented** (#501). Two additions the spec left open, both forced by the
+implementation:
+
+- **Binding is a derivation.** `syncBridgedPlanStep(run, stepId, report, {bind})`
+  is the one write path for a bridged step's status, and it is also how a step
+  first acquires its `nodeId` — attaching the reference without deriving would
+  leave the step bridged while still reporting its stale hand-written status.
+- **The whole-run sweep skips.** `updateAlgorithmPlanStep` was not the only path
+  that wrote a step's status: the VSA sync's VERIFY sweep flipped every open step
+  to `done` from the VSA's phase alone. It is a whole-run map with no single step
+  to refuse for, so `markUnbridgedPlanStepsDone` **skips** bridged steps instead
+  of throwing. A refusal that covers one call site and not the other is not a
+  contract — it is a speed bump.
+
+`status` on a bridged step is therefore a **cache** of the node's reported state,
+and the derived `evidence` names the node and the derivation moment: a derived
+status that is indistinguishable from a written one has the gate's shape without
+its effect.
+
 ## 3. Receipts by autonomy class
 
 ### 3.1 AFK (`auto`)

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -325,23 +325,39 @@ from the node, read via `GraphStore.readNode` (surfaced as
 `docs/algorithm-execution-modes.md` is correspondingly narrowed to "no
 parallel work registry **at the same scope**" (#484).
 
-**Implemented** (#501). The spec named one write path to refuse; the run had
-**three**, and the exhaustiveness had to be established rather than asserted
-(Sage caught the claim standing on an enumeration of two):
+**Implemented** (#501). The spec named one write path to refuse. The run has
+three *mutation helpers* that can reach a step's status, and each is handled — but
+be precise about what that buys, because the first version of this section claimed
+exhaustiveness on the strength of a hand-made list that had missed one:
+
+> The invariant is enforced at the **mutation layer, not in the type.** Nothing
+> stops a caller from constructing an `AlgorithmRun` literal with a bridged step
+> and a hand-written `done` and handing it to `writeAlgorithmRun` — which is on the
+> public barrel and takes a whole run. A list of guarded functions cannot rule that
+> out, and no count of entries makes it exhaustive; only moving `status` out of the
+> bridged step's shape could, and that is a larger change than #501.
+
+So: a bridged step's status cannot be forged *through the helpers a run is
+normally mutated by*, and the three below are those helpers.
 
 - `updateAlgorithmPlanStep` — the per-step write. **Refuses** on a bridged step.
   `applyAlgorithmBatch`'s `step` operation routes through it, so it is covered by
   construction rather than by a second check.
 - `setAlgorithmPlan` — replaces `planSteps[]` wholesale with caller-authored
-  status. **Refuses** any incoming step carrying a `nodeId`: bridging is not a
-  planning act, so a bridged step cannot be *authored* into existence with a
-  status that never came from its node.
+  status. **Refuses in both directions**, which took two passes to get right:
+  - an *incoming* step carrying a `nodeId`, since bridging is not a planning act
+    and a bridged step must not be authored into existence with a status that
+    never came from its node; and
+  - an incoming step reusing an *existing bridged* step's id, which silently
+    dropped the bridge and left `updateAlgorithmPlanStep` willing to accept a
+    hand-written `done` on a step a reader still believed was node-derived.
+
+  Dropping the step from the plan entirely stays legal: the step ceases to exist,
+  so nothing claims a node backs it. What is refused is the id surviving with its
+  authority quietly removed.
 - The VSA sync's VERIFY sweep — flipped every open step to `done` from the VSA's
   phase alone. A whole-run map has no single step to refuse for, so
   `markUnbridgedPlanStepsDone` **skips** bridged steps instead of throwing.
-
-So `syncBridgedPlanStep` is the one write path for a bridged step's status
-because the other two refuse to produce one, not because they were not looked at.
 
 - **Binding is a derivation.** `syncBridgedPlanStep(run, stepId, report, {bind})`
   is also how a step first acquires its `nodeId` — attaching the reference

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -325,19 +325,35 @@ from the node, read via `GraphStore.readNode` (surfaced as
 `docs/algorithm-execution-modes.md` is correspondingly narrowed to "no
 parallel work registry **at the same scope**" (#484).
 
-**Implemented** (#501). Two additions the spec left open, both forced by the
-implementation:
+**Implemented** (#501). The spec named one write path to refuse; the run had
+**three**, and the exhaustiveness had to be established rather than asserted
+(Sage caught the claim standing on an enumeration of two):
+
+- `updateAlgorithmPlanStep` — the per-step write. **Refuses** on a bridged step.
+  `applyAlgorithmBatch`'s `step` operation routes through it, so it is covered by
+  construction rather than by a second check.
+- `setAlgorithmPlan` — replaces `planSteps[]` wholesale with caller-authored
+  status. **Refuses** any incoming step carrying a `nodeId`: bridging is not a
+  planning act, so a bridged step cannot be *authored* into existence with a
+  status that never came from its node.
+- The VSA sync's VERIFY sweep — flipped every open step to `done` from the VSA's
+  phase alone. A whole-run map has no single step to refuse for, so
+  `markUnbridgedPlanStepsDone` **skips** bridged steps instead of throwing.
+
+So `syncBridgedPlanStep` is the one write path for a bridged step's status
+because the other two refuse to produce one, not because they were not looked at.
 
 - **Binding is a derivation.** `syncBridgedPlanStep(run, stepId, report, {bind})`
-  is the one write path for a bridged step's status, and it is also how a step
-  first acquires its `nodeId` — attaching the reference without deriving would
-  leave the step bridged while still reporting its stale hand-written status.
-- **The whole-run sweep skips.** `updateAlgorithmPlanStep` was not the only path
-  that wrote a step's status: the VSA sync's VERIFY sweep flipped every open step
-  to `done` from the VSA's phase alone. It is a whole-run map with no single step
-  to refuse for, so `markUnbridgedPlanStepsDone` **skips** bridged steps instead
-  of throwing. A refusal that covers one call site and not the other is not a
-  contract — it is a speed bump.
+  is also how a step first acquires its `nodeId` — attaching the reference
+  without deriving would leave the step bridged while still reporting its stale
+  hand-written status, which is worse than two homes: it is none. `bind` does not
+  license **re-homing**, either; an already-bridged step refuses a different node,
+  or the one caller that always passes `bind` would make the mismatch check
+  unreachable and a typo'd `--node` would move a step silently.
+- **`BridgedNodeReport` is `Pick`ed from `NodeState`**, not re-declared to match
+  it. Hand-written, its `blockedBy?` was optional where `NodeState`'s is
+  required — a report missing the field type-checked and derived `open` where the
+  node was `blocked`, a fail-open `tsc` could not see.
 
 `status` on a bridged step is therefore a **cache** of the node's reported state,
 and the derived `evidence` names the node and the derivation moment: a derived

--- a/src/algorithm-vsa-sync.ts
+++ b/src/algorithm-vsa-sync.ts
@@ -45,6 +45,7 @@ import { getCriteria, getDecisions, getGoal, isClosedCriterion } from "./vsa-acc
 import { _promoteAlgorithmRunMemoryWithCallback } from "./memory-promotion";
 import type {
   AlgorithmPhase,
+  AlgorithmPlanStep,
   AlgorithmRun,
   VerificationStateArtifact,
   Checkpoint,
@@ -195,7 +196,21 @@ function phaseIndex(phase: AlgorithmPhase): number {
  * is passed/dropped, so we never try to advance past VERIFY when criteria are
  * still open — even if the VSA claims `learn`/`complete`.
  */
-function reachableTargetPhase(target: AlgorithmPhase, criteria: readonly Checkpoint[]): AlgorithmPhase {
+function reachableTargetPhase(
+  target: AlgorithmPhase,
+  criteria: readonly Checkpoint[],
+  planSteps: readonly AlgorithmPlanStep[] = [],
+): AlgorithmPhase {
+  // An open BRIDGED step is un-sweepable by design (§2.7) — only its node closing
+  // moves it — so the VERIFY gate cannot be satisfied here. Cap at EXECUTE rather
+  // than let `advanceRunToPhase` throw: the throw unwinds to the outer
+  // failure-isolation catch, which no-ops the WHOLE sync and discards the criteria
+  // reconciliation done before the advance. Same shape as the LEARN cap below —
+  // stop at the un-passable gate, keep the work that already succeeded.
+  const bridgedOpen = planSteps.some((step) => step.nodeId !== undefined && step.status === "open");
+  if (bridgedOpen && phaseIndex(target === "complete" ? "learn" : target) > phaseIndex("execute")) {
+    return "execute";
+  }
   // Mirror the LEARN integrity gate via the shared rule so the two cannot drift:
   // a `passed` criterion verified by specification only (e.g. a pass fabricated
   // from a frontmatter progress counter) cannot clear LEARN, so sync caps such a
@@ -512,7 +527,7 @@ async function syncAlgorithmRunFromVsaInner(
   const reconciledCriteria = getCriteria(run.vsa);
 
   // 2. Advance forward to (a reachable cap of) the VSA's declared phase. Never backward.
-  const targetPhase = reachableTargetPhase(isa.frontmatter.phase, reconciledCriteria);
+  const targetPhase = reachableTargetPhase(isa.frontmatter.phase, reconciledCriteria, run.planSteps);
   if (phaseIndex(getRunPhase(run)) < phaseIndex(targetPhase)) {
     run = advanceRunToPhase(run, targetPhase, timestamp, options.substrate);
   }

--- a/src/algorithm-vsa-sync.ts
+++ b/src/algorithm-vsa-sync.ts
@@ -25,6 +25,7 @@ import {
   createAlgorithmRun,
   hasCurrentStateProbe,
   learnGateViolations,
+  markUnbridgedPlanStepsDone,
   nextAlgorithmPhase,
   recordAlgorithmChange,
   recordAlgorithmLearning,
@@ -262,12 +263,8 @@ function prepareAndAdvance(run: AlgorithmRun, target: AlgorithmPhase, timestamp:
       }
       break;
     case "verify":
-      next = {
-        ...next,
-        planSteps: next.planSteps.map((step) =>
-          step.status === "open" ? { ...step, status: "done" as const, evidence: step.evidence ?? "synced from VSA" } : step,
-        ),
-      };
+      // Skips bridged steps — see `markUnbridgedPlanStepsDone` (§2.7).
+      next = { ...next, planSteps: markUnbridgedPlanStepsDone(next.planSteps, "synced from VSA") };
       break;
     default:
       break;

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -18,6 +18,9 @@ import {
   removeAlgorithmCapabilitySelection,
   selectAlgorithmCapability,
 } from "./algorithm-capabilities";
+// Type-only, so this stays a compile-time relationship and adds no runtime
+// dependency on the graph from this pure module — see {@link BridgedNodeReport}.
+import type { NodeState } from "./work-graph";
 import { classifyAlgorithmPrompt } from "./algorithm-classifier";
 import { compactSmarterRun } from "./algorithm-reflection-digest";
 import {
@@ -214,6 +217,19 @@ export function setAlgorithmPlan(run: AlgorithmRun, planSteps: AlgorithmPlanStep
 
   for (const step of planSteps) {
     assertNonEmpty(step.text, `plan step ${step.id} text`);
+
+    // §2.7: this call replaces `planSteps[]` wholesale with caller-authored
+    // status, so accepting a `nodeId` here would author a bridged step whose
+    // status never came from its node — the two-homes defect through the plan
+    // call rather than the step call. Bridging goes through
+    // `syncBridgedPlanStep`, where binding and deriving are one act. Without
+    // this, "syncBridgedPlanStep is the one write path" was an assertion with a
+    // second path sitting next to it (Sage, PR #555).
+    if (step.nodeId !== undefined) {
+      throw new Error(
+        `Algorithm plan step ${step.id} cannot be bridged to work-graph node ${step.nodeId} by setAlgorithmPlan: a bridged step's status must be derived from its node. Plan the step unbridged, then bridge it with syncBridgedPlanStep.`,
+      );
+    }
 
     if (step.criteriaIds.length === 0) {
       throw new Error(`Algorithm plan step ${step.id} must map to at least one criterion.`);
@@ -602,6 +618,21 @@ export function advanceAlgorithmRunUntil(
   return next;
 }
 
+/**
+ * Look one plan step up, or refuse. Exported so the CLI resolves a step the same
+ * way the core does — three copies of this `findIndex` plus its message had
+ * drifted apart across two modules (Sage, PR #555).
+ */
+export function requirePlanStep(run: AlgorithmRun, stepId: string): { step: AlgorithmPlanStep; index: number } {
+  const index = run.planSteps.findIndex((step) => step.id === stepId);
+
+  if (index === -1) {
+    throw new Error(`Algorithm plan step not found: ${stepId}`);
+  }
+
+  return { step: run.planSteps[index], index };
+}
+
 export function updateAlgorithmPlanStep(
   run: AlgorithmRun,
   stepId: string,
@@ -609,13 +640,7 @@ export function updateAlgorithmPlanStep(
   evidence?: string,
   timestamp = new Date().toISOString(),
 ): AlgorithmRun {
-  const stepIndex = run.planSteps.findIndex((step) => step.id === stepId);
-
-  if (stepIndex === -1) {
-    throw new Error(`Algorithm plan step not found: ${stepId}`);
-  }
-
-  const step = run.planSteps[stepIndex];
+  const { step, index: stepIndex } = requirePlanStep(run, stepId);
 
   // §2.7: a bridged step's status lives on the node. Accepting a direct write
   // here is exactly the two-authoritative-homes failure the bridge exists to
@@ -668,16 +693,19 @@ export function markUnbridgedPlanStepsDone(
 }
 
 /**
- * The node state the bridge derives from — a structural subset of the work
- * graph's `NodeState`, so a real `NodeState` satisfies it without
- * `src/algorithm.ts` (pure, no I/O) depending on the graph module. The reader is
- * the caller's: `GraphStore.readNode`, or `soma graph node <id> --json`.
+ * The node state the bridge derives from — **`Pick`ed from the real
+ * `NodeState`** rather than re-declared to match it. Written by hand it was a
+ * claim ("a structural subset, so a real `NodeState` satisfies it") that the
+ * compiler did not check, and its `blockedBy?` was optional where `NodeState`'s
+ * is required: a report missing the field type-checked and silently derived
+ * `open` where the node was `blocked` — a fail-OPEN that `tsc` could not see
+ * (Sage, PR #555). Deriving the type makes divergence a compile error.
+ *
+ * The import is type-only, so this pure module still takes no runtime dependency
+ * on the graph. The reader is the caller's: {@link readNodeForBridge},
+ * `GraphStore.readNode`, or `soma graph node <id> --json`.
  */
-export interface BridgedNodeReport {
-  ref: { id: string };
-  status: "open" | "closed";
-  blockedBy?: readonly { id: string; status: "open" | "closed" }[];
-}
+export type BridgedNodeReport = Pick<NodeState, "ref" | "status" | "blockedBy">;
 
 /**
  * Map a node's reported state onto a plan-step status. `closed` is the only
@@ -686,7 +714,7 @@ export interface BridgedNodeReport {
  */
 export function deriveBridgedPlanStepStatus(report: BridgedNodeReport): AlgorithmPlanStep["status"] {
   if (report.status === "closed") return "done";
-  return (report.blockedBy ?? []).some((blocker) => blocker.status === "open") ? "blocked" : "open";
+  return report.blockedBy.some((blocker) => blocker.status === "open") ? "blocked" : "open";
 }
 
 /**
@@ -698,7 +726,10 @@ export function deriveBridgedPlanStepStatus(report: BridgedNodeReport): Algorith
  * Refuses when the report describes a different node than the step is bridged
  * to: syncing step A from node B's state would write a status with no relation
  * to the step's authoritative home, which is the same defect as a direct write
- * wearing a derivation's clothes.
+ * wearing a derivation's clothes. `bind` does NOT license that — re-homing an
+ * already-bridged step is refused too, or `bind` would make the mismatch check
+ * unreachable from the one caller that always sets it, and a typo'd `--node`
+ * would silently move a step to an unrelated node (Sage, PR #555).
  */
 export function syncBridgedPlanStep(
   run: AlgorithmRun,
@@ -707,13 +738,14 @@ export function syncBridgedPlanStep(
   options: { bind?: boolean } = {},
   timestamp = new Date().toISOString(),
 ): AlgorithmRun {
-  const stepIndex = run.planSteps.findIndex((step) => step.id === stepId);
+  const { step, index: stepIndex } = requirePlanStep(run, stepId);
 
-  if (stepIndex === -1) {
-    throw new Error(`Algorithm plan step not found: ${stepId}`);
+  if (options.bind === true && step.nodeId !== undefined && step.nodeId !== report.ref.id) {
+    throw new Error(
+      `Algorithm plan step ${stepId} is already bridged to work-graph node ${step.nodeId}; refusing to re-home it to ${report.ref.id}. Re-plan the step to move it.`,
+    );
   }
 
-  const step = run.planSteps[stepIndex];
   const nodeId = options.bind === true ? report.ref.id : step.nodeId;
 
   if (nodeId === undefined) {

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -229,18 +229,21 @@ export function setAlgorithmPlan(run: AlgorithmRun, planSteps: AlgorithmPlanStep
       );
     }
 
-    // …and the OUTGOING direction, which the incoming check alone left open: an
-    // unbridged step reusing a bridged step's id silently DROPS the bridge, after
-    // which `updateAlgorithmPlanStep` accepts a hand-written `done` on what a
-    // reader still believes is node-derived. Refuse it.
+    // …and the outgoing direction: an unbridged step reusing a bridged step's id
+    // drops the bridge in place, after which `updateAlgorithmPlanStep` accepts a
+    // hand-written `done` on what a reader still believes is node-derived.
     //
-    // Dropping the step from the plan entirely is NOT this defect and stays
-    // legal: the step ceases to exist, so nothing claims a node backs it. What is
-    // refused is the same id surviving with its authority quietly removed.
+    // This is a SPEED BUMP, not a seal, and the distinction is load-bearing:
+    // removing the step in one call and re-adding it unbridged in the next
+    // reproduces the same end state, and nothing here can see across two calls.
+    // What it buys is that un-bridging cannot happen *incidentally* — a re-plan
+    // that happens to omit a `nodeId` is caught, rather than quietly demoting a
+    // step's authority. Deliberately unbridging still works, and the end state is
+    // honest: the step no longer claims a node backs it.
     const existing = run.planSteps.find((current) => current.id === step.id);
     if (existing?.nodeId !== undefined) {
       throw new Error(
-        `Algorithm plan step ${step.id} is bridged to work-graph node ${existing.nodeId}; setAlgorithmPlan cannot un-bridge it. Drop the step from the plan to remove it.`,
+        `Algorithm plan step ${step.id} is bridged to work-graph node ${existing.nodeId}; setAlgorithmPlan cannot un-bridge it in place. A bridged step cannot be re-planned at all — omit it to remove it, then plan it afresh if you want it run-owned.`,
       );
     }
 

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -615,14 +615,131 @@ export function updateAlgorithmPlanStep(
     throw new Error(`Algorithm plan step not found: ${stepId}`);
   }
 
-  const planSteps = run.planSteps.map((step, index) =>
+  const step = run.planSteps[stepIndex];
+
+  // §2.7: a bridged step's status lives on the node. Accepting a direct write
+  // here is exactly the two-authoritative-homes failure the bridge exists to
+  // prevent — and it would fail SILENTLY, since the forged status is
+  // indistinguishable from a derived one once written.
+  if (step.nodeId !== undefined) {
+    throw new Error(
+      `Algorithm plan step ${stepId} is bridged to work-graph node ${step.nodeId}: its status derives from the node, not from a direct write. ` +
+        `Read the node (soma graph node ${step.nodeId} --json) and re-derive via syncBridgedPlanStep.`,
+    );
+  }
+
+  const planSteps = run.planSteps.map((current, index) =>
     index === stepIndex
       ? {
-          ...step,
+          ...current,
           status,
           evidence,
         }
+      : current,
+  );
+
+  return {
+    ...run,
+    updatedAt: timestamp,
+    planSteps,
+  };
+}
+
+/**
+ * Sweep every *unbridged* open step to `done` — the whole-run flush the VSA sync
+ * performs when a VSA is already past VERIFY.
+ *
+ * Bridged steps are skipped, not refused. This is a whole-run map with no single
+ * step to refuse for, and the status it writes comes from the VSA's phase alone,
+ * so applying it to a bridged step would forge a derived status — the exact
+ * write {@link updateAlgorithmPlanStep} refuses one step at a time. The visible
+ * cost is the honest one: an open bridged step leaves the run short of the
+ * VERIFY gate until its node closes.
+ */
+export function markUnbridgedPlanStepsDone(
+  planSteps: readonly AlgorithmPlanStep[],
+  evidence: string,
+): AlgorithmPlanStep[] {
+  return planSteps.map((step) =>
+    step.status === "open" && step.nodeId === undefined
+      ? { ...step, status: "done" as const, evidence: step.evidence ?? evidence }
       : step,
+  );
+}
+
+/**
+ * The node state the bridge derives from — a structural subset of the work
+ * graph's `NodeState`, so a real `NodeState` satisfies it without
+ * `src/algorithm.ts` (pure, no I/O) depending on the graph module. The reader is
+ * the caller's: `GraphStore.readNode`, or `soma graph node <id> --json`.
+ */
+export interface BridgedNodeReport {
+  ref: { id: string };
+  status: "open" | "closed";
+  blockedBy?: readonly { id: string; status: "open" | "closed" }[];
+}
+
+/**
+ * Map a node's reported state onto a plan-step status. `closed` is the only
+ * `done`; an open node with an open blocker is `blocked`, which is what makes
+ * the run's checklist show graph topology rather than restate it.
+ */
+export function deriveBridgedPlanStepStatus(report: BridgedNodeReport): AlgorithmPlanStep["status"] {
+  if (report.status === "closed") return "done";
+  return (report.blockedBy ?? []).some((blocker) => blocker.status === "open") ? "blocked" : "open";
+}
+
+/**
+ * Re-derive a bridged step's status from its node — the ONLY write path for a
+ * bridged step's status (§2.7). Also the path that first binds a step to a node:
+ * pass `bind` to attach `nodeId`, so a step can never be bridged and left
+ * carrying its stale hand-written status.
+ *
+ * Refuses when the report describes a different node than the step is bridged
+ * to: syncing step A from node B's state would write a status with no relation
+ * to the step's authoritative home, which is the same defect as a direct write
+ * wearing a derivation's clothes.
+ */
+export function syncBridgedPlanStep(
+  run: AlgorithmRun,
+  stepId: string,
+  report: BridgedNodeReport,
+  options: { bind?: boolean } = {},
+  timestamp = new Date().toISOString(),
+): AlgorithmRun {
+  const stepIndex = run.planSteps.findIndex((step) => step.id === stepId);
+
+  if (stepIndex === -1) {
+    throw new Error(`Algorithm plan step not found: ${stepId}`);
+  }
+
+  const step = run.planSteps[stepIndex];
+  const nodeId = options.bind === true ? report.ref.id : step.nodeId;
+
+  if (nodeId === undefined) {
+    throw new Error(
+      `Algorithm plan step ${stepId} is not bridged to a work-graph node. Bind it to one first, or set its status directly with updateAlgorithmPlanStep.`,
+    );
+  }
+
+  if (nodeId !== report.ref.id) {
+    throw new Error(
+      `Algorithm plan step ${stepId} is bridged to work-graph node ${nodeId}, but the reported node is ${report.ref.id}.`,
+    );
+  }
+
+  const status = deriveBridgedPlanStepStatus(report);
+  const planSteps = run.planSteps.map((current, index) =>
+    index === stepIndex
+      ? {
+          ...current,
+          nodeId,
+          status,
+          // Derived, never caller-asserted — the pointer names the authority and
+          // the moment, so a reader can tell a fresh derivation from a stale one.
+          evidence: `derived from work-graph node ${nodeId} (${report.status}) at ${timestamp}`,
+        }
+      : current,
   );
 
   return {

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -18,9 +18,10 @@ import {
   removeAlgorithmCapabilitySelection,
   selectAlgorithmCapability,
 } from "./algorithm-capabilities";
-// Type-only, so this stays a compile-time relationship and adds no runtime
-// dependency on the graph from this pure module — see {@link BridgedNodeReport}.
-import type { NodeState } from "./work-graph";
+// The narrow report type the graph publishes for §2.7 — declared THERE, so the
+// graph owns the shape it publishes and this module names a contract rather than
+// a `NodeState`. Type-only: no runtime dependency on the graph from this pure module.
+import type { BridgedNodeReport } from "./work-graph";
 import { classifyAlgorithmPrompt } from "./algorithm-classifier";
 import { compactSmarterRun } from "./algorithm-reflection-digest";
 import {
@@ -218,16 +219,28 @@ export function setAlgorithmPlan(run: AlgorithmRun, planSteps: AlgorithmPlanStep
   for (const step of planSteps) {
     assertNonEmpty(step.text, `plan step ${step.id} text`);
 
-    // §2.7: this call replaces `planSteps[]` wholesale with caller-authored
-    // status, so accepting a `nodeId` here would author a bridged step whose
-    // status never came from its node — the two-homes defect through the plan
-    // call rather than the step call. Bridging goes through
-    // `syncBridgedPlanStep`, where binding and deriving are one act. Without
-    // this, "syncBridgedPlanStep is the one write path" was an assertion with a
-    // second path sitting next to it (Sage, PR #555).
+    // §2.7, incoming direction: this call replaces `planSteps[]` wholesale with
+    // caller-authored status, so accepting a `nodeId` here would author a bridged
+    // step whose status never came from its node. Bridging goes through
+    // `syncBridgedPlanStep`, where binding and deriving are one act.
     if (step.nodeId !== undefined) {
       throw new Error(
         `Algorithm plan step ${step.id} cannot be bridged to work-graph node ${step.nodeId} by setAlgorithmPlan: a bridged step's status must be derived from its node. Plan the step unbridged, then bridge it with syncBridgedPlanStep.`,
+      );
+    }
+
+    // …and the OUTGOING direction, which the incoming check alone left open: an
+    // unbridged step reusing a bridged step's id silently DROPS the bridge, after
+    // which `updateAlgorithmPlanStep` accepts a hand-written `done` on what a
+    // reader still believes is node-derived. Refuse it.
+    //
+    // Dropping the step from the plan entirely is NOT this defect and stays
+    // legal: the step ceases to exist, so nothing claims a node backs it. What is
+    // refused is the same id surviving with its authority quietly removed.
+    const existing = run.planSteps.find((current) => current.id === step.id);
+    if (existing?.nodeId !== undefined) {
+      throw new Error(
+        `Algorithm plan step ${step.id} is bridged to work-graph node ${existing.nodeId}; setAlgorithmPlan cannot un-bridge it. Drop the step from the plan to remove it.`,
       );
     }
 
@@ -620,8 +633,7 @@ export function advanceAlgorithmRunUntil(
 
 /**
  * Look one plan step up, or refuse. Exported so the CLI resolves a step the same
- * way the core does — three copies of this `findIndex` plus its message had
- * drifted apart across two modules (Sage, PR #555).
+ * way the core does, rather than keeping its own copy of this lookup and message.
  */
 export function requirePlanStep(run: AlgorithmRun, stepId: string): { step: AlgorithmPlanStep; index: number } {
   const index = run.planSteps.findIndex((step) => step.id === stepId);
@@ -692,20 +704,7 @@ export function markUnbridgedPlanStepsDone(
   );
 }
 
-/**
- * The node state the bridge derives from — **`Pick`ed from the real
- * `NodeState`** rather than re-declared to match it. Written by hand it was a
- * claim ("a structural subset, so a real `NodeState` satisfies it") that the
- * compiler did not check, and its `blockedBy?` was optional where `NodeState`'s
- * is required: a report missing the field type-checked and silently derived
- * `open` where the node was `blocked` — a fail-OPEN that `tsc` could not see
- * (Sage, PR #555). Deriving the type makes divergence a compile error.
- *
- * The import is type-only, so this pure module still takes no runtime dependency
- * on the graph. The reader is the caller's: {@link readNodeForBridge},
- * `GraphStore.readNode`, or `soma graph node <id> --json`.
- */
-export type BridgedNodeReport = Pick<NodeState, "ref" | "status" | "blockedBy">;
+export type { BridgedNodeReport };
 
 /**
  * Map a node's reported state onto a plan-step status. `closed` is the only
@@ -727,9 +726,9 @@ export function deriveBridgedPlanStepStatus(report: BridgedNodeReport): Algorith
  * to: syncing step A from node B's state would write a status with no relation
  * to the step's authoritative home, which is the same defect as a direct write
  * wearing a derivation's clothes. `bind` does NOT license that — re-homing an
- * already-bridged step is refused too, or `bind` would make the mismatch check
- * unreachable from the one caller that always sets it, and a typo'd `--node`
- * would silently move a step to an unrelated node (Sage, PR #555).
+ * already-bridged step is refused too, or the mismatch check would be unreachable
+ * from the one caller that always sets `bind`, and a typo'd node id would move a
+ * step silently.
  */
 export function syncBridgedPlanStep(
   run: AlgorithmRun,

--- a/src/cli/algorithm.ts
+++ b/src/cli/algorithm.ts
@@ -44,7 +44,7 @@ import { defaultEvidenceKind, getCriteria, getGoal } from "../vsa-accessors";
 import { getRunPhase } from "../algorithm-lifecycle";
 import { readOption } from "./parse-utils";
 import { parseSubstrate } from "./substrate";
-import { readNodeForBridge } from "./graph";
+import { readNodeForBridge } from "../work-graph-bridge";
 import type {
   AlgorithmBatchOperation,
   AlgorithmEffortTier,
@@ -98,9 +98,9 @@ export const ALGORITHM_COMMAND_HELP: { usage: string; subcommands: Record<Algori
     decision: "Usage: soma algorithm decision --id <run-id> --text <text> [--home-dir <dir>] [--soma-home <dir>]",
     change: "Usage: soma algorithm change --id <run-id> --text <text> [--home-dir <dir>] [--soma-home <dir>]",
     step:
-      "Usage: soma algorithm step --id <run-id> --step-id <id> (--status <open|done|blocked> [--evidence <text>] | --node <node-id> | --sync) [--repo <owner/name>]. " +
+      "Usage: soma algorithm step --id <run-id> --step-id <id> (--status <open|done|blocked> [--evidence <text>] | (--node <node-id> | --sync) [--repo <owner/name>]). " +
       "--node bridges the step to a work-graph node and derives its status from it; --sync re-derives an already-bridged step. " +
-      "--status is refused on a bridged step: the node is its one authoritative home (docs/work-graph.md §2.7).",
+      "The bridged arm takes NEITHER --status nor --evidence — both are derived from the node, which is the step's one authoritative home (docs/work-graph.md §2.7).",
     verify: "Usage: soma algorithm verify --id <run-id> --criterion-id <id> --status <passed|failed|dropped|deferred-probe> --evidence <text> [--evidence-kind <specified|probed|tested>] [--substrate <id>]",
     learn: "Usage: soma algorithm learn --id <run-id> --text <text> [--substrate <id>] [--home-dir <dir>] [--soma-home <dir>]",
     reflect:
@@ -484,10 +484,9 @@ export function parseAlgorithmArgs(args: string[]): ParsedAlgorithmArgs {
         options.stepId = readOption(rest, index, arg);
         index += 1;
         break;
-      // Scoped to `step`, matching the `--status` arm below. Unguarded, every
-      // algorithm subcommand silently accepted the graph-bridge flags — two
-      // conventions in one switch, so the next flag's correct shape is a guess
-      // (Sage, PR #555).
+      // Scoped to `step`, matching the `--status` arm below: an unguarded arm
+      // accepts the flag on every algorithm subcommand, and two conventions in one
+      // switch make the next flag's correct shape a guess.
       case "--node":
         if (action !== "step") throw new Error("--node is only valid for step.");
         options.stepNodeId = readOption(rest, index, arg);
@@ -784,7 +783,7 @@ export interface AlgorithmCliDeps {
 async function resolveBridgedNodeId(options: AlgorithmCliOptions, stepId: string): Promise<string> {
   const id = requireAlgorithmId(options);
   const { run } = await readAlgorithmRunById(id, { homeDir: options.homeDir, somaHome: options.somaHome });
-  // Shared lookup, not a third copy of `findIndex` + its message (Sage, PR #555).
+  // The core's lookup, not a third copy of it and its message.
   const { step } = requirePlanStep(run, stepId);
 
   if (step.nodeId === undefined) {
@@ -810,9 +809,8 @@ async function runStepAction(options: AlgorithmCliOptions, deps: AlgorithmCliDep
 
   if (bind || sync) {
     // Naming a collision beats silently preferring one side of it. `--status` is
-    // the write §2.7 refuses outright; `--evidence` is subtler and was being
-    // accepted and then discarded, since the derived pointer always overwrites it
-    // (Sage, PR #555) — the same silent preference this refusal exists to reject.
+    // the write §2.7 refuses outright; `--evidence` is subtler — the derived
+    // pointer always overwrites it, so accepting it would discard it in silence.
     if (options.stepStatus !== undefined) {
       throw new Error("--status cannot be combined with --node or --sync: a bridged step's status derives from its node.");
     }

--- a/src/cli/algorithm.ts
+++ b/src/cli/algorithm.ts
@@ -21,12 +21,13 @@ import {
   runSomaLifecycleAlgorithmUpdated,
   setAlgorithmPlan,
   selectAlgorithmCapability,
+  syncBridgedPlanStep,
   updateAlgorithmPlanStep,
   verifyAlgorithmCriterion,
   writeAlgorithmRun,
   appendSomaMemoryEvent,
 } from "../index";
-import type { ReflectionForDigest } from "../index";
+import type { BridgedNodeReport, ReflectionForDigest } from "../index";
 // VerificationGateError is a CLI-only classification detail — imported straight
 // from its defining module, deliberately NOT re-exported through the public
 // barrel (Sage review, PR #455): keeping it off ../index leaves the internal
@@ -42,6 +43,7 @@ import { defaultEvidenceKind, getCriteria, getGoal } from "../vsa-accessors";
 import { getRunPhase } from "../algorithm-lifecycle";
 import { readOption } from "./parse-utils";
 import { parseSubstrate } from "./substrate";
+import { readNodeForBridge } from "./graph";
 import type {
   AlgorithmBatchOperation,
   AlgorithmEffortTier,
@@ -94,7 +96,10 @@ export const ALGORITHM_COMMAND_HELP: { usage: string; subcommands: Record<Algori
       "Usage: soma algorithm observe --id <run-id> --claim <text> --evidence <text> [--evidence-kind <probed|tested|specified>] [--substrate <id>] [--home-dir <dir>] [--soma-home <dir>] (kind defaults to specified; assert probed/tested to clear the OBSERVE floor)",
     decision: "Usage: soma algorithm decision --id <run-id> --text <text> [--home-dir <dir>] [--soma-home <dir>]",
     change: "Usage: soma algorithm change --id <run-id> --text <text> [--home-dir <dir>] [--soma-home <dir>]",
-    step: "Usage: soma algorithm step --id <run-id> --step-id <id> --status <open|done|blocked> [--evidence <text>]",
+    step:
+      "Usage: soma algorithm step --id <run-id> --step-id <id> (--status <open|done|blocked> [--evidence <text>] | --node <node-id> | --sync) [--repo <owner/name>]. " +
+      "--node bridges the step to a work-graph node and derives its status from it; --sync re-derives an already-bridged step. " +
+      "--status is refused on a bridged step: the node is its one authoritative home (docs/work-graph.md §2.7).",
     verify: "Usage: soma algorithm verify --id <run-id> --criterion-id <id> --status <passed|failed|dropped|deferred-probe> --evidence <text> [--evidence-kind <specified|probed|tested>] [--substrate <id>]",
     learn: "Usage: soma algorithm learn --id <run-id> --text <text> [--substrate <id>] [--home-dir <dir>] [--soma-home <dir>]",
     reflect:
@@ -129,6 +134,12 @@ interface AlgorithmCliOptions {
   claim?: string;
   stepId?: string;
   stepStatus?: AlgorithmPlanStep["status"];
+  /** Work-graph node to bridge the step to (§2.7). */
+  stepNodeId?: string;
+  /** Re-derive an already-bridged step's status from its node. */
+  stepSync?: boolean;
+  /** Which repository backs the graph, when the bridge cannot infer it. */
+  repo?: string;
   criterionId?: string;
   criterionStatus?: "passed" | "failed" | "dropped" | "deferred-probe";
   evidence?: string;
@@ -472,6 +483,17 @@ export function parseAlgorithmArgs(args: string[]): ParsedAlgorithmArgs {
         options.stepId = readOption(rest, index, arg);
         index += 1;
         break;
+      case "--node":
+        options.stepNodeId = readOption(rest, index, arg);
+        index += 1;
+        break;
+      case "--sync":
+        options.stepSync = true;
+        break;
+      case "--repo":
+        options.repo = readOption(rest, index, arg);
+        index += 1;
+        break;
       case "--status":
         if (action === "step") {
           options.stepStatus = parseStepStatus(readOption(rest, index, arg));
@@ -623,7 +645,15 @@ function formatAlgorithmRun(run: AlgorithmRun, path: string): string {
     ...getCriteria(run.vsa).map((criterion) => `- [${criterion.status}] ${criterion.id}: ${criterion.text}${criterion.verification ? ` | ${criterion.verification}` : ""}`),
     "",
     "Plan:",
-    ...(run.planSteps.length > 0 ? run.planSteps.map((step) => `- [${step.status}] ${step.id}: ${step.text} (${step.criteriaIds.join(",")})`) : ["- none"]),
+    ...(run.planSteps.length > 0
+      ? run.planSteps.map(
+          (step) =>
+            `- [${step.status}] ${step.id}: ${step.text} (${step.criteriaIds.join(",")})` +
+            // Naming the node makes the status's authority visible: without it a
+            // derived status reads exactly like a hand-written one.
+            (step.nodeId === undefined ? "" : ` → node ${step.nodeId}`),
+        )
+      : ["- none"]),
     "",
     "Capabilities:",
     ...((run.capabilitySelections ?? []).length > 0
@@ -733,8 +763,35 @@ async function updateAndReportAlgorithmRun(
   return formatAlgorithmRun(written.run, written.path);
 }
 
-export async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<string> {
+/**
+ * The bridge's read path (§2.7), injectable so the planSteps tests can exercise
+ * the contract without a tracker. Production resolves to `readNodeForBridge`,
+ * which is `soma graph node <id>`'s own seam.
+ */
+export interface AlgorithmCliDeps {
+  readNode: (nodeId: string, options: { repo?: string }) => Promise<BridgedNodeReport>;
+}
+
+/** Which node an already-bridged step defers to — read off the run, not argv. */
+async function resolveBridgedNodeId(options: AlgorithmCliOptions, stepId: string): Promise<string> {
+  const id = requireAlgorithmId(options);
+  const { run } = await readAlgorithmRunById(id, { homeDir: options.homeDir, somaHome: options.somaHome });
+  const step = run.planSteps.find((candidate) => candidate.id === stepId);
+
+  if (step === undefined) throw new Error(`Algorithm plan step not found: ${stepId}`);
+  if (step.nodeId === undefined) {
+    throw new Error(`Algorithm plan step ${stepId} is not bridged to a work-graph node. Bridge it with --node <node-id>.`);
+  }
+
+  return step.nodeId;
+}
+
+export async function runAlgorithmCli(
+  parsed: ParsedAlgorithmArgs,
+  overrides: Partial<AlgorithmCliDeps> = {},
+): Promise<string> {
   const options = parsed.options;
+  const deps: AlgorithmCliDeps = { readNode: async (nodeId, opts) => await readNodeForBridge(nodeId, opts), ...overrides };
 
   if (parsed.action === "classify") {
     if (!options.prompt) throw new Error("--prompt is required.");
@@ -861,8 +918,26 @@ export async function runAlgorithmCli(parsed: ParsedAlgorithmArgs): Promise<stri
   }
 
   if (parsed.action === "step") {
-    if (!options.stepId || !options.stepStatus) throw new Error("--step-id and --status are required.");
+    if (!options.stepId) throw new Error("--step-id is required.");
     const stepId = options.stepId;
+    const bind = options.stepNodeId !== undefined;
+    const sync = options.stepSync === true;
+
+    if (bind && sync) throw new Error("--node already derives the status; pass one of --node or --sync.");
+
+    if (bind || sync) {
+      if (options.stepStatus !== undefined) {
+        // Naming the collision beats silently preferring one: --status on a
+        // bridged step is the exact write §2.7 refuses, so an argv that asks for
+        // both is asking for a forged status.
+        throw new Error("--status cannot be combined with --node or --sync: a bridged step's status derives from its node.");
+      }
+      const nodeId = options.stepNodeId ?? (await resolveBridgedNodeId(options, stepId));
+      const state = await deps.readNode(nodeId, { repo: options.repo });
+      return updateAndReportAlgorithmRun(options, (run) => syncBridgedPlanStep(run, stepId, state, { bind }));
+    }
+
+    if (!options.stepStatus) throw new Error("--step-id and --status are required.");
     const stepStatus = options.stepStatus;
     return updateAndReportAlgorithmRun(options, (run) => updateAlgorithmPlanStep(run, stepId, stepStatus, options.evidence));
   }

--- a/src/cli/algorithm.ts
+++ b/src/cli/algorithm.ts
@@ -19,6 +19,7 @@ import {
   removeAlgorithmCapabilitySelection,
   renderReflectionDigest,
   runSomaLifecycleAlgorithmUpdated,
+  requirePlanStep,
   setAlgorithmPlan,
   selectAlgorithmCapability,
   syncBridgedPlanStep,
@@ -483,14 +484,21 @@ export function parseAlgorithmArgs(args: string[]): ParsedAlgorithmArgs {
         options.stepId = readOption(rest, index, arg);
         index += 1;
         break;
+      // Scoped to `step`, matching the `--status` arm below. Unguarded, every
+      // algorithm subcommand silently accepted the graph-bridge flags — two
+      // conventions in one switch, so the next flag's correct shape is a guess
+      // (Sage, PR #555).
       case "--node":
+        if (action !== "step") throw new Error("--node is only valid for step.");
         options.stepNodeId = readOption(rest, index, arg);
         index += 1;
         break;
       case "--sync":
+        if (action !== "step") throw new Error("--sync is only valid for step.");
         options.stepSync = true;
         break;
       case "--repo":
+        if (action !== "step") throw new Error("--repo is only valid for step.");
         options.repo = readOption(rest, index, arg);
         index += 1;
         break;
@@ -776,14 +784,51 @@ export interface AlgorithmCliDeps {
 async function resolveBridgedNodeId(options: AlgorithmCliOptions, stepId: string): Promise<string> {
   const id = requireAlgorithmId(options);
   const { run } = await readAlgorithmRunById(id, { homeDir: options.homeDir, somaHome: options.somaHome });
-  const step = run.planSteps.find((candidate) => candidate.id === stepId);
+  // Shared lookup, not a third copy of `findIndex` + its message (Sage, PR #555).
+  const { step } = requirePlanStep(run, stepId);
 
-  if (step === undefined) throw new Error(`Algorithm plan step not found: ${stepId}`);
   if (step.nodeId === undefined) {
     throw new Error(`Algorithm plan step ${stepId} is not bridged to a work-graph node. Bridge it with --node <node-id>.`);
   }
 
   return step.nodeId;
+}
+
+/**
+ * `soma algorithm step` — three shapes: a direct status write on a run-owned
+ * step, `--node` to bridge one to a work-graph node, and `--sync` to re-derive an
+ * already-bridged one (§2.7). Its own function rather than a fifth inline branch
+ * in the dispatcher's if-chain.
+ */
+async function runStepAction(options: AlgorithmCliOptions, deps: AlgorithmCliDeps): Promise<string> {
+  if (!options.stepId) throw new Error("--step-id is required.");
+  const stepId = options.stepId;
+  const bind = options.stepNodeId !== undefined;
+  const sync = options.stepSync === true;
+
+  if (bind && sync) throw new Error("--node already derives the status; pass one of --node or --sync.");
+
+  if (bind || sync) {
+    // Naming a collision beats silently preferring one side of it. `--status` is
+    // the write §2.7 refuses outright; `--evidence` is subtler and was being
+    // accepted and then discarded, since the derived pointer always overwrites it
+    // (Sage, PR #555) — the same silent preference this refusal exists to reject.
+    if (options.stepStatus !== undefined) {
+      throw new Error("--status cannot be combined with --node or --sync: a bridged step's status derives from its node.");
+    }
+    if (options.evidence !== undefined) {
+      throw new Error(
+        "--evidence cannot be combined with --node or --sync: a bridged step's evidence is the derived pointer to its node.",
+      );
+    }
+    const nodeId = options.stepNodeId ?? (await resolveBridgedNodeId(options, stepId));
+    const state = await deps.readNode(nodeId, { repo: options.repo });
+    return updateAndReportAlgorithmRun(options, (run) => syncBridgedPlanStep(run, stepId, state, { bind }));
+  }
+
+  if (!options.stepStatus) throw new Error("--status is required (or use --node/--sync for a bridged step).");
+  const stepStatus = options.stepStatus;
+  return updateAndReportAlgorithmRun(options, (run) => updateAlgorithmPlanStep(run, stepId, stepStatus, options.evidence));
 }
 
 export async function runAlgorithmCli(
@@ -918,28 +963,7 @@ export async function runAlgorithmCli(
   }
 
   if (parsed.action === "step") {
-    if (!options.stepId) throw new Error("--step-id is required.");
-    const stepId = options.stepId;
-    const bind = options.stepNodeId !== undefined;
-    const sync = options.stepSync === true;
-
-    if (bind && sync) throw new Error("--node already derives the status; pass one of --node or --sync.");
-
-    if (bind || sync) {
-      if (options.stepStatus !== undefined) {
-        // Naming the collision beats silently preferring one: --status on a
-        // bridged step is the exact write §2.7 refuses, so an argv that asks for
-        // both is asking for a forged status.
-        throw new Error("--status cannot be combined with --node or --sync: a bridged step's status derives from its node.");
-      }
-      const nodeId = options.stepNodeId ?? (await resolveBridgedNodeId(options, stepId));
-      const state = await deps.readNode(nodeId, { repo: options.repo });
-      return updateAndReportAlgorithmRun(options, (run) => syncBridgedPlanStep(run, stepId, state, { bind }));
-    }
-
-    if (!options.stepStatus) throw new Error("--step-id and --status are required.");
-    const stepStatus = options.stepStatus;
-    return updateAndReportAlgorithmRun(options, (run) => updateAlgorithmPlanStep(run, stepId, stepStatus, options.evidence));
+    return runStepAction(options, deps);
   }
 
   if (parsed.action === "verify") {

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -58,15 +58,13 @@ import {
   type ProbeRegistry,
 } from "../work-graph-probe-registry";
 import { allProbesPassed, runCommand, runProbes as defaultRunProbes } from "../work-graph-probes";
-import { parseRepoFromRemote, readNodeForBridge, resolveGraphRepo } from "../work-graph-bridge";
+// Repo resolution and the bridge's node read live in `../work-graph-bridge` (core),
+// not here: a seam only `src/cli/` can import forces a library/MCP/daemon consumer
+// to re-implement it, becoming the second reader §2.7 forbids. No re-export — the
+// other importers point at core directly, so there is one path to each symbol.
+import { resolveGraphRepo } from "../work-graph-bridge";
 import { SomaCliError } from "./errors";
 import { readOption } from "./parse-utils";
-
-// Moved to `src/work-graph-bridge.ts` (core) so a library/MCP/daemon consumer can
-// read a node and resolve a repo without importing from `src/cli/` — a seam only
-// the CLI can reach forces exactly the second reader the bridge forbids (Sage,
-// PR #555). Re-exported here for the existing importers.
-export { parseRepoFromRemote, readNodeForBridge, resolveGraphRepo };
 
 const GRAPH_ACTIONS = ["frontier", "node", "claim", "add", "close"] as const;
 type GraphAction = (typeof GRAPH_ACTIONS)[number];
@@ -437,10 +435,6 @@ async function gh(args: string[]): Promise<string> {
   }
   return outcome.stdout.trim();
 }
-
-// `parseRepoFromRemote` and `resolveGraphRepo` moved to `src/work-graph-bridge.ts`
-// (core) so non-CLI consumers resolve a repo the same way — re-exported here for
-// the existing importers.
 
 async function defaultEvidencePointer(): Promise<string | undefined> {
   const head = await runCommand({ argv: ["git", "rev-parse", "HEAD"], timeoutSec: 30 });

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -882,6 +882,23 @@ async function runClose(
   ].join("\n");
 }
 
+/**
+ * Read one node for the planSteps bridge (§2.7). Exported so
+ * `soma algorithm step --sync` reaches the graph through the *same* seam and the
+ * *same* repo resolution `soma graph` uses — a second reader would be a second
+ * answer to "which node backs this step", which is the two-homes defect wearing
+ * a different hat.
+ */
+export async function readNodeForBridge(
+  nodeId: string,
+  options: { repo?: string } = {},
+  overrides: Partial<GraphCliDeps> = {},
+): Promise<NodeState> {
+  const deps: GraphCliDeps = { ...defaultDeps(), ...overrides };
+  const repo = options.repo ?? (await deps.resolveRepo());
+  return await new WorkGraph(deps.createStore(repo)).readNode({ id: nodeId });
+}
+
 export async function runGraphCli(parsed: ParsedGraphArgs, overrides: Partial<GraphCliDeps> = {}): Promise<string> {
   const deps: GraphCliDeps = { ...defaultDeps(), ...overrides };
   const repo = parsed.options.repo ?? (await deps.resolveRepo());

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -58,8 +58,15 @@ import {
   type ProbeRegistry,
 } from "../work-graph-probe-registry";
 import { allProbesPassed, runCommand, runProbes as defaultRunProbes } from "../work-graph-probes";
+import { parseRepoFromRemote, readNodeForBridge, resolveGraphRepo } from "../work-graph-bridge";
 import { SomaCliError } from "./errors";
 import { readOption } from "./parse-utils";
+
+// Moved to `src/work-graph-bridge.ts` (core) so a library/MCP/daemon consumer can
+// read a node and resolve a repo without importing from `src/cli/` — a seam only
+// the CLI can reach forces exactly the second reader the bridge forbids (Sage,
+// PR #555). Re-exported here for the existing importers.
+export { parseRepoFromRemote, readNodeForBridge, resolveGraphRepo };
 
 const GRAPH_ACTIONS = ["frontier", "node", "claim", "add", "close"] as const;
 type GraphAction = (typeof GRAPH_ACTIONS)[number];
@@ -431,34 +438,9 @@ async function gh(args: string[]): Promise<string> {
   return outcome.stdout.trim();
 }
 
-/** `owner/name` out of any of the URL shapes a GitHub remote takes. */
-export function parseRepoFromRemote(remote: string): string | undefined {
-  const match = /github\.com[/:]([^/\s]+)\/([^/\s]+?)(?:\.git)?$/u.exec(remote.trim());
-  if (match === null) return undefined;
-  return `${match[1]}/${match[2]}`;
-}
-
-/**
- * Which repository backs this graph. Exported because the probe registry is
- * scoped by repo identity, so `soma policy probes` has to resolve it the same
- * way `soma graph` does — two answers to "which repo" would mean an adopter
- * declaring commands under a key the close path never looks at.
- */
-export async function resolveGraphRepo(): Promise<string> {
-  const configured = process.env.SOMA_GRAPH_REPO;
-  if (configured !== undefined && configured.trim().length > 0) return configured.trim();
-
-  const remote = await runCommand({ argv: ["git", "remote", "get-url", "origin"], timeoutSec: 30 });
-  if (remote.exitCode === 0) {
-    const parsed = parseRepoFromRemote(remote.stdout);
-    if (parsed !== undefined) return parsed;
-  }
-
-  throw new SomaCliError(
-    "Cannot tell which repository backs this graph. Pass --repo <owner/name> or set SOMA_GRAPH_REPO.",
-    1,
-  );
-}
+// `parseRepoFromRemote` and `resolveGraphRepo` moved to `src/work-graph-bridge.ts`
+// (core) so non-CLI consumers resolve a repo the same way — re-exported here for
+// the existing importers.
 
 async function defaultEvidencePointer(): Promise<string | undefined> {
   const head = await runCommand({ argv: ["git", "rev-parse", "HEAD"], timeoutSec: 30 });
@@ -880,23 +862,6 @@ async function runClose(
     "",
     "Receipt posted to the tracker.",
   ].join("\n");
-}
-
-/**
- * Read one node for the planSteps bridge (§2.7). Exported so
- * `soma algorithm step --sync` reaches the graph through the *same* seam and the
- * *same* repo resolution `soma graph` uses — a second reader would be a second
- * answer to "which node backs this step", which is the two-homes defect wearing
- * a different hat.
- */
-export async function readNodeForBridge(
-  nodeId: string,
-  options: { repo?: string } = {},
-  overrides: Partial<GraphCliDeps> = {},
-): Promise<NodeState> {
-  const deps: GraphCliDeps = { ...defaultDeps(), ...overrides };
-  const repo = options.repo ?? (await deps.resolveRepo());
-  return await new WorkGraph(deps.createStore(repo)).readNode({ id: nodeId });
 }
 
 export async function runGraphCli(parsed: ParsedGraphArgs, overrides: Partial<GraphCliDeps> = {}): Promise<string> {

--- a/src/cli/policy.ts
+++ b/src/cli/policy.ts
@@ -11,7 +11,7 @@ import type {
   SomaPolicyCheckResult,
 } from "../types";
 import { loadProbeRegistry, type ProbeRegistry } from "../work-graph-probe-registry";
-import { resolveGraphRepo } from "./graph";
+import { resolveGraphRepo } from "../work-graph-bridge";
 import { readOption } from "./parse-utils";
 import { parseSubstrate } from "./substrate";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,11 +245,15 @@ export {
   recordAlgorithmLearning,
   recordAlgorithmMetaReflection,
   recordAlgorithmObservation,
+  deriveBridgedPlanStepStatus,
+  markUnbridgedPlanStepsDone,
   setAlgorithmPlan,
+  syncBridgedPlanStep,
   updateAlgorithmPlanStep,
   VerificationGateError,
   verifyAlgorithmCriterion,
 } from "./algorithm";
+export type { BridgedNodeReport } from "./algorithm";
 export {
   assertAlgorithmCapabilitiesSatisfied,
   getAlgorithmCapabilityDefinition,

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,7 +246,7 @@ export {
   recordAlgorithmMetaReflection,
   recordAlgorithmObservation,
   deriveBridgedPlanStepStatus,
-  markUnbridgedPlanStepsDone,
+  requirePlanStep,
   setAlgorithmPlan,
   syncBridgedPlanStep,
   updateAlgorithmPlanStep,
@@ -254,6 +254,13 @@ export {
   verifyAlgorithmCriterion,
 } from "./algorithm";
 export type { BridgedNodeReport } from "./algorithm";
+// The planSteps bridge's READ half (§2.7). Exported beside the write half on
+// purpose: a consumer that can reach `syncBridgedPlanStep` but not the reader has
+// to re-implement repo resolution, becoming the second reader the bridge forbids
+// (Sage, PR #555). `markUnbridgedPlanStepsDone` is deliberately NOT here — its one
+// production consumer imports it directly from `./algorithm`.
+export { parseRepoFromRemote, readNodeForBridge, resolveGraphRepo } from "./work-graph-bridge";
+export type { ReadNodeForBridgeOptions } from "./work-graph-bridge";
 export {
   assertAlgorithmCapabilitiesSatisfied,
   getAlgorithmCapabilityDefinition,

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,12 +254,16 @@ export {
   verifyAlgorithmCriterion,
 } from "./algorithm";
 export type { BridgedNodeReport } from "./algorithm";
-// The planSteps bridge's READ half (§2.7). Exported beside the write half on
-// purpose: a consumer that can reach `syncBridgedPlanStep` but not the reader has
-// to re-implement repo resolution, becoming the second reader the bridge forbids
-// (Sage, PR #555). `markUnbridgedPlanStepsDone` is deliberately NOT here — its one
-// production consumer imports it directly from `./algorithm`.
-export { parseRepoFromRemote, readNodeForBridge, resolveGraphRepo } from "./work-graph-bridge";
+// The planSteps bridge's READ half (§2.7), beside the write half on purpose: a
+// consumer that can reach `syncBridgedPlanStep` but not the reader must
+// re-implement repo resolution, becoming the second reader the bridge forbids.
+//
+// Only the reader. `resolveGraphRepo` and `parseRepoFromRemote` stay off the
+// barrel — a remote-URL regex is not part of the bridge contract, and putting
+// them here would drag a GitHub-shaped transport concern into the import graph of
+// every consumer of the pure algorithm functions. Same reasoning excludes
+// `markUnbridgedPlanStepsDone`: one production consumer, which imports it directly.
+export { readNodeForBridge } from "./work-graph-bridge";
 export type { ReadNodeForBridgeOptions } from "./work-graph-bridge";
 export {
   assertAlgorithmCapabilitiesSatisfied,

--- a/src/types.ts
+++ b/src/types.ts
@@ -232,9 +232,16 @@ export interface AlgorithmPlanStep {
   criteriaIds: string[];
   /**
    * Caller-authored on an unbridged step. On a bridged step it is a **cache of
-   * the node's reported state**, writable only through
-   * `syncBridgedPlanStep` — `updateAlgorithmPlanStep` refuses a direct write,
+   * the node's reported state**: `syncBridgedPlanStep` is the intended writer,
+   * and `updateAlgorithmPlanStep` / `setAlgorithmPlan` refuse a direct write,
    * because one work item never has two authoritative homes (§2.7).
+   *
+   * Read that as a speed bump, not a seal. The refusals live in the mutation
+   * helpers, not in this type — a caller who builds an `AlgorithmRun` literal and
+   * calls `writeAlgorithmRun`, or who removes and re-adds a step across two
+   * `setAlgorithmPlan` calls, can still persist a hand-written status on a step
+   * that was bridged. What the helpers guarantee is that it cannot happen
+   * *incidentally*. See `docs/work-graph.md` §2.7 for the full boundary.
    */
   status: "open" | "done" | "blocked";
   evidence?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -220,12 +220,31 @@ export interface AlgorithmPromptClassification {
   reason: string;
 }
 
+/**
+ * A within-run execution checklist item. `planSteps[]` stays the run's own
+ * checklist; a step may additionally be **bridged** to a work-graph node via
+ * {@link AlgorithmPlanStep.nodeId}, and a bridged step's `status` stops being
+ * caller-authored (`docs/work-graph.md` §2.7).
+ */
 export interface AlgorithmPlanStep {
   id: string;
   text: string;
   criteriaIds: string[];
+  /**
+   * Caller-authored on an unbridged step. On a bridged step it is a **cache of
+   * the node's reported state**, writable only through
+   * `syncBridgedPlanStep` — `updateAlgorithmPlanStep` refuses a direct write,
+   * because one work item never has two authoritative homes (§2.7).
+   */
   status: "open" | "done" | "blocked";
   evidence?: string;
+  /**
+   * Work-graph node this step defers to. Present ⇒ the node is the single
+   * authoritative home for the step's status, and `status`/`evidence` here are
+   * re-derived from `GraphStore.readNode` (surfaced to CLI callers as
+   * `soma graph node <id> --json`). Absent ⇒ the run owns the status outright.
+   */
+  nodeId?: string;
 }
 
 export interface AlgorithmLogEntry {

--- a/src/work-graph-bridge.ts
+++ b/src/work-graph-bridge.ts
@@ -8,7 +8,7 @@
  * this step", and a seam only the CLI can import forces a library, MCP or daemon
  * consumer — every one of which can already reach the *write* half through
  * `src/index.ts` — to re-implement repo resolution and become exactly that second
- * reader (Sage, PR #555).
+ * reader.
  */
 import { WorkGraph } from "./work-graph";
 import type { GraphStore, NodeState } from "./work-graph";

--- a/src/work-graph-bridge.ts
+++ b/src/work-graph-bridge.ts
@@ -1,0 +1,60 @@
+/**
+ * The work graph's **read seam for non-graph consumers** — today the planSteps
+ * bridge (`docs/work-graph.md` §2.7), which needs to read a node without owning
+ * a `GraphStore` or knowing how a repo is resolved.
+ *
+ * It lives in core rather than in `src/cli/`, where it started: the bridge's own
+ * argument is that a second reader means a second answer to "which node backs
+ * this step", and a seam only the CLI can import forces a library, MCP or daemon
+ * consumer — every one of which can already reach the *write* half through
+ * `src/index.ts` — to re-implement repo resolution and become exactly that second
+ * reader (Sage, PR #555).
+ */
+import { WorkGraph } from "./work-graph";
+import type { GraphStore, NodeState } from "./work-graph";
+import { createGitHubGraphStore } from "./work-graph-github";
+import { runCommand } from "./work-graph-probes";
+
+/** `owner/name` out of any of the URL shapes a GitHub remote takes. */
+export function parseRepoFromRemote(remote: string): string | undefined {
+  const match = /github\.com[/:]([^/\s]+)\/([^/\s]+?)(?:\.git)?$/u.exec(remote.trim());
+  if (match === null) return undefined;
+  return `${match[1]}/${match[2]}`;
+}
+
+/**
+ * Which repository backs this graph. One implementation on purpose: the probe
+ * registry is scoped by repo identity, so `soma policy probes` has to resolve it
+ * the same way `soma graph` does — two answers to "which repo" would mean an
+ * adopter declaring commands under a key the close path never looks at.
+ */
+export async function resolveGraphRepo(): Promise<string> {
+  const configured = process.env.SOMA_GRAPH_REPO;
+  if (configured !== undefined && configured.trim().length > 0) return configured.trim();
+
+  const remote = await runCommand({ argv: ["git", "remote", "get-url", "origin"], timeoutSec: 30 });
+  if (remote.exitCode === 0) {
+    const parsed = parseRepoFromRemote(remote.stdout);
+    if (parsed !== undefined) return parsed;
+  }
+
+  throw new Error("Cannot tell which repository backs this graph. Pass --repo <owner/name> or set SOMA_GRAPH_REPO.");
+}
+
+export interface ReadNodeForBridgeOptions {
+  /** Explicit `owner/name`; falls back to {@link resolveGraphRepo}. */
+  repo?: string;
+  /** Injectable so a consumer can supply its own backend or a test double. */
+  createStore?: (repo: string) => GraphStore;
+  resolveRepo?: () => Promise<string>;
+}
+
+/**
+ * Read one node for a bridge consumer — the same `WorkGraph.readNode` the
+ * `soma graph node` verb calls, over the same repo resolution.
+ */
+export async function readNodeForBridge(nodeId: string, options: ReadNodeForBridgeOptions = {}): Promise<NodeState> {
+  const createStore = options.createStore ?? ((repo: string) => createGitHubGraphStore({ repo }));
+  const repo = options.repo ?? (await (options.resolveRepo ?? resolveGraphRepo)());
+  return await new WorkGraph(createStore(repo)).readNode({ id: nodeId });
+}

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -163,6 +163,22 @@ export interface NodeState {
 }
 
 /**
+ * The narrow slice of {@link NodeState} a **status derivation** needs — what the
+ * graph publishes to the planSteps bridge (§2.7).
+ *
+ * It lives here, with the graph, because the graph owns the shape it publishes:
+ * declaring it in `src/algorithm.ts` would point the run module at the graph
+ * module and invert §2.7's dependency direction, in which a plan step *references*
+ * a node and the two scopes never merge.
+ *
+ * `Pick`ed rather than re-declared: written by hand it was a claim the compiler
+ * did not check, and its `blockedBy?` was optional where `NodeState`'s is
+ * required — so a report missing the field type-checked and derived `open` on a
+ * `blocked` node.
+ */
+export type BridgedNodeReport = Pick<NodeState, "ref" | "status" | "blockedBy">;
+
+/**
  * Outcome of a claim attempt after the store's post-write re-read (§2.4).
  * `held` is the question every caller actually asks; `holder` names the winner
  * when it is someone else.

--- a/test/algorithm-plansteps-bridge.test.ts
+++ b/test/algorithm-plansteps-bridge.test.ts
@@ -1,0 +1,287 @@
+import { expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  applyAlgorithmBatch,
+  createAlgorithmRun,
+  deriveBridgedPlanStepStatus,
+  markUnbridgedPlanStepsDone,
+  readAlgorithmRunById,
+  setAlgorithmPlan,
+  syncBridgedPlanStep,
+  updateAlgorithmPlanStep,
+  writeAlgorithmRun,
+} from "../src/index";
+import type { AlgorithmRun, BridgedNodeReport } from "../src/index";
+import { parseAlgorithmArgs, runAlgorithmCli } from "../src/cli/algorithm";
+
+// docs/work-graph.md §2.7 — planSteps bridge. A bridged step's status is the
+// NODE's to report; the run caches it. Every test here defends the same
+// property: one work item never has two authoritative homes.
+
+function freshRun(): AlgorithmRun {
+  return setAlgorithmPlan(
+    createAlgorithmRun({
+      id: "bridge-run",
+      timestamp: "2026-08-06T10:00:00.000Z",
+      prompt: "Bridge a plan step to a work-graph node",
+      intent: "Status derives from the node.",
+      currentState: "planSteps own their status outright.",
+      goal: "A bridged step defers to its node.",
+      criteria: [{ id: "C1", text: "Direct status writes on a bridged step are refused." }],
+    }),
+    [
+      { id: "P1", text: "Bridged work", criteriaIds: ["C1"], status: "open" },
+      { id: "P2", text: "Run-owned work", criteriaIds: ["C1"], status: "open" },
+    ],
+    "2026-08-06T10:01:00.000Z",
+  );
+}
+
+function report(overrides: Partial<BridgedNodeReport> = {}): BridgedNodeReport {
+  return { ref: { id: "501" }, status: "open", ...overrides };
+}
+
+function stepOf(run: AlgorithmRun, id: string) {
+  const step = run.planSteps.find((candidate) => candidate.id === id);
+  if (step === undefined) throw new Error(`missing step ${id}`);
+  return step;
+}
+
+async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
+  const homeDir = await mkdtemp(join(tmpdir(), "soma-plansteps-bridge-"));
+  try {
+    return await fn(homeDir);
+  } finally {
+    await rm(homeDir, { recursive: true, force: true });
+  }
+}
+
+// --- the refusal -----------------------------------------------------------
+
+test("a direct status write on a bridged step is REFUSED", () => {
+  const bridged = syncBridgedPlanStep(freshRun(), "P1", report(), { bind: true }, "2026-08-06T10:02:00.000Z");
+
+  expect(() => updateAlgorithmPlanStep(bridged, "P1", "done", "I say it is done.")).toThrow(
+    /bridged to work-graph node 501/u,
+  );
+  // The refusal names the read path, so the caller learns the legitimate move.
+  expect(() => updateAlgorithmPlanStep(bridged, "P1", "done")).toThrow(/soma graph node 501 --json/u);
+  // …and nothing was written: the step still reads as the node reported it.
+  expect(stepOf(bridged, "P1").status).toBe("open");
+});
+
+test("an unbridged step on the same run still takes a direct write", () => {
+  let run = syncBridgedPlanStep(freshRun(), "P1", report(), { bind: true }, "2026-08-06T10:02:00.000Z");
+  run = updateAlgorithmPlanStep(run, "P2", "done", "Run owns this one.", "2026-08-06T10:03:00.000Z");
+
+  expect(stepOf(run, "P2").status).toBe("done");
+  expect(stepOf(run, "P2").evidence).toBe("Run owns this one.");
+  expect(stepOf(run, "P2").nodeId).toBeUndefined();
+});
+
+test("the batch `step` operation is refused on a bridged step too — one contract, not one call site", () => {
+  const bridged = syncBridgedPlanStep(freshRun(), "P1", report(), { bind: true }, "2026-08-06T10:02:00.000Z");
+
+  expect(() =>
+    applyAlgorithmBatch(bridged, [{ kind: "step", stepId: "P1", status: "done", evidence: "batched" }]),
+  ).toThrow(/bridged to work-graph node 501/u);
+});
+
+// --- the derivation --------------------------------------------------------
+
+test("a closed node is the only `done`", () => {
+  expect(deriveBridgedPlanStepStatus(report({ status: "closed" }))).toBe("done");
+  expect(deriveBridgedPlanStepStatus(report({ status: "open" }))).toBe("open");
+});
+
+test("an open node with an open blocker derives `blocked`", () => {
+  expect(
+    deriveBridgedPlanStepStatus(report({ blockedBy: [{ id: "499", status: "open" }] })),
+  ).toBe("blocked");
+  expect(
+    deriveBridgedPlanStepStatus(report({ blockedBy: [{ id: "499", status: "closed" }] })),
+  ).toBe("open");
+  expect(
+    deriveBridgedPlanStepStatus(
+      report({ blockedBy: [{ id: "499", status: "closed" }, { id: "502", status: "open" }] }),
+    ),
+  ).toBe("blocked");
+});
+
+test("sync records WHICH node it derived from and when — a derived status must not read like a written one", () => {
+  const run = syncBridgedPlanStep(
+    freshRun(),
+    "P1",
+    report({ status: "closed" }),
+    { bind: true },
+    "2026-08-06T10:02:00.000Z",
+  );
+
+  expect(stepOf(run, "P1")).toMatchObject({
+    nodeId: "501",
+    status: "done",
+    evidence: "derived from work-graph node 501 (closed) at 2026-08-06T10:02:00.000Z",
+  });
+  expect(run.updatedAt).toBe("2026-08-06T10:02:00.000Z");
+});
+
+test("binding and deriving are one act — a step is never bridged while carrying its stale status", () => {
+  let run = freshRun();
+  run = updateAlgorithmPlanStep(run, "P1", "done", "hand-written before the bridge existed", "2026-08-06T10:02:00.000Z");
+  expect(stepOf(run, "P1").status).toBe("done");
+
+  run = syncBridgedPlanStep(run, "P1", report({ status: "open" }), { bind: true }, "2026-08-06T10:03:00.000Z");
+  expect(stepOf(run, "P1").status).toBe("open");
+  expect(stepOf(run, "P1").evidence).not.toContain("hand-written");
+});
+
+test("syncing a bridged step from a DIFFERENT node's report is refused", () => {
+  const bridged = syncBridgedPlanStep(freshRun(), "P1", report(), { bind: true }, "2026-08-06T10:02:00.000Z");
+
+  expect(() =>
+    syncBridgedPlanStep(bridged, "P1", report({ ref: { id: "502" }, status: "closed" })),
+  ).toThrow(/bridged to work-graph node 501, but the reported node is 502/u);
+});
+
+test("syncing an unbridged step is refused — there is no node to derive from", () => {
+  expect(() => syncBridgedPlanStep(freshRun(), "P2", report())).toThrow(/not bridged to a work-graph node/u);
+});
+
+test("syncing an unknown step is refused", () => {
+  expect(() => syncBridgedPlanStep(freshRun(), "P9", report(), { bind: true })).toThrow(
+    /plan step not found: P9/u,
+  );
+});
+
+// --- the other write path: the VSA sync's bulk flip ------------------------
+
+test("the VERIFY sweep skips bridged steps rather than forging `done`", () => {
+  const run = syncBridgedPlanStep(freshRun(), "P1", report({ status: "open" }), { bind: true }, "2026-08-06T10:02:00.000Z");
+  const swept = markUnbridgedPlanStepsDone(run.planSteps, "synced from VSA");
+
+  expect(swept.find((step) => step.id === "P1")).toMatchObject({
+    status: "open",
+    evidence: "derived from work-graph node 501 (open) at 2026-08-06T10:02:00.000Z",
+  });
+  expect(swept.find((step) => step.id === "P2")).toMatchObject({ status: "done", evidence: "synced from VSA" });
+});
+
+// --- the CLI surface ------------------------------------------------------
+
+test("`step --node` bridges through the graph read path, and `--status` is then refused", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeAlgorithmRun(freshRun(), { homeDir });
+
+    const reads: { nodeId: string; repo?: string }[] = [];
+    const deps = {
+      readNode: async (nodeId: string, options: { repo?: string }) => {
+        reads.push({ nodeId, repo: options.repo });
+        return report({ ref: { id: nodeId }, status: "closed" as const });
+      },
+    };
+
+    const bound = await runAlgorithmCli(
+      parseAlgorithmArgs([
+        "algorithm",
+        "step",
+        "--home-dir",
+        homeDir,
+        "--id",
+        "bridge-run",
+        "--step-id",
+        "P1",
+        "--node",
+        "501",
+        "--repo",
+        "the-metafactory/soma",
+      ]),
+      deps,
+    );
+
+    expect(reads).toEqual([{ nodeId: "501", repo: "the-metafactory/soma" }]);
+    // The render names the node: the status's authority is visible on sight.
+    expect(bound).toContain("→ node 501");
+    expect(bound).toContain("[done] P1");
+
+    const { run: persisted } = await readAlgorithmRunById("bridge-run", { homeDir });
+    expect(stepOf(persisted, "P1").nodeId).toBe("501");
+    expect(stepOf(persisted, "P1").status).toBe("done");
+
+    await expect(
+      runAlgorithmCli(
+        parseAlgorithmArgs([
+          "algorithm",
+          "step",
+          "--home-dir",
+          homeDir,
+          "--id",
+          "bridge-run",
+          "--step-id",
+          "P1",
+          "--status",
+          "open",
+        ]),
+        deps,
+      ),
+    ).rejects.toThrow(/bridged to work-graph node 501/u);
+  });
+});
+
+test("`step --sync` re-derives from the step's OWN node — the node id comes off the run, not argv", async () => {
+  await withTempHome(async (homeDir) => {
+    const run = syncBridgedPlanStep(freshRun(), "P1", report({ status: "open" }), { bind: true }, "2026-08-06T10:02:00.000Z");
+    await writeAlgorithmRun(run, { homeDir });
+
+    const reads: string[] = [];
+    const output = await runAlgorithmCli(
+      parseAlgorithmArgs(["algorithm", "step", "--home-dir", homeDir, "--id", "bridge-run", "--step-id", "P1", "--sync"]),
+      {
+        readNode: async (nodeId: string) => {
+          reads.push(nodeId);
+          return report({ ref: { id: nodeId }, status: "closed" as const });
+        },
+      },
+    );
+
+    expect(reads).toEqual(["501"]);
+    expect(output).toContain("[done] P1");
+  });
+});
+
+test("`step --sync` on an unbridged step is refused before any read", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeAlgorithmRun(freshRun(), { homeDir });
+
+    let read = false;
+    await expect(
+      runAlgorithmCli(
+        parseAlgorithmArgs(["algorithm", "step", "--home-dir", homeDir, "--id", "bridge-run", "--step-id", "P2", "--sync"]),
+        {
+          readNode: async (nodeId: string) => {
+            read = true;
+            return report({ ref: { id: nodeId } });
+          },
+        },
+      ),
+    ).rejects.toThrow(/not bridged to a work-graph node/u);
+    expect(read).toBe(false);
+  });
+});
+
+test("`--status` combined with `--node` or `--sync` is refused rather than silently preferring one", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeAlgorithmRun(freshRun(), { homeDir });
+    const deps = { readNode: async (nodeId: string) => report({ ref: { id: nodeId } }) };
+    const base = ["algorithm", "step", "--home-dir", homeDir, "--id", "bridge-run", "--step-id", "P1"];
+
+    await expect(
+      runAlgorithmCli(parseAlgorithmArgs([...base, "--node", "501", "--status", "done"]), deps),
+    ).rejects.toThrow(/--status cannot be combined with --node or --sync/u);
+
+    await expect(runAlgorithmCli(parseAlgorithmArgs([...base, "--node", "501", "--sync"]), deps)).rejects.toThrow(
+      /pass one of --node or --sync/u,
+    );
+  });
+});

--- a/test/algorithm-plansteps-bridge.test.ts
+++ b/test/algorithm-plansteps-bridge.test.ts
@@ -3,10 +3,11 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  advanceAlgorithmRun,
   applyAlgorithmBatch,
   createAlgorithmRun,
   deriveBridgedPlanStepStatus,
-  markUnbridgedPlanStepsDone,
+  getRunPhase,
   readAlgorithmRunById,
   setAlgorithmPlan,
   syncBridgedPlanStep,
@@ -14,6 +15,9 @@ import {
   writeAlgorithmRun,
 } from "../src/index";
 import type { AlgorithmRun, BridgedNodeReport } from "../src/index";
+// Not on the public barrel — its one production consumer imports it here too.
+import { markUnbridgedPlanStepsDone } from "../src/algorithm";
+import type { NodeState } from "../src/work-graph";
 import { parseAlgorithmArgs, runAlgorithmCli } from "../src/cli/algorithm";
 
 // docs/work-graph.md §2.7 — planSteps bridge. A bridged step's status is the
@@ -40,7 +44,35 @@ function freshRun(): AlgorithmRun {
 }
 
 function report(overrides: Partial<BridgedNodeReport> = {}): BridgedNodeReport {
-  return { ref: { id: "501" }, status: "open", ...overrides };
+  return { ref: { id: "501" }, status: "open", blockedBy: [], ...overrides };
+}
+
+/**
+ * A FULL `NodeState` — every field a real `readNode` returns, not the three the
+ * derivation happens to touch. `BridgedNodeReport` is `Pick`ed from `NodeState`,
+ * and this is what proves the two still line up: if the graph adds a required
+ * field to the picked set, or the report's shape drifts, this stops compiling.
+ * The hand-built `report()` fixtures cannot catch that (Sage, PR #555).
+ */
+function realNodeState(overrides: Partial<NodeState> = {}): NodeState {
+  return {
+    ref: { id: "501" },
+    node: {
+      id: "501",
+      title: "planSteps nodeId bridge (spec §2.7)",
+      autonomy: "auto",
+      kind: "task",
+      checkpointId: "cp-501",
+      probes: [{ type: "git-ref-exists", ref: "main" }],
+    },
+    status: "open",
+    assignees: ["jcfischer"],
+    blockedBy: [],
+    author: "jcfischer",
+    parent: { id: "495" },
+    typed: true,
+    ...overrides,
+  };
 }
 
 function stepOf(run: AlgorithmRun, id: string) {
@@ -155,7 +187,85 @@ test("syncing an unknown step is refused", () => {
   );
 });
 
+test("`bind` does not license re-homing an already-bridged step", () => {
+  const bridged = syncBridgedPlanStep(freshRun(), "P1", report(), { bind: true }, "2026-08-06T10:02:00.000Z");
+
+  // Without this, `bind: true` made the mismatch refusal unreachable from the one
+  // caller that always sets it — a typo'd `--node` moved the step silently.
+  expect(() =>
+    syncBridgedPlanStep(bridged, "P1", report({ ref: { id: "502" }, status: "closed" }), { bind: true }),
+  ).toThrow(/already bridged to work-graph node 501; refusing to re-home it to 502/u);
+  expect(stepOf(bridged, "P1").nodeId).toBe("501");
+  expect(stepOf(bridged, "P1").status).toBe("open");
+});
+
+test("re-binding a step to the SAME node is a plain re-derive, not a re-home", () => {
+  let run = syncBridgedPlanStep(freshRun(), "P1", report(), { bind: true }, "2026-08-06T10:02:00.000Z");
+  run = syncBridgedPlanStep(run, "P1", report({ status: "closed" }), { bind: true }, "2026-08-06T10:03:00.000Z");
+
+  expect(stepOf(run, "P1").status).toBe("done");
+});
+
+// --- the other write paths -------------------------------------------------
+
+test("setAlgorithmPlan refuses to AUTHOR a bridged step — bridging is not a planning act", () => {
+  const run = createAlgorithmRun({
+    id: "bridge-run",
+    timestamp: "2026-08-06T10:00:00.000Z",
+    prompt: "Bridge a plan step to a work-graph node",
+    intent: "Status derives from the node.",
+    currentState: "planSteps own their status outright.",
+    goal: "A bridged step defers to its node.",
+    criteria: [{ id: "C1", text: "Direct status writes on a bridged step are refused." }],
+  });
+
+  // This was the third write path: `setAlgorithmPlan` replaces planSteps[]
+  // wholesale with caller-authored status, so it could mint a bridged step whose
+  // `done` never came from a node — while the docs claimed one write path.
+  expect(() =>
+    setAlgorithmPlan(run, [{ id: "P1", text: "Bridged work", criteriaIds: ["C1"], status: "done", nodeId: "501" }]),
+  ).toThrow(/cannot be bridged to work-graph node 501 by setAlgorithmPlan/u);
+});
+
+test("a real NodeState is accepted verbatim as a BridgedNodeReport", () => {
+  // The type claims `NodeState` satisfies it; this is the claim being exercised
+  // with a value rather than restated in a comment.
+  const state = realNodeState({ status: "closed" });
+  const run = syncBridgedPlanStep(freshRun(), "P1", state, { bind: true }, "2026-08-06T10:02:00.000Z");
+
+  expect(stepOf(run, "P1")).toMatchObject({ nodeId: "501", status: "done" });
+  expect(deriveBridgedPlanStepStatus(realNodeState({ blockedBy: [{ id: "499", status: "open" }] }))).toBe("blocked");
+  expect(deriveBridgedPlanStepStatus(realNodeState())).toBe("open");
+});
+
 // --- the other write path: the VSA sync's bulk flip ------------------------
+
+test("an OPEN bridged step really does hold the run short of the VERIFY gate", () => {
+  // The skip's advertised cost — "leaves the run short of the VERIFY gate until
+  // its node closes" — was asserted in a comment and verified nowhere. If the
+  // gate read criteria alone, the cost would not exist and the skip would be
+  // silent (Sage, PR #555). Walk the run to EXECUTE and try to advance.
+  let run = freshRun();
+  run = syncBridgedPlanStep(run, "P1", report({ status: "open" }), { bind: true }, "2026-08-06T10:02:00.000Z");
+  run = updateAlgorithmPlanStep(run, "P2", "done", "run-owned, finished", "2026-08-06T10:03:00.000Z");
+  run = {
+    ...run,
+    observations: [
+      { timestamp: "2026-08-06T10:04:00.000Z", claim: "the gate fires", evidence: "this test", evidenceKind: "tested" },
+    ],
+    capabilities: ["sequential-analysis"],
+    changelog: [{ timestamp: "2026-08-06T10:06:00.000Z", phase: "build", text: "bridged the step" }],
+  };
+  while (getRunPhase(run) !== "execute") {
+    run = advanceAlgorithmRun(run, "2026-08-06T10:07:00.000Z");
+  }
+
+  expect(() => advanceAlgorithmRun(run, "2026-08-06T10:08:00.000Z")).toThrow(/every plan step is done or blocked/u);
+
+  // …and closing the node releases it. The cost is real and it is bounded.
+  const closed = syncBridgedPlanStep(run, "P1", report({ status: "closed" }), {}, "2026-08-06T10:09:00.000Z");
+  expect(getRunPhase(advanceAlgorithmRun(closed, "2026-08-06T10:10:00.000Z"))).toBe("verify");
+});
 
 test("the VERIFY sweep skips bridged steps rather than forging `done`", () => {
   const run = syncBridgedPlanStep(freshRun(), "P1", report({ status: "open" }), { bind: true }, "2026-08-06T10:02:00.000Z");
@@ -270,7 +380,7 @@ test("`step --sync` on an unbridged step is refused before any read", async () =
   });
 });
 
-test("`--status` combined with `--node` or `--sync` is refused rather than silently preferring one", async () => {
+test("`--status` or `--evidence` combined with `--node`/`--sync` is refused rather than silently preferring one", async () => {
   await withTempHome(async (homeDir) => {
     await writeAlgorithmRun(freshRun(), { homeDir });
     const deps = { readNode: async (nodeId: string) => report({ ref: { id: nodeId } }) };
@@ -280,8 +390,37 @@ test("`--status` combined with `--node` or `--sync` is refused rather than silen
       runAlgorithmCli(parseAlgorithmArgs([...base, "--node", "501", "--status", "done"]), deps),
     ).rejects.toThrow(/--status cannot be combined with --node or --sync/u);
 
+    // --evidence was accepted and then silently discarded by the derived pointer.
+    await expect(
+      runAlgorithmCli(parseAlgorithmArgs([...base, "--node", "501", "--evidence", "I checked"]), deps),
+    ).rejects.toThrow(/--evidence cannot be combined with --node or --sync/u);
+
     await expect(runAlgorithmCli(parseAlgorithmArgs([...base, "--node", "501", "--sync"]), deps)).rejects.toThrow(
       /pass one of --node or --sync/u,
     );
+  });
+});
+
+test("the bridge flags are scoped to `step` — they do not widen every subcommand", () => {
+  for (const flags of [["--node", "501"], ["--sync"], ["--repo", "the-metafactory/soma"]]) {
+    expect(() => parseAlgorithmArgs(["algorithm", "decision", "--id", "r", "--text", "t", ...flags])).toThrow(
+      /is only valid for step/u,
+    );
+  }
+  // …and still parse on `step` itself.
+  expect(() =>
+    parseAlgorithmArgs(["algorithm", "step", "--id", "r", "--step-id", "P1", "--node", "501", "--repo", "o/n"]),
+  ).not.toThrow();
+});
+
+test("the `--status`-required message names the flag that is actually missing", async () => {
+  await withTempHome(async (homeDir) => {
+    await writeAlgorithmRun(freshRun(), { homeDir });
+    await expect(
+      runAlgorithmCli(
+        parseAlgorithmArgs(["algorithm", "step", "--home-dir", homeDir, "--id", "bridge-run", "--step-id", "P1"]),
+        { readNode: async (nodeId: string) => report({ ref: { id: nodeId } }) },
+      ),
+    ).rejects.toThrow("--status is required (or use --node/--sync for a bridged step).");
   });
 });

--- a/test/algorithm-plansteps-bridge.test.ts
+++ b/test/algorithm-plansteps-bridge.test.ts
@@ -271,6 +271,33 @@ test("setAlgorithmPlan refuses to UN-bridge a step by reusing its id without the
   expect(replanned.planSteps.map((step) => step.id)).toEqual(["P2"]);
 });
 
+test("the un-bridge refusal is a speed bump, not a seal — remove-then-re-add reaches the same end state", () => {
+  // Pinning the LIMIT, not the guarantee. The refusal is per-call and nothing
+  // sees across two, so this sequence works — and the docs and the `status`
+  // docblock must keep saying so. If a future change closes it, this test fails
+  // and the claim gets upgraded deliberately rather than by accident.
+  const bridged = syncBridgedPlanStep(freshRun(), "P1", report(), { bind: true }, "2026-08-06T10:02:00.000Z");
+
+  const removed = setAlgorithmPlan(
+    bridged,
+    [{ id: "P2", text: "Run-owned work", criteriaIds: ["C1"], status: "open" }],
+    "2026-08-06T10:03:00.000Z",
+  );
+  const readded = setAlgorithmPlan(
+    removed,
+    [
+      { id: "P1", text: "Bridged work", criteriaIds: ["C1"], status: "open" },
+      { id: "P2", text: "Run-owned work", criteriaIds: ["C1"], status: "open" },
+    ],
+    "2026-08-06T10:04:00.000Z",
+  );
+
+  expect(stepOf(readded, "P1").nodeId).toBeUndefined();
+  // …and the step is now genuinely run-owned, so a direct write is correct.
+  const written = updateAlgorithmPlanStep(readded, "P1", "done", "run owns it now", "2026-08-06T10:05:00.000Z");
+  expect(stepOf(written, "P1").status).toBe("done");
+});
+
 test("a real NodeState is accepted verbatim as a BridgedNodeReport", () => {
   // The type claims `NodeState` satisfies it; this is the claim being exercised
   // with a value rather than restated in a comment.

--- a/test/algorithm-plansteps-bridge.test.ts
+++ b/test/algorithm-plansteps-bridge.test.ts
@@ -17,7 +17,8 @@ import {
 import type { AlgorithmRun, BridgedNodeReport } from "../src/index";
 // Not on the public barrel — its one production consumer imports it here too.
 import { markUnbridgedPlanStepsDone } from "../src/algorithm";
-import type { NodeState } from "../src/work-graph";
+import type { GraphStore, NodeRef, NodeState } from "../src/work-graph";
+import { readNodeForBridge } from "../src/work-graph-bridge";
 import { parseAlgorithmArgs, runAlgorithmCli } from "../src/cli/algorithm";
 
 // docs/work-graph.md §2.7 — planSteps bridge. A bridged step's status is the
@@ -72,6 +73,26 @@ function realNodeState(overrides: Partial<NodeState> = {}): NodeState {
     parent: { id: "495" },
     typed: true,
     ...overrides,
+  };
+}
+
+/**
+ * A `GraphStore` whose only real method is `readNode` — injected at the STORE
+ * seam so `WorkGraph.readNode` (the contract layer) actually runs, which is what
+ * the CLI tests' reader injection skips past.
+ */
+function stubStore(readNode: (ref: NodeRef) => NodeState): GraphStore {
+  return {
+    attestation: "unverified",
+    createNode: async () => ({ id: "unused" }),
+    addBlockingEdge: async () => {},
+    readNode: async (ref) => readNode(ref),
+    listCandidateFrontier: async () => [],
+    claim: async () => ({ held: true, identity: "jcfischer", holder: null, assignees: [] }),
+    postComment: async () => ({ id: "c1", nodeId: "501" }),
+    readComment: async () => ({ id: "c1", nodeId: "501" }),
+    readCommentReactions: async () => [],
+    close: async () => {},
   };
 }
 
@@ -219,12 +240,35 @@ test("setAlgorithmPlan refuses to AUTHOR a bridged step — bridging is not a pl
     criteria: [{ id: "C1", text: "Direct status writes on a bridged step are refused." }],
   });
 
-  // This was the third write path: `setAlgorithmPlan` replaces planSteps[]
-  // wholesale with caller-authored status, so it could mint a bridged step whose
-  // `done` never came from a node — while the docs claimed one write path.
+  // The third write path: `setAlgorithmPlan` replaces planSteps[] wholesale with
+  // caller-authored status, so it could mint a bridged step whose `done` never
+  // came from a node.
   expect(() =>
     setAlgorithmPlan(run, [{ id: "P1", text: "Bridged work", criteriaIds: ["C1"], status: "done", nodeId: "501" }]),
   ).toThrow(/cannot be bridged to work-graph node 501 by setAlgorithmPlan/u);
+});
+
+test("setAlgorithmPlan refuses to UN-bridge a step by reusing its id without the nodeId", () => {
+  const bridged = syncBridgedPlanStep(freshRun(), "P1", report(), { bind: true }, "2026-08-06T10:02:00.000Z");
+
+  // The incoming-only guard left this open: an unbridged step reusing a bridged
+  // id dropped the bridge silently, after which a hand-written `done` was
+  // accepted on a step a reader still believed was node-derived.
+  expect(() =>
+    setAlgorithmPlan(bridged, [
+      { id: "P1", text: "Bridged work", criteriaIds: ["C1"], status: "done" },
+      { id: "P2", text: "Run-owned work", criteriaIds: ["C1"], status: "open" },
+    ]),
+  ).toThrow(/bridged to work-graph node 501; setAlgorithmPlan cannot un-bridge it/u);
+
+  // Dropping the step is a different act and stays legal — the step ceases to
+  // exist, so nothing claims a node backs it.
+  const replanned = setAlgorithmPlan(
+    bridged,
+    [{ id: "P2", text: "Run-owned work", criteriaIds: ["C1"], status: "open" }],
+    "2026-08-06T10:03:00.000Z",
+  );
+  expect(replanned.planSteps.map((step) => step.id)).toEqual(["P2"]);
 });
 
 test("a real NodeState is accepted verbatim as a BridgedNodeReport", () => {
@@ -276,6 +320,42 @@ test("the VERIFY sweep skips bridged steps rather than forging `done`", () => {
     evidence: "derived from work-graph node 501 (open) at 2026-08-06T10:02:00.000Z",
   });
   expect(swept.find((step) => step.id === "P2")).toMatchObject({ status: "done", evidence: "synced from VSA" });
+});
+
+// --- the reader itself ----------------------------------------------------
+
+test("readNodeForBridge returns a report the derivation accepts, through the real WorkGraph", async () => {
+  // The reader had no test of its own: the CLI tests inject past it, so nothing
+  // showed a `GraphStore` response surviving `WorkGraph.readNode` as a conformant
+  // `BridgedNodeReport`. Inject at the STORE seam instead of at the reader, so the
+  // contract layer actually runs.
+  const calls: string[] = [];
+  const store = stubStore((ref) => {
+    calls.push(ref.id);
+    return realNodeState({ ref, status: "open", blockedBy: [{ id: "499", status: "open" }] });
+  });
+
+  const state = await readNodeForBridge("501", { repo: "the-metafactory/soma", createStore: () => store });
+
+  expect(calls).toEqual(["501"]);
+  // The returned NodeState is passed straight to the derivation — no adaptation
+  // step, which is the whole claim of `Pick`ing the report type from `NodeState`.
+  expect(deriveBridgedPlanStepStatus(state)).toBe("blocked");
+  const run = syncBridgedPlanStep(freshRun(), "P1", state, { bind: true }, "2026-08-06T10:02:00.000Z");
+  expect(stepOf(run, "P1")).toMatchObject({ nodeId: "501", status: "blocked" });
+});
+
+test("readNodeForBridge resolves the repo when none is passed", async () => {
+  const repos: string[] = [];
+  await readNodeForBridge("501", {
+    resolveRepo: async () => "the-metafactory/soma",
+    createStore: (repo: string) => {
+      repos.push(repo);
+      return stubStore((ref) => realNodeState({ ref }));
+    },
+  });
+
+  expect(repos).toEqual(["the-metafactory/soma"]);
 });
 
 // --- the CLI surface ------------------------------------------------------
@@ -357,6 +437,41 @@ test("`step --sync` re-derives from the step's OWN node — the node id comes of
 
     expect(reads).toEqual(["501"]);
     expect(output).toContain("[done] P1");
+  });
+});
+
+test("a concurrent re-bind between the two reads fails CLOSED, not silently", async () => {
+  await withTempHome(async (homeDir) => {
+    // `--sync` reads the run to learn which node the step defers to, then
+    // `updateAndReportAlgorithmRun` reads it again to mutate. A concurrent write
+    // between the two could bind against a stale nodeId — but the mutator derives
+    // `nodeId` from the FRESH run and `syncBridgedPlanStep` refuses a report that
+    // names a different node, so the race is caught rather than absorbed. Simulate
+    // it by rewriting the run inside the injected read.
+    await writeAlgorithmRun(
+      syncBridgedPlanStep(freshRun(), "P1", report(), { bind: true }, "2026-08-06T10:02:00.000Z"),
+      { homeDir },
+    );
+
+    await expect(
+      runAlgorithmCli(
+        parseAlgorithmArgs(["algorithm", "step", "--home-dir", homeDir, "--id", "bridge-run", "--step-id", "P1", "--sync"]),
+        {
+          readNode: async (nodeId: string) => {
+            // Someone re-plans the step onto node 777 while we hold node 501's state.
+            await writeAlgorithmRun(
+              syncBridgedPlanStep(freshRun(), "P1", report({ ref: { id: "777" } }), { bind: true }, "2026-08-06T10:03:00.000Z"),
+              { homeDir },
+            );
+            return report({ ref: { id: nodeId }, status: "closed" });
+          },
+        },
+      ),
+    ).rejects.toThrow(/bridged to work-graph node 777, but the reported node is 501/u);
+
+    // The stale `closed` was NOT written.
+    const { run } = await readAlgorithmRunById("bridge-run", { homeDir });
+    expect(stepOf(run, "P1")).toMatchObject({ nodeId: "777", status: "open" });
   });
 });
 

--- a/test/algorithm-vsa-sync.test.ts
+++ b/test/algorithm-vsa-sync.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, spyOn, test } from "bun:test";
 import { syncAlgorithmRunFromVsa } from "../src/algorithm-vsa-sync";
-import { readAlgorithmRunById } from "../src/algorithm-store";
+import { readAlgorithmRunById, writeAlgorithmRun } from "../src/algorithm-store";
+import { syncBridgedPlanStep } from "../src/algorithm";
 import { getCriteria } from "../src/vsa-accessors";
 import { getRunPhase } from "../src/algorithm-lifecycle";
 
@@ -527,5 +528,75 @@ test("CLI: soma algorithm sync-from-isa wires through and reports a summary", as
     expect(text).toContain("demo-cli");
     expect(text).toContain("phase: think");
     expect(text).toContain("created");
+  });
+});
+
+test("an open BRIDGED plan step caps the sync at EXECUTE instead of discarding the whole sync", async () => {
+  await withSomaHome(async (somaHome, dir) => {
+    // Regression (PR #555): the §2.7 sweep leaves a bridged open step `open`, which
+    // the VERIFY gate refuses. Unguarded, that throw unwound to the outer
+    // failure-isolation catch and no-op'd the ENTIRE sync — silently discarding the
+    // criteria reconciliation that had already succeeded. Cap, don't throw.
+    const vsaPath = await writeVsaFile(
+      dir,
+      "bridged-cap",
+      vsaMarkdown({
+        slug: "bridged-cap",
+        phase: "build",
+        goal: "A bridged step caps the advance",
+        criteria: [{ id: "ISC-1", text: "the sync still reconciles", done: false }],
+      }),
+    );
+
+    const first = await syncAlgorithmRunFromVsa({
+      vsaPath,
+      substrate: "claude-code",
+      somaHome,
+      timestamp: "2026-08-06T10:00:00.000Z",
+    });
+    expect(first.created).toBe(true);
+
+    // The synthetic BUILD plan step exists; bridge it to an OPEN work-graph node.
+    const { run: created } = await readAlgorithmRunById(first.runId!, { somaHome });
+    const stepId = created.planSteps[0].id;
+    expect(getCriteria(created.vsa).find((c) => c.id === "ISC-1")?.status).toBe("open");
+    await writeAlgorithmRun(
+      syncBridgedPlanStep(
+        created,
+        stepId,
+        { ref: { id: "501" }, status: "open", blockedBy: [] },
+        { bind: true },
+        "2026-08-06T10:01:00.000Z",
+      ),
+      { somaHome },
+    );
+
+    // Re-sync with ISC-1 now checked and the VSA declaring `verify`: there is real
+    // reconciliation work to lose if the advance throws instead of capping.
+    const rewritten = await writeVsaFile(
+      dir,
+      "bridged-cap",
+      vsaMarkdown({
+        slug: "bridged-cap",
+        phase: "verify",
+        progress: "1/1",
+        goal: "A bridged step caps the advance",
+        criteria: [{ id: "ISC-1", text: "the sync still reconciles", done: true }],
+      }),
+    );
+
+    await syncAlgorithmRunFromVsa({
+      vsaPath: rewritten,
+      substrate: "claude-code",
+      somaHome,
+      timestamp: "2026-08-06T10:02:00.000Z",
+    });
+
+    const { run } = await readAlgorithmRunById(first.runId!, { somaHome });
+    // The sync did NOT no-op: the criterion reconciled to passed.
+    expect(getCriteria(run.vsa).find((c) => c.id === "ISC-1")?.status).toBe("passed");
+    // …and it stopped at the gate the bridged step blocks, rather than throwing past it.
+    expect(getRunPhase(run)).toBe("execute");
+    expect(run.planSteps.find((step) => step.id === stepId)?.status).toBe("open");
   });
 });

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -3,11 +3,11 @@ import { SomaCliError } from "../src/cli/errors";
 import {
   GRAPH_COMMAND_HELP,
   parseGraphArgs,
-  parseRepoFromRemote,
   runGraphCli,
   selectRatification,
   type GraphCliDeps,
 } from "../src/cli/graph";
+import { parseRepoFromRemote } from "../src/work-graph-bridge";
 import {
   WorkGraphError,
   runProbes,


### PR DESCRIPTION
Closes #501 on map [Wayfinder map: implement the work graph (DD-16)](https://github.com/the-metafactory/soma/issues/495).

Implements `docs/work-graph.md` §2.7. `AlgorithmPlanStep` gains an optional `nodeId`; a bridged step's `status` stops being caller-authored and becomes a **cache** of the node's reported state, re-derived through `GraphStore.readNode`.

## What the review should look at

**Three mutation helpers reach a step's status, and the honest claim is narrow: a bridged status cannot be forged *incidentally*.** The spec named one path to refuse. `updateAlgorithmPlanStep` refuses on a bridged step (`applyAlgorithmBatch`'s `step` op routes through it, so it is covered by construction). `setAlgorithmPlan` refuses **both directions** — an incoming step carrying a `nodeId`, and an incoming step reusing an existing *bridged* step's id, which would drop the bridge silently and leave a hand-written `done` acceptable afterwards. The VSA sync's VERIFY sweep **skips** bridged steps rather than throwing: a whole-run map has no single step to refuse for.

What that does *not* buy is exhaustiveness, and two holes are named in the spec section rather than papered over: `writeAlgorithmRun` is on the public barrel and takes a whole run, so a caller can construct a bridged step with a hand-written status and persist it; and the un-bridge refusal is **per-call**, so removing a step in one `setAlgorithmPlan` call and re-adding it unbridged in the next reproduces the end state a single call rejects. A test pins that limit, so closing it later is a deliberate upgrade. Only moving `status` out of a bridged step's shape would actually seal this, and that is larger than #501.

**Binding is a derivation.** `syncBridgedPlanStep(..., {bind: true})` attaches the `nodeId` and derives in one act — attaching alone leaves a step bridged while reporting its stale hand-written status, which is worse than two homes: it is none. `bind` does not license **re-homing**; an already-bridged step refuses a different node, or the mismatch check would be unreachable from the one caller that always sets `bind`.

**A derived status must not read like a written one.** The derived `evidence` names the node and the derivation moment, and the run render appends `→ node <id>`. Once written, a forged status and a derived one are the same bytes.

**`BridgedNodeReport` is `Pick`ed from `NodeState`, and lives in `src/work-graph.ts`.** Hand-declared, it was a claim the compiler did not check, and its `blockedBy?` was optional where `NodeState`'s is required — a report missing the field type-checked and derived `open` on a `blocked` node. It lives with the graph because the graph owns the shape it publishes; `src/algorithm.ts` imports the narrow contract type, not `NodeState`.

**One reader.** `readNodeForBridge` + `resolveGraphRepo` live in `src/work-graph-bridge.ts` (**core**, not `src/cli/`) — a seam only the CLI can import forces a library/MCP/daemon consumer, all of which can already reach the write half, to re-implement repo resolution and become the second reader the design forbids. Only the reader is on the public barrel: repo parsing is a transport concern, not part of the bridge contract.

**Derivation:** `closed` → `done`; open with ≥1 open blocker → `blocked`; else `open`.

## CLI

```bash
soma algorithm step --id <run> --step-id <step> --node <node-id>   # bridge + derive
soma algorithm step --id <run> --step-id <step> --sync             # re-derive
soma algorithm step --id <run> --step-id <step> --status done      # refused when bridged
```

The bridged arm takes neither `--status` nor `--evidence` — both are refused rather than silently preferred, since the derived pointer would overwrite `--evidence` in silence. The three bridge flags are scoped to `step` and rejected on every other subcommand.

## Verification

`test/algorithm-plansteps-bridge.test.ts` — 28 tests, plus a VSA-sync regression test:

- **Refusals:** direct write on a bridged step (message names the read path; nothing written); the batch op; `setAlgorithmPlan` authoring a bridged step; `setAlgorithmPlan` un-bridging one (and dropping the step staying legal); re-homing under `bind`; a mismatched node report; syncing an unbridged step; `--status`/`--evidence` alongside `--node`/`--sync`; bridge flags on a non-`step` subcommand.
- **Derivation:** the full table, plus a real `NodeState` value flowing through unadapted.
- **The reader:** `readNodeForBridge` injected at the *store* seam, so `WorkGraph.readNode` runs and the response is shown surviving as a conformant report; and repo resolution when no `--repo` is passed.
- **The advertised cost:** a run walked to EXECUTE, held short of the VERIFY gate by an open bridged step, then released when the node closes.
- **Concurrency (bounded):** a re-bind landing between `--sync`'s two reads fails closed on the mismatch refusal rather than writing a stale status. That covers a concurrent write that *changes* `nodeId` only — there is no compare-and-swap, so a concurrent write leaving `nodeId` untouched is last-write-wins and the derived status can be stale at write time. Same read-modify-write exposure the rest of the Algorithm store already has; not introduced here and not closed here.

2293 pass / 0 fail on the branch head; `bunx tsc --noEmit` clean. `eslint` reports 53 errors, all pre-existing on `main` — the count is identical with this branch stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
