### PR TITLE
chore(release): 0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.16.1] - 2026-08-16
+
+### Fixed
+
+- **Quota-safe GitHub work-graph reads (#625, #629, #630).** The normal
+  subtree query now has a deliberately bounded `20/3/3` fanout, with a tested
+  predicted primary-rate cost of 8 points instead of roughly 414 for the former
+  `50/25/10` shape. Parent edges use REST, and a recognizable GraphQL quota
+  error restarts the complete subtree observation through paginated REST reads
+  without mixing partial GraphQL state into the result. The fallback preserves
+  depth-first traversal, blocker hydration, and cycle protection; unrelated
+  GraphQL errors still surface.
+
+  Pagination now asks `gh api` to slurp pages before flattening them, so callers
+  receive one array across REST pages. The quota matcher also accepts the
+  alternate `rate limit already exceeded` wording, which is covered by the
+  backend regression suite.
+
 ## [0.16.0] - 2026-08-15
 
 An **orienteer** release, driven by external feedback on 0.15.0: an adopter

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <img alt="Version" src="https://img.shields.io/badge/version-0.8.4-2A3F6A?labelColor=0E1726" />
+  <img alt="Version" src="https://img.shields.io/badge/version-0.16.1-2A3F6A?labelColor=0E1726" />
   <img alt="License" src="https://img.shields.io/badge/license-MIT-2A3F6A?labelColor=0E1726" />
   <img alt="Runs in" src="https://img.shields.io/badge/runs%20in-Codex%20%C2%B7%20Pi.dev%20%C2%B7%20Claude%20Code%20%C2%B7%20Cursor-2A3F6A?labelColor=0E1726" />
 </p>

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,6 +1,6 @@
 schema: arc/v1
 name: soma
-version: 0.16.0
+version: 0.16.1
 type: tool
 tier: community
 description: Substrate-portable Personal AI Assistant core for identity, memory, VSA, skills, learning, and adapters.

--- a/docs/arc-install-troubleshooting.md
+++ b/docs/arc-install-troubleshooting.md
@@ -18,7 +18,7 @@ To pin a specific release:
 
 ```bash
 arc remove soma
-arc install @metafactory/soma@0.8.3
+arc install @metafactory/soma@0.16.1
 ```
 
 This removes Arc's package registration and symlinks before installing the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soma",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "type": "module",
   "description": "Substrate-portable Personal AI Assistant core.",


### PR DESCRIPTION
## Summary

- bump the Soma package and Arc manifest to 0.16.1
- refresh the public README badge and Arc pinning example
- document the bounded GraphQL read and REST fallback fixes from #625

## Release scope

This is a patch release: metadata and documentation only; the quota-safe graph implementation is already merged on main.