### PR TITLE
fix(skills): the residue guard missed bare PAI; three references still carried it

### DIFF
--- a/src/skills/the-algorithm/references/capabilities.md
+++ b/src/skills/the-algorithm/references/capabilities.md
@@ -143,6 +143,7 @@ declare the capability by what it must achieve, and let whoever can satisfy it
 bind the mechanism.
 
 ```
+| JudgeOutput | VERIFY | Scoring text output against a rubric rather than a metric — optimize's eval mode, prompt/skill comparison, any "is this good?" that no command answers. The judge must not be the thing that produced the output. | `Contract("a model that scores text output against stated criteria")` | E3+ |
 | CrossFamilyAudit | VERIFY | … | `Contract("audit by a model outside the family that produced the work")` | E4+ |
 ```
 
@@ -203,6 +204,7 @@ needs a binding on this machine.
 | IntentEcho | OBSERVE | Every run, before anything else. Restate the request in one sentence; if you cannot restate it accurately, re-read it rather than proceed. | *(inline doctrine — no external tool)* | E1+ |
 | Advisor | THINK, VERIFY | Commitment boundaries on multi-step work: before committing to an approach, when the same problem resists two distinct attempts, and once after a durable deliverable before declaring done. Ask a specific question, not "review this". | `Contract("a second opinion from something that did not produce the work")` | E3+ |
 | CrossFamilyCoder | EXECUTE | Substantial implementation where same-family blind spots compound — E3+ coding routed through one model family only. Family diversity is the point, not a particular vendor. | `Contract("a code-producing capability from a different model family")` | E3+ |
+| JudgeOutput | VERIFY | Scoring text output against a rubric rather than a metric — optimize's eval mode, prompt/skill comparison, any "is this good?" that no command answers. The judge must not be the thing that produced the output. | `Contract("a model that scores text output against stated criteria")` | E3+ |
 | CrossFamilyAudit | VERIFY | Deep and Comprehensive work, before completion: compare the artifacts against the criteria and surface what a same-family reviewer shares with the author. Cannot be satisfied by a reviewer of the same family — that is the blind spot, not the check. | `Contract("an audit by a model outside the family that produced the work")` | E4+ |
 
 ## Binding Commitment

--- a/src/skills/the-algorithm/references/eval-guide.md
+++ b/src/skills/the-algorithm/references/eval-guide.md
@@ -172,7 +172,7 @@ Eval criteria and ISC guard rails serve different purposes:
 
 Guard rails in eval mode are the same as metric mode: things like "no crashes," "output is non-empty," "no PII in output."
 
-### PAI-Specific Guidance
+### Choosing Between Eval And Metric Mode
 
 **When to use eval mode vs metric mode:**
 - You have a `metric_command` that outputs a number → metric mode

--- a/src/skills/the-algorithm/references/optimize-loop.md
+++ b/src/skills/the-algorithm/references/optimize-loop.md
@@ -281,7 +281,7 @@ For each output, judge against each eval criterion:
 
    ANSWER:
    ```
-2. Send to LLM via PAI Inference Tool (`bun TOOLS/Inference.ts fast`)
+2. Send it to a model — whatever judging capability the registry offers on this machine (`algorithm capabilities --list`). A second-opinion or judge capability is the portable name for it; the mechanism is your substrate's.
 3. Parse response: starts with "YES" → pass, starts with "NO" → fail
 4. Any other response → retry once, then count as fail
 

--- a/src/skills/the-algorithm/references/optimize-loop.md
+++ b/src/skills/the-algorithm/references/optimize-loop.md
@@ -281,7 +281,7 @@ For each output, judge against each eval criterion:
 
    ANSWER:
    ```
-2. Send it to a model — whatever judging capability the registry offers on this machine (`algorithm capabilities --list`). A second-opinion or judge capability is the portable name for it; the mechanism is your substrate's.
+2. Send it to the **`JudgeOutput`** capability. It is a contract row — it names what must happen (a model scores the output against the stated criteria) and is bound locally to whatever you have; `algorithm capabilities --list` shows whether it is bound on this machine, and `algorithm invoke` refuses it while it is not.
 3. Parse response: starts with "YES" → pass, starts with "NO" → fail
 4. Any other response → retry once, then count as fail
 

--- a/src/skills/the-algorithm/references/target-types.md
+++ b/src/skills/the-algorithm/references/target-types.md
@@ -82,10 +82,10 @@ Read the target path and content to classify into one of five types:
 
 **How to run in sandbox:**
 1. Copy prompt file to `sandbox/`
-2. For each test input, send `prompt_content + test_input` to LLM via PAI Inference Tool
+2. For each test input, send `prompt_content + test_input` to a model via whatever judging capability the registry offers (`algorithm capabilities --list`)
 3. Capture output text for judging
 
-**Sandbox strategy:** Copy prompt file(s) to `MEMORY/WORK/{slug}/sandbox/`. Simple file copy, no git needed.
+**Sandbox strategy:** Copy prompt file(s) to `<soma-home>/memory/WORK/{slug}/sandbox/`. Simple file copy, no git needed.
 
 ---
 

--- a/src/skills/the-algorithm/references/target-types.md
+++ b/src/skills/the-algorithm/references/target-types.md
@@ -82,7 +82,7 @@ Read the target path and content to classify into one of five types:
 
 **How to run in sandbox:**
 1. Copy prompt file to `sandbox/`
-2. For each test input, send `prompt_content + test_input` to a model via whatever judging capability the registry offers (`algorithm capabilities --list`)
+2. For each test input, send `prompt_content + test_input` to the **`JudgeOutput`** capability (a contract row — bind it locally; `algorithm capabilities --list` shows whether it is bound here)
 3. Capture output text for judging
 
 **Sandbox strategy:** Copy prompt file(s) to `<soma-home>/memory/WORK/{slug}/sandbox/`. Simple file copy, no git needed.

--- a/test/bundled-skill-references.test.ts
+++ b/test/bundled-skill-references.test.ts
@@ -178,6 +178,14 @@ describe("bundled skill references", () => {
     const FORBIDDEN: { pattern: RegExp; why: string }[] = [
       { pattern: /~\/\.claude\//g, why: "Claude-home path in a portable skill" },
       { pattern: /\bPAI\/(?:TOOLS|MEMORY|ALGORITHM|DOCUMENTATION)\b/g, why: "PAI tree path" },
+      // Bare `PAI`, and the PAI tool path written RELATIVE. The narrow patterns
+      // above reported the bundle clean while three shipped references still
+      // carried a "### PAI-Specific Guidance" section and told the agent to
+      // "send to LLM via PAI Inference Tool (`bun TOOLS/Inference.ts`)" — a
+      // guard that matches the spellings you already removed and misses the
+      // ones you did not is worse than none, because it is believed.
+      { pattern: /\bPAI\b/g, why: "PAI named in a portable skill" },
+      { pattern: /\bTOOLS\/[A-Za-z0-9._-]+/g, why: "PAI tool path (relative)" },
       // Identity placeholders only. `{{SHA}}` / `{{VERSION}}` and friends are
       // sample values inside example documents — a generic `{{[A-Z_]+}}` would
       // flag those and train everyone to ignore this test.
@@ -197,7 +205,9 @@ describe("bundled skill references", () => {
     // ONE pattern (Sage review): skipping the whole skill also skipped the PAI-
     // tree and placeholder checks, so the test could not support the universal
     // claim its name makes.
-    const EXEMPT: Record<string, string[]> = { "migrate-pai-purpose": ["Claude-home path in a portable skill"] };
+    const EXEMPT: Record<string, string[]> = {
+      "migrate-pai-purpose": ["Claude-home path in a portable skill", "PAI named in a portable skill"],
+    };
 
     const found: string[] = [];
     for (const skill of await listBundledSkills()) {


### PR DESCRIPTION
Follow-up to #574, which reported the bundle clear. It was not.

The guard I shipped there is why. It matched `~/.claude/` and `PAI/{TOOLS,MEMORY,ALGORITHM,DOCUMENTATION}` — the spellings already removed — and missed **bare `PAI`** and a **relative** tool path. A guard that only catches what you already fixed is worse than none, because it is believed. #574's "PAI residue cleared" was measured with it.

Widened to `\bPAI\b` and `\bTOOLS/…`, which immediately found three shipped references that #462 landed and #574 never audited:

| File | What shipped |
|---|---|
| `references/eval-guide.md` | a `### PAI-Specific Guidance` section |
| `references/optimize-loop.md` | "send to LLM via PAI Inference Tool (`bun TOOLS/Inference.ts fast`)" |
| `references/target-types.md` | the same tool reference, plus a bare `MEMORY/WORK/{slug}/` sandbox path |

**eval-guide** needed only a heading change. Nothing in that section is PAI-specific — it is mode-selection guidance and how eval criteria relate to ISCs. Renamed to "Choosing Between Eval And Metric Mode" rather than deleting content that is fine.

**optimize-loop / target-types** now name the portable thing: whatever judging capability the registry offers, discoverable through `algorithm capabilities --list`, instead of one person's binary at a path that exists on one machine. The sandbox path is `<soma-home>/memory/WORK/{slug}/`.

`migrate-pai-purpose` gains the new reason in its exemption — naming PAI is its subject matter, and it was already exempt from the Claude-home pattern for exactly that.

## Verification

- `bun test` — **2351 tests across 150 files pass**, 0 fail.
- `tsc --noEmit` exits 0; lint clean on the touched file.
- `grep -rn 'PAI\|TOOLS/' src/skills/the-algorithm/` returns nothing.
- The widened guard fails on `main` with exactly these three files listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)