### PR TITLE
fix(skills): reconcile migrated symlink slots safely

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,6 +1,6 @@
 schema: arc/v1
 name: soma
-version: 0.17.0
+version: 0.18.0
 type: tool
 tier: community
 description: Substrate-portable Personal AI Assistant core for identity, memory, VSA, skills, learning, and adapters.

--- a/src/adapters/shared/portable-skill-manifest.ts
+++ b/src/adapters/shared/portable-skill-manifest.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readFile, rm, rmdir, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, rm, rmdir, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, resolve, sep } from "node:path";
 import { isEnoent } from "../../fs-errors";
 
@@ -115,6 +115,29 @@ function isInsideRoot(root: string, target: string): boolean {
   return target !== root && target.startsWith(rootPrefix);
 }
 
+interface SymlinkIdentity {
+  path: string;
+  dev: number;
+  ino: number;
+}
+
+/** Find a directory symlink above a manifest-recorded file without following it. */
+async function symlinkAncestor(root: string, target: string): Promise<SymlinkIdentity | undefined> {
+  for (let dir = dirname(target); isInsideRoot(root, dir); dir = dirname(dir)) {
+    try {
+      const entry = await lstat(dir);
+      if (entry.isSymbolicLink()) return { path: dir, dev: entry.dev, ino: entry.ino };
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      // A missing path or a non-directory ancestor can be the result of another
+      // manifest entry already removing the same migrated slot. Keep walking so
+      // a higher symlink ancestor can still be identified.
+      if (code !== "ENOENT" && code !== "ENOTDIR") throw error;
+    }
+  }
+  return undefined;
+}
+
 export async function readPortableSkillManifest(
   somaHome: string,
   substrate: PortableSkillManifestSubstrate,
@@ -147,6 +170,34 @@ async function removeListedProjectionFiles(
   for (const file of files) {
     const target = resolve(substrateHome, file.path);
     if (!isInsideRoot(substrateHome, target)) continue;
+
+    // Copy-era manifests name files below skill directories. Loader-mode
+    // migration may have replaced such a directory with a symlink. Reading the
+    // recorded file first would follow that link and rm() would delete registry
+    // content. Remove the slot link itself before touching any recorded child.
+    const linkedDir = await symlinkAncestor(substrateHome, target);
+    if (linkedDir !== undefined) {
+      // The substrate's top-level directories are shared surfaces, not
+      // manifest-owned skill slots. If one is itself a symlink, fail open for
+      // this entry rather than unlinking the whole shared loader root.
+      if (dirname(linkedDir.path) === substrateHome) continue;
+      try {
+        // Narrow the lstat→unlink race: only unlink the same symlink inode we
+        // classified. A swapped regular file or replacement link is user state,
+        // so this manifest entry fails open instead of deleting it.
+        const current = await lstat(linkedDir.path);
+        if (!current.isSymbolicLink() || current.dev !== linkedDir.dev || current.ino !== linkedDir.ino) continue;
+        await unlink(linkedDir.path);
+        removed.push(linkedDir.path);
+      } catch (error) {
+        if (!isEnoent(error)) throw error;
+      }
+      for (let dir = dirname(linkedDir.path); isInsideRoot(substrateHome, dir); dir = dirname(dir)) {
+        candidateDirs.add(dir);
+      }
+      continue;
+    }
+
     let content: string;
     try {
       content = await readFile(target, "utf8");
@@ -173,7 +224,7 @@ async function removeListedProjectionFiles(
       // (EACCES/EPERM/EBUSY/…) is a real filesystem fault and must surface,
       // not be silently masked as a keep.
       const code = (error as { code?: string } | null)?.code;
-      if (code !== "ENOTEMPTY" && code !== "ENOENT") throw error;
+      if (code !== "ENOTEMPTY" && code !== "ENOENT" && code !== "ENOTDIR") throw error;
     }
   }
   return removed;

--- a/src/projection-reconcile.ts
+++ b/src/projection-reconcile.ts
@@ -66,7 +66,7 @@ async function removeEmptyDirs(root: string, excludedAbs: readonly string[] = []
     await rmdir(root);
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
-    if (code !== "ENOENT" && code !== "ENOTEMPTY") throw error;
+    if (code !== "ENOENT" && code !== "ENOTEMPTY" && code !== "ENOTDIR") throw error;
   }
 }
 

--- a/test/claude-code-install.test.ts
+++ b/test/claude-code-install.test.ts
@@ -3,7 +3,7 @@
  * Minimal-correct scope: rules/soma/ skeleton + VSA skill projection +
  * lifecycle/writeback hooks + uninstaller.
  */
-import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readdir, readFile, readlink, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -22,6 +22,7 @@ import { unpatchClaudeCodeModeClassifierSettings } from "../src/adapters/claude-
 import { installSpecFor } from "../src/install-spec-registry";
 import type { InstallSubstrate, SkillsDiscoveryMode } from "../src/install-spec";
 import { SOMA_SKILLS_HEADING } from "../src/adapters/shared";
+import { writePortableSkillManifest } from "../src/adapters/shared/portable-skill-manifest";
 import { stripProvenance } from "../src/adapters/shared/provenance";
 import { datePrefixSlug } from "../src/dated-slug";
 import { expectReprojectPrunesStaleTelos, portableProjectionInput } from "./fixtures";
@@ -822,6 +823,43 @@ test("soma#638: the library install projects the registry, not just the CLI", as
 
     expect(result.projectedSkills.map((skill) => skill.skill)).toContain("Lib");
     expect((await stat(join(homeDir, ".claude", "skills", "Lib", "SKILL.md"))).isFile()).toBe(true);
+  });
+});
+
+test("#652: install replaces a migrated manifest slot and continues projecting later skills", async () => {
+  await withTempHome(async (homeDir) => {
+    const somaHome = join(homeDir, ".soma");
+    const substrateHome = join(homeDir, ".claude");
+    await bootstrapSomaHome({ homeDir });
+
+    const migratedContent = "---\nname: Migrated\n---\n# migrated\n";
+    const laterContent = "---\nname: Later\n---\n# later\n";
+    const migratedRegistry = join(somaHome, "skills", "Migrated");
+    const laterRegistry = join(somaHome, "skills", "Later");
+    await mkdir(migratedRegistry, { recursive: true });
+    await mkdir(laterRegistry, { recursive: true });
+    await writeFile(join(migratedRegistry, "SKILL.md"), migratedContent, "utf8");
+    await writeFile(join(laterRegistry, "SKILL.md"), laterContent, "utf8");
+
+    const migratedSlot = join(substrateHome, "skills", "Migrated");
+    await mkdir(join(substrateHome, "skills"), { recursive: true });
+    await symlink(migratedRegistry, migratedSlot);
+    await writePortableSkillManifest({
+      somaHome,
+      substrate: "claude-code",
+      substrateHome,
+      files: [{ path: "skills/Migrated/SKILL.md", content: migratedContent }],
+    });
+
+    const result = await installSomaForClaudeCode({ homeDir });
+    const laterSlot = join(substrateHome, "skills", "Later");
+
+    expect((await lstat(migratedSlot)).isSymbolicLink()).toBe(true);
+    expect((await lstat(laterSlot)).isSymbolicLink()).toBe(true);
+    expect(await readlink(migratedSlot)).toBe(migratedRegistry);
+    expect(await readlink(laterSlot)).toBe(laterRegistry);
+    expect(result.projectedSkills.map((skill) => skill.skill)).toContain("Later");
+    expect(await readFile(join(migratedRegistry, "SKILL.md"), "utf8")).toBe(migratedContent);
   });
 });
 

--- a/test/portable-skill-manifest.test.ts
+++ b/test/portable-skill-manifest.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { lstat, mkdtemp, mkdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import {
@@ -160,6 +160,60 @@ test("reconcile removes only files the current projection dropped, keeping the m
     expect(await gone(join(substrateHome, "skills/Gone"))).toBe(true);
     expect(await gone(join(substrateHome, "skills/Memory/SKILL.md"))).toBe(false);
     expect(await gone(portableSkillManifestPath(somaHome, "claude-code", substrateHome))).toBe(false);
+  });
+});
+
+test("reconcile removes a migrated symlink slot without touching its target (#652)", async () => {
+  await withDirs(async (somaHome, substrateHome) => {
+    const files = [
+      { path: "skills/the-algorithm/SKILL.md", content: "algorithm body\n" },
+      { path: "skills/the-algorithm/Workflows/Run.md", content: "workflow body\n" },
+      { path: "skills/gone/SKILL.md", content: "later stale skill\n" },
+    ];
+    await project(substrateHome, files);
+    await writePortableSkillManifest({ somaHome, substrate: "claude-code", substrateHome, files });
+
+    const slot = join(substrateHome, "skills/the-algorithm");
+    const registrySkill = join(substrateHome, "registry/the-algorithm");
+    await rm(slot, { recursive: true });
+    await project(substrateHome, files.map((file) => ({ ...file, path: file.path.replace("skills/", "registry/") })));
+    await symlink(registrySkill, slot);
+
+    const removed = await reconcilePortableSkillProjection({
+      somaHome,
+      substrate: "claude-code",
+      substrateHome,
+      currentPaths: [],
+    });
+
+    expect(removed).toContain(slot);
+    expect(removed).toContain(resolve(substrateHome, "skills/gone/SKILL.md"));
+    expect(await lstat(slot).then(() => false, () => true)).toBe(true);
+    expect(await gone(join(substrateHome, "skills/gone"))).toBe(true);
+    expect(await readFile(join(registrySkill, "SKILL.md"), "utf8")).toBe("algorithm body\n");
+    expect(await readFile(join(registrySkill, "Workflows/Run.md"), "utf8")).toBe("workflow body\n");
+  });
+});
+
+test("reconcile never unlinks a shared top-level directory symlink", async () => {
+  await withDirs(async (somaHome, substrateHome) => {
+    const files = [{ path: "skills/Memory/SKILL.md", content: "memory body\n" }];
+    const sharedSkills = join(substrateHome, "skills");
+    const externalSkills = join(substrateHome, "external-skills");
+    await project(substrateHome, files.map((file) => ({ ...file, path: file.path.replace("skills/", "external-skills/") })));
+    await symlink(externalSkills, sharedSkills);
+    await writePortableSkillManifest({ somaHome, substrate: "claude-code", substrateHome, files });
+
+    const removed = await reconcilePortableSkillProjection({
+      somaHome,
+      substrate: "claude-code",
+      substrateHome,
+      currentPaths: [],
+    });
+
+    expect(removed).not.toContain(sharedSkills);
+    expect((await lstat(sharedSkills)).isSymbolicLink()).toBe(true);
+    expect(await readFile(join(externalSkills, "Memory/SKILL.md"), "utf8")).toBe("memory body\n");
   });
 });
 

--- a/test/projection-reconcile.test.ts
+++ b/test/projection-reconcile.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { reconcileOwnedDir } from "../src/projection-reconcile";
@@ -53,6 +53,26 @@ test("keeps a desired nested file, removes a sibling stale file (both FS)", asyn
     expect(await exists(join(root, "sub", "keep.md"))).toBe(true);
     expect(await exists(join(root, "sub", "drop.md"))).toBe(false);
     expect(await exists(join(root, "sub"))).toBe(true);
+  });
+});
+
+test("removes a stale symlinked subtree without touching its target (#652)", async () => {
+  await withTempDir(async (root) => {
+    const target = `${root}-target`;
+    try {
+      await mkdir(target, { recursive: true });
+      await writeFile(join(target, "SKILL.md"), "registry content", "utf8");
+      await symlink(target, join(root, "stale-skill"));
+      await writeFile(join(root, "keep.md"), "keep", "utf8");
+
+      const result = await reconcileOwnedDir(root, ["keep.md"]);
+
+      expect(result.removed).toContain("stale-skill");
+      expect(await exists(join(root, "stale-skill"))).toBe(false);
+      expect(await readFile(join(target, "SKILL.md"), "utf8")).toBe("registry content");
+    } finally {
+      await rm(target, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- prevent copy-era manifest cleanup from following a migrated skill-slot symlink into its registry target
- revalidate the slot symlink identity before unlinking and preserve shared loader roots
- tolerate benign ENOTDIR cleanup races and cover manifest, owned-subtree, and full Claude install migration paths

Closes #652

## Verification
- `bun test test/portable-skill-manifest.test.ts test/projection-reconcile.test.ts test/claude-code-install.test.ts` — 51 pass
- `bun run typecheck`
- `bunx eslint src/adapters/shared/portable-skill-manifest.ts src/projection-reconcile.ts test/portable-skill-manifest.test.ts test/projection-reconcile.test.ts test/claude-code-install.test.ts`
- Full `bun test` was run: 2491 pass; one existing unrelated failure reports an arc manifest/package version mismatch (0.17.0 vs 0.18.0).