### PR TITLE
feat(graph): soma graph release — identity-bound self-release (#627)

### DIFF
--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -489,6 +489,13 @@ frontier forever — no claim, no close, no error).
   removes itself (#492 correction 2). All racers compute the same rule over
   the same eventual assignee set, so the race converges to one holder without
   coordination.
+  **Self-release is a verb, not a raw write.** The claim-race loser's
+  self-removal — DELETE self from the assignee set — is promoted to
+  `soma graph release <node>`, the **identity-bound self-release**: a walker
+  abandons its own claim without a raw tracker write. It only ever unassigns
+  the acting identity — releasing a claim you do not hold is a no-op, never a
+  release of someone else's — and it refuses on a closed node, matching
+  `claim`.
 
 ### 2.5 GraphStore seam
 
@@ -535,6 +542,10 @@ soma graph frontier <root>         # open, unassigned, unblocked, over the whole
 soma graph node <id>               # read one node, BODY INCLUDED — the walker's
                                    # first read must not need the tracker's CLI
 soma graph claim <node>            # assign, re-read, tie-break on race
+soma graph release <node>          # identity-bound self-release: abandon your
+                                   # own claim (the claim-race loser's
+                                   # DELETE-self, promoted to a verb); only
+                                   # ever unassigns the acting identity
 soma graph add <root> ...          # create node (+ edges) — additive, structurally
                                    # validated; --checkpoint is REQUIRED, since a
                                    # node without one can never close and no verb

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -89,17 +89,19 @@ import { resolveGraphRepo } from "../work-graph-bridge";
 import { SomaCliError } from "./errors";
 import { readOption } from "./parse-utils";
 
-const GRAPH_ACTIONS = ["frontier", "node", "claim", "add", "close", "audit", "decisions"] as const;
+const GRAPH_ACTIONS = ["frontier", "node", "claim", "release", "add", "close", "audit", "decisions"] as const;
 type GraphAction = (typeof GRAPH_ACTIONS)[number];
 
 const EVIDENCE_KINDS: readonly WorkGraphEvidenceKind[] = ["specified", "probed", "tested", "judged", "approved"];
 
 export const GRAPH_COMMAND_HELP: { usage: string; subcommands: Record<GraphAction, string> } = {
-  usage: "Usage: soma graph <frontier|node|claim|add|close|audit|decisions> ...",
+  usage: "Usage: soma graph <frontier|node|claim|release|add|close|audit|decisions> ...",
   subcommands: {
     frontier: "Usage: soma graph frontier <root> [--repo <owner/name>] [--json]",
     node: "Usage: soma graph node <id> [--repo <owner/name>] [--json]",
     claim: "Usage: soma graph claim <id> [--identity <login>] [--repo <owner/name>] [--json]",
+    release:
+      "Usage: soma graph release <id> [--identity <login>] [--repo <owner/name>] [--json] — identity-bound self-release: abandon your own claim (only ever unassigns the acting identity)",
     add: "Usage: soma graph add <root> --title <text> --autonomy <auto|propose|approve> --checkpoint <id> [--kind <k>] [--label <name>]... [--body <text>|--body-file <path>] [--probe <json>]... [--blocked-by <id>]... [--budget-tokens <n>] [--budget-invocations <n>] [--budget-minutes <n>] [--repo <owner/name>] [--json]",
     close:
       "Usage: soma graph close <id> --resolution-file <path> [--gist <one line>] [--propose --body <text>|--body-file <path>] [--proposal-comment <id>] [--checkpoint <id>] [--evidence <json>]... [--identity <login>] [--dry-run] [--repo <owner/name>]",
@@ -130,6 +132,13 @@ export interface ParsedGraphNodeArgs {
 export interface ParsedGraphClaimArgs {
   command: "graph";
   action: "claim";
+  target: string;
+  options: GraphSharedOptions & { identity?: string };
+}
+
+export interface ParsedGraphReleaseArgs {
+  command: "graph";
+  action: "release";
   target: string;
   options: GraphSharedOptions & { identity?: string };
 }
@@ -186,6 +195,7 @@ export type ParsedGraphArgs =
   | ParsedGraphFrontierArgs
   | ParsedGraphNodeArgs
   | ParsedGraphClaimArgs
+  | ParsedGraphReleaseArgs
   | ParsedGraphAddArgs
   | ParsedGraphCloseArgs
   | ParsedGraphAuditArgs
@@ -454,7 +464,7 @@ export function parseGraphArgs(args: string[]): ParsedGraphArgs {
       index = shared;
       continue;
     }
-    if (arg === "--identity" && action === "claim") {
+    if (arg === "--identity" && (action === "claim" || action === "release")) {
       options.identity = readOption(rest, index, arg);
       index += 1;
       continue;
@@ -467,6 +477,7 @@ export function parseGraphArgs(args: string[]): ParsedGraphArgs {
   }
 
   if (action === "claim") return { command, action, target: resolvedTarget, options };
+  if (action === "release") return { command, action, target: resolvedTarget, options };
   if (action === "decisions") return { command, action, target: resolvedTarget, options };
   return { command, action, target: resolvedTarget, options };
 }
@@ -852,6 +863,32 @@ async function runClaim(
   return [
     `Claimed node ${parsed.target} as ${identity} (${repo}).`,
     `assignees: ${result.assignees.join(", ")}`,
+  ].join("\n");
+}
+
+async function runRelease(
+  parsed: ParsedGraphReleaseArgs,
+  graph: WorkGraph,
+  repo: string,
+  deps: GraphCliDeps,
+): Promise<string> {
+  const identity = parsed.options.identity ?? (await deps.resolveIdentity());
+  const result = await graph.release({ id: parsed.target }, identity);
+
+  if (parsed.options.json === true) {
+    return JSON.stringify({ repo, node: parsed.target, ...result }, null, 2);
+  }
+
+  if (!result.released) {
+    return [
+      `Node ${parsed.target} is not claimed by ${identity} — nothing to release.`,
+      `assignees: ${result.assignees.join(", ") || "—"}`,
+    ].join("\n");
+  }
+
+  return [
+    `Released node ${parsed.target} as ${identity} (${repo}).`,
+    `assignees: ${result.assignees.join(", ") || "—"}`,
   ].join("\n");
 }
 
@@ -1432,6 +1469,8 @@ export async function runGraphCli(parsed: ParsedGraphArgs, overrides: Partial<Gr
       return await runNode(parsed, graph, repo);
     case "claim":
       return await runClaim(parsed, graph, repo, deps);
+    case "release":
+      return await runRelease(parsed, graph, repo, deps);
     case "add":
       return await runAdd(parsed, graph, repo, deps);
     case "close":

--- a/src/index.ts
+++ b/src/index.ts
@@ -722,6 +722,7 @@ export {
   type BlockingRef,
   type ConfinementProbeRecord,
   type ClaimResult,
+  type ReleaseResult,
   type CloseEvidence,
   type CloseReceipt,
   type CommentRef,

--- a/src/skills/orienteer/SKILL.md
+++ b/src/skills/orienteer/SKILL.md
@@ -60,6 +60,7 @@ this doctrine tracker-agnostic by construction.
 | `soma graph frontier <root>` | open ∧ unassigned ∧ unblocked, confirmed by direct fetch |
 | `soma graph node <id>` | read one node, body included — never `gh issue view` |
 | `soma graph claim <id>` | assign, re-read, tie-break on race |
+| `soma graph release <id>` | identity-bound self-release: abandon your own claim (the claim-race loser's DELETE-self, promoted to a verb); only ever unassigns the acting identity |
 | `soma graph add <root> … --checkpoint <id>` | create node (+ `--blocked-by` edges), structurally validated; refuses without a checkpoint |
 | `soma graph close <id> --resolution-file <path> [--gist <line>]` | post the prose, run declared probes, derive the receipt, refuse a hollow close |
 | `soma graph audit <root>` | what the gates cannot see: closed-without-receipt, can-never-close, claimed-in-flight |

--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -34,6 +34,7 @@ import {
   type NodeState,
   type NodeStatus,
   type Reaction,
+  type ReleaseResult,
   type WorkGraphNode,
 } from "./work-graph";
 
@@ -714,6 +715,32 @@ class GitHubGraphStore implements GraphStore {
       return { held, identity, holder, assignees: after.assignees.filter((login) => login !== identity) };
     }
     return { held, identity, holder, assignees: after.assignees };
+  }
+
+  /**
+   * Identity-bound self-release. The same DELETE the claim-race loser
+   * performs, promoted to a verb so a walker can abandon its own claim
+   * without a raw tracker write. It only ever unassigns the acting identity
+   * — a claim you do not hold is a no-op, never a release of someone else's.
+   */
+  async release(ref: NodeRef, identity: string): Promise<ReleaseResult> {
+    const before = await this.fetchIssue(ref);
+    if (before.status === "closed") {
+      throw new WorkGraphError("node-closed", `node ${ref.id} is closed — nothing to release`);
+    }
+    if (!before.assignees.includes(identity)) {
+      return { released: false, identity, assignees: before.assignees };
+    }
+    await this.transport({
+      method: "DELETE",
+      path: `repos/${this.repo}/issues/${ref.id}/assignees`,
+      body: { assignees: [identity] },
+    });
+    const after = await this.fetchIssue(ref);
+    // Filter the re-read defensively, matching the claim-race loser's branch:
+    // the DELETE just happened, so the identity is gone even if the re-read
+    // reflects a slightly earlier snapshot.
+    return { released: true, identity, assignees: after.assignees.filter((login) => login !== identity) };
   }
 
   async postComment(ref: NodeRef, body: string): Promise<CommentRef> {

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -205,6 +205,18 @@ export interface ClaimResult {
   assignees: readonly string[];
 }
 
+/**
+ * Outcome of an identity-bound self-release (§2.4). `released` is whether the
+ * acting identity actually held the claim and was removed — a release of a
+ * claim you never held is a no-op, never an error, and can never remove a
+ * different identity (the verb only ever unassigns itself).
+ */
+export interface ReleaseResult {
+  released: boolean;
+  identity: string;
+  assignees: readonly string[];
+}
+
 export interface CommentRef {
   id: string;
   nodeId: string;
@@ -514,6 +526,13 @@ export interface GraphStore {
   readSubtree(root: NodeRef): Promise<NodeState[]>;
   /** Assigns, then re-reads (no compare-and-swap exists on GitHub) and applies {@link resolveClaimRace}. */
   claim(ref: NodeRef, identity: string): Promise<ClaimResult>;
+  /**
+   * Identity-bound self-release: removes the acting identity from the node's
+   * assignee set (the same DELETE the claim-race loser performs), so a walker
+   * can abandon its own claim without a raw tracker write. Never removes a
+   * different identity; releasing a claim you do not hold is a no-op.
+   */
+  release(ref: NodeRef, identity: string): Promise<ReleaseResult>;
   postComment(ref: NodeRef, body: string): Promise<CommentRef>;
   /**
    * Re-read a comment for its API author field. The HITL close path needs the
@@ -1217,6 +1236,19 @@ export class WorkGraph {
       throw new WorkGraphError("node-closed", `node ${ref.id} is closed — nothing to claim`);
     }
     return await this.store.claim(ref, identity);
+  }
+
+  /**
+   * Identity-bound self-release (§2.4). Refuses on a closed node, matching
+   * {@link claim}: a settled receipt is not the place to mutate the assignee
+   * set, and there is nothing to abandon on a closed node.
+   */
+  async release(ref: NodeRef, identity: string): Promise<ReleaseResult> {
+    const state = await this.store.readNode(ref);
+    if (state.status === "closed") {
+      throw new WorkGraphError("node-closed", `node ${ref.id} is closed — nothing to release`);
+    }
+    return await this.store.release(ref, identity);
   }
 
   async postComment(ref: NodeRef, body: string): Promise<CommentRef> {

--- a/test/algorithm-plansteps-bridge.test.ts
+++ b/test/algorithm-plansteps-bridge.test.ts
@@ -89,6 +89,7 @@ function stubStore(readNode: (ref: NodeRef) => NodeState): GraphStore {
     readNode: async (ref) => readNode(ref),
     readSubtree: async () => [],
     claim: async () => ({ held: true, identity: "jcfischer", holder: null, assignees: [] }),
+    release: async () => ({ released: true, identity: "jcfischer", assignees: [] }),
     postComment: async () => ({ id: "c1", nodeId: "501" }),
     readComment: async () => ({ id: "c1", nodeId: "501" }),
     readCommentReactions: async () => [],

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -20,6 +20,7 @@ import {
   runProbes,
   scanCommentsForReceipt,
   type ClaimResult,
+  type ReleaseResult,
   type CloseReceipt,
   type CommentRef,
   type CreateNodeSpec,
@@ -70,6 +71,7 @@ class FakeStore implements GraphStore {
   readonly created: CreateNodeSpec[] = [];
   readonly edges: [string, string][] = [];
   claimResult: ClaimResult | undefined;
+  releaseResult: ReleaseResult | undefined;
   private nextId = 900;
 
   seed(id: string, seed: SeedNode): this {
@@ -109,6 +111,10 @@ class FakeStore implements GraphStore {
 
   async claim(_ref: NodeRef, identity: string): Promise<ClaimResult> {
     return this.claimResult ?? { held: true, identity, holder: identity, assignees: [identity] };
+  }
+
+  async release(_ref: NodeRef, identity: string): Promise<ReleaseResult> {
+    return this.releaseResult ?? { released: true, identity, assignees: [identity] };
   }
 
   async postComment(ref: NodeRef, body: string): Promise<CommentRef> {
@@ -208,8 +214,8 @@ function autoNode(id: string, overrides: Partial<WorkGraphNode> = {}): WorkGraph
 
 // --- parsing ---------------------------------------------------------------
 
-test("the parser accepts exactly the seven verbs of §2.6", () => {
-  for (const action of ["frontier", "node", "claim", "add", "close", "audit", "decisions"]) {
+test("the parser accepts exactly the verbs of §2.6, release included", () => {
+  for (const action of ["frontier", "node", "claim", "release", "add", "close", "audit", "decisions"]) {
     const parsed = parseGraphArgs(
       action === "add"
         ? ["graph", action, "495", "--title", "t", "--autonomy", "approve", "--checkpoint", "cp-t"]
@@ -217,7 +223,9 @@ test("the parser accepts exactly the seven verbs of §2.6", () => {
     );
     expect(parsed.action).toBe(action as never);
   }
-  expect(() => parseGraphArgs(["graph", "delete", "495"])).toThrow(/frontier\|node\|claim\|add\|close\|audit\|decisions/u);
+  expect(() => parseGraphArgs(["graph", "delete", "495"])).toThrow(
+    /frontier\|node\|claim\|release\|add\|close\|audit\|decisions/u,
+  );
 });
 
 test("add refuses a node with no checkpoint — it could never close, and no verb attaches one later", () => {
@@ -323,6 +331,31 @@ test("claim reports the holder and exits non-zero when the tie-break goes the ot
 test("claim refuses a closed node rather than reopening a settled race", async () => {
   const store = new FakeStore().seed("498", { node: autoNode("498"), status: "closed" });
   expect(await failure(["graph", "claim", "498", "--repo", REPO], store)).toContain("nothing to claim");
+});
+
+// --- release ------------------------------------------------------------------
+
+test("release abandons a held claim and reports the resulting assignee set", async () => {
+  const store = new FakeStore().seed("498", { node: autoNode("498") });
+  store.releaseResult = { released: true, identity: "ivy-agent", assignees: [] };
+
+  const output = await run(["graph", "release", "498", "--repo", REPO], store);
+  expect(output).toContain("Released node 498 as ivy-agent");
+  expect(output).toContain("assignees: —");
+});
+
+test("release of a claim you do not hold is a non-error no-op", async () => {
+  const store = new FakeStore().seed("498", { node: autoNode("498") });
+  store.releaseResult = { released: false, identity: "ivy-agent", assignees: ["Ada"] };
+
+  const output = await run(["graph", "release", "498", "--repo", REPO], store);
+  expect(output).toContain("is not claimed by ivy-agent");
+  expect(output).toContain("assignees: Ada");
+});
+
+test("release refuses a closed node", async () => {
+  const store = new FakeStore().seed("498", { node: autoNode("498"), status: "closed" });
+  expect(await failure(["graph", "release", "498", "--repo", REPO], store)).toContain("nothing to release");
 });
 
 // --- add --------------------------------------------------------------------

--- a/test/work-graph-github.test.ts
+++ b/test/work-graph-github.test.ts
@@ -631,6 +631,53 @@ test("claiming a closed issue is refused by the backend too", async () => {
   expect(calls).toHaveLength(1);
 });
 
+// --- release ----------------------------------------------------------------
+
+test("a self-release removes the acting identity from the assignee set", async () => {
+  const { transport, calls } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload({ assignees: [{ login: "ivy-agent" }] }),
+    [`DELETE repos/${REPO}/issues/497/assignees`]: {},
+  });
+
+  const result = await createGitHubGraphStore({ repo: REPO, transport }).release({ id: "497" }, "ivy-agent");
+
+  expect(result).toEqual({ released: true, identity: "ivy-agent", assignees: [] });
+  expect(calls.map((call) => call.key)).toEqual([
+    `GET repos/${REPO}/issues/497`,
+    `DELETE repos/${REPO}/issues/497/assignees`,
+    `GET repos/${REPO}/issues/497`,
+  ]);
+  expect(calls[1]?.body).toEqual({ assignees: ["ivy-agent"] });
+});
+
+test("releasing a claim you do not hold is a no-op — it never unassigns another identity", async () => {
+  const { transport, calls } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload({ assignees: [{ login: "Ada" }] }),
+  });
+
+  const result = await createGitHubGraphStore({ repo: REPO, transport }).release({ id: "497" }, "ivy-agent");
+
+  expect(result).toEqual({ released: false, identity: "ivy-agent", assignees: ["Ada"] });
+  expect(calls).toHaveLength(1);
+  expect(calls[0]?.key).toBe(`GET repos/${REPO}/issues/497`);
+});
+
+test("releasing a closed issue is refused by the backend too", async () => {
+  const { transport, calls } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload({ state: "closed" }),
+  });
+
+  let thrown: unknown;
+  try {
+    await createGitHubGraphStore({ repo: REPO, transport }).release({ id: "497" }, "ivy-agent");
+  } catch (error) {
+    thrown = error;
+  }
+  expect(thrown).toBeInstanceOf(WorkGraphError);
+  expect((thrown as WorkGraphError).code).toBe("node-closed");
+  expect(calls).toHaveLength(1);
+});
+
 // --- comments, reactions, close --------------------------------------------
 
 test("reaction authors come from the API author field, never from body text", async () => {

--- a/test/work-graph.test.ts
+++ b/test/work-graph.test.ts
@@ -16,6 +16,7 @@ import {
   resolveClaimRace,
   toNode,
   type ClaimResult,
+  type ReleaseResult,
   type CloseReceipt,
   type CommentRef,
   type CreateNodeSpec,
@@ -422,6 +423,11 @@ class FakeStore implements GraphStore {
   async claim(ref: NodeRef, identity: string): Promise<ClaimResult> {
     this.claims.push(`${ref.id}:${identity}`);
     return { held: true, identity, holder: identity, assignees: [identity] };
+  }
+
+  async release(ref: NodeRef, identity: string): Promise<ReleaseResult> {
+    this.claims.push(`release:${ref.id}:${identity}`);
+    return { released: true, identity, assignees: [] };
   }
 
   async postComment(ref: NodeRef, body: string): Promise<CommentRef> {


### PR DESCRIPTION
## What

Ships `soma graph release <id>` — **identity-bound self-release** — per spec #627 (UPSTREAM from ranger map node #10, checkpoint `release-verb-shipped`).

A walker can now abandon its own claim without a raw tracker write, by promoting the claim-race loser's existing DELETE-self (§2.4) to a verb.

## Semantics

- **Identity-bound only** — unassigns exactly the acting identity, never another.
- A claim you do not hold is a **no-op** (`released: false`), not an error, never a release of someone else's claim.
- **Refuses on a closed node** (`node-closed`), matching `claim`.
- **No tie-break** — `release` is unconditional on the acting identity's own membership.

## Changes

- `GraphStore.release(ref, identity)` seam + GitHub backend (the same DELETE-self the claim-race loser performs; re-read defensively filtered)
- `WorkGraph.release(ref, identity)` contract wrapper (refuse on closed)
- CLI: `soma graph release <id> [--identity <login>] [--repo <owner/name>] [--json]`
- Docs: `work-graph.md` §2.4 + §2.6; orienteer skill verb table (fast-path + verbs table)
- Tests: backend (self-release / no-op / closed-refusal) + CLI (release / no-op / closed-refusal) — 6 new tests, all green

## Verification

- `bunx tsc --noEmit` clean
- Full suite: 2395 pass / 0 fail
- Graph files: 183 pass / 0 fail

## Notes

- Spec conversation: #627.
- Out of scope: releasing *other* identities' claims (stale foreign claims stay `audit`-visible); any change to the claim-race itself.
- `close --json` (companion for scripted consumers) noted in #627 as in-scope-if-accepted; not included here.
