### PR TITLE
fix(graph): support alternate rate-limit wording

### DIFF
--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -118,7 +118,7 @@ function isGraphQLRateLimitError(error: unknown): boolean {
   return (
     error instanceof WorkGraphError &&
     error.code === "backend" &&
-    /(?:API\s+)?rate limit exceeded/i.test(error.message)
+    /(?:API\s+)?rate limit (?:already )?exceeded/i.test(error.message)
   );
 }
 

--- a/test/work-graph-github.test.ts
+++ b/test/work-graph-github.test.ts
@@ -510,7 +510,7 @@ test("a GraphQL rate limit falls back to a whole REST subtree in depth-first ord
     if (key === "POST graphql") {
       throw new WorkGraphError(
         "backend",
-        "gh api POST graphql failed (exit 1): GraphQL: API rate limit exceeded for user ID 1.",
+        "gh api POST graphql failed (exit 1): gh: API rate limit already exceeded for user ID 1.",
       );
     }
     const responses: Record<string, unknown> = {


### PR DESCRIPTION
## Summary

- recognize rate-limit errors with an optional already token as GraphQL quota failures
- preserve the existing whole-observation REST fallback for that error variant
- cover the variant with the subtree fallback regression test

## Verification

- focused work-graph suite: 43 pass, 0 fail
- typecheck: pass
- changed-file ESLint: pass

Fixes #625