### PR TITLE
chore(release): 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.16.0] - 2026-08-15
+
+An **orienteer** release, driven by external feedback on 0.15.0: an adopter
+charted a map, the map returned decisions that assumed a budget they did not
+have, and there was no way to feed the missing parameter back in. Their own
+words for it — *"a parameter my agents already know"* — name the gap precisely.
+Their agents knew; the map never asked.
+
+### Added
+- **A `## Constraints` section on the map, and a charting pass that asks for one
+  (#617, #619).** A constraint — no budget, a deadline, a runtime that cannot
+  change — was previously homeless: not fog (it is not a question awaiting an
+  answer), not out of scope (it is not past the destination), not a decision
+  (nobody decided it). It landed in Notes, which nothing checks an answer
+  against. It now sits beside the Destination, since the two together fix the
+  effort's shape, and the test for what belongs there is whether an *answer*
+  could violate it.
+
+  `ChartTheMap` step 1 now asks what is fixed regardless of route, and seeds the
+  question from the principal's own store (`soma memory recall`,
+  `profile/purpose.md`) rather than only the conversation in front of it —
+  degrading to simply asking where there is no Soma home, since orienteer runs
+  in any repository. `WalkTheMap` reads the section as binding on the answer
+  being written, and surfaces the *dimension* a constraint touches in the
+  options it offers, so cost appears where the choice is made.
+
+  Two limits stated rather than papered over. **Nothing enforces it**: no verb
+  reads the section, the close gate does not test against it, `decisions
+  --write` does not project it. It binds the way the Destination binds — by
+  being read. And **constraints live on the map alone**; a node never restates
+  one, or an amendment leaves stale copies behind.
+
+  What charting reads is private, and where it writes is not: the seeding pass
+  proposes *the constraint, never the source*, and never pastes recall output
+  into a map body that is as public as the repository holding it.
+
+### Fixed
+- **The map body template ships the `soma:decisions` markers (#621, #622).**
+  `soma graph decisions --write` refuses a body without them — deliberately,
+  since guessing where an index belongs in prose it does not own is worse than
+  refusing. The template did not carry them, so **every** map charted from it
+  failed its first write, on the first node anyone closed. The verb was right;
+  the template was wrong. It survived because the error prints the two lines to
+  add, so each walker hand-patched their own map and moved on.
+
+  `WalkTheMap`'s wording is corrected with it: *"if the map predates them"* read
+  as legacy handling when it in fact described every map. A regression guard now
+  runs the real `spliceSection` over the real template file — the two are one
+  contract living in two files, and each half was correct alone, which is why
+  nothing caught it.
+
+  Not adopted: injecting the markers at `soma graph add` time. It would append
+  them to a body whose shape it does not know — the same guess the splice
+  refuses to make.
+
 ## [0.15.0] - 2026-08-11
 
 The **work graph** release: a typed primitive for planning work that outlives a

--- a/README.md
+++ b/README.md
@@ -384,7 +384,10 @@ soma policy probes           # read the registry; Soma ships no verb that writes
 ```
 
 The **orienteer** skill is the doctrine for using this: chart a loose idea as a map
-of decision nodes, then resolve them one at a time until the route is clear.
+of decision nodes, then resolve them one at a time until the route is clear. The
+map also records what is **fixed regardless of route** — budget, deadlines,
+tooling that cannot change — so every node's options are weighed against the
+constraints instead of discovering one after the decisions close.
 See [docs/work-graph.md](docs/work-graph.md) for the spec.
 
 ### Skills

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,6 +1,6 @@
 schema: arc/v1
 name: soma
-version: 0.15.0
+version: 0.16.0
 type: tool
 tier: community
 description: Substrate-portable Personal AI Assistant core for identity, memory, VSA, skills, learning, and adapters.

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -572,7 +572,11 @@ which demonstrably drifted toward restating. Derived from receipts, a decision
 lives in exactly one place (its node's receipt, via `--gist`) and the map body
 carries a projection nobody edits by hand. The verb owns only the span between
 its markers, never the prose around it, and refuses when the markers are absent
-rather than guessing where an index belongs in prose it does not own.
+rather than guessing where an index belongs in prose it does not own. The
+orienteer body template ships both markers as of 0.16.0 (#621); until then it did
+not, so every map charted from it failed its first `--write` until someone
+hand-patched the body. The refusal now covers what it was meant to cover —
+hand-rolled bodies and maps charted before the fix.
 `--write` is a read-modify-write with no compare-and-swap (GitHub offers none
 for issue bodies): a concurrent hand edit to the *prose* can be clobbered by the
 re-write. Accepted — the map body is low-contention, the span is derived state

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soma",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "private": true,
   "type": "module",
   "description": "Substrate-portable Personal AI Assistant core.",


### PR DESCRIPTION
The **orienteer** release, driven by external feedback on 0.15.0.

An adopter charted a map; the map returned decisions that assumed a budget they
did not have, and there was no way to feed the missing parameter back in. Their
own phrase — *"a parameter my agents already know"* — names the gap exactly.
Their agents knew. The map never asked.

Ships #619 and #622, already on main, under a version — and puts them where an
adopter reads, not only in the skill.

## Docs

- **README** — the orienteer paragraph said the map holds decision nodes. It now
  also says the map records what is *fixed regardless of route*, which is the
  half that was missing.
- **docs/work-graph.md** — the `decisions` verb's refusal on absent markers is
  correct and stays. What changed is its blast radius: the template now carries
  the markers, so the refusal covers hand-rolled bodies and maps charted before
  the fix, rather than every map ever charted. Recorded rather than quietly
  corrected, since the old behaviour is what adopters on 0.15.0 actually hit.
- **CHANGELOG 0.16.0** — the Constraints section with both stated limits
  (nothing enforces it; it lives on the map alone), the privacy rule on seeding
  from the principal's store, and the markers fix including the design option
  that was declined.

## Version

MINOR rather than PATCH: this adds a documented capability adopters will see
(the Constraints section and the charting pass), alongside the fix. Bumped in
both places the suite checks — `package.json` and `arc-manifest.yaml`;
`src/version.ts` derives from `package.json`, and `test/types.test.ts` asserts
the two agree.

## Verification

- `bun run typecheck` — clean.
- `bun run check-release-privacy` — clean.
- `bun test test/types.test.ts test/cli.test.ts` — 113 pass, the dual-bump
  assertion included.
- Full suite: **2388 of 2389 pass**. The single failure —
  `audit §3: per-tool writeback events are 1-in-10 hash-sampled` — is a
  **pre-existing flake, not a regression**, and I verified that rather than
  assuming it: it fails on unmodified `main` with these changes stashed, and
  passes 3/3 in isolation on this branch. It is timing-sensitive, failing at a
  5 s timeout. CI's own run on #622 hit a *different* flake in the same suite
  (`work registry reclaims one stale lock`), which passed on re-run.

Two flaky tests in the suite is worth its own issue; I have not filed one yet,
and it is not a release blocker.

## Not included

Nothing else landed since v0.15.0 — `git log v0.15.0..main` is exactly these two
commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)