### PR TITLE
chore(release): 0.15.0 — the work graph release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+
+### Fixed
+
+## [0.15.0] - 2026-08-11
+
+The **work graph** release: a typed primitive for planning work that outlives a
+single agent session, walked with `soma graph` verbs, closed only through
+checkpoint gates that refuse a hollow close. Built and dogfooded on its own map
+(#495) from first spec to close — every decision below was resolved as a node on
+the graph it describes.
+
+### Added
+- **The work graph primitive, its verbs, and its trust gate (#484, #499, DD-16).**
+  Nodes of work joined by two relations — *membership* (a node belongs to a map)
+  and *blocking* (a node gates another) — with a typed `GraphStore` seam and a
+  GitHub backend where the tracker is the sole authoritative store. Five verbs:
+
+  ```bash
+  soma graph frontier <root>    # open, unassigned, unblocked nodes in the subtree
+  soma graph node <id>          # the node's state and body
+  soma graph claim <id>         # take it
+  soma graph add <root> …       # attach a node, --checkpoint required
+  soma graph close <id> …       # the gate: probes, prose, receipt
+  ```
+
+  A node carries an `autonomy` class (`auto` / `propose` / `approve`), an
+  uninterpreted `kind`, a checkpoint, and — for anything machine-closable —
+  probes. `assertClosable` is the hollow-close refusal: a node closes only
+  through its checkpoint, and an `auto` node with zero probes is unconstructible
+  rather than merely discouraged.
+
+- **`soma graph audit <root>` (#597)** reports what the gates structurally cannot
+  see: nodes closed with no receipt (the tracker closed them; no gate ran), open
+  nodes with no checkpoint (they can never close), and open-and-claimed nodes.
+  Read-only by design — an auditor that reopened nodes would be a second writer
+  with its own race.
+
+- **`soma graph decisions <root>` (#597)** collects the resolution prose of a
+  map's closed nodes into one document, so a finished map reads as a record
+  rather than as a list of closed tickets.
+
+- **Probe types and the registry gate (DD-16 Amendment A, #524, #526).** Probes
+  are `command`, `url`, `git-ref-exists`, `git-merged-into`, and
+  `artifact-exists`. Tracker content may *parameterise* a probe but may never
+  introduce executable code or a network destination: a `command` probe is
+  refused unless the exact `run` **and** `cwd` pair is declared in
+  `~/.soma/policy/probe-registry.json`, and a `url` probe unless its host is.
+  Inspect with `soma policy probes`; adding an entry is a loosening mutation and
+  stays the adopter's hand — Soma ships no verb that writes it.
+
+- **Close receipts with derived attestation (#502).** Every close posts a
+  receipt naming the checkpoint, the probes and what they observed, the probe
+  trees with their HEAD and dirty state, and an `attestation` of `verified` or
+  `unverified` **derived from authorship and reachable credentials**, never
+  declared. An unverified receipt lists its reasons rather than failing quietly.
+
+- **The `orienteer` skill**, bundled and projected with the primitive rather
+  than after it: doctrine for charting a map of decision nodes for work too big
+  for one session, and walking its frontier one node at a time.
+
+- **`planSteps` ↔ node bridge (#501).** An `AlgorithmPlanStep` may carry an
+  optional `nodeId`; a bridged step's `status` is then a cache of the node's
+  reported state, re-derived through `GraphStore.readNode` rather than authored
+  by the caller.
+
+- **Progressive skill loading on the adapter spec (#542).** `skillsLoading`
+  declares a substrate's loading mode as an install fact; eager substrates get
+  stubs, and Pi.dev gains a `skill_body` promotion action. `soma doctor` now
+  detects skill stubs whose body no longer resolves.
+
+- **`bun run measure-graph-read-path`** counts and times every backend call a
+  graph verb makes.
+
+- **[docs/pai-to-soma-untangling-runbook.md](docs/pai-to-soma-untangling-runbook.md) (#470)** —
+  reference runbook for untangling a live PAI install into Soma.
+
+### Changed
 - **BREAKING — `GraphStore.listCandidateFrontier` is replaced by `readSubtree` (#576).**
   The seam returned candidate `NodeRef`s that `WorkGraph.frontier` then re-fetched one
   by one; it now returns `NodeState[]` for the root's whole membership subtree, already
@@ -31,7 +108,76 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was written for a discovery step assumed to be a lagging search index, and where
   discovery already reads the authoritative store, that read confirms.
 
+- **The frontier walks the whole subtree, at any depth (#564).** It was one level
+  deep, so scaffold nodes attached below their spawning ticket were invisible —
+  and because scaffold outlives its parent by construction, the invisible case was
+  the normal one. Discovery is nested GraphQL `subIssues` with re-rooting on
+  truncation; recursive REST would have scaled with a map's *closed* history,
+  making a map slower as it succeeded. Depth now records provenance and nothing
+  else: gating is what a blocking edge means.
+
+- **Every close carries prose (#588).** `--resolution-file` is required on an
+  `auto` close and on a bare HITL close, exempt only when `--proposal-comment`
+  names a proposal whose body already is the prose. It is folded into the receipt
+  comment, so no ordering exists in which one half lands without the other.
+  Documented as a **forcing function, not evidence** — no machine can check that
+  the prose says anything.
+
+- **The close has an operational envelope (#592).** `observed` output is bounded
+  by outcome (200 chars on pass, 1 200 on fail); a **runtime** 15-minute deadline
+  clamps a close and records unrun probes as failed rather than skipped; and an
+  oversized receipt is refused *before* any probe runs, counting the resolution
+  prose, since GitHub caps a comment at 65 536 characters and the receipt posts
+  after the expensive part.
+
+- **A HITL node closes on the session's say-so (#549).** Ratification is a label
+  on the receipt, not a gate: a node whose autonomy class puts a human in the loop
+  closes when that human closes it. A ratification is a **reaction** on a proposal
+  comment — a deliberate, unambiguous gesture — never inferred from prose.
+
+- **Labels are a write-only human index for a map (#532).** Topology comes from
+  native edges and `kind` from the node block; labels exist because a tracker list
+  view is unreadable without them. The runtime never interprets one.
+
+- **`soma graph add` refuses without `--checkpoint` (#597),** and `soma graph node`
+  prints the node body — the most frequent read in a walk was the one operation
+  with no verb.
+
+- **Skill loading mode belongs to the install spec, not skill frontmatter (#542).**
+
 ### Fixed
+- **Probes ran in whatever directory the close was invoked from (#579, #580).**
+  The probe directory was ambient, unstated and unprinted, so a wrapper with a
+  `cd` silently fixed every session's probes to the install tree. The close now
+  resolves **one** base directory and passes it to both the runner and the
+  registry match — `ProbeRunnerOptions.cwd` is required, so an ambient probe
+  directory is no longer expressible — and the receipt records every tree the
+  probes actually resolved to, with HEAD and dirty state. Dirty is **recorded,
+  never refused**. Named plainly as detection, not prevention.
+
+- **The ungated probes escaped the stated tree (#529, #582).** `artifact-exists`
+  resolves its `path` against the cwd, so an absolute path escaped with no `repo`
+  field at all — verified live, where `path: "/etc/passwd"` passed and echoed into
+  a world-readable receipt. Containment is now one predicate before dispatch: the
+  *resolved* absolute path must be the stated tree or a descendant, by a
+  separator-aware prefix test. Lexical, not `realpath` — a symlink inside the tree
+  pointing out still escapes, and that is written down rather than implied away.
+
+- **The confidentiality gate's generated header claimed it could not block a
+  merge (#560).** It could: `decideExit` returns 1 on any block-class finding
+  under `set -e`, and with the check required by a ruleset a finding does block.
+  The header now states only what the file controls and points at the ruleset,
+  instead of asserting a deployment fact from inside a generated source file.
+
+- **PAI naming leaked into projected artifacts (#577 and follow-ups).** The
+  Algorithm's shipped references, the bundled-skill pointers missed by the #329
+  ISA→VSA rename, and the importer's emitted names all still said PAI; the residue
+  guard missed the bare form. The `the-algorithm` skill now ships a closed,
+  executable reference set.
+
+- **Standalone-binary hook assets no longer break Pi.dev (#531).**
+
+- **The Codex work-registry lock wait is bounded (#583).**
 
 ## [0.14.1] - 2026-08-02
 

--- a/README.md
+++ b/README.md
@@ -347,6 +347,46 @@ already date-prefixed. Use the slug printed by the scaffold command for
 For parallel feature work, Soma can reconcile feature VSAs back into a master
 VSA by stable criterion IDs. See [docs/vsa-reconcile.md](docs/vsa-reconcile.md).
 
+### The work graph
+
+Some work is too big for one agent session and too foggy to plan in one sitting.
+The **work graph** is Soma's typed primitive for that case: nodes of work joined
+by *membership* (a node belongs to a map) and *blocking* (a node gates another),
+walked one node at a time, closed only through a checkpoint gate.
+
+```bash
+soma graph frontier <root>   # open, unassigned, unblocked nodes — anywhere in the subtree
+soma graph node <id>         # its state and body
+soma graph claim <id>        # take it
+soma graph add <root> --title "…" --autonomy approve --checkpoint <id>
+soma graph close <id> --resolution-file <path>
+soma graph audit <root>      # what the gates cannot see
+soma graph decisions <root>  # the map's resolutions, collected
+```
+
+The store is a seam; the shipping backend is your GitHub issue tracker, which
+stays the sole authoritative record — Soma keeps no parallel copy of the graph.
+
+**A node closes only through its gate.** Each carries an autonomy class
+(`auto` / `propose` / `approve`), a checkpoint, and — for anything machine-closable
+— probes: `command`, `url`, `git-ref-exists`, `git-merged-into`, `artifact-exists`.
+An `auto` node with zero probes cannot be constructed. The close runs the probes,
+requires human-readable prose, and posts a **receipt** naming the checkpoint, what
+each probe observed, the tree it ran in with its HEAD and dirty state, and an
+attestation of `verified` or `unverified` derived from authorship and reachable
+credentials rather than declared. An unverified receipt lists its reasons.
+
+Because tracker content is untrusted input, a `command` probe runs only if its
+exact command and directory are declared in your Soma home:
+
+```bash
+soma policy probes           # read the registry; Soma ships no verb that writes it
+```
+
+The **orienteer** skill is the doctrine for using this: chart a loose idea as a map
+of decision nodes, then resolve them one at a time until the route is clear.
+See [docs/work-graph.md](docs/work-graph.md) for the spec.
+
 ### Skills
 
 Skills are portable capability folders. A skill can include `SKILL.md`,
@@ -529,6 +569,11 @@ heuristic — across all 5 install substrates (codex, claude-code, cursor, grok,
 pi-dev), catching hand-edited, stale, or missing projection files with
 CI-friendly exit codes (0 clean, 1 drift, 2 error).
 
+The work graph is phase 1: the primitive, its verbs, and its close gates are on
+`main` and were dogfooded on their own map from spec to close. Phase 2 — a
+scheduled unattended tick that walks a frontier without a human present — is
+specified and deliberately unbuilt.
+
 Daemon mode and deeper Cortex/Myelin integration come after the file format,
 writeback gates, and adapter behavior are stable.
 
@@ -563,6 +608,7 @@ writeback boundaries as substrate sessions. See
 - [docs/home-replication.md](docs/home-replication.md), cross-machine Soma home replication
 - [docs/team-overlays.md](docs/team-overlays.md), read-only team overlays and shared-state boundaries
 - [docs/daemon-mode.md](docs/daemon-mode.md), daemon mode ownership and Myelin contract boundaries
+- [docs/work-graph.md](docs/work-graph.md), the work graph spec — node vocabulary, close gates, probes, and receipts
 - [docs/writeback-and-policy.md](docs/writeback-and-policy.md), projection, writeback, conflict, and policy semantics
 - [docs/portability-proof.md](docs/portability-proof.md), the first portability proof and evidence contract
 

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,6 +1,6 @@
 schema: arc/v1
 name: soma
-version: 0.14.1
+version: 0.15.0
 type: tool
 tier: community
 description: Substrate-portable Personal AI Assistant core for identity, memory, VSA, skills, learning, and adapters.

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -1,7 +1,14 @@
 # Work graph — typed contracts and execution story
 
-**Status:** Phase 1 implemented and on `main` (§2-§4, via map #495); §5 phase 2 unbuilt. Locked by DD-16, wayfinder map #477
-**Date:** 2026-08-02
+**Status:** Phase 1 implemented, on `main`, and released in 0.15.0 (§2-§4). Map #495 closed 2026-08-11 through this spec's own gate — 27 nodes, receipt `unverified`. §5 phase 2 remains unbuilt. Locked by DD-16, wayfinder map #477
+**Date:** 2026-08-02, status refreshed 2026-08-11
+
+One destination clause of #495 did **not** land and is tracked rather than
+assumed: HITL receipts still read `unverified`, because a closing session
+reaches the principal's credential even though a distinct machine account
+exists (#511). Two decisions graduated out of the map on its close — what
+reconciles a node the tracker closed with no gate (#600), and what closes the
+gap between a merged conjunct and an enforcing install (#601).
 
 The **work graph** is Soma's typed primitive for cross-session effort
 topology: nodes of work joined by blocking edges, walked by agent sessions,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soma",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "private": true,
   "type": "module",
   "description": "Substrate-portable Personal AI Assistant core.",


### PR DESCRIPTION
Release PR for **0.15.0** — the work graph release.

The primitive has been on `main` since #499 and was dogfooded on its own map (#495) from first spec to close. This ships it under a version and, more to the point, **documents it where an adopter can find it** — the README had zero mentions of the work graph, `soma graph`, or orienteer.

## What changed

**README** gains a `### The work graph` section under *Portable tools*: the five verbs plus `audit`/`decisions`, the close gate and autonomy classes, the probe types, the registry that keeps tracker content from becoming executable code, receipts with derived attestation, and the orienteer skill. Also linked from *Documentation* and referenced in *Status* (phase 1 shipped, phase 2 specified and deliberately unbuilt).

**docs/work-graph.md** status refreshed — map #495 closed 2026-08-11 through this spec's own gate, 27 nodes. Two things stated rather than assumed: the destination clause that did **not** land (HITL receipts still read `unverified`, because a closing session reaches the principal's credential even with a distinct machine account — #511), and the two decisions that graduated out of the map on close (#600, #601).

**CHANGELOG** — 28 commits since `v0.14.1`, of which exactly one (#576) had been recorded. Now grouped into Added / Changed / Fixed with the breaking `GraphStore` seam change kept at the top of *Changed*.

**Version** bumped in both places the suite checks: `package.json` and `arc-manifest.yaml`. The `arc manifest version matches package.json` test is what catches a half-bump — it caught this one.

## Verification

- `bun test` → **2388 pass / 0 fail** (151 files)
- `bunx tsc --noEmit` → clean
- Bump verified with a repo-wide search for the old version: no `0.14.1` stragglers outside `CHANGELOG.md`.

No source changes — markdown, `package.json`, and `arc-manifest.yaml` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
