### PR TITLE
feat(work-graph): every close carries prose (#588)

### DIFF
--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -565,6 +565,55 @@ its effect.
 
 ## 3. Receipts by autonomy class
 
+### 3.0 Every close carries prose
+
+**Status: enforced**
+([#588](https://github.com/the-metafactory/soma/issues/588)), in
+`assertClosable` (contract) and `soma graph close` (surface).
+
+A close has two halves: the receipt, written for machines, and the **resolution**
+— why this node resolved the way it did, in prose. The second is the half a later
+reader actually reads. It was doctrine with no implementation until
+[#556](https://github.com/the-metafactory/soma/issues/556): `--body`/`--body-file`
+fed `--propose` only, so recording a resolution the documented way meant reaching
+past the verbs to `gh issue comment`, which made the one artefact humans consume
+the one artefact with no contract, no repo resolution and no backend abstraction.
+
+The rule:
+
+| Path | What satisfies it |
+| --- | --- |
+| `auto` close | `--resolution-file <path>` |
+| HITL **bare** close | `--resolution-file <path>` |
+| HITL `--propose` → `close --proposal-comment <id>` | the proposal body, already posted |
+
+One exemption, and only where prose demonstrably exists: the proposal body **is**
+the resolution, and requiring a second would post the same thing twice. A bare
+HITL close has no proposal — it is the normal single-operator route (§3.2) — so
+it carries prose like any other. Exempting HITL wholesale would let a `grilling`
+node whose entire output is a decision close with no human-readable half, while
+an `auto` node that merely ran `bun test` was refused for the same omission.
+
+**Folded into the receipt comment**, not posted beside it: `CloseReceipt.resolution`
+is rendered above the receipt, and the backend's `close` posts one comment from
+it. Posted separately, both orderings lose something — before the probes leaves
+an orphan resolution on a node whose close then refuses; after them leaves a
+receipt whose prose failed to post. Folded, neither state is reachable. The cost,
+accepted: prose cannot react to probe output, because it is written first.
+
+**This conjunct is a forcing function, not evidence.** The other three check
+facts a session could not fake — a checkpoint is attached, a probe ran, a pointer
+resolves. This one checks that *something was written*, and no machine can check
+that it says anything. Adopted knowingly. Stating it plainly is load-bearing: a
+conjunct described as verification when it is a prompt to write something is the
+self-declared verification DD-16 exists to refuse.
+
+The CLI refuses **before the probes run**, so a missing paragraph costs nothing
+rather than a 900-second `bun test`; the contract refuses on the receipt, so the
+rule holds for every consumer of the seam and not merely for the CLI. `--dry-run`
+renders the prose and writes nothing. `--propose` with `--resolution-file` is
+refused rather than silently preferring one.
+
 ### 3.1 AFK (`auto`)
 
 `soma graph close` runs the node's declared probes and requires **≥1

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -921,7 +921,19 @@ async function runClose(
   // cost a re-run of nothing rather than a re-run of `bun test`.
   let resolution: string | undefined;
   if (parsed.options.resolutionFile !== undefined) {
-    resolution = (await deps.readTextFile(parsed.options.resolutionFile)).trim();
+    let raw: string;
+    try {
+      raw = await deps.readTextFile(parsed.options.resolutionFile);
+    } catch (error) {
+      // Named rather than raised raw: the flag is required on every close now, so
+      // a mistyped path is the most common way this verb will fail, and `ENOENT`
+      // with a stack is a worse answer than the path that was not there.
+      throw new SomaCliError(
+        `soma graph close --resolution-file ${parsed.options.resolutionFile} could not be read: ${error instanceof Error ? error.message : String(error)}`,
+        1,
+      );
+    }
+    resolution = raw.trim();
     if (resolution.length === 0) {
       throw new SomaCliError(
         `soma graph close --resolution-file ${parsed.options.resolutionFile} is empty — a resolution is prose, and a blank one satisfies nothing.`,

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -90,7 +90,7 @@ export const GRAPH_COMMAND_HELP: { usage: string; subcommands: Record<GraphActio
     claim: "Usage: soma graph claim <id> [--identity <login>] [--repo <owner/name>] [--json]",
     add: "Usage: soma graph add <root> --title <text> --autonomy <auto|propose|approve> [--kind <k>] [--label <name>]... [--body <text>|--body-file <path>] [--checkpoint <id>] [--probe <json>]... [--blocked-by <id>]... [--budget-tokens <n>] [--budget-invocations <n>] [--budget-minutes <n>] [--repo <owner/name>] [--json]",
     close:
-      "Usage: soma graph close <id> [--propose --body <text>|--body-file <path>] [--proposal-comment <id>] [--checkpoint <id>] [--evidence <json>]... [--identity <login>] [--dry-run] [--repo <owner/name>]",
+      "Usage: soma graph close <id> --resolution-file <path> [--propose --body <text>|--body-file <path>] [--proposal-comment <id>] [--checkpoint <id>] [--evidence <json>]... [--identity <login>] [--dry-run] [--repo <owner/name>]",
   },
 };
 
@@ -139,6 +139,8 @@ export interface ParsedGraphCloseArgs {
     propose?: boolean;
     body?: string;
     bodyFile?: string;
+    /** Path to the resolution prose (#556). File-only: a resolution is a paragraph, not an argv string. */
+    resolutionFile?: string;
     proposalComment?: string;
     checkpointId?: string;
     identity?: string;
@@ -327,6 +329,10 @@ function parseCloseArgs(target: string, rest: string[]): ParsedGraphCloseArgs {
         options.bodyFile = readOption(rest, index, arg);
         index += 1;
         break;
+      case "--resolution-file":
+        options.resolutionFile = readOption(rest, index, arg);
+        index += 1;
+        break;
       case "--proposal-comment":
         options.proposalComment = readOption(rest, index, arg);
         index += 1;
@@ -360,6 +366,14 @@ function parseCloseArgs(target: string, rest: string[]): ParsedGraphCloseArgs {
   if (options.propose === true && options.dryRun === true) {
     throw new Error(
       "soma graph close --propose cannot be combined with --dry-run: proposing posts a comment, which is a write.",
+    );
+  }
+  // Refused rather than silently preferring one: `--propose`'s body already *is*
+  // the resolution (#556), so passing both asks for the same prose twice and the
+  // author cannot tell which copy the close will use.
+  if (options.propose === true && options.resolutionFile !== undefined) {
+    throw new Error(
+      "soma graph close --propose cannot be combined with --resolution-file: the proposal body is the resolution.",
     );
   }
 
@@ -903,6 +917,46 @@ async function runClose(
     );
   }
 
+  // Read before anything runs. The prose is the author's, so a typo'd path must
+  // cost a re-run of nothing rather than a re-run of `bun test`.
+  let resolution: string | undefined;
+  if (parsed.options.resolutionFile !== undefined) {
+    resolution = (await deps.readTextFile(parsed.options.resolutionFile)).trim();
+    if (resolution.length === 0) {
+      throw new SomaCliError(
+        `soma graph close --resolution-file ${parsed.options.resolutionFile} is empty — a resolution is prose, and a blank one satisfies nothing.`,
+        1,
+      );
+    }
+  }
+
+  // Refused here as well as in `assertClosable`, and neither is redundant. The
+  // contract check is on the receipt, so it holds for every consumer of the
+  // primitive; this one runs *before* the probes, so a close missing its prose
+  // costs nothing instead of a 900-second `bun test` — and it can name the flag,
+  // which the core cannot: `assertClosable` knows nothing about a CLI.
+  //
+  // Not on a dry run: showing "would be REFUSED" is what a dry run is for.
+  if (
+    parsed.options.dryRun !== true &&
+    resolution === undefined &&
+    parsed.options.proposalComment === undefined
+  ) {
+    throw new SomaCliError(
+      [
+        `Close refused: node ${ref.id} has no resolution.`,
+        "",
+        "Every close carries prose — the human-readable half, above the receipt in one comment (#556).",
+        `  soma graph close ${ref.id} --resolution-file <path>`,
+        "",
+        "Exempt only when a proposal already carries it: a close naming --proposal-comment reuses that body.",
+        "",
+        "Nothing was written, and no probe ran.",
+      ].join("\n"),
+      1,
+    );
+  }
+
   const identity = parsed.options.identity ?? (await deps.resolveIdentity());
   const probes = state.node.probes ?? [];
   const registry = await deps.loadProbeRegistry(repo);
@@ -1031,6 +1085,7 @@ async function runClose(
     checkpointId: parsed.options.checkpointId ?? state.node.checkpointId ?? "",
     closedBy: identity,
     at: deps.now().toISOString(),
+    ...(resolution === undefined ? {} : { resolution }),
     evidence,
     probeResults,
     ...(probeTrees.length === 0 ? {} : { probeTrees }),

--- a/src/skills/orienteer/SKILL.md
+++ b/src/skills/orienteer/SKILL.md
@@ -28,7 +28,7 @@ soma graph frontier <root>     # what is takeable: open, unassigned, unblocked
 soma graph claim <id>          # claim ONE, before any work
 soma graph node <id>           # read it, and any node it references
 #  … resolve it …
-soma graph close <id>          # runs declared probes; refuses a hollow close
+soma graph close <id> --resolution-file <path>   # prose + probes; refuses a hollow close
 ```
 
 Then append a one-line gist to the map's **Decisions so far**, and graduate any
@@ -58,7 +58,7 @@ this doctrine tracker-agnostic by construction.
 | `soma graph node <id>` | read one node |
 | `soma graph claim <id>` | assign, re-read, tie-break on race |
 | `soma graph add <root> …` | create node (+ `--blocked-by` edges), structurally validated |
-| `soma graph close <id>` | run declared probes, derive the receipt, refuse a hollow close |
+| `soma graph close <id> --resolution-file <path>` | post the prose, run declared probes, derive the receipt, refuse a hollow close |
 
 `--repo <owner/name>` (or `SOMA_GRAPH_REPO`) picks the backing repository; it
 defaults to the origin remote of the working tree.

--- a/src/skills/orienteer/Workflows/WalkTheMap.md
+++ b/src/skills/orienteer/Workflows/WalkTheMap.md
@@ -47,12 +47,16 @@ node**, never to the map (`references/fog.md`).
 Read `references/closing.md` first — the close refuses a hollow one, and the
 refusal is easier to avoid than to fix.
 
-1. Post the answer as a **resolution comment** on the node.
-2. `soma graph close <id>` — add `--dry-run` first when you are unsure the
-   receipt will hold. For a HITL node this is the two-phase `--propose` →
-   ratification → `--proposal-comment` sequence.
-3. Append a one-line gist plus link to the map's **Decisions so far**. Enough to
+1. Write the answer to a file, then
+   `soma graph close <id> --resolution-file <path>` — one act: the prose rides
+   the receipt into a single comment. Add `--dry-run` first when you are unsure
+   the receipt will hold. A close with no prose is refused before any probe runs.
+2. Append a one-line gist plus link to the map's **Decisions so far**. Enough to
    judge relevance; the detail stays in the node.
+
+For a HITL node wanting a second opinion, the two-phase `--propose` →
+ratification → `--proposal-comment` sequence stands, and the proposal body is the
+resolution — do not pass both.
 
 ## 5. Advance the frontier
 

--- a/src/skills/orienteer/references/closing.md
+++ b/src/skills/orienteer/references/closing.md
@@ -2,9 +2,9 @@
 
 A node closes only through its attached checkpoint's completion gate, and
 `soma graph close` refuses a **hollow close**: no attached checkpoint, a
-declared probe that never ran, a probe that ran and failed, or no
-agent-external evidence entry carrying a pointer someone else can check. When it
-refuses, no close is written.
+declared probe that never ran, a probe that ran and failed, no agent-external
+evidence entry carrying a pointer someone else can check, or no resolution prose.
+When it refuses, no close is written.
 
 One write happens before any of that: `--propose` posts its comment (below). It
 checks that the node *has* a checkpoint first, so it cannot publish a proposal
@@ -66,14 +66,32 @@ authorised, and expect a close on a fresh machine to refuse until it declares
 them. Reading is unaffected — `soma graph node` and `soma graph frontier` read
 any node regardless, because a node is data.
 
+## Every close carries prose
+
+Write the resolution to a file and pass it. It rides the receipt — one comment,
+your prose above the machine half — so there is no separate "post the resolution"
+step and no window where one half landed without the other:
+
+```bash
+soma graph close <id> --resolution-file <path>
+```
+
+A close with no prose is **refused**, before a single probe runs. The one
+exemption is a close naming `--proposal-comment`: that proposal's body already is
+the resolution, and a second copy would say the same thing twice.
+
+Say why it resolved as it did, not what you did. The receipt already lists what
+ran; the prose is the half a later reader actually reads, and no machine can
+check that it says anything — the gate only checks that you wrote something.
+
 ## AFK close (`auto`)
 
 Close directly. The verb runs the probes and derives the evidence from them;
 `--evidence` may add entries but never substitutes for a passed probe.
 
 ```bash
-soma graph close <id> --dry-run   # preview the verdict and receipt, write nothing
-soma graph close <id>
+soma graph close <id> --resolution-file <path> --dry-run   # preview, write nothing
+soma graph close <id> --resolution-file <path>
 ```
 
 The receipt proves *existence and probe passage, not quality* — sound because
@@ -83,10 +101,11 @@ downstream HITL node consumes the artifact.
 ## HITL close (`propose` / `approve`)
 
 A HITL node **closes when you close it**. There is no ratification requirement:
-you are the human in the loop, and you are present.
+you are the human in the loop, and you are present. It carries prose like any
+other close — a bare close has no proposal body to stand in for it:
 
 ```bash
-soma graph close <id>
+soma graph close <id> --resolution-file <path>
 ```
 
 The two-phase flow remains for when a second opinion is actually wanted — a
@@ -155,9 +174,9 @@ keyring, which have different fixes.
 
 ## Recording the resolution
 
-1. Post the answer as a **resolution comment** on the node — the human-readable
-   half; the close receipt is the machine-readable half.
-2. Close it with `soma graph close`.
-3. Append a one-line gist plus link to the map's **Decisions so far**.
-4. Graduate any fog the answer sharpened (`references/fog.md`), clearing each
+1. Write the answer to a file and close with it:
+   `soma graph close <id> --resolution-file <path>`. Posting and closing are one
+   act — the prose rides the receipt into a single comment.
+2. Append a one-line gist plus link to the map's **Decisions so far**.
+3. Graduate any fog the answer sharpened (`references/fog.md`), clearing each
    graduated patch from **Not yet specified** so it lives only as its new node.

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -853,7 +853,7 @@ export function assertClosable(node: WorkGraphNode, receipt: CloseReceipt): void
   // alternative, exempting HITL wholesale, would have let a `grilling` node whose
   // entire output is a decision close with no human-readable half while an `auto`
   // node that merely ran `bun test` was refused for the same omission.
-  if ((receipt.resolution ?? "").trim().length === 0 && receipt.attestationFacts?.proposal === undefined) {
+  if (resolutionText(receipt).length === 0 && receipt.attestationFacts?.proposal === undefined) {
     throw new WorkGraphError(
       "close-refused",
       `node ${node.id} closes without a resolution — the receipt carries no prose, and no proposal comment whose body would be it`,
@@ -882,9 +882,22 @@ export function assertClosable(node: WorkGraphNode, receipt: CloseReceipt): void
   }
 }
 
+/**
+ * The resolution prose, trimmed — `""` when there is none.
+ *
+ * One expression, two readers: the gate that requires it and the renderer that
+ * prints it. Two spellings of "is there prose here" would agree today and drift
+ * later into a receipt rendering a paragraph the gate did not count, or a gate
+ * counting whitespace the receipt renders as an empty heading (#582's lesson,
+ * one type along).
+ */
+function resolutionText(receipt: CloseReceipt): string {
+  return receipt.resolution?.trim() ?? "";
+}
+
 /** Render the receipt as the close comment body (§5: checkpoint id + evidence pointers on the tracker). */
 export function renderCloseReceipt(receipt: CloseReceipt): string {
-  const resolution = receipt.resolution?.trim() ?? "";
+  const resolution = resolutionText(receipt);
   const lines: string[] = [
     // The human half first — a later reader reads prose, not a probe table, and
     // burying it under the receipt would make the comment's first screen the half

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -329,6 +329,23 @@ export interface CloseReceipt {
   closedBy: string;
   /** ISO timestamp. */
   at: string;
+  /**
+   * The **human-readable half** of the close: why this node resolved the way it
+   * did, in prose (#556).
+   *
+   * Carried on the receipt rather than posted as a comment of its own so that
+   * both halves land in **one write**. Posted separately, the two orderings each
+   * lose something: before the probes leaves an orphan resolution on a node whose
+   * close then refuses, after them leaves a receipt whose prose failed to post.
+   * Folded, neither state is reachable — which is what "two halves of one close"
+   * has to mean if it means anything.
+   *
+   * Optional on the *type*, required by {@link assertClosable} unless the receipt
+   * records a proposal, whose body already carries the prose. Optional here
+   * because the exemption exists; a required field would make the exempt case
+   * unrepresentable.
+   */
+  resolution?: string;
   evidence: readonly CloseEvidence[];
   probeResults: readonly ProbeResult[];
   /**
@@ -778,7 +795,21 @@ function probeKey(probe: Probe): string {
  *    declaration, `probed` is a fact (§2.2);
  * 3. at least one agent-external evidence entry carries a pointer someone else
  *    can check (§3.1) — what makes the receipt re-auditable by the phase-2
- *    auditor rather than a self-report.
+ *    auditor rather than a self-report;
+ * 4. the receipt carries a **resolution** — prose saying why the node resolved
+ *    as it did — unless it records a proposal, whose body already is that prose
+ *    (#556).
+ *
+ * Conjunct 4 is a different animal from 1–3, and the difference is worth stating
+ * rather than blurring: 1–3 check facts a session could not fake — a checkpoint
+ * is attached or it is not, a probe ran or it did not, a pointer resolves or it
+ * does not. Conjunct 4 checks only that *something was written*, and no machine
+ * can check that what was written says anything. It is a **forcing function, not
+ * evidence**. Adopted knowingly (#556), on the grounds that the human-readable
+ * half is the half a later reader actually reads, and leaving it to discipline
+ * left it absent. Read it as such — a conjunct described as verification when it
+ * is a prompt to write something would be exactly the self-declared verification
+ * DD-16 exists to refuse.
  *
  * `attestation` is deliberately **not** gated on: refusing on `unverified`
  * would deadlock the bootstrap, since the nodes that establish credential
@@ -813,6 +844,22 @@ export function assertClosable(node: WorkGraphNode, receipt: CloseReceipt): void
     }
   }
 
+  // Prose is required of **every** class, unlike the evidence rule below.
+  //
+  // The exemption is the two-phase HITL path and only it: `--propose` posted a
+  // body, that body *is* the resolution, and requiring a second one would post
+  // the same thing twice. A **bare** HITL close has no proposal — it is the
+  // normal single-operator route (§3.2) — so it needs prose like any other. The
+  // alternative, exempting HITL wholesale, would have let a `grilling` node whose
+  // entire output is a decision close with no human-readable half while an `auto`
+  // node that merely ran `bun test` was refused for the same omission.
+  if ((receipt.resolution ?? "").trim().length === 0 && receipt.attestationFacts?.proposal === undefined) {
+    throw new WorkGraphError(
+      "close-refused",
+      `node ${node.id} closes without a resolution — the receipt carries no prose, and no proposal comment whose body would be it`,
+    );
+  }
+
   // Evidence is required of `auto` nodes only, and there it costs nothing: the
   // `probed` entry is derived from probes that already ran and passed.
   //
@@ -837,7 +884,12 @@ export function assertClosable(node: WorkGraphNode, receipt: CloseReceipt): void
 
 /** Render the receipt as the close comment body (§5: checkpoint id + evidence pointers on the tracker). */
 export function renderCloseReceipt(receipt: CloseReceipt): string {
+  const resolution = receipt.resolution?.trim() ?? "";
   const lines: string[] = [
+    // The human half first — a later reader reads prose, not a probe table, and
+    // burying it under the receipt would make the comment's first screen the half
+    // written for machines.
+    ...(resolution.length === 0 ? [] : [`## Resolution`, ``, resolution, ``]),
     `## Close receipt`,
     ``,
     `- **checkpoint:** \`${receipt.checkpointId}\``,

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -1363,6 +1363,19 @@ test("an empty resolution file refuses — a blank paragraph satisfies nothing",
   expect(store.closed).toHaveLength(0);
 });
 
+test("an unreadable resolution file names the path, not an ENOENT stack", async () => {
+  const store = autoGraph();
+  const message = await failure(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store, {
+    readTextFile: async () => {
+      throw new Error("ENOENT: no such file or directory");
+    },
+  });
+
+  expect(message).toContain("resolution.md");
+  expect(message).toContain("could not be read");
+  expect(store.closed).toHaveLength(0);
+});
+
 test("--propose with --resolution-file refuses rather than posting the prose twice", () => {
   expect(() =>
     parseGraphArgs(["graph", "close", "520", "--propose", "--body", "x", ...RESOLUTION]),

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -160,6 +160,14 @@ function deps(store: FakeStore, overrides: Partial<GraphCliDeps> = {}): Partial<
   };
 }
 
+/**
+ * Every close carries prose (#556), so every close test that is not *about* that
+ * rule has to supply it. Spread in explicitly rather than injected by `run`: a
+ * helper that quietly satisfied the requirement would leave no test exercising
+ * the argv a walker actually types.
+ */
+const RESOLUTION = ["--resolution-file", "resolution.md"] as const;
+
 async function run(args: string[], store: FakeStore, overrides: Partial<GraphCliDeps> = {}): Promise<string> {
   return await runGraphCli(parseGraphArgs(args), deps(store, overrides));
 }
@@ -341,7 +349,7 @@ function autoGraph(): FakeStore {
 
 test("an auto close runs the probes, derives probed evidence, and writes the receipt", async () => {
   const store = autoGraph();
-  const output = await run(["graph", "close", "520", "--repo", REPO], store);
+  const output = await run(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store);
 
   expect(store.closed).toHaveLength(1);
   const receipt = store.closed[0].receipt;
@@ -358,7 +366,7 @@ test("an auto close runs the probes, derives probed evidence, and writes the rec
 
 test("a failing probe refuses the close — nothing reaches the tracker", async () => {
   const store = autoGraph();
-  const message = await failure(["graph", "close", "520", "--repo", REPO], store, {
+  const message = await failure(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store, {
     runProbes: async (probes) =>
       probes.map<ProbeResult>((probe) => ({
         probe,
@@ -378,14 +386,14 @@ test("a node with no attached checkpoint cannot be closed at all", async () => {
     node: { id: "520", title: "no checkpoint", autonomy: "auto", probes: [PROBE] },
   });
 
-  const message = await failure(["graph", "close", "520", "--repo", REPO], store);
+  const message = await failure(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store);
   expect(message).toContain("no attached checkpoint");
   expect(store.closed).toHaveLength(0);
 });
 
 test("an auto receipt is honestly unverified — no human ratified it", async () => {
   const store = autoGraph();
-  await run(["graph", "close", "520", "--repo", REPO], store);
+  await run(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store);
 
   const receipt = store.closed[0].receipt;
   expect(receipt.attestation).toBe("unverified");
@@ -402,7 +410,7 @@ test("a bare `close` on a HITL node works — no proposal, no ratification", asy
     .seed("495", { node: autoNode("495"), author: "jcfischer" })
     .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
 
-  const output = await run(["graph", "close", "530", "--repo", REPO], store);
+  const output = await run(["graph", "close", "530", "--repo", REPO, ...RESOLUTION], store);
 
   expect(store.closed).toHaveLength(1);
   expect(output).toContain("Closed node 530");
@@ -645,7 +653,7 @@ test("selectRatification prefers the root author and ignores the proposer's own 
 
 test("--dry-run previews the verdict and the receipt without writing either", async () => {
   const store = autoGraph();
-  const output = await run(["graph", "close", "520", "--dry-run", "--repo", REPO], store);
+  const output = await run(["graph", "close", "520", "--dry-run", "--repo", REPO, ...RESOLUTION], store);
 
   expect(store.closed).toHaveLength(0);
   expect(store.comments.size).toBe(0);
@@ -708,7 +716,7 @@ function realRunner(
 test("close refuses an undeclared command probe and hands back the entry to add", async () => {
   const store = autoGraph();
   const message = await failure(
-    ["graph", "close", "520", "--repo", REPO],
+    ["graph", "close", "520", "--repo", REPO, ...RESOLUTION],
     store,
     realRunner({ status: "loaded", repo: REPO, path: REGISTRY_PATH, commands: [], urlHosts: [] }),
   );
@@ -723,7 +731,7 @@ test("close refuses an undeclared command probe and hands back the entry to add"
 test("close on a machine with no registry refuses rather than running tracker content", async () => {
   const store = autoGraph();
   const message = await failure(
-    ["graph", "close", "520", "--repo", REPO],
+    ["graph", "close", "520", "--repo", REPO, ...RESOLUTION],
     store,
     realRunner({ status: "absent", repo: REPO, path: REGISTRY_PATH }),
   );
@@ -734,7 +742,7 @@ test("close on a machine with no registry refuses rather than running tracker co
 
 test("a declared command probe closes exactly as before — the gate is not a new hurdle", async () => {
   const store = autoGraph();
-  const output = await run(["graph", "close", "520", "--repo", REPO], store, realRunner(DECLARED));
+  const output = await run(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store, realRunner(DECLARED));
 
   expect(store.closed).toHaveLength(1);
   expect(output).toContain("Closed node 520");
@@ -771,7 +779,7 @@ test("probes run in the stated directory, not the process's — and the receipt 
   const spawned: string[] = [];
   const store = autoGraph();
   const output = await run(
-    ["graph", "close", "520", "--repo", REPO],
+    ["graph", "close", "520", "--repo", REPO, ...RESOLUTION],
     store,
     realRunner(
       declaredIn(stated),
@@ -795,7 +803,7 @@ test("the registry match follows the stated tree, so a declaration for another c
   // the runner is handed, not whatever tree happens to hold a declaration.
   const store = autoGraph();
   const message = await failure(
-    ["graph", "close", "520", "--repo", REPO],
+    ["graph", "close", "520", "--repo", REPO, ...RESOLUTION],
     store,
     realRunner(declaredIn("/install/tree"), { probeCwd: () => "/work/tree-under-review" }),
   );
@@ -819,7 +827,7 @@ test("every tree the probes ran in is described, and each line says which one", 
     });
 
   await run(
-    ["graph", "close", "520", "--repo", REPO],
+    ["graph", "close", "520", "--repo", REPO, ...RESOLUTION],
     store,
     realRunner({
       status: "loaded",
@@ -861,7 +869,7 @@ test("a base tree no probe ran in is never described, let alone used as the anch
 
   const described: string[] = [];
   await run(
-    ["graph", "close", "520", "--repo", REPO],
+    ["graph", "close", "520", "--repo", REPO, ...RESOLUTION],
     store,
     realRunner(declaredIn(only), {
       describeProbeTree: async (dir) => {
@@ -892,7 +900,7 @@ test("a probe tree outside the stated tree is never read, let alone described (#
 
   const described: string[] = [];
   const message = await failure(
-    ["graph", "close", "520", "--repo", REPO],
+    ["graph", "close", "520", "--repo", REPO, ...RESOLUTION],
     store,
     realRunner(DECLARED, {
       describeProbeTree: async (dir) => {
@@ -925,7 +933,7 @@ test("one probe tree without a HEAD unanchors the whole set", async () => {
       author: "ivy-agent",
     });
 
-  const message = await failure(["graph", "close", "520", "--repo", REPO], store, {
+  const message = await failure(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store, {
     describeProbeTree: async (dir) => (dir === other ? { dir } : { dir, head: "abc1234", dirty: false }),
   });
 
@@ -939,7 +947,7 @@ test("the probe tree is read before the probes run, not after they have written 
   // rather than the state they ran against.
   const order: string[] = [];
   const store = autoGraph();
-  await run(["graph", "close", "520", "--repo", REPO], store, {
+  await run(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store, {
     describeProbeTree: async (dir) => {
       order.push("describe");
       return { dir, head: "abc1234", dirty: false };
@@ -974,7 +982,7 @@ test("a url-only close records no tree, and anchors on the targets it actually c
     });
 
   let described = 0;
-  await run(["graph", "close", "520", "--repo", REPO], store, {
+  await run(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store, {
     describeProbeTree: async (dir) => {
       described += 1;
       return { dir, head: "abc1234", dirty: false };
@@ -1001,7 +1009,7 @@ test("a mixed close anchors on both halves — trees and targets", async () => {
       author: "ivy-agent",
     });
 
-  await run(["graph", "close", "520", "--repo", REPO], store);
+  await run(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store);
 
   const pointer = store.closed[0].receipt.evidence.find((entry) => entry.kind === "probed")?.pointer;
   expect(pointer).toContain("HEAD abc1234 in /repo");
@@ -1023,7 +1031,7 @@ test("pre-flight tree reads are bounded, however many directories the tracker na
 
   let inFlight = 0;
   let peak = 0;
-  await run(["graph", "close", "520", "--repo", REPO], store, {
+  await run(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store, {
     describeProbeTree: async (dir) => {
       inFlight += 1;
       peak = Math.max(peak, inFlight);
@@ -1043,7 +1051,7 @@ test("a relative probe directory is resolved before it is recorded or compared",
   // same directory and every probe reads as elsewhere.
   const store = autoGraph();
   await run(
-    ["graph", "close", "520", "--repo", REPO],
+    ["graph", "close", "520", "--repo", REPO, ...RESOLUTION],
     store,
     realRunner(declaredIn(process.cwd()), {
       probeCwd: () => ".",
@@ -1058,7 +1066,7 @@ test("a relative probe directory is resolved before it is recorded or compared",
 
 test("a dirty probe tree is recorded, never refused (#579)", async () => {
   const store = autoGraph();
-  const output = await run(["graph", "close", "520", "--repo", REPO], store, {
+  const output = await run(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store, {
     describeProbeTree: async (dir) => ({ dir, head: "abc1234", dirty: true }),
   });
 
@@ -1072,7 +1080,7 @@ test("a tree with no readable HEAD anchors nothing, so an auto close still refus
   // Unchanged from before #580 — moving where the sha is read must not widen
   // what closes an `auto` node.
   const store = autoGraph();
-  const message = await failure(["graph", "close", "520", "--repo", REPO], store, {
+  const message = await failure(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store, {
     describeProbeTree: async (dir) => ({ dir }),
   });
 
@@ -1159,7 +1167,7 @@ test("--evidence cannot supply the kind that closes the node", async () => {
     });
 
   const forged = await failure(
-    ["graph", "close", "520", "--repo", REPO, "--evidence", '{"kind":"approved","summary":"looks fine","pointer":"trust me"}'],
+    ["graph", "close", "520", "--repo", REPO, ...RESOLUTION, "--evidence", '{"kind":"approved","summary":"looks fine","pointer":"trust me"}'],
     hitl,
   );
   expect(forged).toContain("--evidence cannot carry `approved`");
@@ -1169,7 +1177,7 @@ test("--evidence cannot supply the kind that closes the node", async () => {
   // Same rule on the AFK side: `probed`/`tested` are what a passed probe earns.
   const afk = autoGraph();
   const selfReport = await failure(
-    ["graph", "close", "520", "--repo", REPO, "--evidence", '{"kind":"tested","summary":"ran it myself","pointer":"HEAD"}'],
+    ["graph", "close", "520", "--repo", REPO, ...RESOLUTION, "--evidence", '{"kind":"tested","summary":"ran it myself","pointer":"HEAD"}'],
     afk,
   );
   expect(selfReport).toContain("--evidence cannot carry");
@@ -1178,7 +1186,7 @@ test("--evidence cannot supply the kind that closes the node", async () => {
   // Informational kinds still pass through.
   const informed = autoGraph();
   await run(
-    ["graph", "close", "520", "--repo", REPO, "--evidence", '{"kind":"judged","summary":"sage reviewed","pointer":"pr#1"}'],
+    ["graph", "close", "520", "--repo", REPO, ...RESOLUTION, "--evidence", '{"kind":"judged","summary":"sage reviewed","pointer":"pr#1"}'],
     informed,
   );
   expect(informed.closed[0].receipt.evidence.some((entry) => entry.kind === "judged")).toBe(true);
@@ -1224,7 +1232,7 @@ test("the gate is uniform — a HITL node is refused on the same terms as an aut
   });
 
   const message = await failure(
-    ["graph", "close", "520", "--repo", REPO],
+    ["graph", "close", "520", "--repo", REPO, ...RESOLUTION],
     store,
     realRunner({ status: "absent", repo: REPO, path: REGISTRY_PATH }),
   );
@@ -1254,7 +1262,7 @@ test("reading is not executing — node and frontier never consult the registry"
 test("closing from the dev tree warns that the gate is not where §1 clause 5 puts it", async () => {
   const store = autoGraph();
   const warnings: string[] = [];
-  await run(["graph", "close", "520", "--repo", REPO], store, {
+  await run(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store, {
     fromDevTree: true,
     warn: (message) => warnings.push(message),
   });
@@ -1264,7 +1272,101 @@ test("closing from the dev tree warns that the gate is not where §1 clause 5 pu
 
 test("a closed node is not closed twice", async () => {
   const store = autoGraph().seed("520", { node: autoNode("520"), parent: "495", status: "closed" });
-  expect(await failure(["graph", "close", "520", "--repo", REPO], store)).toContain("already closed");
+  expect(await failure(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store)).toContain("already closed");
+});
+
+// --- every close carries prose (#556) --------------------------------------
+
+test("an auto close with no --resolution-file refuses, before a single probe runs", async () => {
+  const store = autoGraph();
+  const probed: string[] = [];
+  const message = await failure(["graph", "close", "520", "--repo", REPO], store, {
+    runProbes: async (probes) => {
+      probed.push("ran");
+      return probes.map<ProbeResult>((probe) => ({
+        probe,
+        state: "probed",
+        outcome: "pass",
+        observed: "exit 0",
+        at: AT.toISOString(),
+      }));
+    },
+  });
+
+  expect(message).toContain("has no resolution");
+  expect(message).toContain("--resolution-file");
+  // Before the probes, deliberately: a missing paragraph must not cost a
+  // 900-second `bun test` before the refusal arrives.
+  expect(probed).toEqual([]);
+  expect(store.closed).toHaveLength(0);
+  expect(store.comments.size).toBe(0);
+});
+
+test("a bare HITL close needs prose too — it has no proposal body to stand in", async () => {
+  // The hole #556 found: closing.md makes the bare close the normal
+  // single-operator route, so exempting HITL wholesale would let a grilling node
+  // — whose entire output IS a decision — close with no human-readable half.
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
+
+  expect(await failure(["graph", "close", "530", "--repo", REPO], store)).toContain("has no resolution");
+  expect(store.closed).toHaveLength(0);
+});
+
+test("a close naming a ratified proposal needs no --resolution-file — that body is the resolution", async () => {
+  const store = new FakeStore()
+    .seed("495", { node: autoNode("495"), author: "jcfischer" })
+    .seed("530", { node: { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" }, parent: "495" });
+  await run(["graph", "close", "530", "--propose", "--body", "the resolution", "--repo", REPO], store);
+  store.reactions.set("c1", [{ id: "r1", content: "+1", author: "jcfischer" }]);
+
+  const output = await run(["graph", "close", "530", "--proposal-comment", "c1", "--repo", REPO], store);
+
+  expect(output).toContain("Closed node 530");
+  expect(store.closed).toHaveLength(1);
+});
+
+test("the resolution rides the receipt — no comment of its own is posted", async () => {
+  const store = autoGraph();
+  await run(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store, {
+    readTextFile: async () => "Containment holds: the resolved path must stay under the stated tree.",
+  });
+
+  // On the receipt, not beside it: the backend's `close` posts one comment from
+  // exactly this value, so there is no ordering in which one half lands without
+  // the other. (The rendered order is pinned in work-graph.test.ts.)
+  expect(store.closed[0].receipt.resolution).toContain("Containment holds");
+  expect(store.comments.size).toBe(0);
+});
+
+test("--dry-run renders the prose and writes nothing", async () => {
+  const store = autoGraph();
+  const output = await run(["graph", "close", "520", "--dry-run", "--repo", REPO, ...RESOLUTION], store, {
+    readTextFile: async () => "Why this closed.",
+  });
+
+  expect(output).toContain("would be ACCEPTED");
+  expect(output).toContain("## Resolution");
+  expect(output).toContain("Why this closed.");
+  expect(store.closed).toHaveLength(0);
+  expect(store.comments.size).toBe(0);
+});
+
+test("an empty resolution file refuses — a blank paragraph satisfies nothing", async () => {
+  const store = autoGraph();
+  const message = await failure(["graph", "close", "520", "--repo", REPO, ...RESOLUTION], store, {
+    readTextFile: async () => "   \n\n  ",
+  });
+
+  expect(message).toContain("is empty");
+  expect(store.closed).toHaveLength(0);
+});
+
+test("--propose with --resolution-file refuses rather than posting the prose twice", () => {
+  expect(() =>
+    parseGraphArgs(["graph", "close", "520", "--propose", "--body", "x", ...RESOLUTION]),
+  ).toThrow(/the proposal body is the resolution/u);
 });
 
 test("SomaCliError carries a non-zero exit for a lost claim", async () => {

--- a/test/work-graph.test.ts
+++ b/test/work-graph.test.ts
@@ -447,6 +447,24 @@ test("claiming a closed node is refused", async () => {
   expect(store.claims).toHaveLength(0);
 });
 
+test("the prose rule holds at the seam, not only in the CLI", async () => {
+  // #556's actual complaint was that resolution-posting lived in one CLI branch
+  // and nowhere else. A rule enforced only by `soma graph close` would reproduce
+  // that, so it is pinned here: a direct consumer of the contract is refused too.
+  const store = new FakeStore();
+  store.add("497", {
+    node: { id: "497", title: "seam", autonomy: "auto", checkpointId: "cp-497", probes: [PASSING_PROBE] },
+  });
+  const graph = new WorkGraph(store);
+
+  expect(await asyncCodeOf(() => graph.close({ id: "497" }, receipt({ resolution: undefined })))).toBe("close-refused");
+  expect(store.closed).toHaveLength(0);
+
+  await graph.close({ id: "497" }, receipt());
+  expect(store.closed).toHaveLength(1);
+  expect(store.closed[0].receipt.resolution).toContain("The seam ships");
+});
+
 test("close gates on the node as the store reports it, not on a caller-supplied copy", async () => {
   const store = new FakeStore();
   // The stored node is `auto` with a probe; a caller who omits the probe result

--- a/test/work-graph.test.ts
+++ b/test/work-graph.test.ts
@@ -153,6 +153,10 @@ function receipt(overrides: Partial<CloseReceipt> = {}): CloseReceipt {
     checkpointId: "cp-497",
     closedBy: "ivy-agent",
     at: "2026-08-04T10:00:00.000Z",
+    // Every close carries prose (#556). Defaulted here so the tests that are
+    // about the other conjuncts stay about them; the ones about this conjunct
+    // override it away.
+    resolution: "The seam ships with its GitHub backend; the typed contracts hold.",
     evidence: [{ kind: "probed", summary: "bun test exit 0", pointer: "https://example.test/run/1" }],
     probeResults: [
       { probe: PASSING_PROBE, state: "probed", outcome: "pass", observed: "exit 0", at: "2026-08-04T09:59:00.000Z" },
@@ -238,6 +242,48 @@ test("the rendered receipt carries the checkpoint, the attestation and the evide
   expect(rendered).toContain("https://example.test/run/1");
   expect(rendered).toContain("**pass**");
   expect(rendered).toContain('"backendCapability": "verifiable"');
+});
+
+test("the rendered receipt puts the resolution above it — one comment, human half first", () => {
+  const rendered = renderCloseReceipt(receipt({ resolution: "The seam ships with its consumer." }));
+
+  expect(rendered.indexOf("## Resolution")).toBeLessThan(rendered.indexOf("## Close receipt"));
+  expect(rendered).toContain("The seam ships with its consumer.");
+  // A later reader reads prose, not a probe table; burying it would make the
+  // comment's first screen the half written for machines (#556).
+  expect(rendered.startsWith("## Resolution")).toBe(true);
+});
+
+test("a receipt with no resolution renders no empty heading", () => {
+  // The exempt case — a ratified proposal carries the prose — must not leave a
+  // bare `## Resolution` with nothing under it.
+  const rendered = renderCloseReceipt(receipt({ resolution: undefined }));
+  expect(rendered).not.toContain("## Resolution");
+  expect(rendered.startsWith("## Close receipt")).toBe(true);
+});
+
+test("a close with neither prose nor a proposal is refused, whatever its autonomy", () => {
+  const bare = receipt({ resolution: undefined });
+  expect(codeOf(() => { assertClosable(AUTO_NODE, bare); })).toBe("close-refused");
+
+  const hitl: WorkGraphNode = { id: "530", title: "hitl", autonomy: "approve", checkpointId: "cp-530" };
+  expect(codeOf(() => { assertClosable(hitl, receipt({ checkpointId: "cp-530", probeResults: [], resolution: undefined })); })).toBe(
+    "close-refused",
+  );
+
+  // Whitespace is not prose.
+  expect(codeOf(() => { assertClosable(AUTO_NODE, receipt({ resolution: "  \n " })); })).toBe("close-refused");
+});
+
+test("a recorded proposal exempts the close — its body already is the resolution", () => {
+  const ratified = receipt({
+    resolution: undefined,
+    attestationFacts: {
+      backendCapability: "verifiable",
+      proposal: { commentId: "c1", author: "ivy-agent" },
+    },
+  });
+  expect(() => { assertClosable(AUTO_NODE, ratified); }).not.toThrow();
 });
 
 // --- contract layer over a store -------------------------------------------


### PR DESCRIPTION
Implements [#588](https://github.com/the-metafactory/soma/issues/588), the decision from [#556](https://github.com/the-metafactory/soma/issues/556).

## The contradiction

Doctrine required a **resolution comment** on every node before it closes, and forbade reaching past the `soma graph` verbs to the tracker's own CLI. On the AFK path those rules contradicted each other: `--body`/`--body-file` fed `--propose` only (`src/cli/graph.ts:844-873`), and `parseClose` rejected them without it. So closing an `auto` node the documented way required `gh issue comment` — leaving the one artefact humans actually read as the one with no contract, no repo resolution and no backend abstraction. #582 and #580 both closed that way, and #556's own close was the third.

## The rule

| Path | What satisfies it |
| --- | --- |
| `auto` close | `--resolution-file <path>` |
| HITL **bare** close | `--resolution-file <path>` |
| HITL `--propose` → `close --proposal-comment <id>` | the proposal body, already posted |

One exemption, only where prose demonstrably exists. Exempting HITL wholesale would have let a `grilling` node — whose entire output *is* a decision — close with no human-readable half, while an `auto` node that merely ran `bun test` was refused for the same omission. The bare close is the normal single-operator route (§3.2), not an edge case.

## Folded, not posted beside

`CloseReceipt.resolution` renders above the receipt and the backend posts **one** comment from it. Posted separately, both orderings lose something — before the probes leaves an orphan resolution on a node whose close then refuses; after them leaves a receipt whose prose failed to post. Folded, neither state is reachable. Cost accepted: prose cannot react to probe output, because it is written first.

## Refused in two places, neither redundant

- **`assertClosable`** checks the receipt, so the rule holds for every consumer of the seam — which was #556's actual complaint, that the behaviour lived only in one CLI branch.
- **`soma graph close`** checks before the probes run, so a missing paragraph costs nothing instead of a 900-second `bun test`, and it can name the flag. The contract cannot: it knows nothing about a CLI.

## The honest part

The new conjunct is **a forcing function, not evidence**, and the spec and the code both say so in those words. Conjuncts 1–3 check facts a session could not fake — a checkpoint is attached, a probe ran, a pointer resolves. This one checks that *something was written*, and no machine can check that it says anything. A conjunct described as verification when it is a prompt to write something would be the self-declared verification DD-16 exists to refuse.

## Verified live

Against the node this PR implements, using the worktree CLI:

```
$ bun src/cli.ts graph close 588
Close refused: node 588 has no resolution.
Every close carries prose — the human-readable half, above the receipt in one comment (#556).
  soma graph close 588 --resolution-file <path>
Exempt only when a proposal already carries it: a close naming --proposal-comment reuses that body.
Nothing was written, and no probe ran.

$ bun src/cli.ts graph close 588 --resolution-file res.md --dry-run
close would be ACCEPTED
## Resolution
…prose…
## Close receipt
```

**A finding from doing that**: `soma` on PATH runs an *installed snapshot* (`~/.claude/bin/soma/src/cli.ts`), not the tree under development — so my first attempt closed #588 with no prose at all, through a binary that predates this change. Reopened, and worth naming rather than hiding: it is §1 clause 5 working as designed (enforcement lives in the installed binary), and it means this gate does not bind any session until the install is refreshed. Same shape as #580's receipt being written by the pre-#580 binary.

## Also

`--dry-run` renders the prose and writes nothing · `--propose` with `--resolution-file` is refused rather than silently preferring one · an empty resolution file is refused the way `--propose` already refuses an empty body.

Spec §3.0. The orienteer skill's `closing.md`, `WalkTheMap.md` and `SKILL.md` collapse "post the resolution, then close" into one act.

`bun test` 2363 pass / 0 fail · `bunx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
