### PR TITLE
docs(work-graph): mirror node #8 ruling — 'autonomous ticking' → 'autonomous graph-mutation'

### DIFF
--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -918,8 +918,9 @@ sessions are the node executors, soma supplies the verbs.
   - *Phase 2 — gated on the bot identity existing:* a scheduled tick claims
     `auto`-class frontier nodes headlessly. Each claim is announced to Discord
     with a **60s 👎 veto window**; silence proceeds; terminal states never
-    auto-resume (operator verbs only). No autonomous ticking under the
-    principal's credentials, ever. The tick runs `command` and `url` probes
+    auto-resume (operator verbs only). No autonomous graph-mutation under the
+    principal's credentials, ever — read-only ticks may run under any
+    identity, token-gated read-only. The tick runs `command` and `url` probes
     under the **same** registry gate as an interactive session (§2.2) — the
     registry answers *whose code this is*, and headlessness changes who is
     watching, not what is authorised. A tick machine with no registry refuses


### PR DESCRIPTION
## What

Mirror the [ranger map node #8 ruling](https://github.com/the-metafactory/ranger/issues/8) (closed 2026-08-15) upstream into `docs/work-graph.md` §5 Phase 2. The source sentence diverged from the ruling: the spec said "no autonomous ticking", but the ruling (and ranger's own operative constraint) is **"no autonomous graph-mutation under the principal's credentials, ever"** — reads are outside the doctrine's teeth.

Change:

> "No autonomous ticking under the principal's credentials, ever."

to:

> "No autonomous graph-mutation under the principal's credentials, ever — read-only ticks may run under any identity, token-gated read-only."

## Why

The divergence is a spec-vs-implementation tension: ranger's map constraint cites this §5 spec, and node #8 amended the wording at the doctrine level. This PR makes the upstream spec match the ruling (tracked as the-metafactory/ranger#17, checkpoint `upstream-wording-mirrored`).

## Non-changes

- §5.1 provisioning checklist unchanged — graph writes still require the machine-account PAT.
- This is wording only; no behaviour change. `attestation`/confinement semantics untouched.

## Notes for reviewers

This is a docs-only change to the work-graph spec. It resolves the tracked divergence; no release impact.
