### PR TITLE
fix(codex): bound work registry lock wait

### DIFF
--- a/src/adapters/codex/hooks/codex-hook-entry.mjs
+++ b/src/adapters/codex/hooks/codex-hook-entry.mjs
@@ -76,6 +76,7 @@ function resolveSessionTranscript(config, input, sessionId) {
 }
 
 function runSomaLifecycle(config, event, input) {
+  const CODEX_SESSION_END_WORK_REGISTRY_LOCK_TIMEOUT_MS = 1_000;
   const sessionId = typeof input.session_id === "string" && input.session_id.trim().length > 0 ? input.session_id : undefined;
   const args = ["run", "soma", "lifecycle", event, "--soma-home", config.somaHome, "--substrate", "codex"];
   if (sessionId) {
@@ -87,6 +88,7 @@ function runSomaLifecycle(config, event, input) {
     args.push("--cwd", process.cwd());
   }
   if (event === "session-end" && sessionId) {
+    args.push("--work-registry-lock-timeout-ms", String(CODEX_SESSION_END_WORK_REGISTRY_LOCK_TIMEOUT_MS));
     const transcript = resolveSessionTranscript(config, input, sessionId);
     if (transcript) {
       args.push("--transcript", transcript);
@@ -94,6 +96,15 @@ function runSomaLifecycle(config, event, input) {
   }
 
   return runSomaCommand(config, args);
+}
+
+function lifecycleFailureDetail(result) {
+  if (typeof result?.error?.code === "string" && result.error.code.length > 0) {
+    return `command error ${result.error.code}`;
+  }
+  if (typeof result?.status === "number") return `exit status ${result.status}`;
+  if (typeof result?.signal === "string" && result.signal.length > 0) return `terminated by ${result.signal}`;
+  return "unknown child failure";
 }
 
 function runSomaClassification(config, prompt) {
@@ -407,7 +418,7 @@ function handleLifecycleEvent(config, event, input) {
     const eventLog = join(config.somaHome, "memory", "STATE", "events.jsonl");
     emitAndExit({
       continue: true,
-      systemMessage: `Soma lifecycle hook failed for ${event}; inspect ${eventLog} for failure details.`,
+      systemMessage: `Soma lifecycle hook failed for ${event} (${lifecycleFailureDetail(result)}); inspect ${eventLog} for recorded Soma events.`,
     });
   }
 

--- a/src/adapters/codex/hooks/codex-hook-entry.mjs
+++ b/src/adapters/codex/hooks/codex-hook-entry.mjs
@@ -404,7 +404,11 @@ function handleLifecycleEvent(config, event, input) {
       });
     }
 
-    emitAndExit({ continue: true, systemMessage: `Soma lifecycle hook failed for ${event}; read projected Soma context when needed.` });
+    const eventLog = join(config.somaHome, "memory", "STATE", "events.jsonl");
+    emitAndExit({
+      continue: true,
+      systemMessage: `Soma lifecycle hook failed for ${event}; inspect ${eventLog} for failure details.`,
+    });
   }
 
   if (event === "session-start") {

--- a/src/adapters/codex/hooks/codex-hook-entry.mjs
+++ b/src/adapters/codex/hooks/codex-hook-entry.mjs
@@ -418,7 +418,7 @@ function handleLifecycleEvent(config, event, input) {
     const eventLog = join(config.somaHome, "memory", "STATE", "events.jsonl");
     emitAndExit({
       continue: true,
-      systemMessage: `Soma lifecycle hook failed for ${event} (${lifecycleFailureDetail(result)}); inspect ${eventLog} for recorded Soma events.`,
+      systemMessage: `Soma lifecycle hook failed for ${event} (${lifecycleFailureDetail(result)}); inspect ${eventLog} for Soma context.`,
     });
   }
 

--- a/src/cli/lifecycle.ts
+++ b/src/cli/lifecycle.ts
@@ -23,7 +23,7 @@ export interface ParsedLifecycleArgs {
 }
 
 const LIFECYCLE_USAGE =
-  "Usage: soma lifecycle <session-start|algorithm-updated|algorithm-observed|session-end> [--home-dir <dir>] [--soma-home <dir>] [--substrate <id>] [--session-id <id>] [--cwd <dir>] [--git-branch <branch>]";
+  "Usage: soma lifecycle <session-start|algorithm-updated|algorithm-observed|session-end> [--home-dir <dir>] [--soma-home <dir>] [--substrate <id>] [--session-id <id>] [--cwd <dir>] [--git-branch <branch>] [--work-registry-lock-timeout-ms <ms>]";
 
 export const LIFECYCLE_COMMAND_HELP: { usage: string; subcommands: Record<ParsedLifecycleArgs["event"], string> } = {
   usage: LIFECYCLE_USAGE,
@@ -72,6 +72,15 @@ export function parseLifecycleArgs(args: string[]): ParsedLifecycleArgs {
         options.gitBranch = readOption(rest, index, arg);
         index += 1;
         break;
+      case "--work-registry-lock-timeout-ms": {
+        const timeout = Number(readOption(rest, index, arg));
+        if (!Number.isSafeInteger(timeout) || timeout <= 0) {
+          throw new Error(`${arg} must be a positive integer`);
+        }
+        options.workRegistryLockTimeoutMs = timeout;
+        index += 1;
+        break;
+      }
       case "--transcript":
         options.transcriptPath = readOption(rest, index, arg);
         index += 1;

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -718,6 +718,9 @@ async function writeSessionEndWorkRegistry(input: {
       progress: "1/1",
       status: "complete",
       timestamp: input.timestamp,
+      ...(input.options.workRegistryLockTimeoutMs !== undefined
+        ? { workRegistryLockTimeoutMs: input.options.workRegistryLockTimeoutMs }
+        : {}),
       ...(input.options.cwd !== undefined ? { signals: { cwd: input.options.cwd } } : {}),
       artifacts,
       learningSources: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2416,6 +2416,8 @@ export interface SomaLifecycleOptions {
   cwd?: string;
   /** Git branch of `cwd`, when known. Detected from `cwd` when omitted. */
   gitBranch?: string;
+  /** Optional adapter-provided deadline for the session work-registry writeback. */
+  workRegistryLockTimeoutMs?: number;
   /**
    * On `session-end`: path to the substrate session transcript. When set (and the
    * substrate has a transcript adapter, e.g. claude-code), the handler attempts the

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -194,6 +194,11 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await rename(tmp, path);
 }
 
+// Work-registry mutations are local read/modify/write operations. Keep lock
+// acquisition below substrate lifecycle-hook deadlines so contention remains a
+// best-effort writeback failure instead of turning session end into a timeout.
+const WORK_REGISTRY_LOCK_TIMEOUT_MS = 1_000;
+
 async function withRegistryFileLock<T>(registryPath: string, fn: () => Promise<T>): Promise<T> {
   await mkdir(dirname(registryPath), { recursive: true });
   const lockPath = `${registryPath}.lock`;
@@ -205,7 +210,7 @@ async function withRegistryFileLock<T>(registryPath: string, fn: () => Promise<T
       break;
     } catch (error: unknown) {
       if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
-      if (Date.now() - started > 30_000) {
+      if (Date.now() - started > WORK_REGISTRY_LOCK_TIMEOUT_MS) {
         throw new Error(`Timed out waiting for work registry lock at ${lockPath}`, { cause: error });
       }
       await sleep(10);

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -199,6 +199,7 @@ async function writeJson(path: string, value: unknown): Promise<void> {
 const DEFAULT_WORK_REGISTRY_LOCK_TIMEOUT_MS = 30_000;
 const STALE_WORK_REGISTRY_LOCK_MS = 30_000;
 const WORK_REGISTRY_LOCK_OWNER_FILE = "owner.json";
+const WORK_REGISTRY_LOCK_RECLAIM_SUFFIX = ".reclaim";
 
 function resolveWorkRegistryLockTimeout(timeoutMs: number | undefined): number {
   if (timeoutMs === undefined) return DEFAULT_WORK_REGISTRY_LOCK_TIMEOUT_MS;
@@ -238,6 +239,35 @@ async function isReclaimableWorkRegistryLock(lockPath: string): Promise<boolean>
   }
 }
 
+async function reclaimStaleWorkRegistryLock(lockPath: string): Promise<boolean> {
+  const reclaimPath = `${lockPath}${WORK_REGISTRY_LOCK_RECLAIM_SUFFIX}`;
+  try {
+    await mkdir(reclaimPath);
+  } catch (error: unknown) {
+    if (error instanceof Error && "code" in error && error.code === "EEXIST") return false;
+    throw error;
+  }
+
+  try {
+    if (!(await isReclaimableWorkRegistryLock(lockPath))) return false;
+
+    // The reclaim guard serializes stale-lock inspection and rename. Once moved,
+    // later writers may acquire a fresh lock at `lockPath`; only this retired
+    // directory is removed, so a fresh owner cannot be deleted by a reclaimer.
+    const retiredPath = `${lockPath}.stale-${process.pid}-${shortHash(`${lockPath}:${Date.now()}:${Math.random()}`)}`;
+    try {
+      await rename(lockPath, retiredPath);
+    } catch (error: unknown) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+      throw error;
+    }
+    await rm(retiredPath, { recursive: true, force: true });
+    return true;
+  } finally {
+    await rm(reclaimPath, { recursive: true, force: true });
+  }
+}
+
 async function withRegistryFileLock<T>(
   registryPath: string,
   fn: () => Promise<T>,
@@ -259,10 +289,7 @@ async function withRegistryFileLock<T>(
       break;
     } catch (error: unknown) {
       if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
-      if (await isReclaimableWorkRegistryLock(lockPath)) {
-        await rm(lockPath, { recursive: true, force: true });
-        continue;
-      }
+      if (await reclaimStaleWorkRegistryLock(lockPath)) continue;
       if (Date.now() - started > timeout) {
         throw new Error(`Timed out waiting for work registry lock at ${lockPath}`, { cause: error });
       }

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { createPaths, type SomaPathsOptions } from "./paths";
@@ -58,6 +58,8 @@ export interface UpsertSomaWorkRegistryEntryOptions extends SomaPathsOptions {
   progress?: string;
   timestamp?: string;
   artifacts?: Record<string, string>;
+  /** Optional caller-owned deadline for acquiring the shared registry lock. */
+  workRegistryLockTimeoutMs?: number;
 }
 
 export interface UpsertSomaCurrentWorkPointerOptions extends UpsertSomaWorkRegistryEntryOptions {
@@ -194,23 +196,74 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await rename(tmp, path);
 }
 
-// Work-registry mutations are local read/modify/write operations. Keep lock
-// acquisition below substrate lifecycle-hook deadlines so contention remains a
-// best-effort writeback failure instead of turning session end into a timeout.
-const WORK_REGISTRY_LOCK_TIMEOUT_MS = 1_000;
+const DEFAULT_WORK_REGISTRY_LOCK_TIMEOUT_MS = 30_000;
+const STALE_WORK_REGISTRY_LOCK_MS = 30_000;
+const WORK_REGISTRY_LOCK_OWNER_FILE = "owner.json";
 
-async function withRegistryFileLock<T>(registryPath: string, fn: () => Promise<T>): Promise<T> {
+function resolveWorkRegistryLockTimeout(timeoutMs: number | undefined): number {
+  if (timeoutMs === undefined) return DEFAULT_WORK_REGISTRY_LOCK_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(`work registry lock timeout must be a positive integer, got ${timeoutMs}`);
+  }
+  return timeoutMs;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error: unknown) {
+    return !(error instanceof Error && "code" in error && error.code === "ESRCH");
+  }
+}
+
+async function isReclaimableWorkRegistryLock(lockPath: string): Promise<boolean> {
+  try {
+    const lock = await stat(lockPath);
+    if (!lock.isDirectory() || Date.now() - lock.mtimeMs < STALE_WORK_REGISTRY_LOCK_MS) return false;
+
+    try {
+      const owner = JSON.parse(await readFile(join(lockPath, WORK_REGISTRY_LOCK_OWNER_FILE), "utf8")) as unknown;
+      if (isPlainRecord(owner) && typeof owner.pid === "number" && Number.isSafeInteger(owner.pid) && owner.pid > 0) {
+        return !isProcessAlive(owner.pid);
+      }
+    } catch {
+      // Legacy locks have no owner record. Once old enough, they are safe to reclaim.
+    }
+
+    return true;
+  } catch (error: unknown) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function withRegistryFileLock<T>(
+  registryPath: string,
+  fn: () => Promise<T>,
+  timeoutMs?: number,
+): Promise<T> {
   await mkdir(dirname(registryPath), { recursive: true });
   const lockPath = `${registryPath}.lock`;
   const started = Date.now();
+  const timeout = resolveWorkRegistryLockTimeout(timeoutMs);
 
   for (;;) {
     try {
       await mkdir(lockPath);
+      await writeFile(
+        join(lockPath, WORK_REGISTRY_LOCK_OWNER_FILE),
+        `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`,
+        "utf8",
+      );
       break;
     } catch (error: unknown) {
       if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
-      if (Date.now() - started > WORK_REGISTRY_LOCK_TIMEOUT_MS) {
+      if (await isReclaimableWorkRegistryLock(lockPath)) {
+        await rm(lockPath, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() - started > timeout) {
         throw new Error(`Timed out waiting for work registry lock at ${lockPath}`, { cause: error });
       }
       await sleep(10);
@@ -391,7 +444,11 @@ export async function listSomaWorkRegistryEntries(options: SomaPathsOptions = {}
 export async function upsertSomaWorkRegistryEntry(
   options: UpsertSomaWorkRegistryEntryOptions,
 ): Promise<UpsertSomaWorkRegistryEntryResult> {
-  return withRegistryFileLock(workRegistryPath(options), () => upsertSomaWorkRegistryEntryLocked(options));
+  return withRegistryFileLock(
+    workRegistryPath(options),
+    () => upsertSomaWorkRegistryEntryLocked(options),
+    options.workRegistryLockTimeoutMs,
+  );
 }
 
 async function upsertSomaWorkRegistryEntryLocked(
@@ -455,7 +512,11 @@ function buildCurrentWorkPointer(
 export async function upsertSomaCurrentWorkPointer(
   options: UpsertSomaCurrentWorkPointerOptions,
 ): Promise<UpsertSomaWorkRegistryEntryResult> {
-  return withRegistryFileLock(workRegistryPath(options), () => upsertSomaWorkRegistryEntryLocked(options));
+  return withRegistryFileLock(
+    workRegistryPath(options),
+    () => upsertSomaWorkRegistryEntryLocked(options),
+    options.workRegistryLockTimeoutMs,
+  );
 }
 
 export function somaWorkRegistryPaths(options: SomaPathsOptions = {}, sessionId?: string): {

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { hostname } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { createPaths, type SomaPathsOptions } from "./paths";
@@ -225,7 +226,7 @@ async function isReclaimableWorkRegistryLock(lockPath: string): Promise<boolean>
 
     try {
       const owner = JSON.parse(await readFile(join(lockPath, WORK_REGISTRY_LOCK_OWNER_FILE), "utf8")) as unknown;
-      return isPlainRecord(owner) && typeof owner.pid === "number" && Number.isSafeInteger(owner.pid) && owner.pid > 0
+      return isPlainRecord(owner) && owner.hostname === hostname() && typeof owner.pid === "number" && Number.isSafeInteger(owner.pid) && owner.pid > 0
         ? !isProcessAlive(owner.pid)
         : false;
     } catch {
@@ -243,7 +244,7 @@ async function acquireReclaimGuard(reclaimPath: string): Promise<boolean> {
     try {
       await mkdir(reclaimPath);
       try {
-        await writeFile(join(reclaimPath, WORK_REGISTRY_LOCK_OWNER_FILE), `${JSON.stringify({ pid: process.pid })}\n`, "utf8");
+        await writeFile(join(reclaimPath, WORK_REGISTRY_LOCK_OWNER_FILE), `${JSON.stringify({ pid: process.pid, hostname: hostname() })}\n`, "utf8");
       } catch (error) {
         await rm(reclaimPath, { recursive: true, force: true });
         throw error;
@@ -298,7 +299,7 @@ async function withRegistryFileLock<T>(
       try {
         await writeFile(
           join(lockPath, WORK_REGISTRY_LOCK_OWNER_FILE),
-          `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`,
+          `${JSON.stringify({ pid: process.pid, hostname: hostname(), acquiredAt: new Date().toISOString() })}\n`,
           "utf8",
         );
       } catch (error) {

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -225,28 +225,41 @@ async function isReclaimableWorkRegistryLock(lockPath: string): Promise<boolean>
 
     try {
       const owner = JSON.parse(await readFile(join(lockPath, WORK_REGISTRY_LOCK_OWNER_FILE), "utf8")) as unknown;
-      if (isPlainRecord(owner) && typeof owner.pid === "number" && Number.isSafeInteger(owner.pid) && owner.pid > 0) {
-        return !isProcessAlive(owner.pid);
-      }
+      return isPlainRecord(owner) && typeof owner.pid === "number" && Number.isSafeInteger(owner.pid) && owner.pid > 0
+        ? !isProcessAlive(owner.pid)
+        : false;
     } catch {
-      // Legacy locks have no owner record. Once old enough, they are safe to reclaim.
+      // An ownerless pre-metadata lock may still be held by an older process.
+      return false;
     }
-
-    return true;
   } catch (error: unknown) {
     if (error instanceof Error && "code" in error && error.code === "ENOENT") return false;
     throw error;
   }
 }
 
+async function acquireReclaimGuard(reclaimPath: string): Promise<boolean> {
+  for (;;) {
+    try {
+      await mkdir(reclaimPath);
+      try {
+        await writeFile(join(reclaimPath, WORK_REGISTRY_LOCK_OWNER_FILE), `${JSON.stringify({ pid: process.pid })}\n`, "utf8");
+      } catch (error) {
+        await rm(reclaimPath, { recursive: true, force: true });
+        throw error;
+      }
+      return true;
+    } catch (error: unknown) {
+      if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
+      if (!(await isReclaimableWorkRegistryLock(reclaimPath))) return false;
+      await rm(reclaimPath, { recursive: true, force: true });
+    }
+  }
+}
+
 async function reclaimStaleWorkRegistryLock(lockPath: string): Promise<boolean> {
   const reclaimPath = `${lockPath}${WORK_REGISTRY_LOCK_RECLAIM_SUFFIX}`;
-  try {
-    await mkdir(reclaimPath);
-  } catch (error: unknown) {
-    if (error instanceof Error && "code" in error && error.code === "EEXIST") return false;
-    throw error;
-  }
+  if (!(await acquireReclaimGuard(reclaimPath))) return false;
 
   try {
     if (!(await isReclaimableWorkRegistryLock(lockPath))) return false;

--- a/src/work-registry.ts
+++ b/src/work-registry.ts
@@ -277,19 +277,28 @@ async function withRegistryFileLock<T>(
   const lockPath = `${registryPath}.lock`;
   const started = Date.now();
   const timeout = resolveWorkRegistryLockTimeout(timeoutMs);
+  let nextReclaimAttemptAt = started;
 
   for (;;) {
     try {
       await mkdir(lockPath);
-      await writeFile(
-        join(lockPath, WORK_REGISTRY_LOCK_OWNER_FILE),
-        `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`,
-        "utf8",
-      );
+      try {
+        await writeFile(
+          join(lockPath, WORK_REGISTRY_LOCK_OWNER_FILE),
+          `${JSON.stringify({ pid: process.pid, acquiredAt: new Date().toISOString() })}\n`,
+          "utf8",
+        );
+      } catch (error) {
+        await rm(lockPath, { recursive: true, force: true });
+        throw error;
+      }
       break;
     } catch (error: unknown) {
       if (!(error instanceof Error && "code" in error && error.code === "EEXIST")) throw error;
-      if (await reclaimStaleWorkRegistryLock(lockPath)) continue;
+      if (Date.now() >= nextReclaimAttemptAt) {
+        nextReclaimAttemptAt = Date.now() + 1_000;
+        if (await reclaimStaleWorkRegistryLock(lockPath)) continue;
+      }
       if (Date.now() - started > timeout) {
         throw new Error(`Timed out waiting for work registry lock at ${lockPath}`, { cause: error });
       }

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -974,6 +974,23 @@ test("installed codex session-end hook reclaims a stale work registry lock", asy
   });
 });
 
+test("installed codex session-end hook records a failure when a live registry lock outlasts its deadline", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const lockPath = `${somaWorkRegistryPaths({ homeDir }).work}.lock`;
+    await mkdir(lockPath, { recursive: true });
+    await writeFile(join(lockPath, "owner.json"), `${JSON.stringify({ pid: process.pid })}\n`);
+
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexHook(hook, "session-end", homeDir, { session_id: "codex-live-lock", cwd: homeDir });
+    const events = await readFile(join(homeDir, ".soma", "memory", "STATE", "events.jsonl"), "utf8");
+
+    expect(result.status).toBe(0);
+    expect(result.output.systemMessage).toBe("Soma lifecycle session-end handled.");
+    expect(events).toContain("lifecycle.session_end.registry-write-failed");
+  });
+});
+
 test("installed codex session-end hook points failures at the durable event log", async () => {
   await withTempHome(async (homeDir) => {
     await installSomaForCodex({ homeDir });

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { isAbsolute, join, resolve } from "node:path";
-import { tmpdir } from "node:os";
+import { hostname, tmpdir } from "node:os";
 import { expect, test } from "bun:test";
 import { bootstrapSomaHome, experimentalAnthropicCowork, installSomaForClaudeCode, installSomaForCodex, installSomaForCursor, installSomaForPiDev, planSomaForCodexInstall, planSomaForPiDevInstall, somaWorkRegistryPaths } from "../src/index";
 import { codexInstallSpec } from "../src/adapters/codex/install";
@@ -959,7 +959,7 @@ test("installed codex session-end hook reclaims a stale work registry lock", asy
     await installSomaForCodex({ homeDir });
     const lockPath = `${somaWorkRegistryPaths({ homeDir }).work}.lock`;
     await mkdir(lockPath, { recursive: true });
-    await writeFile(join(lockPath, "owner.json"), `${JSON.stringify({ pid: 999_999 })}\n`);
+    await writeFile(join(lockPath, "owner.json"), `${JSON.stringify({ pid: 999_999, hostname: hostname() })}\n`);
     const stale = new Date(Date.now() - 60_000);
     await utimes(lockPath, stale, stale);
 
@@ -980,7 +980,7 @@ test("installed codex session-end hook records a failure when a live registry lo
     await installSomaForCodex({ homeDir });
     const lockPath = `${somaWorkRegistryPaths({ homeDir }).work}.lock`;
     await mkdir(lockPath, { recursive: true });
-    await writeFile(join(lockPath, "owner.json"), `${JSON.stringify({ pid: process.pid })}\n`);
+    await writeFile(join(lockPath, "owner.json"), `${JSON.stringify({ pid: process.pid, hostname: hostname() })}\n`);
 
     const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
     const result = runCodexHook(hook, "session-end", homeDir, { session_id: "codex-live-lock", cwd: homeDir });
@@ -1005,7 +1005,7 @@ test("installed codex session-end hook points failures at the durable event log"
 
     expect(result.status).toBe(0);
     expect(result.output.systemMessage).toBe(
-      `Soma lifecycle hook failed for session-end (command error ENOENT); inspect ${join(homeDir, ".soma/memory/STATE/events.jsonl")} for recorded Soma events.`,
+      `Soma lifecycle hook failed for session-end (command error ENOENT); inspect ${join(homeDir, ".soma/memory/STATE/events.jsonl")} for Soma context.`,
     );
   });
 });

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -954,7 +954,7 @@ test("installed codex session-start hook returns concise visible context", async
   });
 });
 
-test("installed codex session-end hook stays successful when the work registry lock is orphaned", async () => {
+test("installed codex session-end hook reclaims a stale work registry lock", async () => {
   await withTempHome(async (homeDir) => {
     await installSomaForCodex({ homeDir });
     const lockPath = `${somaWorkRegistryPaths({ homeDir }).work}.lock`;
@@ -964,11 +964,13 @@ test("installed codex session-end hook stays successful when the work registry l
 
     const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
     const result = runCodexHook(hook, "session-end", homeDir, { session_id: "codex-orphaned-lock", cwd: homeDir });
+    const work = await readFile(join(homeDir, ".soma", "memory", "STATE", "work.json"), "utf8");
     const events = await readFile(join(homeDir, ".soma", "memory", "STATE", "events.jsonl"), "utf8");
 
     expect(result.status).toBe(0);
     expect(result.output.systemMessage).toBe("Soma lifecycle session-end handled.");
-    expect(events).toContain("lifecycle.session_end.registry-write-failed");
+    expect(work).toContain("codex-orphaned-lock");
+    expect(events).not.toContain("lifecycle.session_end.registry-write-failed");
   });
 });
 
@@ -985,7 +987,7 @@ test("installed codex session-end hook points failures at the durable event log"
 
     expect(result.status).toBe(0);
     expect(result.output.systemMessage).toBe(
-      `Soma lifecycle hook failed for session-end; inspect ${join(homeDir, ".soma/memory/STATE/events.jsonl")} for failure details.`,
+      `Soma lifecycle hook failed for session-end (command error ENOENT); inspect ${join(homeDir, ".soma/memory/STATE/events.jsonl")} for recorded Soma events.`,
     );
   });
 });

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -972,6 +972,24 @@ test("installed codex session-end hook stays successful when the work registry l
   });
 });
 
+test("installed codex session-end hook points failures at the durable event log", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const configPath = join(homeDir, ".codex/hooks/soma-lifecycle.config.json");
+    const config = JSON.parse(await readFile(configPath, "utf8")) as { bunPath: string };
+    config.bunPath = join(homeDir, "missing-bun");
+    await writeFile(configPath, `${JSON.stringify(config)}\n`);
+
+    const result = runCodexHook(hook, "session-end", homeDir, { session_id: "codex-lifecycle-failure" });
+
+    expect(result.status).toBe(0);
+    expect(result.output.systemMessage).toBe(
+      `Soma lifecycle hook failed for session-end; inspect ${join(homeDir, ".soma/memory/STATE/events.jsonl")} for failure details.`,
+    );
+  });
+});
+
 test("installed codex session-end hook resolves transcript and writes one digest", async () => {
   await withTempHome(async (homeDir) => {
     await installSomaForCodex({ homeDir });

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -959,6 +959,7 @@ test("installed codex session-end hook reclaims a stale work registry lock", asy
     await installSomaForCodex({ homeDir });
     const lockPath = `${somaWorkRegistryPaths({ homeDir }).work}.lock`;
     await mkdir(lockPath, { recursive: true });
+    await writeFile(join(lockPath, "owner.json"), `${JSON.stringify({ pid: 999_999 })}\n`);
     const stale = new Date(Date.now() - 60_000);
     await utimes(lockPath, stale, stale);
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { isAbsolute, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
@@ -951,6 +951,24 @@ test("installed codex session-start hook returns concise visible context", async
       substrate: "codex",
       status: "active",
     });
+  });
+});
+
+test("installed codex session-end hook stays successful when the work registry lock is orphaned", async () => {
+  await withTempHome(async (homeDir) => {
+    await installSomaForCodex({ homeDir });
+    const lockPath = `${somaWorkRegistryPaths({ homeDir }).work}.lock`;
+    await mkdir(lockPath, { recursive: true });
+    const stale = new Date(Date.now() - 60_000);
+    await utimes(lockPath, stale, stale);
+
+    const hook = join(homeDir, ".codex/hooks/soma-lifecycle.mjs");
+    const result = runCodexHook(hook, "session-end", homeDir, { session_id: "codex-orphaned-lock", cwd: homeDir });
+    const events = await readFile(join(homeDir, ".soma", "memory", "STATE", "events.jsonl"), "utf8");
+
+    expect(result.status).toBe(0);
+    expect(result.output.systemMessage).toBe("Soma lifecycle session-end handled.");
+    expect(events).toContain("lifecycle.session_end.registry-write-failed");
   });
 });
 

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -189,8 +189,13 @@ test("work registry reclaims one stale lock before concurrent upserts", async ()
   await withTempHome(async (homeDir) => {
     const lockPath = `${somaWorkRegistryPaths({ homeDir }).work}.lock`;
     await mkdir(lockPath, { recursive: true });
+    await writeFile(join(lockPath, "owner.json"), `${JSON.stringify({ pid: 999_999 })}\n`);
     const stale = new Date(Date.now() - 60_000);
     await utimes(lockPath, stale, stale);
+    const reclaimPath = `${lockPath}.reclaim`;
+    await mkdir(reclaimPath, { recursive: true });
+    await writeFile(join(reclaimPath, "owner.json"), `${JSON.stringify({ pid: 999_998 })}\n`);
+    await utimes(reclaimPath, stale, stale);
 
     await Promise.all(
       ["session-one", "session-two"].map((sessionId) =>

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { expect, test } from "bun:test";
@@ -182,6 +182,34 @@ test("work registry upserts preserve concurrent sessions", async () => {
 
     const work = JSON.parse(await readFile(join(homeDir, ".soma/memory/STATE/work.json"), "utf8"));
     expect(Object.keys(work.sessions)).toHaveLength(12);
+  });
+});
+
+test("work registry reclaims one stale lock before concurrent upserts", async () => {
+  await withTempHome(async (homeDir) => {
+    const lockPath = `${somaWorkRegistryPaths({ homeDir }).work}.lock`;
+    await mkdir(lockPath, { recursive: true });
+    const stale = new Date(Date.now() - 60_000);
+    await utimes(lockPath, stale, stale);
+
+    await Promise.all(
+      ["session-one", "session-two"].map((sessionId) =>
+        upsertSomaWorkRegistryEntry({
+          homeDir,
+          sessionId,
+          sessionName: sessionId,
+          substrate: "codex",
+          workRegistryLockTimeoutMs: 1_000,
+        }),
+      ),
+    );
+
+    await expect(listSomaWorkRegistryEntries({ homeDir })).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sessionUUID: "session-one" }),
+        expect.objectContaining({ sessionUUID: "session-two" }),
+      ]),
+    );
   });
 });
 

--- a/test/work-registry.test.ts
+++ b/test/work-registry.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { hostname, tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { expect, test } from "bun:test";
 import {
@@ -189,12 +189,12 @@ test("work registry reclaims one stale lock before concurrent upserts", async ()
   await withTempHome(async (homeDir) => {
     const lockPath = `${somaWorkRegistryPaths({ homeDir }).work}.lock`;
     await mkdir(lockPath, { recursive: true });
-    await writeFile(join(lockPath, "owner.json"), `${JSON.stringify({ pid: 999_999 })}\n`);
+    await writeFile(join(lockPath, "owner.json"), `${JSON.stringify({ pid: 999_999, hostname: hostname() })}\n`);
     const stale = new Date(Date.now() - 60_000);
     await utimes(lockPath, stale, stale);
     const reclaimPath = `${lockPath}.reclaim`;
     await mkdir(reclaimPath, { recursive: true });
-    await writeFile(join(reclaimPath, "owner.json"), `${JSON.stringify({ pid: 999_998 })}\n`);
+    await writeFile(join(reclaimPath, "owner.json"), `${JSON.stringify({ pid: 999_998, hostname: hostname() })}\n`);
     await utimes(reclaimPath, stale, stale);
 
     await Promise.all(


### PR DESCRIPTION
Fixes #563.\n\nCodex session-end now:\n- reclaims stale work-registry locks only when a same-host owner record identifies a dead local process;\n- keeps ownerless, foreign-host, and live-owner locks fail-safe and reports their bounded writeback failure instead of risking concurrent writes;\n- supplies a 1-second lock-wait budget while the shared registry default remains 30 seconds;\n- records a durable lifecycle.session_end.registry-write-failed event when a live or legacy lock outlasts that budget; and\n- includes sanitized child-failure status in other lifecycle-hook warnings.\n\nTests:\n- bun test test/install.test.ts\n- bun test test/work-registry.test.ts test/lifecycle.test.ts\n- bun run typecheck\n- bun test