### PR TITLE
fix(skills): recase stale projected symlinks

### DIFF
--- a/src/cli/skill-projection-cli.ts
+++ b/src/cli/skill-projection-cli.ts
@@ -157,7 +157,8 @@ function formatPlan(verb: string, plan: SkillProjectionPlan, marker: string): st
         `- ${link.scope === "registry" ? "registry" : link.substrate} ${marker} ${link.path}` +
         // Name the shape only when it is not the symlink default, so existing
         // on-demand output is unchanged (soma#542).
-        (link.kind === "stub" ? " (stub: frontmatter only)" : ""),
+        (link.kind === "stub" ? " (stub: frontmatter only)" : "") +
+        (link.recasedFrom ? ` (recase from ${link.recasedFrom})` : ""),
     ),
     "",
     `Catalog refresh: ${plan.catalogRefresh.join(", ")}`,
@@ -173,7 +174,8 @@ function formatProjectionResult(title: string, result: SkillProjectionResult): s
     "",
     "Links:",
     ...result.links.map((link) =>
-      `- ${link.scope === "registry" ? "registry" : link.substrate}: ${link.status} ${link.path}`,
+      `- ${link.scope === "registry" ? "registry" : link.substrate}: ${link.status} ${link.path}` +
+        (link.recasedFrom ? ` (recased from ${link.recasedFrom})` : ""),
     ),
     "",
     "Catalog:",

--- a/src/skill-projection.ts
+++ b/src/skill-projection.ts
@@ -81,6 +81,8 @@ export interface SkillLink {
   path: string;
   target?: string;
   status: SkillLinkStatus;
+  /** Stored path replaced only to normalize its casing on a case-insensitive volume. */
+  recasedFrom?: string;
 }
 
 /** The registry + per-substrate loader symlinks created for one skill (no catalog). */
@@ -111,6 +113,8 @@ export interface SkillProjectionPlan {
      * stub.
      */
     kind: "symlink" | "stub";
+    /** Stored path that apply will replace solely to normalize casing. */
+    recasedFrom?: string;
   }[];
   catalogRefresh: InstallSubstrate[];
 }
@@ -187,21 +191,74 @@ function assertSingleSubstrateForHome(options: { substrates: InstallSubstrate[];
   }
 }
 
-async function ensureSymlink(
+/** @internal Returns the differently-cased stored name for a requested slot, if one exists. */
+export function caseFoldedEntryName(entries: readonly string[], requestedName: string): string | undefined {
+  const folded = requestedName.toLowerCase();
+  return entries.find((entry) => entry !== requestedName && entry.toLowerCase() === folded);
+}
+
+/**
+ * Return a stale casing only when both spellings address the same filesystem entry.
+ * Case-sensitive filesystems can hold case-distinct siblings, which must stay distinct.
+ */
+/** @internal True only when two spelling lookups reach one directory entry. */
+export function isSameFilesystemEntry(
+  first: Pick<Awaited<ReturnType<typeof lstat>>, "dev" | "ino">,
+  second: Pick<Awaited<ReturnType<typeof lstat>>, "dev" | "ino">,
+): boolean {
+  return first.dev === second.dev && first.ino === second.ino;
+}
+
+async function storedCaseVariant(linkPath: string, entry: Awaited<ReturnType<typeof lstat>>): Promise<string | undefined> {
+  const parent = dirname(linkPath);
+  const storedName = caseFoldedEntryName(await readdir(parent), basename(linkPath));
+  if (storedName === undefined) return undefined;
+  const storedPath = join(parent, storedName);
+  const storedEntry = await lstat(storedPath);
+  return isSameFilesystemEntry(storedEntry, entry) ? storedPath : undefined;
+}
+
+async function equalTargetStaleCaseVariant(linkPath: string, targetPath: string): Promise<string | undefined> {
+  try {
+    const entry = await lstat(linkPath);
+    if (!entry.isSymbolicLink()) return undefined;
+    const current = await readlink(linkPath);
+    if (resolve(dirname(linkPath), current) !== resolve(targetPath)) return undefined;
+    return await storedCaseVariant(linkPath, entry);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw error;
+  }
+}
+
+interface SymlinkWriteResult {
+  status: "linked" | "unchanged" | "replaced";
+  recasedFrom?: string;
+}
+
+type StaleCaseVariantFinder = (linkPath: string, targetPath: string) => Promise<string | undefined>;
+
+/** @internal Exported to exercise deterministic replacement without an APFS-only test. */
+export async function ensureSymlink(
   linkPath: string,
   targetPath: string,
   force: boolean,
-): Promise<"linked" | "unchanged" | "replaced"> {
+  findStaleCaseVariant: StaleCaseVariantFinder = equalTargetStaleCaseVariant,
+): Promise<SymlinkWriteResult> {
   const target = resolve(targetPath);
   await mkdir(dirname(linkPath), { recursive: true });
 
   let existed = false;
+  let recasedFrom: string | undefined;
   try {
     const stat = await lstat(linkPath);
     existed = true;
     if (stat.isSymbolicLink()) {
       const current = await readlink(linkPath);
-      if (resolve(dirname(linkPath), current) === target) return "unchanged";
+      if (resolve(dirname(linkPath), current) === target) {
+        recasedFrom = await findStaleCaseVariant(linkPath, target);
+        if (recasedFrom === undefined) return { status: "unchanged" };
+      }
       // Any symlink in the slot is replaced without a provenance check — including
       // a user-created one pointing elsewhere. This is intentional: project-skill
       // owns the `<skillsRoot>/<name>` slot, and replacing a link loses no data
@@ -223,7 +280,7 @@ async function ensureSymlink(
   }
 
   await symlink(target, linkPath);
-  return existed ? "replaced" : "linked";
+  return { status: existed ? "replaced" : "linked", recasedFrom };
 }
 
 /**
@@ -390,9 +447,9 @@ async function linkSkill(
     //    Skipped when the source already lives under the registry (authored in place).
     const sourceAlreadyInRegistry = dirname(skillDir) === resolve(registrySkillsDir(somaHome));
     if (!sourceAlreadyInRegistry) {
-      const status = await ensureSymlink(slots.registry, skillDir, force);
-      if (status !== "unchanged") created.push(slots.registry);
-      links.push({ scope: "registry", path: slots.registry, target: skillDir, status });
+      const written = await ensureSymlink(slots.registry, skillDir, force);
+      if (written.status !== "unchanged") created.push(slots.registry);
+      links.push({ scope: "registry", path: slots.registry, target: skillDir, ...written });
     }
 
     // 2. Loader entry in each substrate. An on-demand loader gets a symlink to
@@ -401,12 +458,12 @@ async function linkSkill(
     //    (soma#542). Rollback below treats both shapes identically — the created
     //    path is removed either way.
     for (const { substrate, path } of slots.substrates) {
-      const status =
+      const written =
         installSpecFor(substrate).skillsLoading === "eager"
-          ? await ensureSkillStub(path, skillDir, slots.registry, substrate, force)
+          ? { status: await ensureSkillStub(path, skillDir, slots.registry, substrate, force) }
           : await ensureSymlink(path, skillDir, force);
-      if (status !== "unchanged") created.push(path);
-      links.push({ scope: "substrate", substrate, path, target: skillDir, status });
+      if (written.status !== "unchanged") created.push(path);
+      links.push({ scope: "substrate", substrate, path, target: skillDir, ...written });
     }
   } catch (error) {
     // Best-effort rollback of this skill's partial links, then rethrow.
@@ -461,13 +518,26 @@ export async function planProjectSkill(options: ProjectSkillOptions): Promise<Sk
   const slots = skillSlots(name, somaHome, options.substrates, options);
   const links: SkillProjectionPlan["links"] = [];
   if (dirname(skillDir) !== resolve(registrySkillsDir(somaHome))) {
-    links.push({ scope: "registry", path: slots.registry, target: skillDir, kind: "symlink" });
+    links.push({
+      scope: "registry",
+      path: slots.registry,
+      target: skillDir,
+      kind: "symlink",
+      recasedFrom: await equalTargetStaleCaseVariant(slots.registry, skillDir),
+    });
   }
   for (const { substrate, path } of slots.substrates) {
     // Same branch apply takes in linkSkill, so plan and apply cannot disagree
     // on the shape written into a substrate slot.
     const kind = installSpecFor(substrate).skillsLoading === "eager" ? "stub" : "symlink";
-    links.push({ scope: "substrate", substrate, path, target: skillDir, kind });
+    links.push({
+      scope: "substrate",
+      substrate,
+      path,
+      target: skillDir,
+      kind,
+      recasedFrom: kind === "symlink" ? await equalTargetStaleCaseVariant(path, skillDir) : undefined,
+    });
   }
 
   return { skill: name, skillDir, links, catalogRefresh: [...options.substrates] };

--- a/test/skill-projection.test.ts
+++ b/test/skill-projection.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { lstat, mkdir, mkdtemp, readFile, readlink, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readdir, readFile, readlink, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
-import { planProjectSkill, planUnprojectSkill, projectSkill, projectSkills, unprojectSkill } from "../src/skill-projection";
+import { dirname, join, resolve } from "node:path";
+import { caseFoldedEntryName, ensureSymlink, isSameFilesystemEntry, planProjectSkill, planUnprojectSkill, projectSkill, projectSkills, unprojectSkill } from "../src/skill-projection";
 import { bootstrapSomaHome } from "../src/index";
 import { runSomaCli } from "../src/cli";
 
@@ -35,6 +35,34 @@ async function readlinkAbs(linkPath: string): Promise<string> {
   return resolve(linkPath, "..", target);
 }
 
+describe("case-folded loader slots", () => {
+  test("recognizes a stored slot whose case differs from the requested name", () => {
+    expect(caseFoldedEntryName(["Council", "Other"], "council")).toBe("Council");
+    expect(caseFoldedEntryName(["council"], "council")).toBeUndefined();
+    expect(caseFoldedEntryName(["Other"], "council")).toBeUndefined();
+    expect(isSameFilesystemEntry({ dev: 1, ino: 2 }, { dev: 1, ino: 2 })).toBe(true);
+    expect(isSameFilesystemEntry({ dev: 1, ino: 2 }, { dev: 1, ino: 3 })).toBe(false);
+  });
+});
+
+describe("ensureSymlink", () => {
+  test("replaces an equal-target slot when the stale-casing detector finds one", async () => {
+    await withTempHome(async (homeDir) => {
+      const target = await writeSourceSkill(homeDir, "council");
+      const link = join(homeDir, "loader", "council");
+      const stale = join(homeDir, "loader", "Council");
+      await mkdir(dirname(link), { recursive: true });
+      await symlink(target, link);
+
+      const result = await ensureSymlink(link, target, false, async () => stale);
+
+      expect(result).toEqual({ status: "replaced", recasedFrom: stale });
+      expect((await lstat(link)).isSymbolicLink()).toBe(true);
+      expect(await readlinkAbs(link)).toBe(resolve(target));
+    });
+  });
+});
+
 describe("projectSkill", () => {
   test("symlinks into the claude-code loader and the soma registry, and lists it in the catalog", async () => {
     await withTempHome(async (homeDir) => {
@@ -57,6 +85,33 @@ describe("projectSkill", () => {
       // Catalog lists it (soma#371: compact registry entry, not a `## <name>` heading).
       const catalog = await readFile(join(homeDir, ".cursor", "rules", "soma", "SKILLS.md"), "utf8");
       expect(catalog).toContain("**MyTool**");
+    });
+  });
+
+  test("recases folded slots and preserves case-distinct siblings", async () => {
+    await withTempHome(async (homeDir) => {
+      const skillDir = await writeSourceSkill(homeDir, "council");
+      const loader = join(homeDir, ".claude", "skills");
+      const requested = join(loader, "council");
+      const stale = join(loader, "Council");
+      await mkdir(loader, { recursive: true });
+      await symlink(skillDir, stale);
+      const foldsCase = await lstat(requested).then(() => true).catch(() => false);
+
+      const result = await projectSkill({ skillDir, substrates: ["claude-code"], homeDir });
+      const projected = result.links.find((link) => link.scope === "substrate");
+      const entries = await readdir(loader);
+      if (foldsCase) {
+        expect(projected?.status).toBe("replaced");
+        expect(projected?.recasedFrom).toBe(stale);
+        expect(entries).toContain("council");
+        expect(entries).not.toContain("Council");
+      } else {
+        expect(projected?.status).toBe("linked");
+        expect(projected?.recasedFrom).toBeUndefined();
+        expect(entries).toContain("council");
+        expect(entries).toContain("Council");
+      }
     });
   });
 


### PR DESCRIPTION
Closes #653

## Summary
- normalize equal-target symlinks whose stored slot casing differs on case-insensitive filesystems
- expose the prior spelling in dry-run and apply output
- cover the case-folding decision without requiring a case-insensitive CI volume

## Verification
- `bun test test/skill-projection.test.ts`
- `bun run typecheck`
- `bunx eslint src/skill-projection.ts src/cli/skill-projection-cli.ts test/skill-projection.test.ts`
- `bun test` (existing unrelated failures: arc-manifest version mismatch, one Codex executor timeout, and two 5s timeout flakes)