### PR TITLE
fix(orienteer): the map template ships the decisions markers (#621)

### DIFF
--- a/src/skills/orienteer/Workflows/WalkTheMap.md
+++ b/src/skills/orienteer/Workflows/WalkTheMap.md
@@ -67,9 +67,11 @@ refusal is easier to avoid than to fix.
    let a map reader judge relevance without opening the node; the detail stays
    in the resolution.
 2. `soma graph decisions <root> --write` — the map's decision index re-derives
-   from receipts. Never hand-edit the span between the decisions markers; if the
-   map predates them, add the two marker lines once and the verb owns the span
-   from then on.
+   from receipts. Never hand-edit the span between the decisions markers. The
+   body template carries them, so a map charted from it is writable; a map
+   charted before they were in the template — or from a hand-rolled body — has
+   none, and the verb refuses rather than guessing where the index belongs. Its
+   error prints the two lines: add them once, and it owns the span from then on.
 
 For a HITL node wanting a second opinion, the two-phase `--propose` →
 ratification → `--proposal-comment` sequence stands, and the proposal body is the

--- a/src/skills/orienteer/references/map.md
+++ b/src/skills/orienteer/references/map.md
@@ -37,9 +37,13 @@ before choosing a node.>
 ## Decisions so far
 
 <!-- the index — one line per closed node: enough to judge relevance, then zoom
-     the link for the detail the node holds -->
+     the link for the detail the node holds. `soma graph decisions --write` owns
+     the span between the markers and refuses without them: keep both lines, and
+     never hand-edit between them -->
 
+<!-- soma:decisions:begin -->
 - [<closed node title>](link) — <one-line gist of the answer>
+<!-- soma:decisions:end -->
 
 ## Not yet specified
 

--- a/test/work-graph.test.ts
+++ b/test/work-graph.test.ts
@@ -25,6 +25,7 @@ import {
   type Probe,
   type WorkGraphNode,
 } from "../src/index";
+import { readFile } from "node:fs/promises";
 import { walkFakeSubtree } from "./fixtures/work-graph-fixtures";
 
 const PASSING_PROBE: Probe = { type: "command", run: "bun test", timeoutSec: 600, expectExit: 0 };
@@ -335,6 +336,26 @@ test("spliceSection replaces only the marked span, and refuses malformed markers
   expect(spliceSection("no markers here", "x")).toBeUndefined();
   // An end marker BEFORE the begin marker is malformed, not a zero-length span.
   expect(spliceSection(`${DECISIONS_END}\n${DECISIONS_BEGIN}`, "x")).toBeUndefined();
+});
+
+// The map body template and the splice are one contract in two files: the
+// template is what a charted map is copied from, and `decisions --write`
+// refuses a body without the markers. Shipped without them (#621), every map
+// failed its first write — a defect no test could see, because each half was
+// correct alone. Assert the template against the real splice, not against a
+// copy of the marker strings.
+test("the orienteer map template is writable by spliceSection (#621)", async () => {
+  const template = await readFile(
+    new URL("../src/skills/orienteer/references/map.md", import.meta.url),
+    "utf8",
+  );
+  const spliced = spliceSection(template, "- [A closed node](link) — the gist");
+  expect(spliced).toBeDefined();
+  expect(spliced).toContain("- [A closed node](link) — the gist");
+  // The placeholder line lives inside the span, so the first write clears it.
+  expect(spliced).not.toContain("<closed node title>");
+  // …and the prose around the span is untouched.
+  expect(spliced).toContain("## Not yet specified");
 });
 
 // --- contract layer over a store -------------------------------------------


### PR DESCRIPTION
Closes #621.

## The defect

`soma graph decisions <root> --write` refused on **every** map charted from the
body template, because the template did not carry the markers the splice
requires.

- `references/map.md` — `## Decisions so far` had a prose comment and a
  placeholder line, and neither `<!-- soma:decisions:begin -->` nor its `end`.
- `src/work-graph.ts:1020` — `spliceSection` returns `undefined` without them,
  deliberately: *"the caller refuses rather than guessing where a decisions list
  belongs in prose it does not own."*
- `src/cli/graph.ts:1382` — that becomes `Map <id> has no decisions markers`.

The verb is right. The template was wrong, and it produced maps the verb could
not write to — on the first node anyone closed, on every map, since the fast
path and `WalkTheMap.md` step 4 both run `decisions --write` after every close.

It survived because the error prints the two lines to add, so each walker
hand-patched their own map and moved on: a per-map tax standing in for a
one-time template fix.

## The fix

**`references/map.md`** — both markers in `## Decisions so far`, with the
placeholder line *inside* the span so the first write clears it, and a comment
saying the verb owns that span.

**`Workflows/WalkTheMap.md`** — the old wording, *"if the map predates them, add
the two marker lines once"*, read as legacy handling for old maps when it
actually described every map, including one charted that morning. Now that the
template carries them, the sentence says what is genuinely left over: maps
charted before this, or from a hand-rolled body.

**`test/work-graph.test.ts`** — a regression guard that runs the real
`spliceSection` over the real template file, rather than asserting the marker
strings appear in it. The template and the splice are one contract living in two
files, and each half was correct in isolation — which is precisely why no
existing test could see the defect. Asserting them against each other is what
closes that gap.

## Not adopted

Injecting the markers at `soma graph add` time, floated in the issue. It would
have to append them to a body whose shape it does not know — the same guess
`spliceSection` refuses to make, and refuses for the same reason. A hand-rolled
map body stays the author's responsibility, with an actionable error when they
get it wrong.

## Verification

- `bun test test/work-graph.test.ts` — 40 pass, 0 fail, including the new guard.
  It fails by construction if the markers leave the template: `spliceSection`
  returns `undefined` and `expect(spliced).toBeDefined()` trips.
- `bun run typecheck` — clean.
- Docs-only besides the test; no file added or removed, so per-substrate
  projection counts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)