### PR TITLE
docs(orienteer): give the map a home for a constraint, and make charting ask (#617)

### DIFF
--- a/src/skills/orienteer/SKILL.md
+++ b/src/skills/orienteer/SKILL.md
@@ -103,7 +103,7 @@ Load only what the task routes to.
 | `Workflows/WalkTheMap.md` | Resolving a node on an existing map |
 | `references/map.md` | Writing the map body, or creating a node — anatomy, constraints, `autonomy` vs `kind`, the four work kinds |
 | `references/closing.md` | Closing a node — checkpoints, probes, the probe registry, AFK vs HITL receipts, attestation |
-| `references/fog.md` | Deciding whether something is fog, a node, or out of scope |
+| `references/fog.md` | Deciding whether something is fog, a node, or out of scope — or a constraint instead (`map.md`) |
 
 ## Lineage
 

--- a/src/skills/orienteer/SKILL.md
+++ b/src/skills/orienteer/SKILL.md
@@ -101,7 +101,7 @@ Load only what the task routes to.
 | --- | --- |
 | `Workflows/ChartTheMap.md` | Charting a new map from a loose idea |
 | `Workflows/WalkTheMap.md` | Resolving a node on an existing map |
-| `references/map.md` | Writing the map body, or creating a node — anatomy, `autonomy` vs `kind`, the four work kinds |
+| `references/map.md` | Writing the map body, or creating a node — anatomy, constraints, `autonomy` vs `kind`, the four work kinds |
 | `references/closing.md` | Closing a node — checkpoints, probes, the probe registry, AFK vs HITL receipts, attestation |
 | `references/fog.md` | Deciding whether something is fog, a node, or out of scope |
 

--- a/src/skills/orienteer/Workflows/ChartTheMap.md
+++ b/src/skills/orienteer/Workflows/ChartTheMap.md
@@ -3,7 +3,7 @@
 The user arrived with a loose idea. Charting is **one session's work and it
 hand-resolves nothing** — you end with a map and its first nodes, not answers.
 
-## 1. Name the destination
+## 1. Name the destination, and what constrains the way there
 
 Run a `/grilling` and `/domain-modeling` session to pin down what this map is
 finding its way to — the spec, decision, or change. One or two lines that a
@@ -11,6 +11,36 @@ later session can orient to before choosing a node.
 
 The destination fixes the scope, so it is settled first: everything past it is
 out of scope, and everything short of it is either charted or fog.
+
+Then ask what is **fixed regardless of route** — budget, time, tooling that
+cannot change, things that must not break, capabilities not available. This pass
+is easy to skip, because nobody volunteers a constraint they think is obvious;
+it is not obvious to the map. And a constraint that surfaces late is expensive:
+the decisions it invalidates were charted, worked, and closed against options
+that were never on the table. What to do with those closed decisions is an open
+question with no verb behind it — which is why eliciting the constraint now is
+the cheap half.
+
+**Seed it from the principal's own store, then confirm.** A principal's recorded
+purpose and constraints routinely encode exactly this class of fact — capacity,
+budget, time, non-negotiables — and reading them costs less than waiting to be
+told:
+
+```bash
+soma memory recall "budget capacity constraint deadline"   # read-only
+```
+
+`~/.soma/profile/purpose.md` carries the same class under Commitments. Where
+there is no Soma home — orienteer runs in any repository — this pass is simply
+the question, asked.
+
+**Propose what you find; never assume it.** A constraint read out of a store is a
+candidate, not a fact about this effort: put it to the human and let them
+confirm, amend, or drop it. Silently assuming one is worse than never eliciting
+it, because the map then carries a predicate on every answer that nobody agreed
+to.
+
+What survives goes in the map's **Constraints** section (`references/map.md`).
 
 ## 2. Map the frontier
 
@@ -24,14 +54,16 @@ the user how they'd like to proceed.
 
 ## 3. Create the map
 
-The map is the root node: an issue whose body carries Destination and Notes
-filled in, Decisions-so-far empty, and the fog sketched into **Not yet
+The map is the root node: an issue whose body carries Destination, Constraints,
+and Notes filled in, Decisions-so-far empty, and the fog sketched into **Not yet
 specified**. The body template is in `references/map.md`. Label it
 `orienteer:map` — that label is how anyone finds this map again.
 
 Put in **Notes** what every later session needs before choosing a node: the
 domain, the skills to consult, standing preferences, and any override of the
-plan-don't-do default.
+plan-don't-do default. Notes orient the session; anything an *answer* could
+violate is a constraint, and belongs in Constraints where a later session will
+check its options against it.
 
 ## 4. Create the nodes you can specify now
 

--- a/src/skills/orienteer/Workflows/ChartTheMap.md
+++ b/src/skills/orienteer/Workflows/ChartTheMap.md
@@ -30,6 +30,12 @@ told:
 soma memory recall "budget capacity constraint deadline"   # read-only
 ```
 
+Vary the query to the effort — that one is a starting point, and whole-file term
+scoring returns near-misses beside the hits. Every result carries a verification
+banner with an age on it: **respect it**. A note records what was true when it
+was written, and a stale one proposed as a live constraint puts a predicate on
+every answer that may no longer hold.
+
 `~/.soma/profile/purpose.md` carries the same class under Commitments. Where
 there is no Soma home — orienteer runs in any repository — this pass is simply
 the question, asked.
@@ -39,6 +45,14 @@ candidate, not a fact about this effort: put it to the human and let them
 confirm, amend, or drop it. Silently assuming one is worse than never eliciting
 it, because the map then carries a predicate on every answer that nobody agreed
 to.
+
+**Propose the constraint, never the source.** That store holds a principal's
+private material — health, finances, relationships, whatever they have recorded
+— and a map body is an issue on a tracker, as public as the repository holding
+it. So translate before you ask: put *"no budget for paid services"* to the
+human, not the note you read it in, and never paste recall output into the map.
+They are confirming a constraint on this effort, not approving a disclosure, and
+should not have to catch one on your behalf.
 
 What survives goes in the map's **Constraints** section (`references/map.md`).
 

--- a/src/skills/orienteer/Workflows/WalkTheMap.md
+++ b/src/skills/orienteer/Workflows/WalkTheMap.md
@@ -12,9 +12,15 @@ graph concurrently.
 soma graph node <root>
 ```
 
-Read its body: Destination, Notes, Decisions so far, Not yet specified, Out of
-scope. This is the low-resolution view — do **not** load every child. Orient to
-the destination before choosing anything, and honour whatever the Notes name.
+Read its body: Destination, Constraints, Notes, Decisions so far, Not yet
+specified, Out of scope. This is the low-resolution view — do **not** load every
+child. Orient to the destination before choosing anything, and honour whatever
+the Notes name.
+
+**Treat the Constraints as binding on the answer you are about to write**: an
+option that violates one is not on the table. Nothing checks this for you — no
+verb reads that section and the close gate does not test against it
+(`references/map.md`) — so it holds exactly as far as you read it.
 
 ## 2. Choose and claim
 
@@ -38,6 +44,12 @@ name. If in doubt, use `/grilling` and `/domain-modeling`.
 
 A HITL node (`propose` / `approve`) resolves only through live exchange with the
 human. Never stand in for their side of it.
+
+Where a constraint touches the options you are weighing, make that **dimension
+visible in them** — cost under a budget constraint, effort under a deadline — so
+the constraint is applied where the choice is offered rather than discovered
+after it. The node never restates the constraint itself: it lives on the map
+alone.
 
 If resolving this node throws off work of its own, attach that **below this
 node**, never to the map (`references/fog.md`).
@@ -72,6 +84,11 @@ resolution — do not pass both.
   destination — close it and record one line under **Out of scope**, not under
   Decisions so far.
 - **Update or delete** nodes the decision invalidated.
+- **Record a constraint the work surfaced** in the map's **Constraints**
+  section, never only in this node's resolution — a constraint buried in a
+  receipt is one no later session reads. If it invalidates decisions already
+  closed, say so plainly in your report rather than quietly working around it:
+  re-resolving them is hand work with no verb behind it yet.
 
 Then report: what closed, what it means for the frontier, and what is now
 takeable. Name things by their titles.

--- a/src/skills/orienteer/references/fog.md
+++ b/src/skills/orienteer/references/fog.md
@@ -29,6 +29,11 @@ can answer it now.
 **Not yet specified** excludes what's already decided (Decisions so far), what's
 already a live node, and what's out of scope.
 
+It also excludes what is **simply true regardless of route** — no budget, a
+deadline, a runtime that cannot change. That is a **constraint**, not fog: fog is
+a question awaiting an answer, a constraint is a predicate every answer must
+respect. It belongs in the map's Constraints section (`references/map.md`).
+
 ### Graduating a patch
 
 When a resolution sharpens a patch, create its node(s) and **clear the patch

--- a/src/skills/orienteer/references/map.md
+++ b/src/skills/orienteer/references/map.md
@@ -22,6 +22,14 @@ listed — they are open children, found by `soma graph frontier`.
 this effort is finding its way to. One or two lines; every session orients to it
 before choosing a node.>
 
+## Constraints
+
+<!-- see below: what is fixed regardless of route — every node's answer must
+     respect these -->
+
+- <one line each: budget, time, tooling that cannot change, things that must not
+  break, capabilities not available>
+
 ## Notes
 
 <domain; skills every session should consult; standing preferences for this effort>
@@ -43,6 +51,36 @@ before choosing a node.>
 <!-- see references/fog.md: work ruled beyond the destination; closed, never
      graduates -->
 ```
+
+### Constraints
+
+A constraint is what is **fixed regardless of route**: no budget, a deadline, a
+runtime that cannot change, something that must not break, a capability not
+available. It sits with the destination because the two together fix the
+effort's shape — the destination says where this is going, the constraints say
+what the way there may not cost.
+
+The test is whether an **answer could violate it**. That is what separates it
+from the four sections around it:
+
+- not **fog** — it is not a question awaiting an answer,
+- not **out of scope** — it is not past the destination,
+- not a **decision** — nobody decided it, it is simply true,
+- not a **Note** — Notes orient *the session* (the domain, the skills to
+  consult, standing preferences); a constraint is a predicate on the *answers*.
+
+Nothing enforces it. No verb reads this section, the close gate does not test an
+answer against it, and `decisions --write` does not project it. It binds the way
+the Destination binds — the agent reads it and honours it — so write constraints
+a reader can actually check an option against: "no budget for paid services" is
+checkable, "keep it cheap" is not.
+
+Constraints live on the map and **only** on the map. A node never restates one:
+a constraint amended in one place would leave stale copies in every node that
+had copied it, which is the two-authoritative-homes problem the index rule
+exists to prevent. What a node carries instead is the *dimension* — under a
+budget constraint, options come with their cost visible, so the constraint is
+applied where the choice is made rather than discovered after it.
 
 ## Nodes
 

--- a/src/skills/orienteer/references/map.md
+++ b/src/skills/orienteer/references/map.md
@@ -24,8 +24,8 @@ before choosing a node.>
 
 ## Constraints
 
-<!-- see below: what is fixed regardless of route — every node's answer must
-     respect these -->
+<!-- see references/map.md: what is fixed regardless of route — every node's
+     answer must respect these; `- none identified` when there are none -->
 
 - <one line each: budget, time, tooling that cannot change, things that must not
   break, capabilities not available>
@@ -74,6 +74,10 @@ answer against it, and `decisions --write` does not project it. It binds the way
 the Destination binds — the agent reads it and honours it — so write constraints
 a reader can actually check an option against: "no budget for paid services" is
 checkable, "keep it cheap" is not.
+
+**No constraints is a real answer**, and a common one. Write `- none identified`
+rather than leaving the placeholder standing, so a later session can tell an
+unconstrained effort from a question nobody asked.
 
 Constraints live on the map and **only** on the map. A node never restates one:
 a constraint amended in one place would leave stale copies in every node that


### PR DESCRIPTION
Closes #617.

## What happened

External feedback on 0.15.0 (Robert Chuvala): a charted map produced decisions
that assumed a budget the user did not have, and there was no way to feed the
missing parameter back in. The sharpest line in the report was *"a parameter my
agents already know"* — their agents knew; the map did not.

The map did not mishandle the constraint. It never elicited it, and had nowhere
to put it if it had: "no budget" is not fog (not a question awaiting an answer),
not out of scope (not past the destination), and not a decision (nobody decided
it) — so it lands in **Notes**, which nothing checks an answer against.

## What this changes

**`references/map.md`** — a `## Constraints` section in the body template,
sitting with Destination because the two together fix the effort's shape. The
test for what belongs there is whether an **answer could violate it**, which is
what separates it from the four sections around it. Notes orient *the session*;
a constraint is a predicate on the *answers*.

**`Workflows/ChartTheMap.md`** — step 1 now asks what is fixed regardless of
route, and seeds the question from the principal's own store rather than only
the conversation in front of it:

- `soma memory recall "budget capacity constraint deadline"` (read-only)
- `~/.soma/profile/purpose.md`, which carries this class under Commitments

Whatever it finds is **proposed for confirmation, never assumed** — a silently
assumed constraint is worse than one never elicited, because the map then
carries a predicate on every answer nobody agreed to. Where there is no Soma
home (orienteer runs in any repository) the pass degrades to the question,
asked.

**`Workflows/WalkTheMap.md`** — the map load reads Constraints and treats them as
binding on the answer being written; where a constraint touches the options,
that *dimension* is made visible in them (cost under a budget constraint) so it
applies where the choice is offered rather than after; a constraint the work
surfaces is recorded on the map, not buried in a receipt.

## Two decisions worth flagging

**It does not bind, and says so.** A Constraints section that nothing reads is
structurally identical to the Notes section it was created to escape — the
failure #602 names for anti-criteria. Rather than paper over that, `map.md`
states it outright: no verb reads the section, the close gate does not test
against it, `decisions --write` does not project it. It binds the way the
Destination binds — by being read — so the guidance is to write constraints a
reader can actually check an option against ("no budget for paid services" is
checkable, "keep it cheap" is not).

**Nodes do not inherit the constraint** (departing from #617's item 4).
Copying constraints into node bodies is the two-authoritative-homes problem the
map-as-index rule exists to prevent: amend a constraint and every copy goes
stale. Constraints live on the map and only on the map; what a node carries is
the dimension, not the text.

## Scope

Prevention only, and deliberately no runtime change: no new verb, no schema
change, no change to the close gate. The late-arriving-constraint case — what
happens to decisions already closed — stays with #618, which needs the
reopen-vs-supersede fork decided first.

## Verification

- `bun test test/install.test.ts` — 91 pass, 0 fail. No files added or removed,
  so the per-substrate projection counts (orienteer ×6) are unchanged.
- `bun run check-skill-version` — ok.
- Grepped for other places enumerating the map body sections
  (`"Destination, Notes"`, `"Destination and Notes"`): none outside the files
  changed here.

Not verified: this lands in live homes only after `soma install --apply`
reprojection — the change is to the source skill, not to any installed copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)