### PR TITLE
fix(skills): the #329 ISA→VSA rename missed two bundled-skill pointers

### DIFF
--- a/src/skills/VSA/SKILL.md
+++ b/src/skills/VSA/SKILL.md
@@ -82,11 +82,11 @@ taxonomy, ID-stability contract, and Algorithm relationship.
 | Section order, tier requirements, guardrail taxonomy, ID stability | `references/format.md` |
 | Failure modes and non-obvious operational traps | `references/gotchas.md` |
 | Example selection by tier and domain | `references/examples.md` |
-| Canonical full example | `Examples/canonical-isa.md` |
+| Canonical full example | `Examples/canonical-vsa.md` |
 | Minimal E1 example | `Examples/e1-minimal.md` |
 
 ## Example Selection
 
-Start with `Examples/canonical-isa.md` only when you need the full shape or
+Start with `Examples/canonical-vsa.md` only when you need the full shape or
 tone. Otherwise load `references/examples.md` and choose the closest small
 reference from that single map.

--- a/src/skills/VSA/Workflows/Scaffold.md
+++ b/src/skills/VSA/Workflows/Scaffold.md
@@ -39,7 +39,7 @@ curl -s -X POST http://localhost:31337/notify \
 
 ### Step 2 — Pick the canonical template
 
-Always start by reading `~/.claude/skills/VSA/Examples/canonical-isa.md` for section headers and tone. For E1 reference, read `e1-minimal.md`. For E5 reference, pick the example closest to the work shape — `e5-enterprise.md`, `e5-desktop-app.md`, or `e5-album.md`.
+Always start by reading `Examples/canonical-vsa.md` for section headers and tone. For E1 reference, read `e1-minimal.md`. For E5 reference, pick the example closest to the work shape — `e5-enterprise.md`, `e5-desktop-app.md`, or `e5-album.md`.
 
 ### Step 3 — Reverse-engineer the prompt
 

--- a/src/skills/VSA/references/examples.md
+++ b/src/skills/VSA/references/examples.md
@@ -7,7 +7,7 @@ Do not load the whole `Examples/` directory by default.
 
 | File | Purpose |
 | --- | --- |
-| `Examples/canonical-isa.md` | Fully populated all-section reference. Read when you need tone, complete structure, or a high-fidelity template. |
+| `Examples/canonical-vsa.md` | Fully populated all-section reference. Read when you need tone, complete structure, or a high-fidelity template. |
 
 ## Code
 

--- a/src/skills/the-algorithm/references/capabilities.md
+++ b/src/skills/the-algorithm/references/capabilities.md
@@ -28,7 +28,7 @@ Use these to enrich understanding BEFORE or DURING ISC writing. Select in the pr
 | WorldThreatModel | THINK | Long-term strategy stress-test, future-proofing | `Skill("WorldThreatModel")` | E5 |
 | Fabric patterns | any | Targeted transform via a specific Fabric pattern (extract_wisdom, summarize, etc.) | `Skill("Fabric")` | E1+ |
 | ContextSearch | OBSERVE | Prior PAI work, session recovery, cold-start | `Skill("ContextSearch")` | E1+ |
-| **ISA Skill** | **OBSERVE, PLAN, EXECUTE, VERIFY, LEARN** | **MANDATORY at E2+ for ISA scaffolding (`Skill("ISA", "scaffold from prompt at tier T")`), tier completeness checks (`Skill("ISA", "check completeness")`), ephemeral feature extraction at PLAN, canonical Decisions/Changelog/Verification entries via Append at any phase, and Reconcile after ephemeral feature work at LEARN. E1 may inline-write the minimal Goal+Criteria ISA to preserve <90s budget. The skill owns the canonical twelve-section template and refuses to write partial Deutsch C/R/L Changelog entries.** | `Skill("ISA", "<verb> <args>")` | E1+ |
+| **VSA Skill** | **OBSERVE, PLAN, EXECUTE, VERIFY, LEARN** | **MANDATORY at E2+ for VSA scaffolding (`Skill("VSA", "scaffold from prompt at tier T")`), tier completeness checks (`Skill("VSA", "check completeness")`), ephemeral feature extraction at PLAN, canonical Decisions/Changelog/Verification entries via Append at any phase, and Reconcile after ephemeral feature work at LEARN. E1 may inline-write the minimal Goal+Criteria VSA to preserve <90s budget. The skill owns the canonical twelve-section template and refuses to write partial Deutsch C/R/L Changelog entries.** | `Skill("VSA", "<verb> <args>")` | E1+ |
 
 ## Code Quality Capabilities
 

--- a/test/bundled-skill-references.test.ts
+++ b/test/bundled-skill-references.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+import { listBundledSkills } from "../src/bundled-skills";
+import { loadSomaHomeAlgorithmCapabilityRegistry } from "../src/algorithm-capabilities";
+
+const SKILLS_ROOT = resolve(import.meta.dir, "..", "src", "skills");
+
+/**
+ * Matches an in-repo skill-relative pointer the way a bundled skill writes one:
+ * a backticked path under `references/`, `Workflows/`, or `Examples/` ending in
+ * `.md`. Deliberately narrow — prose that merely mentions a directory ("the
+ * references above") must not read as a pointer, or the guard becomes noise
+ * nobody trusts.
+ */
+const POINTER = /`((?:references|Workflows|Examples)\/[A-Za-z0-9._-]+\.md)`/g;
+
+async function walkMarkdown(root: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const child = join(root, entry.name);
+    if (entry.isDirectory()) out.push(...(await walkMarkdown(child)));
+    else if (entry.name.endsWith(".md")) out.push(child);
+  }
+  return out;
+}
+
+async function exists(path: string): Promise<boolean> {
+  return stat(path)
+    .then(() => true)
+    .catch(() => false);
+}
+
+describe("bundled skill references", () => {
+  test("every skill-relative pointer in a bundled skill resolves inside the bundle", async () => {
+    const dangling: string[] = [];
+
+    for (const skill of await listBundledSkills()) {
+      const skillRoot = join(SKILLS_ROOT, skill);
+      for (const file of await walkMarkdown(skillRoot)) {
+        for (const match of (await readFile(file, "utf8")).matchAll(POINTER)) {
+          const pointer = match[1];
+          if (!(await exists(join(skillRoot, pointer)))) {
+            dangling.push(`${skill}/${relative(skillRoot, file)}  ->  ${pointer}`);
+          }
+        }
+      }
+    }
+
+    // A bundled skill that tells the agent to read a file the bundle does not
+    // ship is a defect the AUTHOR's machine hides: install leaves
+    // principal-added files under a skill dir untouched, so a pointer that
+    // resolves against a rich local home dangles on every fresh install. Same
+    // blindness for a renamed target — the old name keeps resolving locally
+    // long after the file moved.
+    expect(dangling).toEqual([]);
+  });
+
+  test("the-algorithm's capability table parses with no unsupported rows", async () => {
+    // `references/capabilities.md` is runtime input, not prose:
+    // loadSomaHomeAlgorithmCapabilityRegistry reads it out of the soma home and
+    // turns its rows into capability definitions, degrading SILENTLY to an
+    // empty table when the file is missing or a row is malformed. Point the
+    // loader at the repo bundle (shaped as a soma home) so the shipped table is
+    // parsed here rather than only on someone's laptop.
+    const registry = await loadSomaHomeAlgorithmCapabilityRegistry({
+      somaHome: resolve(import.meta.dir, "..", "src"),
+    });
+
+    // A parse that yields nothing means the table stopped being a table —
+    // a mis-edited header cell silently empties the registry.
+    expect(registry.definitions.length).toBeGreaterThan(0);
+
+    // `unsupported` is how a row reports that it could not become a capability:
+    // a `Skill("…")` target nothing answers to, or an invoke cell in none of the
+    // recognised shapes. Most shipped rows target principal-authored skills and
+    // legitimately land here on a machine that lacks them — that is a policy
+    // question, not a defect. What is a defect is a row aimed at a skill Soma
+    // itself ships under a DIFFERENT name than the row uses: the #329 ISA→VSA
+    // rename left `Skill("ISA")` in the mandatory scaffolding row, dead
+    // everywhere. Bundled targets must resolve.
+    const bundled = await listBundledSkills();
+    const staleBundledTargets = registry.unsupported.filter((name) =>
+      bundled.some((skill) => name.toLowerCase().includes(skill.toLowerCase())),
+    );
+    expect(staleBundledTargets).toEqual([]);
+  });
+});


### PR DESCRIPTION
The #329 ISA→VSA rename migrated the code and left behind two files that code reads. Both were invisible because nothing checked, and both keep resolving on the machine that authored them — install leaves principal-added files under a skill dir untouched, so a stale pointer resolves against a rich local home and dies on every fresh install.

## The capability row

`references/capabilities.md` declared the mandatory scaffolding capability as `ISA Skill` / `Skill("ISA", …)`. The parser was migrated — `stripCapabilityLabel` (`src/algorithm-capabilities.ts:121`) literally special-cases `"VSA Skill" → "VSA"` — but the file it parses was not. So the row resolved to no skill and was dropped as `unsupported`.

The VSA skill still auto-registered under its own name (`maybeRegisterSkillCapability`'s second pass takes every remaining skill), so nothing was unreachable. What was lost is the row's declared metadata: five specific phases and its trigger signals, silently replaced by all-phase defaults and the skill's own description.

Before / after, loading the bundle as a soma home:

```
- unsupported: [..., "ISA Skill", ...]        VSA registered by fallback, all 7 phases
+ unsupported: [...]                          VSA registered from the row, 5 declared phases
```

## The example pointers

The VSA skill pointed at `Examples/canonical-isa.md` in three places; the file is `canonical-vsa.md`. `Workflows/Scaffold.md` reached for it through a hardcoded `~/.claude/skills/VSA/…` path inside a portable skill — now skill-relative, with its sibling example pointers qualified the same way.

## The guard

`test/bundled-skill-references.test.ts` covers the class rather than the two instances:

- every backticked `references/` / `Workflows/` / `Examples/` pointer in a bundled skill resolves inside the bundle;
- the capability table still parses into at least one definition (a mis-edited header cell silently empties the registry — `parseMarkdownTableRows` keys on a first header cell of `Capability`);
- no `unsupported` row names a skill Soma itself ships.

That last assertion is deliberately narrow. Most shipped rows target principal-authored skills and legitimately land in `unsupported` on a machine that lacks them — that is a policy question, filed as #574, not a defect. A row aimed at a skill Soma *does* ship, under a name Soma no longer uses, is a defect.

## Scope

Two lines of content plus a test. The broader condition of these files — 2169 lines carrying 11 `~/.claude` paths, 16 unsubstituted `{{DA_NAME}}`/`{{PRINCIPAL_NAME}}` placeholders, 53 mentions of Forge/Anvil/Cato/Advisor, and a capability table two-thirds inert off the author's machine — is measured in **#574** and deliberately out of scope here.

A third instance of the same pattern is recorded in #574 and not fixed here: `CLAUDE_ONLY_LINE` (`src/substrate-projection-rewrites.ts:9`) matches `VSASync.hook.ts` while the doctrine it filters says `ISASync.hook.ts`, so it strips zero lines from `algorithm.md`. Fixing it changes what non-claude-code substrates receive, which is a bigger call than this PR.

Closes nothing. #573 was filed off a stale checkout and is already closed as invalid; these are the real bugs that investigation turned up.

## Verification

- `bun run typecheck` clean.
- `bun test test/bundled-skill-references.test.ts` — 2 pass. Fails on `main` with both defects listed.
- `bun test test/algorithm.test.ts test/algorithm-importer.test.ts test/algorithm-compat.test.ts test/algorithm-capability-registry.test.ts test/install.test.ts` — 131 pass, 0 fail.
- Registry probe against the bundle confirms `VSA` now registers from the row with its five declared phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
