### PR TITLE
fix(release): persist Arc root between steps

### DIFF
--- a/.github/workflows/publish-soma.yml
+++ b/.github/workflows/publish-soma.yml
@@ -38,6 +38,7 @@ jobs:
           SH
           chmod +x "${RUNNER_TEMP}/bin/arc"
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+          echo "ARC_ROOT=${ARC_ROOT}" >> "${GITHUB_ENV}"
 
       - name: Configure Arc source
         env:


### PR DESCRIPTION
Fixes the v0.16.1 publish preflight: ARC_ROOT was scoped to the Install Arc shell step, so the following source-serialization step could not resolve Arc’s yaml dependency.

Persist ARC_ROOT through GITHUB_ENV. This completes the isolated-config and safe-token serialization workflow repair in #633 and #634.