### PR TITLE
fix(adapters): standalone-binary hook assets, without breaking pi (#531)

### DIFF
--- a/src/adapters/anthropic-cowork.ts
+++ b/src/adapters/anthropic-cowork.ts
@@ -22,7 +22,9 @@ export const ANTHROPIC_COWORK_POLICY_PATH = "soma/policy.md";
 export const ANTHROPIC_COWORK_MEMORY_SNAPSHOT_PATH = "soma/memory-snapshot.md";
 export const ANTHROPIC_COWORK_ACTIVE_VSA_PATH = activeVsaProjectionPath("anthropic-cowork");
 export const ANTHROPIC_COWORK_CAPTURE_README_PATH = "capture/README.md";
-export const ANTHROPIC_COWORK_DEFAULT_HOME = ".anthropic-cowork";
+// Owned by the leaf `adapters/private-roots` module (which must not import an
+// adapter) and re-exported here so existing importers are unchanged.
+export { ANTHROPIC_COWORK_DEFAULT_HOME } from "./private-roots";
 export const ANTHROPIC_COWORK_SKILLS_ROOT_PATH = "skills";
 
 const COWORK_README_HEADING = "# Soma Anthropic Cowork Projection";

--- a/src/adapters/anthropic-cowork/install.ts
+++ b/src/adapters/anthropic-cowork/install.ts
@@ -1,9 +1,9 @@
-import { homedir } from "node:os";
 import { readFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { isEnoent } from "../../fs-errors";
 import { skillsLoaderUnder, type SubstrateInstallSpec, type UninstallContext } from "../../install-spec";
 import { projectVsaSkillBundleFiles } from "../../vsa-skill-installer";
+import { anthropicCoworkProjectionPrivateRoots } from "../private-roots";
 import {
   ANTHROPIC_COWORK_ACTIVE_VSA_PATH,
   ANTHROPIC_COWORK_ACTIVE_VSA_MARKER,
@@ -98,15 +98,7 @@ export const anthropicCoworkInstallSpec: SubstrateInstallSpec<"anthropic-cowork"
     destinationDir: (substrateHome) => resolve(substrateHome, "skills", "VSA"),
   },
   privateRoots: {
-    projection: (options) => {
-      const homeDir = resolve(options?.homeDir ?? homedir());
-      const substrateHome = resolve(options?.substrateHome ?? join(homeDir, ANTHROPIC_COWORK_DEFAULT_HOME));
-      return [
-        resolve(substrateHome, "soma"),
-        resolve(substrateHome, "capture"),
-        resolve(substrateHome, "skills/VSA"),
-      ];
-    },
+    projection: anthropicCoworkProjectionPrivateRoots,
   },
   uninstall: {
     kind: "implemented",

--- a/src/adapters/claude-code/hooks.ts
+++ b/src/adapters/claude-code/hooks.ts
@@ -1,10 +1,26 @@
-import { readFileSync } from "node:fs";
 import { chmod, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { resolveBunExecutable } from "../../bun-probe";
 import { isEnoent } from "../../fs-errors";
 import { renderFeedbackHookHelper } from "../shared/feedback-helper";
 import { isClaudeCodeInstallOptions } from "./install-options";
+
+// Hook assets are inlined at bundle time (`with { type: "text" }`) so the
+// compiled binary can project them; a runtime readFileSync against
+// import.meta.url resolves to /$bunfs/root inside a single-file bundle and
+// throws ENOENT (soma#531). tsc has no notion of text imports, hence the
+// suppressions; a blanket `declare module "*.mjs"` is not safe here because
+// grok imports one of its .mjs assets as a real module.
+// @ts-expect-error text import: inlined by bun, unknown to tsc
+import hookRunnerSource from "./hook-runner.mjs" with { type: "text" };
+// @ts-expect-error text import: inlined by bun, unknown to tsc
+import modeClassifierSource from "./mode-classifier-hook.mjs" with { type: "text" };
+// @ts-expect-error text import: inlined by bun, unknown to tsc
+import policyGuardSource from "./policy-guard-hook.mjs" with { type: "text" };
+// @ts-expect-error text import: inlined by bun, unknown to tsc
+import preCompactSource from "./precompact-hook.mjs" with { type: "text" };
+// @ts-expect-error text import: inlined by bun, unknown to tsc
+import statusLineSource from "./statusline.sh" with { type: "text" };
 
 /**
  * soma#369: adapter-owned session hooks (mode classifier, policy guard) are
@@ -950,22 +966,22 @@ async function readInstalledClaudeCodeHookConfigBunPath(substrateHome: string, r
 
 function renderClaudeCodeSomaHook(): string {
   const runnerHandlers = Object.fromEntries(SOMA_CLAUDE_HOOK_EVENTS.map((event) => [event.commandEvent, event.runner]));
-  const source = readFileSync(new URL("./hook-runner.mjs", import.meta.url), "utf8");
+  const source = hookRunnerSource as string;
   const rendered = source.replace("__SOMA_CLAUDE_HOOK_EVENT_HANDLERS__", JSON.stringify(runnerHandlers, null, 2));
   if (rendered === source) throw new Error("Claude Code hook runner asset is missing the handler placeholder.");
   return rendered;
 }
 
 function renderClaudeCodeModeClassifierHook(): string {
-  return readFileSync(new URL("./mode-classifier-hook.mjs", import.meta.url), "utf8");
+  return modeClassifierSource as string;
 }
 
 function renderClaudeCodePolicyGuardHook(): string {
-  return readFileSync(new URL("./policy-guard-hook.mjs", import.meta.url), "utf8");
+  return policyGuardSource as string;
 }
 
 function renderClaudeCodePreCompactHook(): string {
-  return readFileSync(new URL("./precompact-hook.mjs", import.meta.url), "utf8");
+  return preCompactSource as string;
 }
 
 // Generated (not a static asset) so the trigger regex stays single-sourced
@@ -1065,7 +1081,7 @@ export function renderClaudeCodeStatusLineScript(somaHome: string): string {
   // Cache the static template: this renderer is called on the SessionStart
   // projection self-repair path (#460) as a drift oracle, so avoid a blocking
   // fs read on every healthy session start. The asset never changes at runtime.
-  statusLineTemplateCache ??= readFileSync(new URL("./statusline.sh", import.meta.url), "utf8");
+  statusLineTemplateCache ??= statusLineSource as string;
   const source = statusLineTemplateCache;
   const escaped = somaHome.replace(/[\\"$`]/g, "\\$&");
   const rendered = source.replace("__SOMA_HOME__", () => escaped);

--- a/src/adapters/codex/hooks/assets.ts
+++ b/src/adapters/codex/hooks/assets.ts
@@ -1,15 +1,43 @@
-import { readFileSync } from "node:fs";
+/**
+ * Codex hook assets, inlined at bundle time so they survive `bun build --compile`.
+ *
+ * These were read at runtime via `readFileSync(new URL("./x.mjs",
+ * import.meta.url))`. Inside a single-file bundle that resolves to
+ * `/$bunfs/root/…`, where the .mjs files do not exist, so `soma install codex
+ * --apply` died with ENOENT before writing anything (soma#531 — the c-005 pack
+ * ships a compiled soma to people who have no bun and no repo).
+ *
+ * `with { type: "text" }` makes bun inline the bytes at bundle time and still
+ * read from disk in dev, so both paths get the same content. TypeScript has no
+ * notion of text imports and resolves `.mjs` as a module, hence the
+ * suppressions — a blanket `declare module "*.mjs"` is NOT an option: grok
+ * imports `grok-hook-verbs.mjs` as a real module elsewhere, and a global text
+ * declaration would break that.
+ */
+// @ts-expect-error text import: inlined by bun, unknown to tsc
+import codexHookEntry from "./codex-hook-entry.mjs" with { type: "text" };
+// @ts-expect-error text import: inlined by bun, unknown to tsc
+import codexPolicyTargets from "./codex-policy-targets.mjs" with { type: "text" };
+// @ts-expect-error text import: inlined by bun, unknown to tsc
+import policyMarker from "./policy-marker.mjs" with { type: "text" };
+// @ts-expect-error text import: inlined by bun, unknown to tsc
+import somaLifecycle from "./soma-lifecycle.mjs" with { type: "text" };
 
-export function readCodexHookAsset(
-  name:
-    | "codex-hook-entry.mjs"
-    | "codex-policy-targets.mjs"
-    | "policy-marker.mjs"
-    | "soma-lifecycle.mjs",
-): string {
-  const assetUrl = new URL(`./${name}`, import.meta.url);
+type CodexHookAsset =
+  | "codex-hook-entry.mjs"
+  | "codex-policy-targets.mjs"
+  | "policy-marker.mjs"
+  | "soma-lifecycle.mjs";
 
-  return readFileSync(assetUrl, "utf8");
+const ASSETS: Record<CodexHookAsset, string> = {
+  "codex-hook-entry.mjs": codexHookEntry as string,
+  "codex-policy-targets.mjs": codexPolicyTargets as string,
+  "policy-marker.mjs": policyMarker as string,
+  "soma-lifecycle.mjs": somaLifecycle as string,
+};
+
+export function readCodexHookAsset(name: CodexHookAsset): string {
+  return ASSETS[name];
 }
 
 export function renderCodexPolicyHook(): string {

--- a/src/adapters/codex/install.ts
+++ b/src/adapters/codex/install.ts
@@ -1,12 +1,9 @@
-import { homedir } from "node:os";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import { configureCodexInstall } from "./config";
 import { skillsLoaderUnder, vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
 import { vsaSiblingPrunePrepare } from "../../legacy-skill-prune";
-import type { PrivateRootOptions } from "../../install-spec";
-
-const CODEX_DEFAULT_HOME = ".codex";
+import { CODEX_DEFAULT_HOME, codexMemoryPrivateRoots, codexProjectionPrivateRoots } from "../private-roots";
 
 export const CODEX_HOME_FILES = [
   "rules/soma.rules",
@@ -33,18 +30,6 @@ export const CODEX_HOME_FILES = [
 ] as const;
 
 export const CODEX_AGENTS_IMPORTS = ["@./skills/the-algorithm/SKILL.md", "@./memories/soma/startup-context.md"] as const;
-
-export function codexProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
-  if (options.substrate !== undefined && options.substrate !== "codex") return [];
-  const home = resolve(options.homeDir ?? homedir());
-  return [join(home, CODEX_DEFAULT_HOME, "skills", "soma")].map((path) => resolve(path));
-}
-
-export function codexMemoryPrivateRoots(options: PrivateRootOptions = {}): string[] {
-  if (options.substrate !== undefined && options.substrate !== "codex") return [];
-  const home = resolve(options.homeDir ?? homedir());
-  return [join(home, CODEX_DEFAULT_HOME, "memories")].map((path) => resolve(path));
-}
 
 export async function configureCodexAgentsImport(codexHome: string): Promise<string[]> {
   const path = join(codexHome, "AGENTS.md");

--- a/src/adapters/grok/hooks/assets.ts
+++ b/src/adapters/grok/hooks/assets.ts
@@ -1,3 +1,18 @@
+/**
+ * Grok hook assets, still read at runtime — deliberately NOT converted to the
+ * `with { type: "text" }` imports the codex adapter uses for soma#531.
+ *
+ * `grok-hook-verbs.mjs` is dual-use: `../adapter.ts` imports it as a real
+ * module for `GROK_PRE_TOOL_USE_VERB`, and it is also shipped verbatim to the
+ * user's machine. Bun resolves a specifier once, so a text import of the same
+ * path strips the named exports and breaks that module import at load time —
+ * which takes down anything that loads soma, hooks included.
+ *
+ * Consequence: `soma install grok --apply` does not work from a compiled
+ * binary (ENOENT under /$bunfs). Fixing it means breaking the dual use first —
+ * e.g. moving the verb constant into a .ts module that both the adapter and the
+ * shipped .mjs can source from — which is #531 work, not a drive-by.
+ */
 import { readFileSync } from "node:fs";
 
 export function readGrokHookAsset(

--- a/src/adapters/grok/install.ts
+++ b/src/adapters/grok/install.ts
@@ -2,7 +2,8 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
 import { isEnoent } from "../../fs-errors";
-import { skillsLoaderUnder, vsaSkillUnder, type PrivateRootOptions, type SubstrateInstallSpec } from "../../install-spec";
+import { skillsLoaderUnder, vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
+import { GROK_DEFAULT_HOME, grokProjectionPrivateRoots } from "../private-roots";
 import {
   GROK_AGENT_MARKER,
   GROK_PERSONA_MARKER,
@@ -19,8 +20,6 @@ import {
 import { smokeTestInstalledGrokHookCommand } from "./hook-smoke";
 import { removeGrokPortableSkillProjection } from "./install-manifest";
 import { validateGrokInstallRuntime } from "./version";
-
-const GROK_DEFAULT_HOME = ".grok";
 
 /**
  * Static file set emitted by `projectGrokHome`, relative to `~/.grok` —
@@ -164,14 +163,6 @@ async function shouldRemoveGrokTarget(target: string): Promise<boolean> {
 export function isGrokPortableSkillProjectionPath(path: string): boolean {
   const name = /^skills\/([^/]+)\//.exec(path)?.[1];
   return name !== undefined && name !== "VSA" && !(GROK_PROJECTED_SKILL_NAMES as readonly string[]).includes(name);
-}
-
-export function grokProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
-  if (options.substrate !== undefined && options.substrate !== "grok") return [];
-  const home = resolve(options.homeDir ?? homedir());
-  // The projected identity/context surface (Soma never writes into
-  // ~/.grok/memory/, so there is no separate memory private root).
-  return [join(home, GROK_DEFAULT_HOME, "skills", "soma")].map((path) => resolve(path));
 }
 
 export const grokInstallSpec: SubstrateInstallSpec<"grok"> = {

--- a/src/adapters/pi-dev/install.ts
+++ b/src/adapters/pi-dev/install.ts
@@ -1,14 +1,11 @@
-import { homedir } from "node:os";
-import { join, resolve } from "node:path";
-import { skillsLoaderUnder, type PrivateRootOptions, type SubstrateInstallSpec } from "../../install-spec";
+import { skillsLoaderUnder, type SubstrateInstallSpec } from "../../install-spec";
+import { PI_DEV_DEFAULT_HOME, piDevProjectionPrivateRoots } from "../private-roots";
 import {
   PI_DEV_VSA_SKILL_ID,
   piDevVsaSkillDestinationDir,
   removeLegacyPiDevVsaSkillProjection,
 } from "./skill-projection";
 import { validatePiDevInstallRuntime } from "./version";
-
-const PI_DEV_DEFAULT_HOME = ".pi";
 
 export const PI_DEV_HOME_FILES = [
   "agent/extensions/soma.ts",
@@ -25,15 +22,6 @@ export const PI_DEV_HOME_FILES = [
   "agent/soma/soma-repo.txt",
   "agent/skills/soma/SKILL.md",
 ] as const;
-
-function piDevProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
-  if (options.substrate !== undefined && options.substrate !== "pi-dev") return [];
-  const home = resolve(options.homeDir ?? homedir());
-  return [
-    join(home, PI_DEV_DEFAULT_HOME, "agent", "soma"),
-    join(home, PI_DEV_DEFAULT_HOME, "agent", "skills", "soma"),
-  ];
-}
 
 export const piDevInstallSpec: SubstrateInstallSpec<"pi-dev"> = {
   substrate: "pi-dev",

--- a/src/adapters/private-roots.ts
+++ b/src/adapters/private-roots.ts
@@ -1,6 +1,6 @@
 import { homedir } from "node:os";
 import { join, resolve } from "node:path";
-import type { PrivateRootOptions } from "../install-spec";
+import type { InstallSubstrate, PrivateRootOptions } from "../install-spec";
 
 /**
  * Per-substrate default homes and private-root path builders, deliberately kept
@@ -32,35 +32,51 @@ export const GROK_DEFAULT_HOME = ".grok";
 export const PI_DEV_DEFAULT_HOME = ".pi";
 export const ANTHROPIC_COWORK_DEFAULT_HOME = ".anthropic-cowork";
 
-export function codexProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
-  if (options.substrate !== undefined && options.substrate !== "codex") return [];
+/**
+ * The shared shape: a private root is `<homeDir>/<defaultHome>/<segments...>`,
+ * and a builder yields nothing when the caller has narrowed the query to a
+ * different substrate. `somaProjectionPrivateRoots` narrows by substrate too,
+ * but the self-filter is what makes each builder correct when called directly.
+ */
+function substrateRoots(
+  options: PrivateRootOptions,
+  substrate: InstallSubstrate,
+  defaultHome: string,
+  segments: readonly (readonly string[])[],
+): string[] {
+  if (options.substrate !== undefined && options.substrate !== substrate) return [];
   const home = resolve(options.homeDir ?? homedir());
-  return [join(home, CODEX_DEFAULT_HOME, "skills", "soma")].map((path) => resolve(path));
+  return segments.map((segment) => resolve(join(home, defaultHome, ...segment)));
+}
+
+export function codexProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
+  return substrateRoots(options, "codex", CODEX_DEFAULT_HOME, [["skills", "soma"]]);
 }
 
 export function codexMemoryPrivateRoots(options: PrivateRootOptions = {}): string[] {
-  if (options.substrate !== undefined && options.substrate !== "codex") return [];
-  const home = resolve(options.homeDir ?? homedir());
-  return [join(home, CODEX_DEFAULT_HOME, "memories")].map((path) => resolve(path));
+  return substrateRoots(options, "codex", CODEX_DEFAULT_HOME, [["memories"]]);
 }
 
 export function grokProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
-  if (options.substrate !== undefined && options.substrate !== "grok") return [];
-  const home = resolve(options.homeDir ?? homedir());
   // The projected identity/context surface (Soma never writes into
   // ~/.grok/memory/, so there is no separate memory private root).
-  return [join(home, GROK_DEFAULT_HOME, "skills", "soma")].map((path) => resolve(path));
+  return substrateRoots(options, "grok", GROK_DEFAULT_HOME, [["skills", "soma"]]);
 }
 
 export function piDevProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
-  if (options.substrate !== undefined && options.substrate !== "pi-dev") return [];
-  const home = resolve(options.homeDir ?? homedir());
-  return [
-    join(home, PI_DEV_DEFAULT_HOME, "agent", "soma"),
-    join(home, PI_DEV_DEFAULT_HOME, "agent", "skills", "soma"),
-  ];
+  return substrateRoots(options, "pi-dev", PI_DEV_DEFAULT_HOME, [
+    ["agent", "soma"],
+    ["agent", "skills", "soma"],
+  ]);
 }
 
+/**
+ * Does NOT use `substrateRoots`, on purpose. Cowork roots hang off an explicit
+ * `substrateHome` when the caller supplies one — the default home is only the
+ * fallback — and this builder has never self-filtered on `options.substrate`;
+ * `somaProjectionPrivateRoots` does the narrowing for it. Folding it into the
+ * helper would silently change both behaviours.
+ */
 export function anthropicCoworkProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
   const homeDir = resolve(options.homeDir ?? homedir());
   const substrateHome = resolve(options.substrateHome ?? join(homeDir, ANTHROPIC_COWORK_DEFAULT_HOME));

--- a/src/adapters/private-roots.ts
+++ b/src/adapters/private-roots.ts
@@ -1,0 +1,68 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import type { PrivateRootOptions } from "../install-spec";
+
+/**
+ * Per-substrate default homes and private-root path builders, deliberately kept
+ * in a LEAF module — nothing here may import an adapter.
+ *
+ * Two very different callers need these facts:
+ *
+ *   1. the install specs (`adapters/<substrate>/install.ts`), which drag in the
+ *      whole projection surface — hook assets, config writers, skill projection;
+ *   2. `src/policy-audit.ts` via `src/projection-private-roots.ts`, which every
+ *      Soma policy check goes through — including the checks inside the
+ *      GENERATED pi.dev extensions, which `import` this repo's `src/` directly
+ *      (see `adapters/pi-dev/adapter.ts`).
+ *
+ * Routing (2) through `install-spec-registry` made a policy check pull in every
+ * adapter's installer, and that broke pi.dev outright (soma#531 follow-up): the
+ * claude-code installer imports its hook assets with bun's
+ * `import ... with { type: "text" }`, pi loads extensions through jiti, jiti
+ * strips the import attribute, and `hook-runner.mjs` was then evaluated as a
+ * real module — dying on its unreplaced `__SOMA_CLAUDE_HOOK_EVENT_HANDLERS__`
+ * placeholder before the extension could register anything.
+ *
+ * So the install specs import FROM here, never the reverse.
+ * `test/pi-dev-extension-import-graph.test.ts` holds the line.
+ */
+
+export const CODEX_DEFAULT_HOME = ".codex";
+export const GROK_DEFAULT_HOME = ".grok";
+export const PI_DEV_DEFAULT_HOME = ".pi";
+export const ANTHROPIC_COWORK_DEFAULT_HOME = ".anthropic-cowork";
+
+export function codexProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
+  if (options.substrate !== undefined && options.substrate !== "codex") return [];
+  const home = resolve(options.homeDir ?? homedir());
+  return [join(home, CODEX_DEFAULT_HOME, "skills", "soma")].map((path) => resolve(path));
+}
+
+export function codexMemoryPrivateRoots(options: PrivateRootOptions = {}): string[] {
+  if (options.substrate !== undefined && options.substrate !== "codex") return [];
+  const home = resolve(options.homeDir ?? homedir());
+  return [join(home, CODEX_DEFAULT_HOME, "memories")].map((path) => resolve(path));
+}
+
+export function grokProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
+  if (options.substrate !== undefined && options.substrate !== "grok") return [];
+  const home = resolve(options.homeDir ?? homedir());
+  // The projected identity/context surface (Soma never writes into
+  // ~/.grok/memory/, so there is no separate memory private root).
+  return [join(home, GROK_DEFAULT_HOME, "skills", "soma")].map((path) => resolve(path));
+}
+
+export function piDevProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
+  if (options.substrate !== undefined && options.substrate !== "pi-dev") return [];
+  const home = resolve(options.homeDir ?? homedir());
+  return [
+    join(home, PI_DEV_DEFAULT_HOME, "agent", "soma"),
+    join(home, PI_DEV_DEFAULT_HOME, "agent", "skills", "soma"),
+  ];
+}
+
+export function anthropicCoworkProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
+  const homeDir = resolve(options.homeDir ?? homedir());
+  const substrateHome = resolve(options.substrateHome ?? join(homeDir, ANTHROPIC_COWORK_DEFAULT_HOME));
+  return [resolve(substrateHome, "soma"), resolve(substrateHome, "capture"), resolve(substrateHome, "skills/VSA")];
+}

--- a/src/projection-private-roots.ts
+++ b/src/projection-private-roots.ts
@@ -1,13 +1,59 @@
 import { resolve } from "node:path";
-import { allInstallSpecs, installSpecFor, isRegisteredInstallSubstrate } from "./install-spec-registry";
-import type { PrivateRootOptions } from "./install-spec";
+import {
+  anthropicCoworkProjectionPrivateRoots,
+  codexMemoryPrivateRoots,
+  codexProjectionPrivateRoots,
+  grokProjectionPrivateRoots,
+  piDevProjectionPrivateRoots,
+} from "./adapters/private-roots";
+import type { InstallSubstrate, PrivateRootOptions } from "./install-spec";
+
+type PrivateRootBuilder = (options: PrivateRootOptions) => string[];
+
+/**
+ * Deliberately NOT routed through `install-spec-registry`.
+ *
+ * This module sits on every `checkSomaPolicy` call (src/policy-audit.ts) —
+ * including the checks inside the GENERATED pi.dev extensions, which import this
+ * repo's `src/` directly through pi's jiti loader. Walking the install-spec
+ * registry pulled every adapter's *installer* into that graph, and the
+ * claude-code installer imports its hook assets with bun's
+ * `with { type: "text" }`. jiti strips that attribute, so `hook-runner.mjs` got
+ * evaluated as a real module and the extension died on its unreplaced
+ * `__SOMA_CLAUDE_HOOK_EVENT_HANDLERS__` placeholder (soma#531 follow-up).
+ *
+ * The registry keyed the lookup by substrate, so this table is keyed the same
+ * way — a `Record<InstallSubstrate, ...>`, so adding a substrate is a type error
+ * until it declares its private roots here. Order matches the registry's
+ * insertion order because callers compare these lists positionally.
+ */
+const PRIVATE_ROOT_BUILDERS: Record<
+  InstallSubstrate,
+  { projection?: PrivateRootBuilder; memory?: PrivateRootBuilder }
+> = {
+  codex: { projection: codexProjectionPrivateRoots, memory: codexMemoryPrivateRoots },
+  "pi-dev": { projection: piDevProjectionPrivateRoots },
+  "claude-code": {},
+  cursor: {},
+  grok: { projection: grokProjectionPrivateRoots },
+  "anthropic-cowork": { projection: anthropicCoworkProjectionPrivateRoots },
+};
+
+function isRegisteredPrivateRootSubstrate(value: string | undefined): value is InstallSubstrate {
+  return value !== undefined && Object.prototype.hasOwnProperty.call(PRIVATE_ROOT_BUILDERS, value);
+}
+
+function privateRootsFor(options: PrivateRootOptions, kind: "projection" | "memory"): string[] {
+  const entries = isRegisteredPrivateRootSubstrate(options.substrate)
+    ? [PRIVATE_ROOT_BUILDERS[options.substrate]]
+    : Object.values(PRIVATE_ROOT_BUILDERS);
+  return entries.flatMap((entry) => entry[kind]?.(options) ?? []).map((path) => resolve(path));
+}
 
 export function somaProjectionPrivateRoots(options: PrivateRootOptions = {}): string[] {
-  const specs = isRegisteredInstallSubstrate(options.substrate) ? [installSpecFor(options.substrate)] : allInstallSpecs();
-  return specs.flatMap((spec) => spec.privateRoots?.projection?.(options) ?? []).map((path) => resolve(path));
+  return privateRootsFor(options, "projection");
 }
 
 export function somaMemoryPrivateRoots(options: PrivateRootOptions = {}): string[] {
-  const specs = isRegisteredInstallSubstrate(options.substrate) ? [installSpecFor(options.substrate)] : allInstallSpecs();
-  return specs.flatMap((spec) => spec.privateRoots?.memory?.(options) ?? []).map((path) => resolve(path));
+  return privateRootsFor(options, "memory");
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,16 +1,14 @@
 /**
  * Single source of truth for the Soma version.
  *
- * Read from `package.json` at module load time. Every other module
- * (CLI banner, adapter projections, skill manifests) imports
- * `SOMA_VERSION` from here. Hardcoded version strings are forbidden
- * by lint convention — bump `package.json` and the rest follows.
+ * Imported statically from `package.json` so the value is inlined at bundle
+ * time. A runtime `readFileSync` of `../package.json` breaks under
+ * `bun build --compile`: inside the single-file bundle `import.meta.url`
+ * resolves to `/$bunfs/`, where no package.json exists (soma#531). Every
+ * other module (CLI banner, adapter projections, skill manifests) imports
+ * `SOMA_VERSION` from here. Hardcoded version strings stay forbidden — bump
+ * `package.json` and the rest follows.
  */
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-import { dirname, join } from "node:path";
+import packageJson from "../package.json";
 
-const here = dirname(fileURLToPath(import.meta.url));
-const pkg = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf8")) as { version: string };
-
-export const SOMA_VERSION: string = pkg.version;
+export const SOMA_VERSION: string = (packageJson as { version: string }).version;

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1,13 +1,13 @@
-import { mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { isAbsolute, join, resolve } from "node:path";
 import { hostname, tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
 import { expect, test } from "bun:test";
 import { bootstrapSomaHome, experimentalAnthropicCowork, installSomaForClaudeCode, installSomaForCodex, installSomaForCursor, installSomaForPiDev, planSomaForCodexInstall, planSomaForPiDevInstall, somaWorkRegistryPaths } from "../src/index";
 import { codexInstallSpec } from "../src/adapters/codex/install";
 import { ANTHROPIC_COWORK_ACTIVE_VSA_MARKER, isAnthropicCoworkSkillProjectionPath } from "../src/adapters/anthropic-cowork";
 import { removeLegacyPiDevVsaSkillProjection } from "../src/adapters/pi-dev/skill-projection";
-import { renderStartupContextSummary } from "../src/adapters/codex/hooks/codex-hook-entry.mjs";
 import {
   SOMA_MEMORY_CATEGORIES,
   SOMA_PAI_BOUND_MEMORY_CATEGORIES,
@@ -28,9 +28,22 @@ const {
 // maintainability finding).
 const SOMA_CANONICAL_MEMORY_DIRS = SOMA_MEMORY_CATEGORIES;
 const SOMA_PAI_BOUND_MEMORY_DIRS = SOMA_PAI_BOUND_MEMORY_CATEGORIES;
+// codex-hook-entry.mjs wird von hooks/assets.ts als Text eingebettet, damit die
+// kompilierte Binary projizieren kann (soma#531). Ein zusaetzlicher Modul-Import
+// desselben Pfades kollidiert in bun's Modulregistry — der Text-Import gewinnt und
+// das Modul haette keine benannten Exporte. Darum aus einer Kopie laden: gleiche
+// Bytes, anderer aufgeloester Pfad. Testet zudem genau das, was ausgeliefert wird.
+const hookEntryDir = await mkdtemp(join(tmpdir(), "soma-hook-entry-"));
+for (const asset of ["codex-hook-entry.mjs", "codex-policy-hook.mjs", "codex-policy-targets.mjs", "policy-marker.mjs"]) {
+  await copyFile(new URL(`../src/adapters/codex/hooks/${asset}`, import.meta.url), join(hookEntryDir, asset));
+}
+const { renderStartupContextSummary } = (await import(
+  pathToFileURL(join(hookEntryDir, "codex-hook-entry.mjs")).href
+)) as { renderStartupContextSummary: (context: string | undefined) => string };
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-install-"));
+
 
   try {
     return await fn(homeDir);

--- a/test/pi-dev-extension-import-graph.test.ts
+++ b/test/pi-dev-extension-import-graph.test.ts
@@ -1,0 +1,186 @@
+import { readFileSync, statSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "bun:test";
+import { projectPiDevHome } from "../src/index";
+import { portableProjectionInput } from "./fixtures";
+
+/**
+ * Drift guard for the pi.dev extension import graph (soma#531 follow-up).
+ *
+ * The generated `~/.pi/agent/extensions/*.ts` modules import this repo's `src/`
+ * through `file://` URLs, and pi loads them with **jiti** — not bun. jiti (like
+ * node) honours only `type: "json"` import attributes and silently STRIPS the
+ * rest. So a bun-only `import x from "./y.mjs" with { type: "text" }` anywhere
+ * in the reachable graph does not fail at the import: the target is evaluated as
+ * a real ES module. That is exactly how `soma install claude-code`'s hook-asset
+ * inlining broke every pi session with
+ *
+ *     Failed to load extension: __SOMA_CLAUDE_HOOK_EVENT_HANDLERS__ is not defined
+ *
+ * (`hook-runner.mjs` evaluated as a module, hitting its unreplaced projection
+ * placeholder). Nothing in the graph pointed at claude-code deliberately — a
+ * `checkSomaPolicy` call reached `install-spec-registry`, which eagerly imports
+ * every adapter's installer.
+ *
+ * The fix was `src/adapters/private-roots.ts` + `src/projection-private-roots.ts`;
+ * this test is what stops the graph from re-acquiring the syntax by accident.
+ */
+
+const REPO_ROOT = resolve(import.meta.dir, "..");
+
+/**
+ * An import statement carrying any attribute other than `type: "json"` — json is
+ * the one form both bun and jiti/node implement. Covers the legacy `assert`
+ * spelling too. Applied to comment-stripped source, because the modules that
+ * document this hazard quote the syntax in prose.
+ */
+const NON_PORTABLE_IMPORT_ATTRIBUTE =
+  /\bimport\b[^;]*?\b(?:with|assert)\s*\{\s*type\s*:\s*["'](?!json["'])([^"']+)["']/gu;
+
+/** `from "<specifier>"` plus bare side-effect `import "<specifier>"`. */
+const IMPORT_SPECIFIER = /(?:\bfrom\s*|\bimport\s*)["']([^"']+)["']/gu;
+
+/**
+ * Good enough for the attribute scan: block + line comments, no string
+ * awareness. `//` preceded by `:` is left alone so the generated extensions'
+ * `file://` specifiers survive.
+ */
+function stripComments(source: string): string {
+  return source.replaceAll(/\/\*[\s\S]*?\*\//gu, "").replaceAll(/(^|[^:])\/\/[^\n]*/gmu, "$1");
+}
+
+/** Extension-less TS imports are the house style, so resolution has to guess. */
+const RESOLUTION_SUFFIXES = ["", ".ts", ".mts", ".mjs", ".js", "/index.ts", "/index.mjs", "/index.js"];
+
+function resolveModule(specifier: string, importerPath: string): string | undefined {
+  const base = specifier.startsWith("file://")
+    ? fileURLToPath(specifier)
+    : specifier.startsWith(".")
+      ? resolve(dirname(importerPath), specifier)
+      : undefined;
+  if (base === undefined) return undefined; // bare specifier: node:*, npm dep — not ours to walk
+  for (const suffix of RESOLUTION_SUFFIXES) {
+    const candidate = `${base}${suffix}`;
+    // `""` is tried first for specifiers that already carry an extension, but it
+    // also matches a same-named DIRECTORY (`./tools` next to `tools/`) — hence
+    // the isFile check rather than a bare existsSync.
+    if (isFile(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+function isFile(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function matchAll(source: string, pattern: RegExp): RegExpExecArray[] {
+  const matches: RegExpExecArray[] = [];
+  const scanner = new RegExp(pattern.source, pattern.flags);
+  let match = scanner.exec(source);
+  while (match !== null) {
+    matches.push(match);
+    match = scanner.exec(source);
+  }
+  return matches;
+}
+
+interface GraphWalk {
+  visited: Set<string>;
+  /** Offending file -> the import chain that reached it, from the seed root. */
+  offenders: Map<string, { attribute: string; chain: string[] }>;
+}
+
+function walkImportGraph(seeds: { label: string; source: string; importerPath: string }[]): GraphWalk {
+  const visited = new Set<string>();
+  const offenders = new Map<string, { attribute: string; chain: string[] }>();
+  const queue: { path: string; source: string; chain: string[] }[] = [];
+
+  for (const seed of seeds) {
+    for (const match of matchAll(seed.source, IMPORT_SPECIFIER)) {
+      const resolved = resolveModule(match[1] ?? "", seed.importerPath);
+      if (resolved !== undefined && !visited.has(resolved)) {
+        visited.add(resolved);
+        queue.push({ path: resolved, source: readFileSync(resolved, "utf8"), chain: [seed.label] });
+      }
+    }
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (current === undefined) break;
+    const chain = [...current.chain, relative(REPO_ROOT, current.path)];
+
+    const attribute = matchAll(stripComments(current.source), NON_PORTABLE_IMPORT_ATTRIBUTE)[0]?.[1];
+    if (attribute !== undefined) offenders.set(relative(REPO_ROOT, current.path), { attribute, chain });
+
+    for (const match of matchAll(current.source, IMPORT_SPECIFIER)) {
+      const resolved = resolveModule(match[1] ?? "", current.path);
+      if (resolved === undefined || visited.has(resolved)) continue;
+      visited.add(resolved);
+      queue.push({ path: resolved, source: readFileSync(resolved, "utf8"), chain });
+    }
+  }
+
+  return { visited, offenders };
+}
+
+function generatedExtensionSeeds(): { label: string; source: string; importerPath: string }[] {
+  const bundle = projectPiDevHome(portableProjectionInput, "/tmp/soma-home-import-graph");
+  const extensions = bundle.files.filter((file) => /^agent\/extensions\/.+\.ts$/u.test(file.path));
+  // The generated modules address the repo by absolute `file://` URL, so the
+  // importer path is irrelevant for them — but keep it honest anyway.
+  return extensions.map((file) => ({ label: file.path, source: file.content, importerPath: REPO_ROOT }));
+}
+
+test("the generated pi.dev extensions reach at least one real Soma module", () => {
+  const seeds = generatedExtensionSeeds();
+  expect(seeds.length).toBeGreaterThan(0);
+
+  const { visited } = walkImportGraph(seeds);
+
+  // Vacuity guard: a walk that resolves nothing would pass the real assertion
+  // below for the wrong reason.
+  expect(visited.size).toBeGreaterThan(10);
+  expect([...visited].map((path) => relative(REPO_ROOT, path))).toContain("src/policy-audit.ts");
+});
+
+test("no module reachable from a generated pi.dev extension uses a bun-only import attribute", () => {
+  const { offenders } = walkImportGraph(generatedExtensionSeeds());
+
+  const report = [...offenders.entries()].map(
+    ([path, { attribute, chain }]) => `${path} uses \`type: "${attribute}"\` — reached via ${chain.join(" -> ")}`,
+  );
+
+  expect(report).toEqual([]);
+});
+
+test("the detector still fires on the import that actually broke pi", () => {
+  // Negative control. `install-spec-registry` eagerly imports every adapter's
+  // installer, which is how a policy check used to reach the claude-code hook
+  // assets. Seeding the walk there must still produce a finding — otherwise the
+  // assertion above would be passing because the detector went blind, not
+  // because the graph is clean.
+  const seed = {
+    label: "<synthetic>",
+    source: `import "file://${REPO_ROOT}/src/install-spec-registry.ts";`,
+    importerPath: REPO_ROOT,
+  };
+
+  const { offenders } = walkImportGraph([seed]);
+
+  expect([...offenders.keys()]).toContain("src/adapters/claude-code/hooks.ts");
+  expect(offenders.get("src/adapters/claude-code/hooks.ts")?.attribute).toBe("text");
+});
+
+test("the claude-code hook assets stay OUT of the pi.dev extension graph", () => {
+  // The specific regression: hook-runner.mjs must never be evaluated by jiti.
+  const reachable = [...walkImportGraph(generatedExtensionSeeds()).visited].map((path) => relative(REPO_ROOT, path));
+
+  expect(reachable).not.toContain("src/adapters/claude-code/hooks.ts");
+  expect(reachable).not.toContain("src/adapters/claude-code/hook-runner.mjs");
+});

--- a/test/policy.test.ts
+++ b/test/policy.test.ts
@@ -1,11 +1,24 @@
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
 import { expect, test } from "bun:test";
 import { bootstrapSomaHome, checkSomaPolicy, evaluateSomaPolicy, somaMemoryEventsPath } from "../src/index";
 import { somaPolicyPrivateMarkers } from "../src/policy";
 import { hasSomaPolicyPrivateMarker as hasSomaPolicyPrivateMarkerTs, renderPolicyMarkerMjs } from "../src/policy-marker";
-import { hasSomaPolicyPrivateMarker as hasSomaPolicyPrivateMarkerJs } from "../src/adapters/codex/hooks/policy-marker.mjs";
+
+// policy-marker.mjs wird von hooks/assets.ts als Text eingebettet, damit die
+// kompilierte Binary projizieren kann (soma#531). Derselbe Pfad zusaetzlich als
+// Modul importiert kollidiert in bun's Modulregistry, darum aus einer Kopie laden:
+// gleiche Bytes, anderer aufgeloester Pfad.
+const policyMarkerDir = await mkdtemp(join(tmpdir(), "soma-policy-marker-"));
+await copyFile(
+  new URL("../src/adapters/codex/hooks/policy-marker.mjs", import.meta.url),
+  join(policyMarkerDir, "policy-marker.mjs"),
+);
+const { hasSomaPolicyPrivateMarker: hasSomaPolicyPrivateMarkerJs } = (await import(
+  pathToFileURL(join(policyMarkerDir, "policy-marker.mjs")).href
+)) as { hasSomaPolicyPrivateMarker: (content: string | undefined, marker: string) => boolean };
 
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-policy-"));


### PR DESCRIPTION
Closes #531.

Four commits. The first two give **codex and claude-code** a working `--apply` path from a `bun --compile` binary; the third repairs the collateral damage the second one caused to pi; the fourth is a review follow-up.

## Scope, precisely

**`soma install codex --apply` and `soma install claude-code --apply` work from a compiled binary. `soma install grok --apply` still does not** — it remains on the runtime read and fails with ENOENT under `/$bunfs`. That exclusion is deliberate and commented in `src/adapters/grok/hooks/assets.ts`: `grok-hook-verbs.mjs` is dual-use — `../adapter.ts` imports it as a real module for `GROK_PRE_TOOL_USE_VERB` *and* it ships verbatim to the user's machine. Bun resolves a specifier once, so a text import of the same path strips the named exports and breaks module load for anything that loads soma, hooks included. Untangling that means moving the verb constant into a `.ts` module both sides can source from — not a drive-by.

This still closes #531, whose Ask names `soma install codex` on no-terminal participant Macs (c-005 pilot). claude-code came along for free. Grok was never in scope.

## Why these ship together

`a5285e6` switched the codex + claude-code hook assets to `with { type: "text" }` so bun inlines them at bundle time — without it a compiled binary resolves `import.meta.url` to `/$bunfs/root` and dies with ENOENT before writing a single file.

That change also broke every pi session:

```
Failed to load extension "~/.pi/agent/extensions/soma-algorithm.ts":
__SOMA_CLAUDE_HOOK_EVENT_HANDLERS__ is not defined
```

pi loads extensions through **jiti**, not bun. jiti — like node — honours only `type: "json"` import attributes and silently **strips** the rest, so the target gets evaluated as a real ES module. `hook-runner.mjs` then died on its unreplaced projection placeholder before the extension could register anything.

Merging the two halves separately would put a knowingly-broken state on `main` in between, so they are one PR.

## How claude-code ended up in pi's import graph

Nothing pointed at it deliberately. The generated pi extension calls `checkSomaPolicy`, and the chain ran:

```
agent/extensions/soma-algorithm.ts
  -> src/policy-audit.ts
  -> src/projection-private-roots.ts
  -> src/install-spec-registry.ts     <- eagerly imports EVERY adapter's installer
  -> src/adapters/claude-code/install.ts
  -> src/adapters/claude-code/hooks.ts   <- with { type: "text" }
```

A policy check was pulling in six installers to read a `privateRoots` field that four of them define.

## The fix

Break the chain rather than revert the text imports, so the compiled-binary path stays intact.

- **`src/adapters/private-roots.ts`** (new) — leaf module owning the four substrate default homes and all five private-root builders. Imports only `node:*` and two types. Install specs import *from* it, never the reverse.
- **`src/projection-private-roots.ts`** — a `Record<InstallSubstrate, ...>` table instead of a registry walk. Keyed by substrate so a new substrate is a type error until it declares its roots; registry order preserved because callers compare positionally.
- **`test/pi-dev-extension-import-graph.test.ts`** (new) — walks the real generated extension import graph for any non-`json` import attribute. Includes a vacuity guard and a **negative control** seeded at `install-spec-registry` that must still flag `hooks.ts` — so the assertion cannot pass by going blind.

## Verification

- **jiti probe** (the exact call pi makes, `jiti.import(path, { default: true })`) on `~/.pi/agent/extensions/soma-algorithm.ts`: `FAILED __SOMA_CLAUDE_HOOK_EVENT_HANDLERS__ is not defined` → `OK`.
- **Differential probe** of the new private-roots table against a verbatim copy of the pre-fix registry walk: equivalent across 9 option shapes (default, `homeDir`, each of the 6 substrates, and an unregistered string). This caught a real diff — `anthropic-cowork` declared its builder inline with no substrate self-filter, so a naive extraction changed behaviour in 4 of those cases.
- **Compiled binary** writes the full codex projection — hooks, `hooks.json`, `config.toml`, `memories/soma/*`, rules, `AGENTS.md` — with the `.mjs` assets intact.
- `bun run typecheck` clean; `bun test` **2378 pass / 0 fail**; the touched files lint clean (the pre-existing `src/` lint errors are unchanged).

## Not covered

An actual interactive `pi` startup was not verified from the authoring session — the non-interactive probe blocked on a provider. The jiti probe exercises the identical loader call, so the defect is addressed, but a real pi start is the last mile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)