### PR TITLE
fix(work-graph): contain the ungated probes to the stated tree (#582)

### DIFF
--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -219,7 +219,10 @@ The rule, now enforced:
 - **Escape is a failed probe**, never an exception and never a skip — same shape
   as a registry refusal, refusing through the path `assertClosable` already owns.
   The message names the resolved path *and* the tree, since the node's literal
-  field and the resolved path are different strings.
+  field and the resolved path are different strings. `soma graph close` surfaces
+  it ahead of that generic failure in its **own** section, separate from the
+  registry's: the fix is the node, and pointing an adopter at their registry over
+  an escape would send them to widen a gate that was never the one refusing.
 - The pre-flight tree read (§2.2) skips uncontained directories **before**
   spawning in them: it runs in a directory a node body names and before any gate
   has refused anything.

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -183,7 +183,69 @@ depend on knowing who is trusted there.
 | --- | --- |
 | `command` | Refused unless the exact `run` **and** `cwd` pair is declared in the local probe registry for this repo. `cwd` is part of the match: a declared command run in an attacker-chosen directory is a different command. |
 | `url` | Refused unless the target host is in the declared host set. Ungated, this is a blind SSRF oracle — the request issues from the closing machine and the receipt publishes the observed status to a possibly world-readable tracker. |
-| `git-ref-exists`, `git-merged-into`, `artifact-exists` | Ungated — argv, no shell, no egress, bounded to existence checks in a local tree. |
+| `git-ref-exists`, `git-merged-into`, `artifact-exists` | Ungated by the registry — argv, no shell, no egress — and **contained to the stated probe tree** (below). |
+
+##### Containment of the ungated probes
+
+**Status: enforced**
+([#582](https://github.com/the-metafactory/soma/issues/582)), in
+`src/work-graph-probes.ts` beside the registry gate, before dispatch and with the
+same exhaustive switch — a probe type added later must not inherit "contained" by
+omission either.
+
+The row above previously read *"bounded to existence checks in a local tree"*.
+That clause was **false as written**, which is what
+[#529](https://github.com/the-metafactory/soma/issues/529) refuted: `repo` and
+`path` are tracker content resolved against the runner's base cwd with no bound,
+so a node body could name any directory on the closing machine. Verified live at
+`dfea720`: `artifact-exists path:"/etc/passwd"` passed, as did
+`path:"~/.ssh/id_rsa"` and `git-ref-exists repo:"../../.."`. The disclosure this
+creates is the *same* one cited as the reason `url` is gated — the receipt
+publishes the observed string to a possibly world-readable tracker — and it
+applies to a probe whose path the reader chose.
+
+The rule, now enforced:
+
+- **Contained** means the *resolved absolute* path is the probe tree (§2.2's
+  stated base cwd, [#580](https://github.com/the-metafactory/soma/issues/580)) or
+  a descendant of it. The comparison is a separator-aware prefix test, so
+  `/base-evil` is not a descendant of `/base`.
+- **Every path the probe touches**, not just its directory. Two resolutions
+  exist: `repo` → the probe directory, and `artifact-exists`'s `path` when no
+  `atRef` is given, which resolves against that directory. A check seeing only
+  the first is the defect, not the fix. With `atRef` the path is a
+  repository-relative object name handed to `git cat-file` and never touches the
+  filesystem, so only the directory is contained there.
+- **Escape is a failed probe**, never an exception and never a skip — same shape
+  as a registry refusal, refusing through the path `assertClosable` already owns.
+  The message names the resolved path *and* the tree, since the node's literal
+  field and the resolved path are different strings.
+- The pre-flight tree read (§2.2) skips uncontained directories **before**
+  spawning in them: it runs in a directory a node body names and before any gate
+  has refused anything.
+- **Lexical, not `realpath`.** A symlink inside the tree pointing out of it still
+  escapes. Resolving links would mean filesystem I/O in a predicate that runs
+  before the runner has decided to touch anything, and would still race the probe.
+- `command` and `url` are **not** contained, deliberately: a `command`'s resolved
+  `cwd` must already match an absolute directory the adopter declared in
+  soma-home, and a `url` names a host and no tree. Containment on top would
+  forbid the adopter's own declaration — the authority the three argv probes
+  never pass through.
+
+The exemption rests on **containment, not on `git` being inert**. #529 pointed
+five exec-capable config knobs (`core.fsmonitor`, `core.pager`,
+`core.alternateRefsCommand`, `core.sshCommand`, `core.editor`) at a marker script
+and none fired under the three verbs' exact argv on git 2.40.0. That is a
+negative result on a tested set, and on this map a tested-negative has four times
+looked identical to a proof (#557, #510, #561, #579). It is recorded as evidence,
+not as the justification.
+
+**Not covered, deliberately:** a registry `repoRoots` list for genuine cross-tree
+probes — #529 ruled it fog, since no cross-tree probe has a consumer and #579
+found the registry's existing worktree entries had never once been used. It
+graduates when a real one appears. Bounding the `observed` string is also out:
+against a chosen-path oracle the attacker already knows the path, so `pass`/`fail`
+is the whole answer, and containment removes the oracle rather than muffling it.
 
 The registry lives in **soma-home only, scoped by repo identity**, under the
 `soma policy` surface (§4 forbids a parallel policy registry). Not repo-local:

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -64,6 +64,7 @@ import {
 import {
   allProbesPassed,
   authorizeProbeTree,
+  isProbeEscape,
   probeDirectory,
   runCommand,
   runProbes as defaultRunProbes,
@@ -909,22 +910,39 @@ async function runClose(
 
   const probeResults = await deps.runProbes(probes, registry, probeDir);
   const refusals = probeResults.filter((result) => isProbeRefusal(result));
+  const escapes = probeResults.filter((result) => isProbeEscape(result));
 
-  // A refused probe reaches `assertClosable` as "ran and failed", which is true
-  // but useless to act on. Surface it here instead, where the reason — and the
-  // exact entry to declare — is still in hand. A dry run keeps going: showing
-  // the whole receipt is the point of asking for one.
-  if (refusals.length > 0 && parsed.options.dryRun !== true) {
-    throw new SomaCliError(
-      [
-        `Close refused: ${refusals.length} of ${probeResults.length} declared probe(s) are not authorised on this machine.`,
+  // A refused or escaping probe reaches `assertClosable` as "ran and failed",
+  // which is true but useless to act on. Surface both here instead, where the
+  // reason is still in hand. A dry run keeps going: showing the whole receipt is
+  // the point of asking for one.
+  //
+  // Two sections, not one list: they have different fixes, and the trailer is the
+  // fix. Telling an adopter to edit their registry over a path that escaped the
+  // tree would send them to widen a gate that was never the one refusing (#582).
+  if (refusals.length + escapes.length > 0 && parsed.options.dryRun !== true) {
+    const observed = (result: ProbeResult): string => (result.state === "probed" ? result.observed : "");
+    const sections: string[] = [];
+    if (refusals.length > 0) {
+      sections.push(
+        `${refusals.length} of ${probeResults.length} declared probe(s) are not authorised on this machine.`,
         "",
-        ...refusals.map((refusal) => (refusal.state === "probed" ? refusal.observed : "")),
+        ...refusals.map(observed),
         "",
-        "Nothing was written. The registry is yours to edit — soma has no verb that widens it (§4: loosening is identity-bound).",
-      ].join("\n"),
-      1,
-    );
+        "The registry is yours to edit — soma has no verb that widens it (§4: loosening is identity-bound).",
+      );
+    }
+    if (escapes.length > 0) {
+      if (sections.length > 0) sections.push("");
+      sections.push(
+        `${escapes.length} of ${probeResults.length} declared probe(s) name a path outside the probe tree.`,
+        "",
+        ...escapes.map(observed),
+        "",
+        "Make the path tree-relative on the node. There is no declaration that widens this one: an ungated probe reads the tree being closed, and nothing else.",
+      );
+    }
+    throw new SomaCliError(["Close refused.", "", ...sections, "", "Nothing was written."].join("\n"), 1);
   }
 
   const evidence: CloseEvidence[] = [...parsed.options.evidence];

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -63,6 +63,7 @@ import {
 } from "../work-graph-probe-registry";
 import {
   allProbesPassed,
+  authorizeProbeTree,
   probeDirectory,
   runCommand,
   runProbes as defaultRunProbes,
@@ -564,7 +565,17 @@ async function prepareProbeTrees(
   // and every "did this probe run outside the tree?" comparison downstream is
   // string equality between the two.
   const probeDir = resolve(deps.probeCwd());
-  const probeDirs = [...new Set(probes.flatMap((probe) => probeDirectory(probe, probeDir) ?? []))];
+  // Uncontained directories are dropped before the read, not after (#582). This
+  // pre-flight spawns `git status` in a directory a **node body** names, and it
+  // runs before any gate has refused anything — so a probe whose `repo` escapes
+  // the stated tree would get that tree read, and its HEAD published in
+  // `probeTrees`, on the way to being refused. The refusal names the path; the
+  // receipt does not need to describe a tree nothing was allowed to touch.
+  const probeDirs = [
+    ...new Set(
+      probes.filter((probe) => authorizeProbeTree(probe, probeDir).allowed).flatMap((probe) => probeDirectory(probe, probeDir) ?? []),
+    ),
+  ];
   // Concurrent, unlike the probes themselves — these are read-only reads of
   // distinct directories, so the reason `runProbes` is sequential (probes share
   // a tree and see each other's side effects) does not apply — but **bounded**,

--- a/src/index.ts
+++ b/src/index.ts
@@ -750,6 +750,7 @@ export {
   allProbesPassed,
   authorizeProbeTree,
   boundObserved,
+  isProbeEscape,
   probeDirectory,
   resolvedProbePaths,
   runCommand,

--- a/src/index.ts
+++ b/src/index.ts
@@ -748,14 +748,19 @@ export {
 } from "./work-graph-github";
 export {
   allProbesPassed,
+  authorizeProbeTree,
   boundObserved,
+  probeDirectory,
+  resolvedProbePaths,
   runCommand,
   runProbe,
   runProbes,
+  PROBE_ESCAPED_PREFIX,
   type CommandOutcome,
   type CommandRequest,
   type ProbeRunnerDeps,
   type ProbeRunnerOptions,
+  type ResolvedProbePath,
 } from "./work-graph-probes";
 export {
   authorizeProbe,

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -53,7 +53,9 @@ soma policy probes [--repo <owner/name>]
   absolute `cwd` are declared.
 - `url` — refused unless the target host is declared; non-http(s) targets are
   refused outright.
-- `git-ref-exists`, `git-merged-into`, `artifact-exists` — ungated.
+- `git-ref-exists`, `git-merged-into`, `artifact-exists` — ungated by the
+  registry, but **contained**: a `repo` or `path` that resolves outside the tree
+  the close runs in is a failed probe (#582). Keep them tree-relative.
 
 A refused probe is a failed probe, so the close refuses and names the exact
 entry to declare. There is deliberately no verb that adds one: widening the

--- a/src/work-graph-probe-registry.ts
+++ b/src/work-graph-probe-registry.ts
@@ -19,9 +19,15 @@
  *   probe is a blind SSRF oracle: the request issues from the closing machine
  *   and the receipt publishes the observed status back to a possibly
  *   world-readable tracker.
- * - **`git-ref-exists` / `git-merged-into` / `artifact-exists`** — ungated. They
- *   execute as argv with no shell, cause no egress, and are bounded to existence
- *   checks in a local tree.
+ * - **`git-ref-exists` / `git-merged-into` / `artifact-exists`** — ungated *by
+ *   this registry*. They execute as argv with no shell and cause no egress, and
+ *   the "local tree" half of that justification is enforced elsewhere: their
+ *   `repo`/`path` fields are tracker content that resolves against the runner's
+ *   base cwd, so an unconstrained one probes any directory on the closing
+ *   machine and publishes the answer (#529, #582). Containment lives in the
+ *   runner beside the call to {@link authorizeProbe} — see
+ *   `authorizeProbeTree` in `work-graph-probes.ts` — because it is a question
+ *   about *which tree*, which no per-repo declaration answers.
  *
  * The document lives in **soma-home, never the repo**: §1 clause 5 keeps
  * enforcement off the tree it guards, and a committed registry is writable by
@@ -474,6 +480,13 @@ function expandTilde(path: string, homeDir: string | undefined): string {
 function abbreviate(text: string, limit = ECHO_LIMIT): string {
   return text.length <= limit ? text : `${text.slice(0, limit)}… (truncated — copy the exact value from the node block)`;
 }
+
+/**
+ * The same bound, for the containment refusal in `work-graph-probes.ts`. Aliased
+ * rather than re-spelled: both refusals echo a field the node author wrote, and
+ * two limits would be two answers to one question.
+ */
+export { abbreviate as abbreviateTrackerEcho };
 
 function describe(error: unknown): string {
   return error instanceof Error ? error.message : String(error);

--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -26,9 +26,14 @@
  */
 
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
-import { authorizeProbe, type ProbeRegistry } from "./work-graph-probe-registry";
-import type { Probe, ProbeResult } from "./work-graph";
+import { resolve, sep } from "node:path";
+import {
+  abbreviateTrackerEcho,
+  authorizeProbe,
+  type ProbeAuthorization,
+  type ProbeRegistry,
+} from "./work-graph-probe-registry";
+import { collapseHome, type Probe, type ProbeResult } from "./work-graph";
 
 /** How much of a command's output survives into the receipt (§2.2: a *bounded* tail). */
 const OBSERVED_TAIL_LIMIT = 1_200;
@@ -233,6 +238,133 @@ export function probeDirectory(probe: Probe, baseCwd: string): string | undefine
 }
 
 /**
+ * Every refusal `observed` string from the containment check opens with this, the
+ * way {@link PROBE_REFUSED_PREFIX} opens a registry refusal. Two prefixes, not
+ * one, because the two have different fixes: a registry refusal is answered by
+ * declaring something in soma-home, this one only by changing the node.
+ */
+export const PROBE_ESCAPED_PREFIX = "probe refused — outside the probe tree (DD-16 Amendment A):";
+
+/**
+ * Is this probe type contained to the stated probe tree?
+ *
+ * Exhaustive with no `default`, for the reason #526 gave the gate the same
+ * shape: a probe type added later must not inherit "contained" by omission — it
+ * has to be classified here, or the build fails.
+ *
+ * `command` and `url` answer **false** because a stricter rule already holds
+ * them. A `command`'s resolved `cwd` must match an absolute directory the
+ * adopter declared in soma-home byte for byte, and a `url` names a host and no
+ * tree at all. Containment on top would forbid the adopter's own declaration —
+ * a registry entry pointing at a sibling checkout is that adopter's deliberate
+ * act, which is exactly the authority the three argv probes do not pass through.
+ */
+function containmentApplies(probe: Probe): boolean {
+  switch (probe.type) {
+    case "command":
+    case "url":
+      return false;
+    case "git-ref-exists":
+    case "git-merged-into":
+    case "artifact-exists":
+      return true;
+  }
+}
+
+/**
+ * Every filesystem path an ungated probe is about to touch, resolved against the
+ * base, with the node field each one came from.
+ *
+ * **Two per probe, not one.** #529 asked whether `repo` is bounded; it is not the
+ * only escape. `artifact-exists` with no `atRef` resolves `path` against the
+ * probe directory itself, so an *absolute* `path` escapes with no `repo` at all
+ * — verified live at `dfea720`, where `path: "/etc/passwd"` passed. A
+ * containment check that saw only the directory would be the defect, not the fix.
+ *
+ * The directory half comes from {@link probeDirectory} rather than a second
+ * resolution of the same fields: "the directory we checked" and "the directory
+ * we ran in" have to be one value, which is #579's whole lesson.
+ */
+export interface ResolvedProbePath {
+  /** The node field this path came from — `cwd`, `repo`, or `path`. */
+  field: string;
+  /** What the node declared, verbatim (bounded before it is echoed anywhere). */
+  value: string;
+  /** Absolute, resolved against the base. */
+  resolved: string;
+}
+
+export function resolvedProbePaths(probe: Probe, baseCwd: string): ResolvedProbePath[] {
+  const directory = probeDirectory(probe, baseCwd);
+  if (directory === undefined) return [];
+  const field = probe.type === "command" ? "cwd" : "repo";
+  const declared = (probe.type === "command" ? probe.cwd : probe.type === "url" ? undefined : probe.repo) ?? ".";
+  const paths: ResolvedProbePath[] = [{ field, value: declared, resolved: directory }];
+  if (probe.type === "artifact-exists" && probe.atRef === undefined) {
+    // The `atRef` branch reads through `git cat-file <ref>:<path>`, where `path`
+    // is a repository-relative object name and never touches the filesystem —
+    // so the directory is the only thing to contain there.
+    paths.push({ field: "path", value: probe.path, resolved: resolve(directory, probe.path) });
+  }
+  return paths;
+}
+
+/**
+ * Is `candidate` the base tree or a descendant of it?
+ *
+ * Separator-aware on purpose: a bare `startsWith(base)` would call `/base-evil` a
+ * descendant of `/base`. Both sides arrive already resolved to absolute form.
+ *
+ * **Lexical, not `realpath`.** A symlink *inside* the tree that points outside it
+ * still escapes, and saying so is more honest than implying otherwise: resolving
+ * links would mean filesystem I/O in a predicate the runner calls before it has
+ * decided to touch anything, and the result would still race the probe itself.
+ */
+function isWithin(candidate: string, base: string): boolean {
+  if (candidate === base) return true;
+  return candidate.startsWith(base.endsWith(sep) ? base : `${base}${sep}`);
+}
+
+/**
+ * Containment: an ungated probe may read the stated probe tree (#580) or a
+ * descendant, and nothing else.
+ *
+ * DD-16 Amendment A ungates the three argv probes as "argv, no shell, no egress,
+ * bounded to existence checks in a local tree". Sage's review of #528 showed the
+ * last clause was false as written — `repo` and `path` are *tracker content*
+ * resolved against the runner's cwd with no bound, so a node body could probe
+ * any directory on the closing machine and read the answer back out of the close
+ * receipt (`~/.ssh/id_rsa exists`). This is that clause made true.
+ *
+ * An escape is a **failed probe**, never an exception and never a skip, so the
+ * close refuses through the path {@link assertClosable} already owns — the same
+ * shape a registry refusal takes, for the same reason.
+ *
+ * The message names the **resolved** path and the base tree, not just the field:
+ * the two differ, and #526's `cwd` lesson is that an adopter who cannot see
+ * which of the two the runtime meant cannot fix anything. Published paths are
+ * home-collapsed, since a refusal lands in a receipt on a tracker whose
+ * visibility soma cannot know.
+ */
+export function authorizeProbeTree(probe: Probe, baseCwd: string): ProbeAuthorization {
+  if (!containmentApplies(probe)) return { allowed: true };
+  const base = resolve(baseCwd);
+  for (const path of resolvedProbePaths(probe, base)) {
+    if (isWithin(path.resolved, base)) continue;
+    return {
+      allowed: false,
+      reason: [
+        `${PROBE_ESCAPED_PREFIX} \`${path.field}: ${JSON.stringify(abbreviateTrackerEcho(path.value))}\``,
+        `resolves to ${collapseHome(path.resolved)}, which is not ${collapseHome(base)} or a descendant of it.`,
+        `An ungated probe reads the stated probe tree and nothing else: its result is published to the tracker,`,
+        `so any directory it can reach is a directory it can disclose.`,
+      ].join("\n"),
+    };
+  }
+  return { allowed: true };
+}
+
+/**
  * Run one probe. Always resolves to a `probed` result — pass or fail — because a
  * probe that throws is a probe that did not pass, and the close gate needs that
  * as data, not as an exception to interpret.
@@ -263,8 +395,16 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions): Promi
     probed(probe, outcome, observed, at, ranIn);
 
   try {
-    // The gate runs before dispatch, not inside the two gated cases, so a probe
-    // type added later cannot slip past by forgetting to call it.
+    // Both gates run before dispatch, not inside the cases they apply to, so a
+    // probe type added later cannot slip past either by forgetting to call it.
+    // They answer different questions — `authorizeProbe` asks whose code this is,
+    // `authorizeProbeTree` asks which tree it may read — and every probe passes
+    // through both.
+    const containment = authorizeProbeTree(probe, baseCwd);
+    if (!containment.allowed) {
+      return finish("fail", containment.reason);
+    }
+
     const authorization = authorizeProbe(probe, resolvedCwd, options.registry);
     if (!authorization.allowed) {
       return finish("fail", authorization.reason);

--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -246,6 +246,18 @@ export function probeDirectory(probe: Probe, baseCwd: string): string | undefine
 export const PROBE_ESCAPED_PREFIX = "probe refused — outside the probe tree (DD-16 Amendment A):";
 
 /**
+ * Did this probe fail because its path escaped the tree, rather than because it
+ * ran and failed? The sibling of {@link isProbeRefusal}, and separate from it for
+ * the reason the prefixes are separate: a registry refusal is fixed by declaring
+ * something in soma-home, an escape only by changing the node, and a close path
+ * that told an adopter to edit their registry over an escape would be sending
+ * them to widen a gate that was never the one refusing.
+ */
+export function isProbeEscape(result: ProbeResult): boolean {
+  return result.state === "probed" && result.outcome === "fail" && result.observed.startsWith(PROBE_ESCAPED_PREFIX);
+}
+
+/**
  * Is this probe type contained to the stated probe tree?
  *
  * Exhaustive with no `default`, for the reason #526 gave the gate the same
@@ -271,6 +283,28 @@ function containmentApplies(probe: Probe): boolean {
   }
 }
 
+/** One path a probe resolves, and the node field it came from. */
+export interface ResolvedProbePath {
+  /** The node field that produced it. */
+  field: "cwd" | "repo" | "path";
+  /** What the node declared, verbatim (bounded before it is echoed anywhere). */
+  value: string;
+  /** Absolute, resolved against the base. */
+  resolved: string;
+}
+
+/**
+ * Where an `artifact-exists` probe with no `atRef` looks on disk.
+ *
+ * One expression, two callers — the containment check and the runner's own
+ * branch. Deriving it twice is exactly the shape #579 was: two resolutions that
+ * agree today, and a receipt describing one path while the probe used another
+ * the day one of them changes.
+ */
+function artifactFilePath(path: string, directory: string): string {
+  return resolve(directory, path);
+}
+
 /**
  * Every filesystem path an ungated probe is about to touch, resolved against the
  * base, with the node field each one came from.
@@ -285,15 +319,6 @@ function containmentApplies(probe: Probe): boolean {
  * resolution of the same fields: "the directory we checked" and "the directory
  * we ran in" have to be one value, which is #579's whole lesson.
  */
-export interface ResolvedProbePath {
-  /** The node field this path came from — `cwd`, `repo`, or `path`. */
-  field: string;
-  /** What the node declared, verbatim (bounded before it is echoed anywhere). */
-  value: string;
-  /** Absolute, resolved against the base. */
-  resolved: string;
-}
-
 export function resolvedProbePaths(probe: Probe, baseCwd: string): ResolvedProbePath[] {
   const directory = probeDirectory(probe, baseCwd);
   if (directory === undefined) return [];
@@ -304,7 +329,7 @@ export function resolvedProbePaths(probe: Probe, baseCwd: string): ResolvedProbe
     // The `atRef` branch reads through `git cat-file <ref>:<path>`, where `path`
     // is a repository-relative object name and never touches the filesystem —
     // so the directory is the only thing to contain there.
-    paths.push({ field: "path", value: probe.path, resolved: resolve(directory, probe.path) });
+    paths.push({ field: "path", value: probe.path, resolved: artifactFilePath(probe.path, directory) });
   }
   return paths;
 }
@@ -448,7 +473,8 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions): Promi
 
       case "artifact-exists": {
         if (probe.atRef === undefined) {
-          const full = resolve(resolvedCwd, probe.path);
+          // Same expression the containment check used — see {@link artifactFilePath}.
+          const full = artifactFilePath(probe.path, resolvedCwd);
           const passed = deps.pathExists(full);
           return finish(passed ? "pass" : "fail", `${full} ${passed ? "exists" : "is absent"}`);
         }

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -382,7 +382,7 @@ export function describeProbeTree(tree: ProbeTree, home: string | undefined = pr
  * `home` is a parameter with an ambient default rather than a bare env read, so
  * the rendering stays a function of its inputs when a caller says so.
  */
-function collapseHome(dir: string, home: string | undefined): string {
+export function collapseHome(dir: string, home: string | undefined = process.env.HOME): string {
   if (home === undefined || home.length === 0) return dir;
   // Separator-agnostic: the runner has a `win32` branch, so a probe directory
   // can arrive backslash-separated, and a boundary check that only knows `/`

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -903,8 +903,14 @@ test("a probe tree outside the stated tree is never read, let alone described (#
   );
 
   expect(described).toEqual([]);
-  expect(message).toContain("ran and failed");
   expect(store.closed).toHaveLength(0);
+  // Surfaced with its reason, not swallowed into assertClosable's generic "ran
+  // and failed" — the message names the path and the tree, and the fix is the
+  // node, never the registry.
+  expect(message).toContain("outside the probe tree");
+  expect(message).toContain("/elsewhere");
+  expect(message).toContain("Make the path tree-relative on the node");
+  expect(message).not.toContain("The registry is yours to edit");
 });
 
 test("one probe tree without a HEAD unanchors the whole set", async () => {

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -876,6 +876,37 @@ test("a base tree no probe ran in is never described, let alone used as the anch
   expect(store.closed[0].receipt.evidence.find((entry) => entry.kind === "probed")?.pointer).toContain(only);
 });
 
+test("a probe tree outside the stated tree is never read, let alone described (#582)", async () => {
+  // The pre-flight spawns `git status` in a directory a **node body** names, and
+  // it runs before any gate has refused anything. An escaping `repo` would get
+  // that tree read and its HEAD published on the way to being refused, which is
+  // the disclosure containment exists to remove — so the uncontained directory
+  // is dropped before the read, not after it.
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("520", {
+      node: autoNode("520", { probes: [{ type: "git-ref-exists", ref: "HEAD", repo: "/elsewhere" }] }),
+      parent: "495",
+      author: "ivy-agent",
+    });
+
+  const described: string[] = [];
+  const message = await failure(
+    ["graph", "close", "520", "--repo", REPO],
+    store,
+    realRunner(DECLARED, {
+      describeProbeTree: async (dir) => {
+        described.push(dir);
+        return { dir, head: "f00dcafe", dirty: false };
+      },
+    }),
+  );
+
+  expect(described).toEqual([]);
+  expect(message).toContain("ran and failed");
+  expect(store.closed).toHaveLength(0);
+});
+
 test("one probe tree without a HEAD unanchors the whole set", async () => {
   // `2/2 passed` beside a pointer that can only account for one of the trees is
   // the overstatement this change exists to remove, so it withholds instead.

--- a/test/work-graph-probes.test.ts
+++ b/test/work-graph-probes.test.ts
@@ -1,16 +1,22 @@
 import { expect, test } from "bun:test";
 import {
   allProbesPassed,
+  assertClosable,
+  authorizeProbeTree,
   boundObserved,
   isProbeRefusal,
+  resolvedProbePaths,
   runProbe,
   runProbes,
+  PROBE_ESCAPED_PREFIX,
+  type CloseReceipt,
   type CommandOutcome,
   type CommandRequest,
   type DeclaredCommand,
   type Probe,
   type ProbeRegistry,
   type ProbeRunnerOptions,
+  type WorkGraphNode,
 } from "../src/index";
 
 const AT = new Date("2026-08-04T09:00:00.000Z");
@@ -377,4 +383,166 @@ test("observed output keeps the tail, where the failure reason lives", () => {
   const bounded = boundObserved(long, 20);
   expect(bounded).toContain("THE-REASON");
   expect(bounded.length).toBeLessThan(30);
+});
+
+// ---------------------------------------------------------------------------
+// Containment: the ungated probes read the stated tree and nothing else (#582)
+// ---------------------------------------------------------------------------
+//
+// DD-16 Amendment A ungated the three argv probes as "bounded to existence
+// checks in a local tree". That clause was false as written (#529): `repo` and
+// `path` are tracker content resolved against the runner's base cwd, and at
+// `dfea720` a node body could probe `/etc/passwd` or `~/.ssh/id_rsa` and read
+// the answer back out of its own close receipt.
+
+/** No registry needed: containment refuses before the gate, and these types are ungated anyway. */
+function contained(cwd = "/repo"): ProbeRunnerOptions {
+  return { cwd, deps: { pathExists: () => true, now: () => AT } };
+}
+
+const ESCAPES: { what: string; probe: Probe }[] = [
+  { what: "git-ref-exists via a relative repo", probe: { type: "git-ref-exists", ref: "HEAD", repo: "../.." } },
+  { what: "git-merged-into via a relative repo", probe: { type: "git-merged-into", ref: "x", into: "main", repo: "../.." } },
+  { what: "artifact-exists via a relative repo", probe: { type: "artifact-exists", path: "README.md", repo: "../.." } },
+  { what: "git-ref-exists via an absolute repo", probe: { type: "git-ref-exists", ref: "HEAD", repo: "/elsewhere" } },
+  { what: "git-merged-into via an absolute repo", probe: { type: "git-merged-into", ref: "x", into: "main", repo: "/elsewhere" } },
+  { what: "artifact-exists via an absolute repo", probe: { type: "artifact-exists", path: "README.md", repo: "/elsewhere" } },
+];
+
+test("every ungated probe type is refused when its repo escapes the stated tree", async () => {
+  for (const escape of ESCAPES) {
+    const result = requireProbed(await runProbe(escape.probe, contained()));
+    // The label rides in the assertion so a failing row says which one.
+    expect(`${escape.what}: ${result.outcome}`).toBe(`${escape.what}: fail`);
+    expect(result.observed).toContain(PROBE_ESCAPED_PREFIX);
+    // The base tree *and* the resolved path, because the node's literal field and
+    // the directory the runner would touch are different strings (#526's lesson).
+    expect(result.observed).toContain("/repo");
+  }
+});
+
+test("an absolute artifact-exists path escapes with no repo at all", async () => {
+  // #582's premise correction: #529 asked whether `repo` was bounded, and `path`
+  // resolves against the cwd too. A check that saw only the directory would pass
+  // this probe — as dfea720 did, live, against /etc/passwd.
+  const result = requireProbed(await runProbe({ type: "artifact-exists", path: "/etc/passwd" }, contained()));
+
+  expect(result.outcome).toBe("fail");
+  expect(result.observed).toContain(PROBE_ESCAPED_PREFIX);
+  expect(result.observed).toContain("/etc/passwd");
+});
+
+test("containment is separator-aware — /base-evil is not a descendant of /base", async () => {
+  const sibling = requireProbed(
+    await runProbe({ type: "git-ref-exists", ref: "HEAD", repo: "/base-evil" }, contained("/base")),
+  );
+  expect(sibling.outcome).toBe("fail");
+  expect(sibling.observed).toContain(PROBE_ESCAPED_PREFIX);
+});
+
+test("a contained probe still runs — the tree itself, and any descendant of it", async () => {
+  const seen: CommandRequest[] = [];
+  const options: ProbeRunnerOptions = {
+    cwd: "/repo",
+    deps: {
+      runCommand: async (request) => {
+        seen.push(request);
+        return { exitCode: 0, stdout: "cafef00d", stderr: "", timedOut: false };
+      },
+      pathExists: () => true,
+      now: () => AT,
+    },
+  };
+
+  const base = requireProbed(await runProbe({ type: "git-ref-exists", ref: "HEAD" }, options));
+  expect(base.outcome).toBe("pass");
+
+  const subdirectory = requireProbed(
+    await runProbe({ type: "git-ref-exists", ref: "HEAD", repo: "vendor/checkout" }, options),
+  );
+  expect(subdirectory.outcome).toBe("pass");
+  expect(seen[1].argv).toEqual([
+    "git",
+    "-C",
+    "/repo/vendor/checkout",
+    "rev-parse",
+    "--verify",
+    "--quiet",
+    "HEAD^{commit}",
+  ]);
+
+  const descendantPath = requireProbed(await runProbe({ type: "artifact-exists", path: "src/thing.ts" }, options));
+  expect(descendantPath.outcome).toBe("pass");
+});
+
+test("an atRef artifact-exists reads through git, so only its directory is contained", async () => {
+  // `path` there is a repository-relative object name handed to `git cat-file`,
+  // never a filesystem path — so an absolute-looking one is a lookup that fails,
+  // not an escape to refuse. Containment must not invent a second meaning for it.
+  const seen: CommandRequest[] = [];
+  const result = requireProbed(
+    await runProbe(
+      { type: "artifact-exists", path: "/etc/passwd", atRef: "main" },
+      {
+        cwd: "/repo",
+        deps: {
+          runCommand: async (request) => {
+            seen.push(request);
+            return { exitCode: 1, stdout: "", stderr: "", timedOut: false };
+          },
+          now: () => AT,
+        },
+      },
+    ),
+  );
+
+  expect(result.observed).not.toContain(PROBE_ESCAPED_PREFIX);
+  expect(seen[0].argv).toEqual(["git", "-C", "/repo", "cat-file", "-e", "main:/etc/passwd"]);
+  expect(result.outcome).toBe("fail");
+});
+
+test("an escape is a probed failure, so the close gate refuses through the path it already owns", async () => {
+  const probe: Probe = { type: "artifact-exists", path: "/etc/passwd" };
+  const result = await runProbe(probe, contained());
+  const node: WorkGraphNode = {
+    id: "582",
+    title: "containment",
+    autonomy: "auto",
+    checkpointId: "cp-x",
+    probes: [probe],
+  };
+  const receipt: CloseReceipt = {
+    checkpointId: "cp-x",
+    closedBy: "jcfischer",
+    at: AT.toISOString(),
+    evidence: [{ kind: "probed", summary: "1 probe", pointer: "https://example.test/#issuecomment-1" }],
+    probeResults: [result],
+    attestation: "unverified",
+  };
+
+  // Not a new outcome and not an exception: "the node named a tree it may not
+  // read" and "the command ran and failed" are both simply *not passed*.
+  expect(result.state).toBe("probed");
+  expect(() => {
+    assertClosable(node, receipt);
+  }).toThrow(/ran and failed/u);
+});
+
+test("containment does not apply to command and url — the registry is their stronger bound", () => {
+  // A declared `cwd` is an absolute directory the adopter wrote in soma-home,
+  // matched byte for byte. Containment on top would forbid that deliberate act,
+  // which is precisely the authority the three argv probes never pass through.
+  const command: Probe = { type: "command", run: "bun test", timeoutSec: 60, expectExit: 0, cwd: "/elsewhere" };
+  const url: Probe = { type: "url", target: "https://example.test/health", expectStatus: 200 };
+
+  expect(authorizeProbeTree(command, "/repo").allowed).toBe(true);
+  expect(authorizeProbeTree(url, "/repo").allowed).toBe(true);
+});
+
+test("resolvedProbePaths names every path a probe touches, and the field it came from", () => {
+  expect(resolvedProbePaths({ type: "artifact-exists", path: "docs/x.md", repo: "sub" }, "/repo")).toEqual([
+    { field: "repo", value: "sub", resolved: "/repo/sub" },
+    { field: "path", value: "docs/x.md", resolved: "/repo/sub/docs/x.md" },
+  ]);
+  expect(resolvedProbePaths({ type: "url", target: "https://example.test/", expectStatus: 200 }, "/repo")).toEqual([]);
 });


### PR DESCRIPTION
Implements [#582](https://github.com/the-metafactory/soma/issues/582), the containment half of [#529](https://github.com/the-metafactory/soma/issues/529), on the tree [#580](https://github.com/the-metafactory/soma/issues/580) made explicit.

## What was false

DD-16 Amendment A ungates `git-ref-exists`, `git-merged-into` and `artifact-exists` as *"argv, no shell, no egress, bounded to existence checks in a local tree"*. The last clause was false as written. `repo` and `path` are **tracker content** resolved against the runner's base cwd with no bound, so a node body could name any directory on the closing machine — and the receipt publishes the answer.

Verified live at `dfea720`, before this change:

```
artifact-exists path:"/etc/passwd"                   → pass | /etc/passwd exists
artifact-exists path:"~/.ssh/id_rsa"                 → pass | …/.ssh/id_rsa exists
git-ref-exists  ref:HEAD repo:"../../.."             → pass | HEAD → 6887d503…
git-ref-exists  ref:main repo:"/Users/fischer/.soma" → pass | main → a4ca03e4…
```

And after, at this branch's HEAD:

```
artifact-exists path:"/etc/passwd"                   → fail | probe refused — outside the probe tree …
artifact-exists path:"~/.ssh/id_rsa"                 → fail | probe refused — outside the probe tree …
git-ref-exists  ref:HEAD repo:"../../.."             → fail | probe refused — outside the probe tree …
git-ref-exists  ref:main repo:"/Users/fischer/.soma" → fail | probe refused — outside the probe tree …
artifact-exists path:"src/work-graph-probes.ts"      → pass | …/src/work-graph-probes.ts exists
git-ref-exists  ref:HEAD                             → pass | HEAD → dc9bcdf9…
```

**The premise correction:** #529 asked whether **`repo`** is bounded. It is not the only escape — `artifact-exists.path` resolves against the cwd too, so an absolute `path` escapes with **no `repo` at all**. A containment check that saw only the probe directory would have been the defect being fixed, not the fix.

## Shape

- **One predicate, before dispatch, beside `authorizeProbe`**, exhaustive with no `default` — for the reason #526 put the gate there: a probe type added later must be classified, not inherit "contained" by omission.
- **Contained** = the resolved absolute path is the stated probe tree or a descendant, by a separator-aware prefix test, so `/base-evil` is not a descendant of `/base`.
- **Both resolutions** pass through it: the probe directory, and `artifact-exists`'s `path` in the no-`atRef` branch. With `atRef` the path is a repository-relative object name for `git cat-file` and never touches the filesystem, so only the directory is contained there.
- **Escape is a failed probe** — never an exception, never a skip — so `assertClosable` refuses through the path it already owns. Same shape as a registry refusal, with its own prefix, because the two have different fixes.
- The refusal **names the resolved path and the tree**, home-collapsed: the node's literal field and the path the runner would touch are different strings (#526's `cwd` lesson).
- The **pre-flight tree read** skips uncontained directories before spawning `git status` in them — that read runs in a directory a node body names, ahead of any gate.
- **`command` and `url` stay uncontained**, deliberately: a `command`'s resolved `cwd` must already match an absolute directory the adopter declared in soma-home, and a `url` names a host and no tree. Containment on top would forbid the adopter's own deliberate act.
- Nothing reads a node's autonomy class — uniformity stays structural.

**Lexical, not `realpath`**: a symlink inside the tree pointing out of it still escapes. Resolving links would mean filesystem I/O in a predicate that runs before the runner has decided to touch anything, and would still race the probe. Recorded in the spec rather than implied away.

## Spec

`docs/work-graph.md` §2.2's gate row is rewritten to what is now true, plus a *Containment of the ungated probes* subsection. A **spec** amendment, not a DD one — DD-16 delegates mechanics to the spec and no normative clause moves (precedent: #549, #530, #579).

It carries #529's tested-negative honestly: the exemption rests on **containment**, not on a proof that `git`'s config surface is inert. Five exec-capable knobs were pointed at a marker script and none fired under the three verbs' exact argv on git 2.40.0 — a negative result on a tested set, which on this map has four times looked identical to a positive one (#557, #510, #561, #579).

## Tests

Each of the three types refused on a relative escape, on an absolute `repo`, and — for `artifact-exists` — on an absolute `path` with no `repo`; the sibling-prefix case refused; contained probes still pass, including a `repo` naming a subdirectory; the refusal is a `probed`/`fail` result and `assertClosable` refuses on it; the pre-flight never reads an uncontained tree.

`bun test` 2351 pass / 0 fail · `bunx tsc --noEmit` clean.

## Not in scope

A registry `repoRoots` list for cross-tree probes (#529 ruled it fog — no consumer, and #579 found the registry's existing worktree entries had never once been used), bounding the `observed` string (useless against a chosen-path oracle; containment removes the oracle instead), and output volume bounds (#527).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
