### PR TITLE
chore(release): 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [0.17.0] - 2026-08-19
+
+### Added
+
 - **Communication contract (Identity compartment).** Section structure and part
   of the banned-phrase list are adapted (not copied) from
   [disler/fixing-smartass-opus-5](https://github.com/disler/fixing-smartass-opus-5), MIT.
@@ -39,10 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   time — a prose file on the home-load path must never be able to fail
   `install` or a hook. `AlgorithmRun.references` is additive and defaulted by the store — no
   schema-version bump, and pre-existing runs load with an empty list.
-
-### Changed
-
-### Fixed
+- **Docs:** [docs/communication-and-behavior.md](docs/communication-and-behavior.md)
+  covers both files, how each reaches a substrate, the behavioral-policy
+  authoring rules, and the reference-code CLI.
 
 ## [0.16.1] - 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -543,6 +543,44 @@ the PAI mode classifier entry while Soma owns that hook.
 
 ---
 
+## How the assistant talks, and what it may do
+
+Two principal-authored files in the Soma home govern conduct, and they reach
+every substrate:
+
+- **`profile/communication.md`** — the *communication contract*: voice, positive
+  and negative patterns, a banned-phrase list, reference codes, aliases, and
+  authored do/don't examples. Identity compartment. `soma init` writes a generic
+  starter; edit it directly. It projects **verbatim** into every substrate, and
+  Pi.dev injects it into the system prompt so it is present on every turn.
+  Soma parses nothing out of it — every section works by being read.
+- **`policy/behavior.md`** — the *behavioral policy*: verification, scope
+  discipline, permission boundaries, external-content handling. Policy
+  compartment. Its `## Heading` sections become advisory lines in every
+  substrate's policy projection. `soma init` does **not** create it: Soma
+  projects conduct rules you wrote, or none.
+
+One rule, one home. An absent file projects nothing rather than a default.
+
+### Reference codes
+
+When the assistant presents three or more findings, options, risks, questions,
+actions, or decisions, it labels each with a short code that stays stable for
+the conversation, so your reply collapses to `keep D1, reject O2, answer Q1`.
+
+`C` and `P` are reserved — `C1` is a VSA criterion and `P1` an Algorithm plan
+step — so recording a code under either is refused. A code becomes durable when
+written to a run, and a `D` code also lands in that run's decisions log:
+
+```bash
+soma algorithm ref     --id <run-id> --code D1 --text "Drop the co-author rule."
+soma algorithm resolve --id <run-id> --code D1 --verdict kept --note "Applied."
+```
+
+See [docs/communication-and-behavior.md](docs/communication-and-behavior.md).
+
+---
+
 ## Privacy and policy
 
 Soma's V0 policy guard blocks obvious movement of private Soma or projection
@@ -601,6 +639,7 @@ writeback boundaries as substrate sessions. See
 
 - [CONTEXT.md](CONTEXT.md), the shared Soma vocabulary used by docs, CLI, and VSA
 - [docs/soma-home-layout.md](docs/soma-home-layout.md), what `soma init` creates and where Algorithm/VSA state lives
+- [docs/communication-and-behavior.md](docs/communication-and-behavior.md), the communication contract, the behavioral policy, and reference codes
 - [docs/architecture.md](docs/architecture.md), the core/adapters/runtime model
 - [docs/boundaries.md](docs/boundaries.md), exactly what Soma owns and does not own
 - [docs/substrate-adapters.md](docs/substrate-adapters.md), adapter behavior by host

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,6 +1,6 @@
 schema: arc/v1
 name: soma
-version: 0.16.1
+version: 0.17.0
 type: tool
 tier: community
 description: Substrate-portable Personal AI Assistant core for identity, memory, VSA, skills, learning, and adapters.

--- a/docs/communication-and-behavior.md
+++ b/docs/communication-and-behavior.md
@@ -1,0 +1,209 @@
+# How the assistant talks, and what it may do
+
+Two principal-authored files govern conduct. They are deliberately separate,
+they live in different compartments, and they reach a substrate by different
+mechanisms. Both paths below are relative to the Soma home.
+
+| | Communication contract | Behavioral policy |
+|---|---|---|
+| File | `profile/communication.md` | `policy/behavior.md` |
+| Compartment | Identity (owns "voice, personality") | Policy (security, permission, evidence rules) |
+| Governs | How the assistant *talks* | What the assistant *may do* |
+| Created by `soma init` | Yes, a generic starter | **No** — principal-authored only |
+| How it projects | Verbatim, as its own file | Parsed into each substrate's advisory policy list |
+| Parsed by Soma | Nothing | `## Heading` sections → advisory lines |
+
+One rule, one home: an operational boundary goes in `policy/behavior.md`, a
+habit of speech goes in `profile/communication.md`. Neither file is invented for
+you — an absent file projects nothing rather than a default.
+
+---
+
+## The communication contract
+
+The contract is the highest-leverage place to change how an assistant
+communicates, because it is present on every turn of every session. Editing it
+beats re-tuning individual prompts, which is one task's worth of leverage at a
+time.
+
+`soma init` writes a starter with these sections. They are a starting point, not
+a finished product — the structure is what transfers between models; only the
+word lists change.
+
+| Section | What it does |
+|---|---|
+| Positive patterns | Behaviours to replicate. |
+| Negative patterns | Behaviours to avoid. |
+| Banned phrases | Model-specific verbal tics. Expected to churn; owned by you. |
+| Reference codes | The letters used to label findings, options, risks, questions, actions, decisions. |
+| Aliases | Short tokens that expand into full instructions when typed alone. |
+| Examples | Authored do/don't pairs. A model matches an example harder than it follows a rule. |
+
+### Soma parses nothing out of it
+
+The file projects **verbatim** — no provenance header, no re-render. Every
+section does its work by *being read*: aliases work because the model sees them,
+banned phrases work because the model sees them. There is nothing for Soma to
+extract, so nothing is extracted.
+
+This is also a safety property. The contract sits on the path every command
+takes to load the Soma home, so a parse would let a typo in a prose file fail
+`install`, `reproject`, or a hook. It cannot: the file is read, not interpreted.
+
+### Where it lands
+
+| Substrate | Home path | Workspace path |
+|---|---|---|
+| claude-code | `rules/soma/COMMUNICATION.md` | `.claude/soma/communication.md` |
+| codex | `memories/soma/communication.md` | `.codex/soma/communication.md` |
+| grok | `skills/soma/communication.md` | `.grok/rules/soma/communication.md` |
+| pi-dev | `agent/soma/communication.md` | `.pi/extensions/soma-core/communication.md` |
+| cursor | `.cursor/rules/soma/COMMUNICATION.md` | — |
+| anthropic-cowork | `soma/communication.md` | — |
+
+How it *arrives* differs by substrate, and the difference matters:
+
+- **Pi.dev** injects it into the system prompt itself — the native equivalent of
+  an appended system-prompt file. Read once per session and cached, so it costs
+  no file read on the message path. The cache is process-scoped and cleared at
+  `session_start`; a resumed process that never fires `session_start` holds its
+  first read until it restarts.
+- **Auto-discovered rules directories** (claude-code, cursor) load it as session
+  context with no instruction needed.
+- **Everywhere else** the substrate's own instruction file carries a "read this
+  when present" line. A projected file that nothing is told to open is the
+  failure this whole rail exists to fix, so a test derives its list of surfaces
+  from the projection itself: a new surface fails until its reader is wired.
+
+---
+
+## The behavioral policy
+
+`policy/behavior.md` holds cross-substrate rules for conduct: verification,
+scope discipline, permission boundaries, external-content handling. Its
+`## Heading` sections become `<Heading>: <rule>` advisory lines in every
+substrate's policy projection, ahead of the shipped SelfHealing doctrine.
+
+`soma init` does **not** create this file. Homes migrated from PAI have one; a
+fresh home does not, and the rail simply projects nothing until you write it.
+Soma never invents conduct rules.
+
+### Authoring rules
+
+The parser is built for hand-written prose, not a strict format:
+
+- **Wrapped bullets fold.** A rule spanning several source lines arrives whole.
+  (`sectionBullets`, the older identity-file scanner, keeps only lines starting
+  with `- ` — a rule that lost its second half would be worse than one that
+  never projected.)
+- **Prose counts as rules.** Whether you write a bullet or a paragraph is
+  formatting, not meaning. Both project.
+- **Source order is preserved.** A section that opens with a paragraph and then
+  lists bullets projects in that order.
+- **Numbered lists** (`1.`, `1)`) are bullets.
+- **Fenced blocks are dropped**, markers and contents both, so a command example
+  never becomes an advisory rule and a `#` inside one cannot close the section.
+  If the file's fences are unbalanced, fence handling is disabled for the whole
+  file: one stray fence would otherwise swallow every section below it, and
+  losing rules to a typo is worse than projecting a stray code line, because
+  only the second is visible in the projection.
+- **Sub-headings** (`###`) are structure. Their text is dropped; their rules stay
+  attached to the parent `##` section.
+- **Everything before the first `## `** is preamble and is dropped. No section
+  is ever discarded for its *name*.
+
+### One source, N projections
+
+`policy/behavior.md` is authoritative and `src/policy/behavior-policy.ts` only
+reads it. That is the mirror image of `src/policy/self-healing-doctrine.ts`,
+where the module is authoritative and the markdown mirrors it — because that
+doctrine ships with Soma, while behavioural rules belong to you.
+
+No adapter restates a rule. Each renders from
+`behaviorPolicyAdvisory(input.behavior)` and nothing else, and a drift test
+uppercases every rule at the source, then asserts each projection carries the
+mutated form and neither the original rendered line nor its bare text.
+
+---
+
+## Reference codes
+
+When presenting three or more findings, options, risks, questions, actions, or
+decisions, the assistant labels each with a short code, stable for the whole
+conversation:
+
+```
+F1 findings · O1 options · R1 risks · Q1 questions · A1 actions · D1 decisions
+```
+
+Your reply collapses to `keep D1, reject O2, answer Q1` — no re-quoting, no
+re-explaining. You and the assistant share an index into the conversation.
+
+### C and P are reserved
+
+`C1` is a VSA criterion and `P1` an Algorithm plan step. Recording a code under
+either letter is **refused**, because `keep C1` must never be ambiguous between
+a criterion and a chat finding.
+
+The refusal lives at the write path only. Declaring `C` in your contract is
+harmless — a collision can only happen when a code is actually recorded, and a
+prose file on the home-load path must never be able to fail `install`.
+
+### Making a code durable
+
+A code typed in chat is shorthand until it is written to a run. There is no
+implicit "active run":
+
+```bash
+soma algorithm ref     --id <run-id> --code F1 --text "The parser truncates wrapped rules."
+soma algorithm ref     --id <run-id> --code D1 --text "Drop the co-author rule."
+soma algorithm resolve --id <run-id> --code D1 --verdict kept --note "Applied in the starter."
+```
+
+Batch form:
+
+```bash
+soma algorithm batch --id <run-id> \
+  --op "ref:F1:The parser truncates wrapped rules." \
+  --op "resolve:D1:kept:Applied in the starter."
+```
+
+Verdicts are `kept`, `rejected`, `answered`, `done`, `dropped`. Re-resolving
+overwrites — a decision revisited later is a real event, and refusing it would
+push the correction back into prose where nothing can read it.
+
+`soma algorithm show --id <run-id>` prints a **References** block when the run
+has any; runs without references show none.
+
+A reference verdict is **not** a checkpoint verdict: it is an ungated
+conversational disposition with no required evidence and no completion gate, and
+`soma algorithm resolve` is not `soma graph close`. See
+[CONTEXT.md](../CONTEXT.md) for the full vocabulary.
+
+### D codes mirror into decisions
+
+Recording or resolving a `D` code also appends to the run's `decisions` log.
+Decisions already have a durable home; a parallel one would let
+`soma algorithm show` disagree with itself about what was decided.
+
+`AlgorithmRun.references` is additive and store-defaulted, so runs written
+before this shipped load with an empty list.
+
+---
+
+## Provenance
+
+The contract's section structure — positive/negative patterns, banned phrases,
+reference codes, aliases, authored examples — and several of the banned phrases
+are adapted from [disler/fixing-smartass-opus-5](https://github.com/disler/fixing-smartass-opus-5)
+(MIT). Adapted, not copied. Four deliberate divergences:
+
+1. That project's "never add a co-author to a commit message" rule is **absent**;
+   it contradicts this repo's trailer convention.
+2. Its "no decorative headings" rule is **relaxed** — the VSA and Algorithm
+   rendering contracts are heading-dense by design.
+3. `C` and `P` are **reserved** out of the reference-code space, and `D` maps
+   onto the Algorithm's existing decisions log rather than a parallel record.
+4. Its side-by-side compare loop (`just` + `herdr` panes) is **not** ported: it
+   is a two-pane terminal comparison you eyeball, not a metric, and neither tool
+   can become a Soma dependency.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soma",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "description": "Substrate-portable Personal AI Assistant core.",


### PR DESCRIPTION
Docs for the communication contract and behavioral policy shipped in #636, plus the version bump.

## Docs

**New — [`docs/communication-and-behavior.md`](docs/communication-and-behavior.md).** The two files side by side: which compartment owns each, which one `soma init` creates (only the contract), how each reaches a substrate, and the per-substrate projection paths.

It documents the behavioural-policy authoring rules a principal actually needs, because they are not obvious from the file: wrapped bullets fold into whole rules, prose counts as rules, source order is preserved, numbered lists are bullets, fenced blocks are dropped whole (and an unbalanced fence disables fence handling rather than swallowing the rest of the file), `###` sub-headings are structure, and no section is ever discarded for its name.

It also covers the reference-code CLI — including that there is no implicit active run, so a code typed in chat is shorthand until `soma algorithm ref --id …` writes it — and carries the MIT provenance with the four places this deliberately diverges from the source project.

**`README.md`** — new "How the assistant talks, and what it may do" section before Privacy and policy, plus a documentation-index entry.

## Version

`0.16.1` → `0.17.0` in `package.json` and `arc-manifest.yaml`. Minor: additive feature, no breaking change. `SOMA_VERSION` derives from `package.json`, so nothing else needs touching — verified by importing it and printing `0.17.0`.

`CHANGELOG.md`: Unreleased cut to `## [0.17.0] - 2026-08-19`.

## Verification

- `bun test` — 2438 pass, 0 fail, 155 files.
- `bun run typecheck` — clean.
- `bun run check-release-privacy` — ok, no private release markers.
- `bun run check-skill-version` — ok, no VSA skill changes.

No registry publish is intended. `publish-soma.yml` is `workflow_dispatch`-only, so tagging and releasing on GitHub does not trigger it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)