### PR TITLE
fix(ci): the confidentiality-gate header claimed it cannot block a merge (#560)

### DIFF
--- a/.github/workflows/confidentiality-gate.yml
+++ b/.github/workflows/confidentiality-gate.yml
@@ -3,12 +3,23 @@
 # commit SHA (never a tag/branch) so a moved tag cannot swap the gate or engine.
 # Bump via rollout-gate.ts, never by hand.
 #
-# WARN-ONLY BURN-IN: this standalone workflow is NOT enrolled in any required
-# status check, so a finding here never blocks a merge. require_denylist:false
-# degrades the same-repo path to tiers 1+2 + a warning instead of failing closed
-# when the denylist secret is absent. A principal flips enforcement later by
-# adding this check context to the repo ruleset (rollout-gate.ts --rulesets) —
-# deliberately NOT done here.
+# DIVERGED FROM THE GENERATOR — this header block only (soma#560, compass#156).
+# The generated text asserted "NOT enrolled in any required status check, so a
+# finding here never blocks a merge". Both clauses are false for this repo:
+# `gate / confidentiality-gate` is a required check on the protect-main ruleset
+# (soma#510), and a block-class finding exits 1, which a required check turns
+# into a blocked merge. The second clause is a false statement about a security
+# control's blast radius, which is why this is corrected by hand rather than
+# left for the generator. The next rollout-gate.ts bump WILL revert this block —
+# that revert is the signal compass#156 has not landed.
+#
+# WARN-ONLY CONFIG: require_denylist:false degrades the same-repo path to
+# tiers 1+2 + a warning instead of failing closed when the denylist secret is
+# absent. Warn-class findings do not fail the job; block-class findings do.
+#
+# Whether that failure blocks a MERGE is not stated here: enrollment lives in
+# the repo ruleset, not in this file, and can change without touching it.
+#   gh api repos/the-metafactory/soma/rulesets
 name: confidentiality-gate
 on:
   pull_request:


### PR DESCRIPTION
Resolves the soma half of [#560](https://github.com/the-metafactory/soma/issues/560). The generator fix is [compass#156](https://github.com/the-metafactory/compass/issues/156).

## What the header claimed

> WARN-ONLY BURN-IN: this standalone workflow is NOT enrolled in any required status check, **so a finding here never blocks a merge.**

**Both clauses are false for this repo.**

**Enrolled.** `gate / confidentiality-gate` is a required status check on the `protect-main` ruleset (id `17446144`), added as part of [#510](https://github.com/the-metafactory/soma/issues/510). That is the half #560 caught.

**A finding can block a merge.** `decideExit` returns `1` on any `action: "block"` finding (metafactory-actions `scan/confidentiality-scan.ts:722`), and the reusable runs the engine under `set -euo pipefail` with no `|| true`. Required context + failing job = blocked merge. "Warn-only" only ever covered *warn*-class findings (`failOnWarn` off); block-class findings could always fail the job, enrolled or not.

That second clause is what makes this more than doc drift, and #560 did not have it: a file in the tree told a reader that a security control cannot block them, when today it can.

## What it says now

Only what this **file** controls, plus a pointer to where enrollment actually lives:

```
# WARN-ONLY CONFIG: require_denylist:false degrades the same-repo path to
# tiers 1+2 + a warning instead of failing closed when the denylist secret is
# absent. Warn-class findings do not fail the job; block-class findings do.
#
# Whether that failure blocks a MERGE is not stated here: enrollment lives in
# the repo ruleset, not in this file, and can change without touching it.
#   gh api repos/the-metafactory/soma/rulesets
```

Deployment state in a source file is the category error. A generator taught to read the ruleset — #560's other candidate — would be accurate only at generation time, since anyone with L5 ops flips the ruleset a minute later without touching the file: the same bug with a smaller window, plus an API read per repo added to a file-writing path.

## Hand-edited on purpose

The file says *"Bump via rollout-gate.ts, never by hand."* This diverges from that knowingly, and marks itself:

```
# DIVERGED FROM THE GENERATOR — this header block only (soma#560, compass#156).
```

The next `rollout-gate.ts` bump **will** revert this block, and that revert is the signal compass#156 has not landed. Only the header diverges — the `uses:` SHA pin, `engine_sha`, `require_denylist` and every secret reference are byte-identical.

## Verified

- Ruleset read live: `gh api repos/the-metafactory/soma/rulesets/17446144` lists `gate / confidentiality-gate` and `Deterministic portability` as required contexts.
- Exit path read in `metafactory-actions`: `decideExit` → `1` on block-class; the caller step has no `|| true`.
- Workflow still parses and the pin is intact; this PR's own `gate / confidentiality-gate` run is the check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
