### PR TITLE
feat(runtime): freeze enforcement artifact

### DIFF
--- a/src/adapters/claude-code/policy-guard-hook.mjs
+++ b/src/adapters/claude-code/policy-guard-hook.mjs
@@ -164,7 +164,7 @@ function main() {
 
   const output = result.stdout || result.stderr || "";
   if (result.status !== 0) {
-    deny(`Soma runtime policy inspection failed closed: ${output || "unknown error"}.`);
+    deny(`Soma runtime policy inspection failed closed: ${output || "unknown error"}. Reinstall the active enforcement artifact with soma install claude-code --apply, or run soma runtime rollback.`);
     return;
   }
   let inspection;

--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -39,9 +39,6 @@ function codexLifecycleConfig(somaHome: string, homeDir?: string, somaRepoPath =
   const privateRoots = [
     ...somaProjectionPrivateRoots({ homeDir, substrate: "codex" }),
     ...somaMemoryPrivateRoots({ homeDir, substrate: "codex" }),
-    join(home, ".claude", "memory"),
-    join(home, ".claude", "memories"),
-    join(home, ".claude", "PAI", "MEMORY"),
   ].map((path) => resolve(path));
   const policyMarkers = somaPolicyPrivateMarkers(somaHome, homeDir, privateRoots);
   return {

--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -36,9 +36,16 @@ function codexLifecycleConfig(somaHome: string, homeDir?: string, somaRepoPath =
   };
 } {
   const home = resolve(homeDir ?? homedir());
+  // Codex's hook can operate over the principal's existing Claude/PAI
+  // memory as well as its own projection. These are intentionally local to
+  // the Codex hook config: they are not Codex projection roots and must not
+  // broaden other substrates' policy scope.
   const privateRoots = [
     ...somaProjectionPrivateRoots({ homeDir, substrate: "codex" }),
     ...somaMemoryPrivateRoots({ homeDir, substrate: "codex" }),
+    join(home, ".claude", "memory"),
+    join(home, ".claude", "memories"),
+    join(home, ".claude", "PAI", "MEMORY"),
   ].map((path) => resolve(path));
   const policyMarkers = somaPolicyPrivateMarkers(somaHome, homeDir, privateRoots);
   return {

--- a/src/adapters/content-compare-doctor.ts
+++ b/src/adapters/content-compare-doctor.ts
@@ -4,7 +4,7 @@ import { CURSOR_RULES_BLOCK_BEGIN, buildSubstrateHomeProjection, mergeCursorRule
 import { SomaHomeNotLoadableError, loadProjectionInputForDoctor } from "../doctor-projection-input";
 import { defaultSomaRepoPath } from "../repo-path";
 import { isEnoent, pathExists } from "../fs-utils";
-import { runtimeArtifactActivePath } from "../runtime-artifact";
+import { runtimeArtifactActivePath, type GuardedRuntimeSubstrate } from "../runtime-artifact";
 import { CURSOR_RULES_PATH } from "./cursor";
 import { hasProvenanceHeader } from "./shared";
 import type { InstallSubstrate, SomaDoctorFinding } from "../types";
@@ -179,10 +179,10 @@ function buildFindings(substrate: ContentCompareSubstrate, totalFiles: number, b
 
 export async function diagnoseContentCompareDrift(options: ContentCompareDoctorOptions): Promise<SomaDoctorFinding[]> {
   const sourceRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();
-  // Guarded hook configs intentionally point at the stable runtime/current
-  // symlink. Rebuild with the same target when it exists, otherwise retain the
+  // Guarded hook configs intentionally point at their stable substrate-scoped
+  // runtime pointer. Rebuild with the same target when it exists, otherwise retain the
   // source path so an uninstalled home remains diagnosable in the usual way.
-  const activeRuntime = runtimeArtifactActivePath(options.somaHome);
+  const activeRuntime = runtimeArtifactActivePath(options.somaHome, options.substrate as GuardedRuntimeSubstrate);
   const somaRepoPath = ["claude-code", "codex", "grok"].includes(options.substrate) && await pathExists(activeRuntime)
     ? activeRuntime
     : sourceRepoPath;

--- a/src/adapters/content-compare-doctor.ts
+++ b/src/adapters/content-compare-doctor.ts
@@ -3,7 +3,8 @@ import { join } from "node:path";
 import { CURSOR_RULES_BLOCK_BEGIN, buildSubstrateHomeProjection, mergeCursorRulesContent } from "../home-projection";
 import { SomaHomeNotLoadableError, loadProjectionInputForDoctor } from "../doctor-projection-input";
 import { defaultSomaRepoPath } from "../repo-path";
-import { isEnoent } from "../fs-utils";
+import { isEnoent, pathExists } from "../fs-utils";
+import { runtimeArtifactActivePath } from "../runtime-artifact";
 import { CURSOR_RULES_PATH } from "./cursor";
 import { hasProvenanceHeader } from "./shared";
 import type { InstallSubstrate, SomaDoctorFinding } from "../types";
@@ -177,7 +178,14 @@ function buildFindings(substrate: ContentCompareSubstrate, totalFiles: number, b
 }
 
 export async function diagnoseContentCompareDrift(options: ContentCompareDoctorOptions): Promise<SomaDoctorFinding[]> {
-  const somaRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();
+  const sourceRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();
+  // Guarded hook configs intentionally point at the stable runtime/current
+  // symlink. Rebuild with the same target when it exists, otherwise retain the
+  // source path so an uninstalled home remains diagnosable in the usual way.
+  const activeRuntime = runtimeArtifactActivePath(options.somaHome);
+  const somaRepoPath = ["claude-code", "codex", "grok"].includes(options.substrate) && await pathExists(activeRuntime)
+    ? activeRuntime
+    : sourceRepoPath;
   let input: Awaited<ReturnType<typeof loadProjectionInputForDoctor>>;
   try {
     input = await loadProjectionInputForDoctor({ somaHome: options.somaHome, somaRepoPath });

--- a/src/algorithm.ts
+++ b/src/algorithm.ts
@@ -828,7 +828,7 @@ export type { BridgedNodeReport };
  * the run's checklist show graph topology rather than restate it.
  */
 export function deriveBridgedPlanStepStatus(report: BridgedNodeReport): AlgorithmPlanStep["status"] {
-  if (report.status === "closed") return "done";
+  if (report.status === "closed") return report.hasCloseReceipt ? "done" : "blocked";
   return report.blockedBy.some((blocker) => blocker.status === "open") ? "blocked" : "open";
 }
 
@@ -884,7 +884,7 @@ export function syncBridgedPlanStep(
           status,
           // Derived, never caller-asserted — the pointer names the authority and
           // the moment, so a reader can tell a fresh derivation from a stale one.
-          evidence: `derived from work-graph node ${nodeId} (${report.status}) at ${timestamp}`,
+          evidence: `derived from work-graph node ${nodeId} (${report.status}; ${report.hasCloseReceipt ? "Soma-complete receipt" : "no close receipt"}) at ${timestamp}`,
         }
       : current,
   );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -119,6 +119,7 @@ import {
   runPreCompactCli,
   type ParsedPreCompactArgs,
 } from "./cli/precompact";
+import { RUNTIME_COMMAND_HELP, parseRuntimeArgs, runRuntimeCli, type ParsedRuntimeArgs } from "./cli/runtime";
 import {
   GRAPH_COMMAND_HELP,
   parseGraphArgs,
@@ -170,7 +171,8 @@ type ParsedArgs =
   | ParsedWritebackArgs
   | ParsedVsaArgs
   | ParsedSnapshotCommandArgs
-  | ParsedToolArgs;
+  | ParsedToolArgs
+  | ParsedRuntimeArgs;
 
 const TOP_LEVEL_COMMANDS = [
   "adopt",
@@ -200,6 +202,7 @@ const TOP_LEVEL_COMMANDS = [
   "reproject",
   "unproject-skill",
   "result",
+  "runtime",
   "rollback",
   "session",
   "stats",
@@ -237,6 +240,7 @@ const COMMAND_HELP: Record<string, { usage: string; subcommands?: Record<string,
   import: IMPORT_COMMAND_HELP,
   migrate: MIGRATE_COMMAND_HELP,
   ...SNAPSHOT_COMMAND_HELP,
+  runtime: RUNTIME_COMMAND_HELP,
   adopt: ONBOARDING_COMMAND_HELP.adopt,
   vsa: {
     // Single source of truth lives in `./cli-vsa.ts` (Sage round-1 dedup).
@@ -369,6 +373,10 @@ function parseArgs(args: string[]): ParsedArgs {
 
   if (args[0] === "migrate") {
     return parseMigrateArgs(args);
+  }
+
+  if (args[0] === "runtime") {
+    return parseRuntimeArgs(args);
   }
 
   if (args[0] === "snapshot") {
@@ -568,6 +576,10 @@ export async function runSomaCli(args: string[]): Promise<string> {
 
   if (parsed.command === "migrate") {
     return runMigrateCli(parsed);
+  }
+
+  if (parsed.command === "runtime") {
+    return runRuntimeCli(parsed);
   }
 
   if (parsed.command === "snapshot" || parsed.command === "history" || parsed.command === "rollback") {

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -104,7 +104,7 @@ export const GRAPH_COMMAND_HELP: { usage: string; subcommands: Record<GraphActio
       "Usage: soma graph release <id> [--identity <login>] [--repo <owner/name>] [--json] — identity-bound self-release: abandon your own claim (only ever unassigns the acting identity)",
     add: "Usage: soma graph add <root> --title <text> --autonomy <auto|propose|approve> --checkpoint <id> [--kind <k>] [--label <name>]... [--body <text>|--body-file <path>] [--probe <json>]... [--blocked-by <id>]... [--budget-tokens <n>] [--budget-invocations <n>] [--budget-minutes <n>] [--repo <owner/name>] [--json]",
     close:
-      "Usage: soma graph close <id> --resolution-file <path> [--gist <one line>] [--propose --body <text>|--body-file <path>] [--proposal-comment <id>] [--checkpoint <id>] [--evidence <json>]... [--identity <login>] [--dry-run] [--repo <owner/name>]",
+      "Usage: soma graph close <id> --resolution-file <path> [--gist <one line>] [--ci <checkRunId>@<headSha>] [--propose --body <text>|--body-file <path>] [--proposal-comment <id>] [--checkpoint <id>] [--evidence <json>]... [--identity <login>] [--dry-run] [--repo <owner/name>]",
     audit: "Usage: soma graph audit <root> [--repo <owner/name>] [--json]",
     decisions: "Usage: soma graph decisions <root> [--write] [--repo <owner/name>] [--json]",
   },
@@ -168,6 +168,7 @@ export interface ParsedGraphCloseArgs {
     gist?: string;
     proposalComment?: string;
     checkpointId?: string;
+    ci?: { checkRunId: string; headSha: string };
     identity?: string;
     dryRun?: boolean;
     evidence: CloseEvidence[];
@@ -405,6 +406,16 @@ function parseCloseArgs(target: string, rest: string[]): ParsedGraphCloseArgs {
         options.checkpointId = readOption(rest, index, arg);
         index += 1;
         break;
+      case "--ci": {
+        const value = readOption(rest, index, arg);
+        const at = value.lastIndexOf("@");
+        if (at <= 0 || at === value.length - 1) {
+          throw new Error("--ci must be <checkRunId>@<headSha>");
+        }
+        options.ci = { checkRunId: value.slice(0, at), headSha: value.slice(at + 1) };
+        index += 1;
+        break;
+      }
       case "--identity":
         options.identity = readOption(rest, index, arg);
         index += 1;
@@ -1259,6 +1270,7 @@ async function runClose(
     at: deps.now().toISOString(),
     ...(resolution === undefined ? {} : { resolution }),
     ...(parsed.options.gist === undefined ? {} : { gist: parsed.options.gist }),
+    ...(parsed.options.ci === undefined ? {} : { ci: parsed.options.ci }),
     evidence,
     probeResults,
     ...(probeTrees.length === 0 ? {} : { probeTrees }),

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -1,25 +1,30 @@
 import { homedir } from "node:os";
 import { resolve } from "node:path";
-import { inspectRuntimeArtifact, rollbackRuntimeArtifact } from "../runtime-artifact";
+import { inspectRuntimeArtifact, isGuardedRuntimeSubstrate, rollbackRuntimeArtifact, type GuardedRuntimeSubstrate } from "../runtime-artifact";
 
-export interface ParsedRuntimeArgs { command: "runtime"; action: "status" | "rollback"; somaHome?: string; }
-export const RUNTIME_COMMAND_HELP = { usage: "Usage: soma runtime <status|rollback> [--soma-home <dir>]", subcommands: { status: "Usage: soma runtime status [--soma-home <dir>]", rollback: "Usage: soma runtime rollback [--soma-home <dir>]" } };
+export interface ParsedRuntimeArgs { command: "runtime"; action: "status" | "rollback"; substrate: GuardedRuntimeSubstrate; somaHome?: string; }
+export const RUNTIME_COMMAND_HELP = { usage: "Usage: soma runtime <status|rollback> --substrate <claude-code|codex|grok> [--soma-home <dir>]", subcommands: { status: "Usage: soma runtime status --substrate <claude-code|codex|grok> [--soma-home <dir>]", rollback: "Usage: soma runtime rollback --substrate <claude-code|codex|grok> [--soma-home <dir>]" } };
 export function parseRuntimeArgs(args: string[]): ParsedRuntimeArgs {
   const [, action, ...rest] = args;
   if (action !== "status" && action !== "rollback") throw new Error(RUNTIME_COMMAND_HELP.usage);
   let somaHome: string | undefined;
+  let substrate: GuardedRuntimeSubstrate | undefined;
   for (let i = 0; i < rest.length; i += 1) {
-    if (rest[i] !== "--soma-home" || !rest[i + 1]) throw new Error(RUNTIME_COMMAND_HELP.subcommands[action]);
-    somaHome = rest[++i];
+    const flag = rest[i]; const value = rest[++i];
+    if (!value) throw new Error(RUNTIME_COMMAND_HELP.subcommands[action]);
+    if (flag === "--soma-home") somaHome = value;
+    else if (flag === "--substrate" && isGuardedRuntimeSubstrate(value)) substrate = value;
+    else throw new Error(RUNTIME_COMMAND_HELP.subcommands[action]);
   }
-  return { command: "runtime", action, somaHome };
+  if (!substrate) throw new Error(RUNTIME_COMMAND_HELP.subcommands[action]);
+  return { command: "runtime", action, substrate, somaHome };
 }
 export async function runRuntimeCli(args: ParsedRuntimeArgs): Promise<string> {
   const somaHome = resolve(args.somaHome ?? `${homedir()}/.soma`);
   if (args.action === "rollback") {
-    const state = await rollbackRuntimeArtifact(somaHome);
-    return `soma runtime — activated retained artifact ${state.active}`;
+    const state = await rollbackRuntimeArtifact(somaHome, args.substrate);
+    return `soma runtime — activated retained ${args.substrate} artifact ${state.active}`;
   }
-  const result = await inspectRuntimeArtifact(somaHome);
-  return result.status === "ready" ? `soma runtime — active artifact ${result.state?.active}` : `soma runtime — ${result.status}`;
+  const result = await inspectRuntimeArtifact(somaHome, args.substrate);
+  return result.status === "ready" ? `soma runtime — active ${args.substrate} artifact ${result.state?.active}` : `soma runtime — ${args.substrate} ${result.status}`;
 }

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -1,0 +1,25 @@
+import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { inspectRuntimeArtifact, rollbackRuntimeArtifact } from "../runtime-artifact";
+
+export interface ParsedRuntimeArgs { command: "runtime"; action: "status" | "rollback"; somaHome?: string; }
+export const RUNTIME_COMMAND_HELP = { usage: "Usage: soma runtime <status|rollback> [--soma-home <dir>]", subcommands: { status: "Usage: soma runtime status [--soma-home <dir>]", rollback: "Usage: soma runtime rollback [--soma-home <dir>]" } };
+export function parseRuntimeArgs(args: string[]): ParsedRuntimeArgs {
+  const [, action, ...rest] = args;
+  if (action !== "status" && action !== "rollback") throw new Error(RUNTIME_COMMAND_HELP.usage);
+  let somaHome: string | undefined;
+  for (let i = 0; i < rest.length; i += 1) {
+    if (rest[i] !== "--soma-home" || !rest[i + 1]) throw new Error(RUNTIME_COMMAND_HELP.subcommands[action]);
+    somaHome = rest[++i];
+  }
+  return { command: "runtime", action, somaHome };
+}
+export async function runRuntimeCli(args: ParsedRuntimeArgs): Promise<string> {
+  const somaHome = resolve(args.somaHome ?? `${homedir()}/.soma`);
+  if (args.action === "rollback") {
+    const state = await rollbackRuntimeArtifact(somaHome);
+    return `soma runtime — activated retained artifact ${state.active}`;
+  }
+  const result = await inspectRuntimeArtifact(somaHome);
+  return result.status === "ready" ? `soma runtime — active artifact ${result.state?.active}` : `soma runtime — ${result.status}`;
+}

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -758,6 +758,7 @@ export function formatInstallResult(result: SomaInstallResult): string {
     `substrate: ${result.substrate}`,
     `somaHome: ${result.somaHome.somaHome}`,
     `substrateHome: ${result.substrateHome.rootDir}`,
+    ...(result.runtimeArtifact ? [`runtimeArtifact: ${result.runtimeArtifact.hash} (${result.runtimeArtifact.path})`, `runtimeRollback: soma runtime rollback --soma-home ${result.somaHome.somaHome}`] : []),
     "",
     "Soma files:",
     ...result.somaHome.files.map((path) => `- ${path}`),

--- a/src/index.ts
+++ b/src/index.ts
@@ -506,7 +506,7 @@ export {
   type UninstallGrokOptions,
   type UninstallGrokResult,
 } from "./install";
-export { inspectRuntimeArtifact, isGuardedRuntimeSubstrate, readRuntimeArtifactState, rollbackRuntimeArtifact, runtimeArtifactActivePath, runtimeArtifactRoot } from "./runtime-artifact";
+export { inspectRuntimeArtifact, rollbackRuntimeArtifact } from "./runtime-artifact";
 export * as experimentalAnthropicCowork from "./experimental/anthropic-cowork";
 export type { ClaudeCodeInstallOptions } from "./adapters/claude-code/install-options";
 // Adapter active-VSA projection helpers (#37).
@@ -726,6 +726,7 @@ export {
   WorkGraphError,
   agentExternalEvidenceKinds,
   assertClosable,
+  hashGatedNodeFields,
   normalizeKind,
   parseNodeSpec,
   parseProbe,

--- a/src/index.ts
+++ b/src/index.ts
@@ -506,6 +506,7 @@ export {
   type UninstallGrokOptions,
   type UninstallGrokResult,
 } from "./install";
+export { inspectRuntimeArtifact, readRuntimeArtifactState, rollbackRuntimeArtifact, runtimeArtifactActivePath, runtimeArtifactRoot, stageRuntimeArtifact } from "./runtime-artifact";
 export * as experimentalAnthropicCowork from "./experimental/anthropic-cowork";
 export type { ClaudeCodeInstallOptions } from "./adapters/claude-code/install-options";
 // Adapter active-VSA projection helpers (#37).

--- a/src/index.ts
+++ b/src/index.ts
@@ -506,7 +506,7 @@ export {
   type UninstallGrokOptions,
   type UninstallGrokResult,
 } from "./install";
-export { inspectRuntimeArtifact, readRuntimeArtifactState, rollbackRuntimeArtifact, runtimeArtifactActivePath, runtimeArtifactRoot, stageRuntimeArtifact } from "./runtime-artifact";
+export { inspectRuntimeArtifact, isGuardedRuntimeSubstrate, readRuntimeArtifactState, rollbackRuntimeArtifact, runtimeArtifactActivePath, runtimeArtifactRoot } from "./runtime-artifact";
 export * as experimentalAnthropicCowork from "./experimental/anthropic-cowork";
 export type { ClaudeCodeInstallOptions } from "./adapters/claude-code/install-options";
 // Adapter active-VSA projection helpers (#37).

--- a/src/install.ts
+++ b/src/install.ts
@@ -23,6 +23,7 @@ import { loadActiveVsaForBundle } from "./adapter-active-vsa";
 import { loadMemoryIndexForProjection } from "./memory-index";
 import { isUnderOrEqual, reconcileOwnedDir } from "./projection-reconcile";
 import { isEnoent } from "./fs-errors";
+import { stageRuntimeArtifact } from "./runtime-artifact";
 import {
   type ImplementedUninstallSpec,
   type InstallSubstrate,
@@ -155,6 +156,11 @@ async function installSomaForSubstrate(
     includeSkills: !codeOnly,
   });
   const somaRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();
+  // Guarded substrates execute only the immutable artifact, never this editable checkout.
+  const guardedRuntime = (["claude-code", "codex", "grok"] as const).includes(substrate as "claude-code" | "codex" | "grok")
+    ? await stageRuntimeArtifact({ somaHome: somaHome.somaHome, sourceRoot: somaRepoPath })
+    : undefined;
+  const runtimeRepoPath = guardedRuntime?.path ?? somaRepoPath;
   let projectionContext = somaHome.context;
   // Repo-bundled skill dir names — set from installBundledSkillsIntoHome below
   // (non-codeOnly only) and reused to scope the portable-skill loop, avoiding a
@@ -201,7 +207,7 @@ async function installSomaForSubstrate(
     homeDir: options.homeDir,
     somaHome: options.somaHome,
     substrateHome: options.substrateHome,
-    somaRepoPath,
+    somaRepoPath: runtimeRepoPath,
     codeOnly,
   };
   // Per-substrate skill projection (#37 AC-3). Each substrate gets the
@@ -283,6 +289,7 @@ async function installSomaForSubstrate(
 
   return {
     substrate,
+    ...(guardedRuntime ? { runtimeArtifact: guardedRuntime } : {}),
     somaHome,
     substrateHome: {
       ...substrateHome,

--- a/src/install.ts
+++ b/src/install.ts
@@ -158,7 +158,7 @@ async function installSomaForSubstrate(
   const somaRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();
   // Guarded substrates execute only the immutable artifact, never this editable checkout.
   const guardedRuntime = isGuardedRuntimeSubstrate(substrate)
-    ? await stageRuntimeArtifact({ somaHome: somaHome.somaHome, sourceRoot: somaRepoPath })
+    ? await stageRuntimeArtifact({ somaHome: somaHome.somaHome, substrate, sourceRoot: somaRepoPath })
     : undefined;
   const runtimeRepoPath = guardedRuntime?.path ?? somaRepoPath;
   let projectionContext = somaHome.context;

--- a/src/install.ts
+++ b/src/install.ts
@@ -23,7 +23,7 @@ import { loadActiveVsaForBundle } from "./adapter-active-vsa";
 import { loadMemoryIndexForProjection } from "./memory-index";
 import { isUnderOrEqual, reconcileOwnedDir } from "./projection-reconcile";
 import { isEnoent } from "./fs-errors";
-import { stageRuntimeArtifact } from "./runtime-artifact";
+import { isGuardedRuntimeSubstrate, stageRuntimeArtifact } from "./runtime-artifact";
 import {
   type ImplementedUninstallSpec,
   type InstallSubstrate,
@@ -157,7 +157,7 @@ async function installSomaForSubstrate(
   });
   const somaRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();
   // Guarded substrates execute only the immutable artifact, never this editable checkout.
-  const guardedRuntime = (["claude-code", "codex", "grok"] as const).includes(substrate as "claude-code" | "codex" | "grok")
+  const guardedRuntime = isGuardedRuntimeSubstrate(substrate)
     ? await stageRuntimeArtifact({ somaHome: somaHome.somaHome, sourceRoot: somaRepoPath })
     : undefined;
   const runtimeRepoPath = guardedRuntime?.path ?? somaRepoPath;

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -5,6 +5,7 @@ import { DOCTOR_UNSUPPORTED_DRIFT_MESSAGE, diagnoseProjectionDrift, isDoctorSubs
 import { installSomaForClaudeCode, installSomaForCodex, installSomaForCursor, installSomaForDsh, installSomaForGrok, installSomaForPiDev } from "./install";
 import { migrateClaudeSkills, probeClaudeSkillsSource } from "./claude-skills-migrator";
 import { bootstrapSomaHome } from "./soma-home";
+import { inspectRuntimeArtifact } from "./runtime-artifact";
 import { migratePai } from "./pai-migration";
 import { isEnoent, pathExists } from "./fs-utils";
 import type {
@@ -293,6 +294,26 @@ export async function diagnoseSomaDoctor(options: SomaOnboardingOptions = {}): P
       message: "PAI source exists, but Soma has no PAI migration manifest.",
       action: `soma migrate pai --pai-install ${shellQuote(detected.detected.paiInstall)} --apply ${sharedPathFlags(detected)}`,
     });
+  }
+
+  const guardedHookConfigs: Partial<Record<InitSubstrate, string>> = {
+    "claude-code": join(detected.homeDir, ".claude", "hooks/soma/soma-policy-guard.config.json"),
+    codex: join(detected.homeDir, ".codex", "hooks/soma-lifecycle.config.json"),
+    grok: join(detected.homeDir, ".grok", "hooks/soma-lifecycle.config.json"),
+  };
+  const guardedHookConfig = guardedHookConfigs[substrate];
+  const hasGuardedHook = guardedHookConfig !== undefined && await pathExists(guardedHookConfig);
+  // An artifact is required only after this substrate has a guarded hook configured.
+  if (hasGuardedHook) {
+    const runtime = await inspectRuntimeArtifact(detected.somaHome);
+    if (runtime.status !== "ready") {
+      findings.push({
+        id: runtime.status === "unloadable" ? "runtime-artifact-unloadable" : "runtime-artifact-missing",
+        severity: "error",
+        message: `Active enforcement artifact is ${runtime.status.replace(/-/g, " ")}; guarded hooks fail closed until it is restored.`,
+        action: `soma install ${substrate} --apply --home-dir ${shellQuote(detected.homeDir)} --soma-home ${shellQuote(detected.somaHome)}; if a retained artifact exists, run soma runtime rollback --soma-home ${shellQuote(detected.somaHome)}`,
+      });
+    }
   }
 
   findings.push(...await diagnoseProjectionDrift({

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -5,7 +5,7 @@ import { DOCTOR_UNSUPPORTED_DRIFT_MESSAGE, diagnoseProjectionDrift, isDoctorSubs
 import { installSomaForClaudeCode, installSomaForCodex, installSomaForCursor, installSomaForDsh, installSomaForGrok, installSomaForPiDev } from "./install";
 import { migrateClaudeSkills, probeClaudeSkillsSource } from "./claude-skills-migrator";
 import { bootstrapSomaHome } from "./soma-home";
-import { inspectRuntimeArtifact } from "./runtime-artifact";
+import { inspectRuntimeArtifact, isGuardedRuntimeSubstrate } from "./runtime-artifact";
 import { migratePai } from "./pai-migration";
 import { isEnoent, pathExists } from "./fs-utils";
 import type {
@@ -304,14 +304,14 @@ export async function diagnoseSomaDoctor(options: SomaOnboardingOptions = {}): P
   const guardedHookConfig = guardedHookConfigs[substrate];
   const hasGuardedHook = guardedHookConfig !== undefined && await pathExists(guardedHookConfig);
   // An artifact is required only after this substrate has a guarded hook configured.
-  if (hasGuardedHook) {
-    const runtime = await inspectRuntimeArtifact(detected.somaHome);
+  if (hasGuardedHook && isGuardedRuntimeSubstrate(substrate)) {
+    const runtime = await inspectRuntimeArtifact(detected.somaHome, substrate);
     if (runtime.status !== "ready") {
       findings.push({
         id: runtime.status === "unloadable" ? "runtime-artifact-unloadable" : "runtime-artifact-missing",
         severity: "error",
         message: `Active enforcement artifact is ${runtime.status.replace(/-/g, " ")}; guarded hooks fail closed until it is restored.`,
-        action: `soma install ${substrate} --apply --home-dir ${shellQuote(detected.homeDir)} --soma-home ${shellQuote(detected.somaHome)}; if a retained artifact exists, run soma runtime rollback --soma-home ${shellQuote(detected.somaHome)}`,
+        action: `soma install ${substrate} --apply --home-dir ${shellQuote(detected.homeDir)} --soma-home ${shellQuote(detected.somaHome)}; if a retained artifact exists, run soma runtime rollback --substrate ${substrate} --soma-home ${shellQuote(detected.somaHome)}`,
       });
     }
   }

--- a/src/runtime-artifact.ts
+++ b/src/runtime-artifact.ts
@@ -103,12 +103,15 @@ async function sealArtifact(root: string): Promise<void> {
     const path = join(root, entry.name);
     if (entry.isDirectory()) {
       await sealArtifact(path);
-      await chmod(path, 0o555);
+      // Directories stay writable so home cleanup and atomic replacement work;
+      // payload files are read-only. Same-UID permissions are best-effort
+      // hardening, not a tamper-proof boundary (detection, not prevention).
+      await chmod(path, 0o755);
     } else if (entry.isFile()) {
       await chmod(path, 0o444);
     }
   }
-  await chmod(root, 0o555);
+  await chmod(root, 0o755);
 }
 
 /** Refuse links and special files before hashing or copying an enforcement runtime. */
@@ -227,10 +230,10 @@ export async function stageRuntimeArtifact(input: { somaHome: string; substrate:
     await pruneUnreferencedArtifacts(input.somaHome);
     return { path: runtimeArtifactActivePath(input.somaHome, input.substrate), hash, ...(state.previous ? { previous: state.previous } : {}) };
   } finally {
-    // Artifact directories are read-only deployment snapshots between installs.
-    // Same-UID filesystem permissions are best-effort hardening, not a
+    // The shared store stays writable between installs; individual payload files
+    // are read-only. Same-UID permissions are best-effort hardening, not a
     // tamper-proof boundary; W1 intentionally does not hash on every hook invocation.
-    await chmod(store, 0o555).catch(() => undefined);
+    await chmod(store, 0o755).catch(() => undefined);
   }
 }
 

--- a/src/runtime-artifact.ts
+++ b/src/runtime-artifact.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { cp, mkdir, mkdtemp, readFile, readdir, realpath, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { chmod, cp, mkdir, mkdtemp, readFile, readdir, realpath, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -47,6 +47,10 @@ async function loadArtifact(entry: string): Promise<boolean> {
     });
     return result.status === 0;
   } finally {
+    // `cp` preserves read-only artifact modes; reopen the disposable probe copy
+    // solely so its temporary directories can be removed.
+    await chmod(join(probeRoot, "src"), 0o755).catch(() => undefined);
+    await chmod(join(probeRoot, "src", "cli.ts"), 0o644).catch(() => undefined);
     await rm(probeRoot, { recursive: true, force: true });
   }
 }
@@ -57,6 +61,22 @@ async function writeRuntimeArtifactState(somaHome: string, state: RuntimeArtifac
   const pending = statePath + ".tmp";
   await writeFile(pending, JSON.stringify(state, null, 2) + "\n", "utf8");
   await rename(pending, statePath);
+}
+
+async function sealArtifact(root: string): Promise<void> {
+  const entries = await readdir(root, { withFileTypes: true });
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      await sealArtifact(path);
+      // Keep directories writable so home cleanup and atomic replacement work;
+      // payload files themselves are read-only and hash-validated at install/doctor.
+      await chmod(path, 0o755);
+    } else if (entry.isFile()) {
+      await chmod(path, 0o444);
+    }
+  }
+  await chmod(root, 0o755);
 }
 
 async function sourceHash(sourceRoot: string): Promise<string> {
@@ -87,43 +107,37 @@ export async function readRuntimeArtifactState(somaHome: string): Promise<Runtim
 }
 
 /** Stages a source-complete, content-addressed policy runtime and atomically activates it. */
-export async function stageRuntimeArtifact(input: { somaHome: string; sourceRoot: string }): Promise<{ path: string; hash: string; previous?: string }> {
+export async function stageRuntimeArtifact(input: { somaHome: string; sourceRoot: string; afterCopy?: (staging: string) => Promise<void> }): Promise<{ path: string; hash: string; previous?: string }> {
   const hash = await sourceHash(input.sourceRoot);
   const root = runtimeArtifactRoot(input.somaHome);
   const target = join(root, hash);
-  const entry = join(target, "src", "cli.ts");
   const existingHash = await sourceHash(target).catch(() => undefined);
   if (existingHash !== hash) {
     const staging = join(root, ".staging-" + hash);
     const displaced = join(root, ".replaced-" + hash);
+    const targetExists = await stat(target).then(() => true).catch(() => false);
     await rm(staging, { recursive: true, force: true });
     await rm(displaced, { recursive: true, force: true });
     await mkdir(staging, { recursive: true });
     await cp(join(input.sourceRoot, "src"), join(staging, "src"), { recursive: true });
     await cp(join(input.sourceRoot, "package.json"), join(staging, "package.json"));
-    // Load the staged artifact before activation. This runs outside the editable
-    // checkout, so a syntactically valid but unloadable artifact never becomes active.
-    if (!(await loadArtifact(join(staging, "src", "cli.ts")))) {
-      throw new Error("runtime artifact load check failed");
-    }
-    // Replace a tampered same-hash directory only after its staged replacement loads.
-    // The stable current link remains an artifact path, never editable source.
-    if (existingHash !== undefined) await rename(target, displaced);
+    await input.afterCopy?.(staging);
+    if (await sourceHash(staging) !== hash) throw new Error("runtime artifact staging hash mismatch");
+    if (!(await loadArtifact(join(staging, "src", "cli.ts")))) throw new Error("runtime artifact load check failed");
+    await sealArtifact(staging);
+    if (targetExists) await rename(target, displaced);
     try {
       await rename(staging, target);
     } catch (error) {
-      if (existingHash !== undefined) await rename(displaced, target).catch(() => undefined);
+      if (targetExists) await rename(displaced, target).catch(() => undefined);
       throw error;
     }
     await rm(displaced, { recursive: true, force: true });
   }
   const current = await readRuntimeArtifactState(input.somaHome);
   const state: RuntimeArtifactState = { active: hash, ...(current?.active !== hash ? { previous: current?.active } : current?.previous ? { previous: current.previous } : {}) };
-  // The hook follows `current`; switch that atomically before publishing matching
-  // diagnostic state. A torn update is visible as a mismatch, never as ready.
   await activateRuntimeArtifact(input.somaHome, hash);
   await writeRuntimeArtifactState(input.somaHome, state);
-  // Hooks are configured with this stable pointer, never an editable checkout.
   return { path: runtimeArtifactActivePath(input.somaHome), hash, ...(state.previous ? { previous: state.previous } : {}) };
 }
 
@@ -150,8 +164,11 @@ export async function inspectRuntimeArtifact(somaHome: string): Promise<{ state?
 export async function rollbackRuntimeArtifact(somaHome: string): Promise<RuntimeArtifactState> {
   const current = await readRuntimeArtifactState(somaHome);
   if (!current?.previous) throw new Error("No previous runtime artifact is available for rollback.");
-  const priorPath = join(runtimeArtifactRoot(somaHome), current.previous, "src", "cli.ts");
-  await stat(priorPath);
+  const priorRoot = join(runtimeArtifactRoot(somaHome), current.previous);
+  const priorPath = join(priorRoot, "src", "cli.ts");
+  if (await sourceHash(priorRoot) !== current.previous || !(await loadArtifact(priorPath))) {
+    throw new Error("Retained runtime artifact failed integrity or load validation.");
+  }
   const next: RuntimeArtifactState = { active: current.previous, previous: current.active };
   await activateRuntimeArtifact(somaHome, next.active);
   await writeRuntimeArtifactState(somaHome, next);

--- a/src/runtime-artifact.ts
+++ b/src/runtime-artifact.ts
@@ -9,6 +9,11 @@ export interface RuntimeArtifactState {
   previous?: string;
 }
 
+const GUARDED_RUNTIME_SUBSTRATES = new Set(["claude-code", "codex", "grok"]);
+export function isGuardedRuntimeSubstrate(substrate: string): boolean {
+  return GUARDED_RUNTIME_SUBSTRATES.has(substrate);
+}
+
 export function runtimeArtifactRoot(somaHome: string): string {
   return resolve(somaHome, "runtime");
 }
@@ -107,7 +112,8 @@ export async function readRuntimeArtifactState(somaHome: string): Promise<Runtim
 }
 
 /** Stages a source-complete, content-addressed policy runtime and atomically activates it. */
-export async function stageRuntimeArtifact(input: { somaHome: string; sourceRoot: string; afterCopy?: (staging: string) => Promise<void> }): Promise<{ path: string; hash: string; previous?: string }> {
+/** Installer-internal staging seam; deliberately not exported from the public API. */
+export async function stageRuntimeArtifact(input: { somaHome: string; sourceRoot: string }): Promise<{ path: string; hash: string; previous?: string }> {
   const hash = await sourceHash(input.sourceRoot);
   const root = runtimeArtifactRoot(input.somaHome);
   const target = join(root, hash);
@@ -121,7 +127,6 @@ export async function stageRuntimeArtifact(input: { somaHome: string; sourceRoot
     await mkdir(staging, { recursive: true });
     await cp(join(input.sourceRoot, "src"), join(staging, "src"), { recursive: true });
     await cp(join(input.sourceRoot, "package.json"), join(staging, "package.json"));
-    await input.afterCopy?.(staging);
     if (await sourceHash(staging) !== hash) throw new Error("runtime artifact staging hash mismatch");
     if (!(await loadArtifact(join(staging, "src", "cli.ts")))) throw new Error("runtime artifact load check failed");
     await sealArtifact(staging);
@@ -153,20 +158,26 @@ export async function inspectRuntimeArtifact(somaHome: string): Promise<{ state?
     const activePath = await realpath(activeEntry);
     if (expectedPath !== activePath) return { state, status: "missing-active" };
     // Doctor hashes on demand; guarded hooks never hash on the tool-call path.
-    if (await sourceHash(join(runtimeArtifactRoot(somaHome), state.active)) !== state.active) return { state, status: "unloadable" };
-    if (!(await loadArtifact(entry))) return { state, status: "unloadable" };
+    if (!(await isValidArtifact(join(runtimeArtifactRoot(somaHome), state.active), state.active))) return { state, status: "unloadable" };
   } catch {
     return { state, status: "missing-active" };
   }
   return { state, status: "ready" };
 }
 
+async function isValidArtifact(root: string, expectedHash: string): Promise<boolean> {
+  try {
+    return await sourceHash(root) === expectedHash && await loadArtifact(join(root, "src", "cli.ts"));
+  } catch {
+    return false;
+  }
+}
+
 export async function rollbackRuntimeArtifact(somaHome: string): Promise<RuntimeArtifactState> {
   const current = await readRuntimeArtifactState(somaHome);
   if (!current?.previous) throw new Error("No previous runtime artifact is available for rollback.");
   const priorRoot = join(runtimeArtifactRoot(somaHome), current.previous);
-  const priorPath = join(priorRoot, "src", "cli.ts");
-  if (await sourceHash(priorRoot) !== current.previous || !(await loadArtifact(priorPath))) {
+  if (!(await isValidArtifact(priorRoot, current.previous))) {
     throw new Error("Retained runtime artifact failed integrity or load validation.");
   }
   const next: RuntimeArtifactState = { active: current.previous, previous: current.active };

--- a/src/runtime-artifact.ts
+++ b/src/runtime-artifact.ts
@@ -9,32 +9,48 @@ export interface RuntimeArtifactState {
   previous?: string;
 }
 
-const GUARDED_RUNTIME_SUBSTRATES = new Set(["claude-code", "codex", "grok"]);
-export function isGuardedRuntimeSubstrate(substrate: string): boolean {
-  return GUARDED_RUNTIME_SUBSTRATES.has(substrate);
+export const GUARDED_RUNTIME_SUBSTRATES = ["claude-code", "codex", "grok"] as const;
+export type GuardedRuntimeSubstrate = (typeof GUARDED_RUNTIME_SUBSTRATES)[number];
+export function isGuardedRuntimeSubstrate(substrate: string): substrate is GuardedRuntimeSubstrate {
+  return (GUARDED_RUNTIME_SUBSTRATES as readonly string[]).includes(substrate);
 }
 
 export function runtimeArtifactRoot(somaHome: string): string {
   return resolve(somaHome, "runtime");
 }
 
-export function runtimeArtifactStatePath(somaHome: string): string {
-  return join(runtimeArtifactRoot(somaHome), "active.json");
+function runtimeArtifactStoreRoot(somaHome: string): string {
+  return join(runtimeArtifactRoot(somaHome), "artifacts");
 }
 
-/** Stable hook target; it atomically resolves to the selected immutable artifact. */
-export function runtimeArtifactActivePath(somaHome: string): string {
-  return join(runtimeArtifactRoot(somaHome), "current");
+export function runtimeArtifactStatePath(somaHome: string, substrate: GuardedRuntimeSubstrate): string {
+  return join(runtimeArtifactRoot(somaHome), substrate, "active.json");
 }
 
-async function activateRuntimeArtifact(somaHome: string, hash: string): Promise<void> {
-  const root = runtimeArtifactRoot(somaHome);
-  const target = join(root, hash);
+/** Stable, substrate-scoped hook target; it atomically resolves to an immutable artifact. */
+export function runtimeArtifactActivePath(somaHome: string, substrate: GuardedRuntimeSubstrate): string {
+  return join(runtimeArtifactRoot(somaHome), substrate, "current");
+}
+
+async function activateRuntimeArtifact(somaHome: string, substrate: GuardedRuntimeSubstrate, hash: string): Promise<void> {
+  const lifecycleRoot = dirname(runtimeArtifactActivePath(somaHome, substrate));
+  const target = join(runtimeArtifactStoreRoot(somaHome), hash);
   await stat(join(target, "src", "cli.ts"));
-  const pending = join(root, ".current-next");
+  await mkdir(lifecycleRoot, { recursive: true });
+  const pending = join(lifecycleRoot, ".current-next");
   await rm(pending, { force: true });
-  await symlink(hash, pending);
-  await rename(pending, runtimeArtifactActivePath(somaHome));
+  await symlink(join("..", "artifacts", hash), pending);
+  await rename(pending, runtimeArtifactActivePath(somaHome, substrate));
+}
+
+async function makeWritable(path: string): Promise<void> {
+  await chmod(path, 0o755).catch(() => undefined);
+  for (const entry of await readdir(path, { withFileTypes: true }).catch(() => [])) {
+    const child = join(path, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) await makeWritable(child);
+    else if (entry.isFile()) await chmod(child, 0o644).catch(() => undefined);
+  }
 }
 
 async function loadArtifact(entry: string): Promise<boolean> {
@@ -52,16 +68,15 @@ async function loadArtifact(entry: string): Promise<boolean> {
     });
     return result.status === 0;
   } finally {
-    // `cp` preserves read-only artifact modes; reopen the disposable probe copy
-    // solely so its temporary directories can be removed.
-    await chmod(join(probeRoot, "src"), 0o755).catch(() => undefined);
-    await chmod(join(probeRoot, "src", "cli.ts"), 0o644).catch(() => undefined);
+    // Copies preserve the artifact's read-only modes; reopen only this disposable
+    // probe tree so nested source directories never obstruct cleanup.
+    await makeWritable(probeRoot);
     await rm(probeRoot, { recursive: true, force: true });
   }
 }
 
-async function writeRuntimeArtifactState(somaHome: string, state: RuntimeArtifactState): Promise<void> {
-  const statePath = runtimeArtifactStatePath(somaHome);
+async function writeRuntimeArtifactState(somaHome: string, substrate: GuardedRuntimeSubstrate, state: RuntimeArtifactState): Promise<void> {
+  const statePath = runtimeArtifactStatePath(somaHome, substrate);
   await mkdir(dirname(statePath), { recursive: true });
   const pending = statePath + ".tmp";
   await writeFile(pending, JSON.stringify(state, null, 2) + "\n", "utf8");
@@ -74,14 +89,12 @@ async function sealArtifact(root: string): Promise<void> {
     const path = join(root, entry.name);
     if (entry.isDirectory()) {
       await sealArtifact(path);
-      // Keep directories writable so home cleanup and atomic replacement work;
-      // payload files themselves are read-only and hash-validated at install/doctor.
-      await chmod(path, 0o755);
+      await chmod(path, 0o555);
     } else if (entry.isFile()) {
       await chmod(path, 0o444);
     }
   }
-  await chmod(root, 0o755);
+  await chmod(root, 0o555);
 }
 
 async function sourceHash(sourceRoot: string): Promise<string> {
@@ -102,63 +115,70 @@ async function sourceHash(sourceRoot: string): Promise<string> {
   return hash.digest("hex");
 }
 
-export async function readRuntimeArtifactState(somaHome: string): Promise<RuntimeArtifactState | undefined> {
+export async function readRuntimeArtifactState(somaHome: string, substrate: GuardedRuntimeSubstrate): Promise<RuntimeArtifactState | undefined> {
   try {
-    const value: unknown = JSON.parse(await readFile(runtimeArtifactStatePath(somaHome), "utf8"));
+    const value: unknown = JSON.parse(await readFile(runtimeArtifactStatePath(somaHome, substrate), "utf8"));
     if (!value || typeof value !== "object" || typeof (value as { active?: unknown }).active !== "string") return undefined;
     const state = value as { active: string; previous?: unknown };
     return { active: state.active, ...(typeof state.previous === "string" ? { previous: state.previous } : {}) };
   } catch { return undefined; }
 }
 
-/** Stages a source-complete, content-addressed policy runtime and atomically activates it. */
-/** Installer-internal staging seam; deliberately not exported from the public API. */
-export async function stageRuntimeArtifact(input: { somaHome: string; sourceRoot: string }): Promise<{ path: string; hash: string; previous?: string }> {
+/** Stages a source-complete, content-addressed policy runtime and atomically activates one substrate. */
+export async function stageRuntimeArtifact(input: { somaHome: string; substrate: GuardedRuntimeSubstrate; sourceRoot: string }): Promise<{ path: string; hash: string; previous?: string }> {
   const hash = await sourceHash(input.sourceRoot);
-  const root = runtimeArtifactRoot(input.somaHome);
-  const target = join(root, hash);
-  const existingHash = await sourceHash(target).catch(() => undefined);
-  if (existingHash !== hash) {
-    const staging = join(root, ".staging-" + hash);
-    const displaced = join(root, ".replaced-" + hash);
-    const targetExists = await stat(target).then(() => true).catch(() => false);
-    await rm(staging, { recursive: true, force: true });
-    await rm(displaced, { recursive: true, force: true });
-    await mkdir(staging, { recursive: true });
-    await cp(join(input.sourceRoot, "src"), join(staging, "src"), { recursive: true });
-    await cp(join(input.sourceRoot, "package.json"), join(staging, "package.json"));
-    if (await sourceHash(staging) !== hash) throw new Error("runtime artifact staging hash mismatch");
-    if (!(await loadArtifact(join(staging, "src", "cli.ts")))) throw new Error("runtime artifact load check failed");
-    await sealArtifact(staging);
-    if (targetExists) await rename(target, displaced);
-    try {
-      await rename(staging, target);
-    } catch (error) {
-      if (targetExists) await rename(displaced, target).catch(() => undefined);
-      throw error;
+  const store = runtimeArtifactStoreRoot(input.somaHome);
+  const target = join(store, hash);
+  await mkdir(store, { recursive: true });
+  // Only installation mutates the shared artifact store. Hooks never hash it.
+  await chmod(store, 0o755);
+  try {
+    const existingHash = await sourceHash(target).catch(() => undefined);
+    if (existingHash !== hash) {
+      const staging = join(store, ".staging-" + hash);
+      const displaced = join(store, ".replaced-" + hash);
+      const targetExists = await stat(target).then(() => true).catch(() => false);
+      await rm(staging, { recursive: true, force: true });
+      await rm(displaced, { recursive: true, force: true });
+      await mkdir(staging, { recursive: true });
+      await cp(join(input.sourceRoot, "src"), join(staging, "src"), { recursive: true });
+      await cp(join(input.sourceRoot, "package.json"), join(staging, "package.json"));
+      if (await sourceHash(staging) !== hash) throw new Error("runtime artifact staging hash mismatch");
+      if (!(await loadArtifact(join(staging, "src", "cli.ts")))) throw new Error("runtime artifact load check failed");
+      await sealArtifact(staging);
+      if (targetExists) await rename(target, displaced);
+      try {
+        await rename(staging, target);
+      } catch (error) {
+        if (targetExists) await rename(displaced, target).catch(() => undefined);
+        throw error;
+      }
+      await rm(displaced, { recursive: true, force: true });
     }
-    await rm(displaced, { recursive: true, force: true });
+    const current = await readRuntimeArtifactState(input.somaHome, input.substrate);
+    const state: RuntimeArtifactState = { active: hash, ...(current?.active !== hash ? { previous: current?.active } : current?.previous ? { previous: current.previous } : {}) };
+    await activateRuntimeArtifact(input.somaHome, input.substrate, hash);
+    await writeRuntimeArtifactState(input.somaHome, input.substrate, state);
+    return { path: runtimeArtifactActivePath(input.somaHome, input.substrate), hash, ...(state.previous ? { previous: state.previous } : {}) };
+  } finally {
+    // Artifact directories are structurally immutable between installs; this
+    // preserves runtime integrity without a hash on every hook invocation.
+    await chmod(store, 0o555).catch(() => undefined);
   }
-  const current = await readRuntimeArtifactState(input.somaHome);
-  const state: RuntimeArtifactState = { active: hash, ...(current?.active !== hash ? { previous: current?.active } : current?.previous ? { previous: current.previous } : {}) };
-  await activateRuntimeArtifact(input.somaHome, hash);
-  await writeRuntimeArtifactState(input.somaHome, state);
-  return { path: runtimeArtifactActivePath(input.somaHome), hash, ...(state.previous ? { previous: state.previous } : {}) };
 }
 
-/** Explicit local recovery switch; it never fetches or rebuilds an artifact. */
-export async function inspectRuntimeArtifact(somaHome: string): Promise<{ state?: RuntimeArtifactState; status: "missing-state" | "missing-active" | "unloadable" | "ready" }> {
-  const state = await readRuntimeArtifactState(somaHome);
+/** Explicit local recovery inspection; it never fetches or rebuilds an artifact. */
+export async function inspectRuntimeArtifact(somaHome: string, substrate: GuardedRuntimeSubstrate): Promise<{ state?: RuntimeArtifactState; status: "missing-state" | "missing-active" | "unloadable" | "ready" }> {
+  const state = await readRuntimeArtifactState(somaHome, substrate);
   if (!state) return { status: "missing-state" };
-  const entry = join(runtimeArtifactRoot(somaHome), state.active, "src", "cli.ts");
-  const activeEntry = join(runtimeArtifactActivePath(somaHome), "src", "cli.ts");
+  const entry = join(runtimeArtifactStoreRoot(somaHome), state.active, "src", "cli.ts");
+  const activeEntry = join(runtimeArtifactActivePath(somaHome, substrate), "src", "cli.ts");
   try {
-    await readFile(join(runtimeArtifactRoot(somaHome), state.active, "package.json"), "utf8");
+    await readFile(join(runtimeArtifactStoreRoot(somaHome), state.active, "package.json"), "utf8");
     const expectedPath = await realpath(entry);
     const activePath = await realpath(activeEntry);
     if (expectedPath !== activePath) return { state, status: "missing-active" };
-    // Doctor hashes on demand; guarded hooks never hash on the tool-call path.
-    if (!(await isValidArtifact(join(runtimeArtifactRoot(somaHome), state.active), state.active))) return { state, status: "unloadable" };
+    if (!(await isValidArtifact(join(runtimeArtifactStoreRoot(somaHome), state.active), state.active))) return { state, status: "unloadable" };
   } catch {
     return { state, status: "missing-active" };
   }
@@ -173,15 +193,15 @@ async function isValidArtifact(root: string, expectedHash: string): Promise<bool
   }
 }
 
-export async function rollbackRuntimeArtifact(somaHome: string): Promise<RuntimeArtifactState> {
-  const current = await readRuntimeArtifactState(somaHome);
+export async function rollbackRuntimeArtifact(somaHome: string, substrate: GuardedRuntimeSubstrate): Promise<RuntimeArtifactState> {
+  const current = await readRuntimeArtifactState(somaHome, substrate);
   if (!current?.previous) throw new Error("No previous runtime artifact is available for rollback.");
-  const priorRoot = join(runtimeArtifactRoot(somaHome), current.previous);
+  const priorRoot = join(runtimeArtifactStoreRoot(somaHome), current.previous);
   if (!(await isValidArtifact(priorRoot, current.previous))) {
     throw new Error("Retained runtime artifact failed integrity or load validation.");
   }
   const next: RuntimeArtifactState = { active: current.previous, previous: current.active };
-  await activateRuntimeArtifact(somaHome, next.active);
-  await writeRuntimeArtifactState(somaHome, next);
+  await activateRuntimeArtifact(somaHome, substrate, next.active);
+  await writeRuntimeArtifactState(somaHome, substrate, next);
   return next;
 }

--- a/src/runtime-artifact.ts
+++ b/src/runtime-artifact.ts
@@ -32,9 +32,23 @@ export function runtimeArtifactActivePath(somaHome: string, substrate: GuardedRu
   return join(runtimeArtifactRoot(somaHome), substrate, "current");
 }
 
+async function assertArtifactTargetRoot(path: string): Promise<boolean> {
+  try {
+    const info = await lstat(path);
+    if (info.isSymbolicLink() || !info.isDirectory()) {
+      throw new Error(`runtime artifact target must be a non-symlink directory: ${path}`);
+    }
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
 async function activateRuntimeArtifact(somaHome: string, substrate: GuardedRuntimeSubstrate, hash: string): Promise<void> {
   const lifecycleRoot = dirname(runtimeArtifactActivePath(somaHome, substrate));
   const target = join(runtimeArtifactStoreRoot(somaHome), hash);
+  if (!(await assertArtifactTargetRoot(target))) throw new Error(`runtime artifact target is missing: ${target}`);
   await stat(join(target, "src", "cli.ts"));
   await mkdir(lifecycleRoot, { recursive: true });
   const pending = join(lifecycleRoot, ".current-next");
@@ -180,11 +194,11 @@ export async function stageRuntimeArtifact(input: { somaHome: string; substrate:
   // Only installation mutates the shared artifact store. Hooks never hash it.
   await chmod(store, 0o755);
   try {
-    const existingHash = await sourceHash(target).catch(() => undefined);
+    const targetExists = await assertArtifactTargetRoot(target);
+    const existingHash = targetExists ? await sourceHash(target).catch(() => undefined) : undefined;
     if (existingHash !== hash) {
       const staging = join(store, ".staging-" + hash);
       const displaced = join(store, ".replaced-" + hash);
-      const targetExists = await stat(target).then(() => true).catch(() => false);
       await rm(staging, { recursive: true, force: true });
       await rm(displaced, { recursive: true, force: true });
       await mkdir(staging, { recursive: true });

--- a/src/runtime-artifact.ts
+++ b/src/runtime-artifact.ts
@@ -99,6 +99,11 @@ async function sealArtifact(root: string): Promise<void> {
 
 /** Refuse links and special files before hashing or copying an enforcement runtime. */
 async function assertRuntimeSourceTree(sourceRoot: string): Promise<void> {
+  const srcPath = join(sourceRoot, "src");
+  const srcStat = await lstat(srcPath);
+  if (srcStat.isSymbolicLink() || !srcStat.isDirectory()) {
+    throw new Error("runtime artifact source src must be a non-symlink directory");
+  }
   const packagePath = join(sourceRoot, "package.json");
   const packageStat = await lstat(packagePath);
   if (packageStat.isSymbolicLink() || !packageStat.isFile()) {

--- a/src/runtime-artifact.ts
+++ b/src/runtime-artifact.ts
@@ -137,19 +137,23 @@ async function assertRuntimeSourceTree(sourceRoot: string): Promise<void> {
 async function sourceHash(sourceRoot: string): Promise<string> {
   await assertRuntimeSourceTree(sourceRoot);
   const hash = createHash("sha256");
-  async function visit(dir: string): Promise<void> {
-    const entries = await readdir(dir, { withFileTypes: true });
-    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
-      const path = join(dir, entry.name);
-      if (entry.isDirectory()) await visit(path);
-      else if (entry.isFile()) {
-        hash.update(path.slice(sourceRoot.length));
-        hash.update(await readFile(path));
-      }
+  const frame = (type: string, path: string, bytes: Uint8Array = new Uint8Array()): void => {
+    hash.update(`${type.length}:${type}${path.length}:${path}${bytes.byteLength}:`, "utf8");
+    hash.update(bytes);
+  };
+  async function visit(directory: string, relative: string): Promise<void> {
+    frame("dir", relative);
+    const entries = await readdir(directory, { withFileTypes: true });
+    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+      const path = join(directory, entry.name);
+      const child = relative.length === 0 ? entry.name : `${relative}/${entry.name}`;
+      if (entry.isDirectory()) await visit(path, child);
+      else if (entry.isFile()) frame("file", child, await readFile(path));
+      else throw new Error(`runtime artifact source contains unsupported entry: ${path}`);
     }
   }
-  await visit(join(sourceRoot, "src"));
-  hash.update(await readFile(join(sourceRoot, "package.json")));
+  await visit(join(sourceRoot, "src"), "src");
+  frame("file", "package.json", await readFile(join(sourceRoot, "package.json")));
   return hash.digest("hex");
 }
 

--- a/src/runtime-artifact.ts
+++ b/src/runtime-artifact.ts
@@ -27,7 +27,7 @@ export function runtimeArtifactStatePath(somaHome: string, substrate: GuardedRun
   return join(runtimeArtifactRoot(somaHome), substrate, "active.json");
 }
 
-/** Stable, substrate-scoped hook target; it atomically resolves to an immutable artifact. */
+/** Stable, substrate-scoped hook target; it atomically resolves to a read-only deployment snapshot. */
 export function runtimeArtifactActivePath(somaHome: string, substrate: GuardedRuntimeSubstrate): string {
   return join(runtimeArtifactRoot(somaHome), substrate, "current");
 }
@@ -227,8 +227,9 @@ export async function stageRuntimeArtifact(input: { somaHome: string; substrate:
     await pruneUnreferencedArtifacts(input.somaHome);
     return { path: runtimeArtifactActivePath(input.somaHome, input.substrate), hash, ...(state.previous ? { previous: state.previous } : {}) };
   } finally {
-    // Artifact directories are structurally immutable between installs; this
-    // preserves runtime integrity without a hash on every hook invocation.
+    // Artifact directories are read-only deployment snapshots between installs.
+    // Same-UID filesystem permissions are best-effort hardening, not a
+    // tamper-proof boundary; W1 intentionally does not hash on every hook invocation.
     await chmod(store, 0o555).catch(() => undefined);
   }
 }

--- a/src/runtime-artifact.ts
+++ b/src/runtime-artifact.ts
@@ -1,0 +1,159 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { cp, mkdir, mkdtemp, readFile, readdir, realpath, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export interface RuntimeArtifactState {
+  active: string;
+  previous?: string;
+}
+
+export function runtimeArtifactRoot(somaHome: string): string {
+  return resolve(somaHome, "runtime");
+}
+
+export function runtimeArtifactStatePath(somaHome: string): string {
+  return join(runtimeArtifactRoot(somaHome), "active.json");
+}
+
+/** Stable hook target; it atomically resolves to the selected immutable artifact. */
+export function runtimeArtifactActivePath(somaHome: string): string {
+  return join(runtimeArtifactRoot(somaHome), "current");
+}
+
+async function activateRuntimeArtifact(somaHome: string, hash: string): Promise<void> {
+  const root = runtimeArtifactRoot(somaHome);
+  const target = join(root, hash);
+  await stat(join(target, "src", "cli.ts"));
+  const pending = join(root, ".current-next");
+  await rm(pending, { force: true });
+  await symlink(hash, pending);
+  await rename(pending, runtimeArtifactActivePath(somaHome));
+}
+
+async function loadArtifact(entry: string): Promise<boolean> {
+  // Bun cannot reliably import an entry below a home path containing shell
+  // metacharacters. Copy the complete minimal runtime into an OS-temp directory
+  // with a generated safe name, then load that copy.
+  const artifactRoot = dirname(dirname(entry));
+  const probeRoot = await mkdtemp(join(tmpdir(), "soma-runtime-probe-"));
+  try {
+    await cp(join(artifactRoot, "src"), join(probeRoot, "src"), { recursive: true });
+    await cp(join(artifactRoot, "package.json"), join(probeRoot, "package.json"));
+    const result = spawnSync(process.execPath, [join(probeRoot, "src", "cli.ts"), "--version"], {
+      cwd: probeRoot,
+      encoding: "utf8",
+    });
+    return result.status === 0;
+  } finally {
+    await rm(probeRoot, { recursive: true, force: true });
+  }
+}
+
+async function writeRuntimeArtifactState(somaHome: string, state: RuntimeArtifactState): Promise<void> {
+  const statePath = runtimeArtifactStatePath(somaHome);
+  await mkdir(dirname(statePath), { recursive: true });
+  const pending = statePath + ".tmp";
+  await writeFile(pending, JSON.stringify(state, null, 2) + "\n", "utf8");
+  await rename(pending, statePath);
+}
+
+async function sourceHash(sourceRoot: string): Promise<string> {
+  const hash = createHash("sha256");
+  async function visit(dir: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) await visit(path);
+      else if (entry.isFile()) {
+        hash.update(path.slice(sourceRoot.length));
+        hash.update(await readFile(path));
+      }
+    }
+  }
+  await visit(join(sourceRoot, "src"));
+  hash.update(await readFile(join(sourceRoot, "package.json")));
+  return hash.digest("hex");
+}
+
+export async function readRuntimeArtifactState(somaHome: string): Promise<RuntimeArtifactState | undefined> {
+  try {
+    const value: unknown = JSON.parse(await readFile(runtimeArtifactStatePath(somaHome), "utf8"));
+    if (!value || typeof value !== "object" || typeof (value as { active?: unknown }).active !== "string") return undefined;
+    const state = value as { active: string; previous?: unknown };
+    return { active: state.active, ...(typeof state.previous === "string" ? { previous: state.previous } : {}) };
+  } catch { return undefined; }
+}
+
+/** Stages a source-complete, content-addressed policy runtime and atomically activates it. */
+export async function stageRuntimeArtifact(input: { somaHome: string; sourceRoot: string }): Promise<{ path: string; hash: string; previous?: string }> {
+  const hash = await sourceHash(input.sourceRoot);
+  const root = runtimeArtifactRoot(input.somaHome);
+  const target = join(root, hash);
+  const entry = join(target, "src", "cli.ts");
+  const existingHash = await sourceHash(target).catch(() => undefined);
+  if (existingHash !== hash) {
+    const staging = join(root, ".staging-" + hash);
+    const displaced = join(root, ".replaced-" + hash);
+    await rm(staging, { recursive: true, force: true });
+    await rm(displaced, { recursive: true, force: true });
+    await mkdir(staging, { recursive: true });
+    await cp(join(input.sourceRoot, "src"), join(staging, "src"), { recursive: true });
+    await cp(join(input.sourceRoot, "package.json"), join(staging, "package.json"));
+    // Load the staged artifact before activation. This runs outside the editable
+    // checkout, so a syntactically valid but unloadable artifact never becomes active.
+    if (!(await loadArtifact(join(staging, "src", "cli.ts")))) {
+      throw new Error("runtime artifact load check failed");
+    }
+    // Replace a tampered same-hash directory only after its staged replacement loads.
+    // The stable current link remains an artifact path, never editable source.
+    if (existingHash !== undefined) await rename(target, displaced);
+    try {
+      await rename(staging, target);
+    } catch (error) {
+      if (existingHash !== undefined) await rename(displaced, target).catch(() => undefined);
+      throw error;
+    }
+    await rm(displaced, { recursive: true, force: true });
+  }
+  const current = await readRuntimeArtifactState(input.somaHome);
+  const state: RuntimeArtifactState = { active: hash, ...(current?.active !== hash ? { previous: current?.active } : current?.previous ? { previous: current.previous } : {}) };
+  // The hook follows `current`; switch that atomically before publishing matching
+  // diagnostic state. A torn update is visible as a mismatch, never as ready.
+  await activateRuntimeArtifact(input.somaHome, hash);
+  await writeRuntimeArtifactState(input.somaHome, state);
+  // Hooks are configured with this stable pointer, never an editable checkout.
+  return { path: runtimeArtifactActivePath(input.somaHome), hash, ...(state.previous ? { previous: state.previous } : {}) };
+}
+
+/** Explicit local recovery switch; it never fetches or rebuilds an artifact. */
+export async function inspectRuntimeArtifact(somaHome: string): Promise<{ state?: RuntimeArtifactState; status: "missing-state" | "missing-active" | "unloadable" | "ready" }> {
+  const state = await readRuntimeArtifactState(somaHome);
+  if (!state) return { status: "missing-state" };
+  const entry = join(runtimeArtifactRoot(somaHome), state.active, "src", "cli.ts");
+  const activeEntry = join(runtimeArtifactActivePath(somaHome), "src", "cli.ts");
+  try {
+    await readFile(join(runtimeArtifactRoot(somaHome), state.active, "package.json"), "utf8");
+    const expectedPath = await realpath(entry);
+    const activePath = await realpath(activeEntry);
+    if (expectedPath !== activePath) return { state, status: "missing-active" };
+    // Doctor hashes on demand; guarded hooks never hash on the tool-call path.
+    if (await sourceHash(join(runtimeArtifactRoot(somaHome), state.active)) !== state.active) return { state, status: "unloadable" };
+    if (!(await loadArtifact(entry))) return { state, status: "unloadable" };
+  } catch {
+    return { state, status: "missing-active" };
+  }
+  return { state, status: "ready" };
+}
+
+export async function rollbackRuntimeArtifact(somaHome: string): Promise<RuntimeArtifactState> {
+  const current = await readRuntimeArtifactState(somaHome);
+  if (!current?.previous) throw new Error("No previous runtime artifact is available for rollback.");
+  const priorPath = join(runtimeArtifactRoot(somaHome), current.previous, "src", "cli.ts");
+  await stat(priorPath);
+  const next: RuntimeArtifactState = { active: current.previous, previous: current.active };
+  await activateRuntimeArtifact(somaHome, next.active);
+  await writeRuntimeArtifactState(somaHome, next);
+  return next;
+}

--- a/src/runtime-artifact.ts
+++ b/src/runtime-artifact.ts
@@ -147,6 +147,29 @@ export async function readRuntimeArtifactState(somaHome: string, substrate: Guar
     return { active: state.active, ...(typeof state.previous === "string" ? { previous: state.previous } : {}) };
   } catch { return undefined; }
 }
+/** Keep only artifacts referenced by any guarded substrate's active or predecessor state. */
+async function pruneUnreferencedArtifacts(somaHome: string): Promise<void> {
+  const store = runtimeArtifactStoreRoot(somaHome);
+  const retained = new Set<string>();
+  for (const substrate of GUARDED_RUNTIME_SUBSTRATES) {
+    const state = await readRuntimeArtifactState(somaHome, substrate);
+    if (state !== undefined) {
+      retained.add(state.active);
+      if (state.previous !== undefined) retained.add(state.previous);
+    }
+  }
+  for (const entry of await readdir(store, { withFileTypes: true })) {
+    if (entry.name.startsWith(".") || retained.has(entry.name)) continue;
+    const path = join(store, entry.name);
+    // Never traverse a link while pruning; remove the directory entry itself.
+    if (entry.isSymbolicLink()) {
+      await rm(path, { force: true });
+    } else if (entry.isDirectory()) {
+      await makeWritable(path);
+      await rm(path, { recursive: true, force: true });
+    }
+  }
+}
 
 /** Stages a source-complete, content-addressed policy runtime and atomically activates one substrate. */
 export async function stageRuntimeArtifact(input: { somaHome: string; substrate: GuardedRuntimeSubstrate; sourceRoot: string }): Promise<{ path: string; hash: string; previous?: string }> {
@@ -183,6 +206,7 @@ export async function stageRuntimeArtifact(input: { somaHome: string; substrate:
     const state: RuntimeArtifactState = { active: hash, ...(current?.active !== hash ? { previous: current?.active } : current?.previous ? { previous: current.previous } : {}) };
     await activateRuntimeArtifact(input.somaHome, input.substrate, hash);
     await writeRuntimeArtifactState(input.somaHome, input.substrate, state);
+    await pruneUnreferencedArtifacts(input.somaHome);
     return { path: runtimeArtifactActivePath(input.somaHome, input.substrate), hash, ...(state.previous ? { previous: state.previous } : {}) };
   } finally {
     // Artifact directories are structurally immutable between installs; this

--- a/src/runtime-artifact.ts
+++ b/src/runtime-artifact.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { chmod, cp, mkdir, mkdtemp, readFile, readdir, realpath, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { chmod, cp, lstat, mkdir, mkdtemp, readFile, readdir, realpath, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -97,7 +97,26 @@ async function sealArtifact(root: string): Promise<void> {
   await chmod(root, 0o555);
 }
 
+/** Refuse links and special files before hashing or copying an enforcement runtime. */
+async function assertRuntimeSourceTree(sourceRoot: string): Promise<void> {
+  const packagePath = join(sourceRoot, "package.json");
+  const packageStat = await lstat(packagePath);
+  if (packageStat.isSymbolicLink() || !packageStat.isFile()) {
+    throw new Error("runtime artifact source package.json must be a regular file");
+  }
+  async function visit(directory: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name);
+      if (entry.isSymbolicLink()) throw new Error(`runtime artifact source contains symlink: ${path}`);
+      if (entry.isDirectory()) await visit(path);
+      else if (!entry.isFile()) throw new Error(`runtime artifact source contains unsupported entry: ${path}`);
+    }
+  }
+  await visit(join(sourceRoot, "src"));
+}
+
 async function sourceHash(sourceRoot: string): Promise<string> {
+  await assertRuntimeSourceTree(sourceRoot);
   const hash = createHash("sha256");
   async function visit(dir: string): Promise<void> {
     const entries = await readdir(dir, { withFileTypes: true });

--- a/src/types.ts
+++ b/src/types.ts
@@ -828,6 +828,8 @@ export interface UninstallableSkillReport {
 
 export interface SomaInstallResult {
   substrate: InstallSubstrate;
+  /** Present when a guarded substrate was projected against the frozen runtime. */
+  runtimeArtifact?: { path: string; hash: string; previous?: string };
   somaHome: SomaHomeBootstrapResult;
   substrateHome: WrittenProjection;
   /**
@@ -1934,7 +1936,9 @@ export type SomaDoctorFindingId =
   | "grok-hook-missing"
   | "grok-hook-files-incomplete"
   | "grok-hook-interpreter-missing"
-  | "grok-inspect-unavailable";
+  | "grok-inspect-unavailable"
+  | "runtime-artifact-missing"
+  | "runtime-artifact-unloadable";
 
 export type SomaOnboardingSubstrate = Exclude<InstallSubstrate, "anthropic-cowork">;
 

--- a/src/work-graph-bridge.ts
+++ b/src/work-graph-bridge.ts
@@ -10,7 +10,7 @@
  * `src/index.ts` — to re-implement repo resolution and become exactly that second
  * reader.
  */
-import { scanCommentsForReceipt, WorkGraph } from "./work-graph";
+import { WorkGraph } from "./work-graph";
 import type { BridgedNodeReport, GraphStore } from "./work-graph";
 import { createGitHubGraphStore } from "./work-graph-github";
 import { runCommand } from "./work-graph-probes";
@@ -58,8 +58,7 @@ export async function readNodeForBridge(nodeId: string, options: ReadNodeForBrid
   const repo = options.repo ?? (await (options.resolveRepo ?? resolveGraphRepo)());
   const store = createStore(repo);
   const state = await new WorkGraph(store).readNode({ id: nodeId });
-  const hasCloseReceipt = state.status === "closed"
-    ? scanCommentsForReceipt((await store.listComments(state.ref)).map((comment) => comment.body)).hasReceipt
-    : false;
-  return { ref: state.ref, status: state.status, blockedBy: state.blockedBy, hasCloseReceipt };
+  // The production GraphStore binds this to the current tracker close; bridge
+  // consumers never inspect comments and therefore cannot bless stale receipts.
+  return { ref: state.ref, status: state.status, blockedBy: state.blockedBy, hasCloseReceipt: state.currentCloseReceipt === true };
 }

--- a/src/work-graph-bridge.ts
+++ b/src/work-graph-bridge.ts
@@ -10,8 +10,8 @@
  * `src/index.ts` — to re-implement repo resolution and become exactly that second
  * reader.
  */
-import { WorkGraph } from "./work-graph";
-import type { GraphStore, NodeState } from "./work-graph";
+import { scanCommentsForReceipt, WorkGraph } from "./work-graph";
+import type { BridgedNodeReport, GraphStore } from "./work-graph";
 import { createGitHubGraphStore } from "./work-graph-github";
 import { runCommand } from "./work-graph-probes";
 
@@ -53,8 +53,13 @@ export interface ReadNodeForBridgeOptions {
  * Read one node for a bridge consumer — the same `WorkGraph.readNode` the
  * `soma graph node` verb calls, over the same repo resolution.
  */
-export async function readNodeForBridge(nodeId: string, options: ReadNodeForBridgeOptions = {}): Promise<NodeState> {
+export async function readNodeForBridge(nodeId: string, options: ReadNodeForBridgeOptions = {}): Promise<BridgedNodeReport> {
   const createStore = options.createStore ?? ((repo: string) => createGitHubGraphStore({ repo }));
   const repo = options.repo ?? (await (options.resolveRepo ?? resolveGraphRepo)());
-  return await new WorkGraph(createStore(repo)).readNode({ id: nodeId });
+  const store = createStore(repo);
+  const state = await new WorkGraph(store).readNode({ id: nodeId });
+  const hasCloseReceipt = state.status === "closed"
+    ? scanCommentsForReceipt((await store.listComments(state.ref)).map((comment) => comment.body)).hasReceipt
+    : false;
+  return { ref: state.ref, status: state.status, blockedBy: state.blockedBy, hasCloseReceipt };
 }

--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -917,8 +917,8 @@ class GitHubGraphStore implements GraphStore {
     const receiptAt = /^- \*\*at:\*\* ([^\n]+)$/mu.exec(comment.body)?.[1];
     const gatedNodeHash = /^- \*\*gated node hash:\*\* `([a-f0-9]{64})`$/mu.exec(comment.body)?.[1];
     return close.actor === completion.closer
-      && Number.isFinite(commentAt)
-      && commentAt <= close.at && (reopened === undefined || commentAt > reopened.at)
+      && Number.isFinite(commentAt) && Number.isFinite(boundAt)
+      && commentAt <= close.at && (reopened === undefined || commentAt >= reopened.at)
       && checkpoint === completion.checkpointId && autonomy === completion.autonomy
       && receiptAt === completion.closedAt && gatedNodeHash === completion.gatedNodeHash;
   }

--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -577,7 +577,7 @@ class GitHubGraphStore implements GraphStore {
     const parentNumber = issue.parentNumber ?? (await this.fetchParentNumber(issue.number));
     const state = toNodeState(issue, await this.fetchBlockers(ref), parentNumber === undefined ? undefined : { id: String(parentNumber) });
     if (issue.status !== "closed") return state;
-    return { ...state, currentCloseReceipt: await this.hasCurrentCloseReceipt(ref) };
+    return { ...state, currentCloseReceipt: await this.hasCurrentCloseReceipt(ref, issue) };
   }
 
   /**
@@ -873,7 +873,9 @@ class GitHubGraphStore implements GraphStore {
   }
 
   /** Receipt authority is the current tracker closure interval, never a historical marker. */
-  private async hasCurrentCloseReceipt(ref: NodeRef): Promise<boolean> {
+  private async hasCurrentCloseReceipt(ref: NodeRef, issue: GitHubIssue): Promise<boolean> {
+    const checkpointId = nodeFromIssue(issue).node.checkpointId;
+    if (checkpointId === undefined) return false;
     const [comments, events] = await Promise.all([
       this.listComments(ref),
       this.transport({ method: "GET", path: `repos/${this.repo}/issues/${ref.id}/events`, paginate: true }),
@@ -882,15 +884,20 @@ class GitHubGraphStore implements GraphStore {
       const record = asRecord(entry, "issue event");
       const at = typeof record.created_at === "string" ? Date.parse(record.created_at) : NaN;
       const event = record.event;
-      return Number.isFinite(at) && (event === "closed" || event === "reopened") ? [{ event, at }] : [];
+      const actor = event === "closed" ? readLogin(record.actor) : undefined;
+      return Number.isFinite(at) && (event === "closed" || event === "reopened") ? [{ event, at, actor }] : [];
     }).sort((left, right) => left.at - right.at);
     const close = [...timeline].reverse().find((entry) => entry.event === "closed");
-    if (close === undefined) return false;
+    if (close === undefined || close.actor === undefined) return false;
     const reopened = [...timeline].reverse().find((entry) => entry.event === "reopened" && entry.at < close.at);
     const start = reopened?.at ?? Number.NEGATIVE_INFINITY;
     return comments.some((comment) => {
       const at = comment.createdAt === undefined ? NaN : Date.parse(comment.createdAt);
-      return Number.isFinite(at) && at >= start && at <= close.at && isStructurallyValidCloseReceipt(comment.body);
+      const receiptCheckpoint = /^- \*\*checkpoint:\*\* `([^`\n]+)`$/mu.exec(comment.body)?.[1];
+      return Number.isFinite(at) && at >= start && at <= close.at
+        && comment.author === close.actor
+        && receiptCheckpoint === checkpointId
+        && isStructurallyValidCloseReceipt(comment.body);
     });
   }
 

--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -467,6 +467,7 @@ export function encodeNodeBlock(spec: CreateNodeSpec): string {
   if (spec.checkpointId !== undefined) payload.checkpointId = spec.checkpointId;
   if (spec.budget !== undefined) payload.budget = spec.budget;
   if (spec.probes !== undefined && spec.probes.length > 0) payload.probes = spec.probes;
+  if (spec.completion !== undefined) payload.completion = spec.completion;
   return `${NODE_BLOCK_OPEN}\n${JSON.stringify(payload, null, 2)}\n${NODE_BLOCK_CLOSE}`;
 }
 
@@ -577,7 +578,8 @@ class GitHubGraphStore implements GraphStore {
     const parentNumber = issue.parentNumber ?? (await this.fetchParentNumber(issue.number));
     const state = toNodeState(issue, await this.fetchBlockers(ref), parentNumber === undefined ? undefined : { id: String(parentNumber) });
     if (issue.status !== "closed") return state;
-    return { ...state, currentCloseReceipt: await this.hasCurrentCloseReceipt(ref, issue) };
+    if (state.node.completion === undefined) return { ...state, currentCloseReceipt: false };
+    return { ...state, currentCloseReceipt: await this.hasCurrentCloseReceipt(ref, issue, state.node.completion) };
   }
 
   /**
@@ -872,12 +874,13 @@ class GitHubGraphStore implements GraphStore {
     });
   }
 
-  /** Receipt authority is the current tracker closure interval, never a historical marker. */
-  private async hasCurrentCloseReceipt(ref: NodeRef, issue: GitHubIssue): Promise<boolean> {
-    const checkpointId = nodeFromIssue(issue).node.checkpointId;
-    if (checkpointId === undefined) return false;
-    const [comments, events] = await Promise.all([
-      this.listComments(ref),
+  /** Completion is authority only when its persisted binding matches this closure. */
+  private async hasCurrentCloseReceipt(ref: NodeRef, issue: GitHubIssue, completion: NonNullable<WorkGraphNode["completion"]>): Promise<boolean> {
+    const node = nodeFromIssue(issue).node;
+    if (completion.checkpointId !== node.checkpointId || completion.autonomy !== node.autonomy) return false;
+    if (node.autonomy === "auto" && JSON.stringify(completion.autoProbeKeys ?? []) !== JSON.stringify((node.probes ?? []).map((probe) => JSON.stringify(probe)).sort())) return false;
+    const [comment, events] = await Promise.all([
+      this.readComment({ id: completion.receiptCommentId, nodeId: ref.id }),
       this.transport({ method: "GET", path: `repos/${this.repo}/issues/${ref.id}/events`, paginate: true }),
     ]);
     const timeline = asArray(events, "issue events").flatMap((entry) => {
@@ -889,16 +892,7 @@ class GitHubGraphStore implements GraphStore {
     }).sort((left, right) => left.at - right.at);
     const close = [...timeline].reverse().find((entry) => entry.event === "closed");
     if (close === undefined || close.actor === undefined) return false;
-    const reopened = [...timeline].reverse().find((entry) => entry.event === "reopened" && entry.at < close.at);
-    const start = reopened?.at ?? Number.NEGATIVE_INFINITY;
-    return comments.some((comment) => {
-      const at = comment.createdAt === undefined ? NaN : Date.parse(comment.createdAt);
-      const receiptCheckpoint = /^- \*\*checkpoint:\*\* `([^`\n]+)`$/mu.exec(comment.body)?.[1];
-      return Number.isFinite(at) && at >= start && at <= close.at
-        && comment.author === close.actor
-        && receiptCheckpoint === checkpointId
-        && isStructurallyValidCloseReceipt(comment.body);
-    });
+    return close.actor === completion.closer && comment.author === completion.closer;
   }
 
   /** Bodies included — the read half of {@link postComment}. Paginated: receipts are often the last comment. */
@@ -937,7 +931,25 @@ class GitHubGraphStore implements GraphStore {
 
   /** Receipt first, then the state change: a close that fails halfway leaves the evidence, not a bare closed issue. */
   async close(ref: NodeRef, receipt: CloseReceipt): Promise<void> {
-    await this.postComment(ref, renderCloseReceipt(receipt));
+    const issue = await this.fetchIssue(ref);
+    const decoded = nodeFromIssue(issue);
+    const posted = await this.postComment(ref, renderCloseReceipt(receipt));
+    const comment = await this.readComment(posted);
+    if (comment.author === undefined || comment.author.length === 0) {
+      throw new WorkGraphError("backend", "posted close receipt has no authenticated author");
+    }
+    const node = decoded.node;
+    const completion = {
+      receiptCommentId: comment.id,
+      checkpointId: receipt.checkpointId,
+      autonomy: receipt.autonomy ?? node.autonomy,
+      closer: comment.author,
+      closedAt: receipt.at,
+      ...(node.autonomy === "auto" ? { autoProbeKeys: (node.probes ?? []).map((probe) => JSON.stringify(probe)).sort() } : {}),
+    };
+    const body = [decoded.text, encodeNodeBlock({ ...node, title: issue.title, completion })]
+      .filter((part) => part.length > 0).join("\n\n");
+    await this.writeRawBody(ref, body);
     await this.transport({
       method: "PATCH",
       path: `repos/${this.repo}/issues/${ref.id}`,

--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -915,12 +915,13 @@ class GitHubGraphStore implements GraphStore {
     const checkpoint = /^- \*\*checkpoint:\*\* `([^`\n]+)`$/mu.exec(comment.body)?.[1];
     const autonomy = /^- \*\*autonomy:\*\* `([^`\n]+)`$/mu.exec(comment.body)?.[1];
     const receiptAt = /^- \*\*at:\*\* ([^\n]+)$/mu.exec(comment.body)?.[1];
+    const attestation = /^- \*\*attestation:\*\* `(verified|unverified)`$/mu.exec(comment.body)?.[1];
     const gatedNodeHash = /^- \*\*gated node hash:\*\* `([a-f0-9]{64})`$/mu.exec(comment.body)?.[1];
     return close.actor === completion.closer
       && Number.isFinite(commentAt) && Number.isFinite(boundAt)
       && commentAt <= close.at && (reopened === undefined || commentAt >= reopened.at)
       && checkpoint === completion.checkpointId && autonomy === completion.autonomy
-      && receiptAt === completion.closedAt && gatedNodeHash === completion.gatedNodeHash;
+      && receiptAt === completion.closedAt && attestation === "verified" && gatedNodeHash === completion.gatedNodeHash;
   }
 
   /** Bodies included — the read half of {@link postComment}. Paginated: receipts are often the last comment. */

--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -461,7 +461,7 @@ function readComment(value: unknown, context: string): GitHubComment {
 }
 
 /** The typed half of a node, as stored in the issue body. Title lives in the issue title; parent is a native edge. */
-export function encodeNodeBlock(spec: CreateNodeSpec): string {
+export function encodeNodeBlock(spec: CreateNodeSpec & { completion?: WorkGraphNode["completion"] }): string {
   const payload: Record<string, unknown> = { autonomy: spec.autonomy };
   if (spec.kind !== undefined) payload.kind = spec.kind;
   if (spec.checkpointId !== undefined) payload.checkpointId = spec.checkpointId;
@@ -506,8 +506,22 @@ function nodeFromIssue(issue: GitHubIssue): { node: WorkGraphNode; typed: boolea
   }
   try {
     const block = asRecord(JSON.parse(decoded.raw) as unknown, "node block");
+    const rawCompletion = block.completion;
+    delete block.completion;
     const spec = parseNodeSpec({ ...block, title: issue.title });
-    return { node: toNode(String(issue.number), spec), typed: true, text: decoded.text };
+    const node = toNode(String(issue.number), spec);
+    if (rawCompletion === undefined) return { node, typed: true, text: decoded.text };
+    const completion = asRecord(rawCompletion, "node completion");
+    const fields = ["receiptCommentId", "checkpointId", "closer", "closedAt"] as const;
+    if (fields.some((field) => typeof completion[field] !== "string")
+      || !["auto", "propose", "approve"].includes(String(completion.autonomy))) {
+      throw new WorkGraphError("invalid-node", "invalid persisted completion binding");
+    }
+    const autoProbeKeys = completion.autoProbeKeys;
+    if (autoProbeKeys !== undefined && (!Array.isArray(autoProbeKeys) || autoProbeKeys.some((key) => typeof key !== "string"))) {
+      throw new WorkGraphError("invalid-node", "invalid persisted completion probe keys");
+    }
+    return { node: { ...node, completion: { receiptCommentId: completion.receiptCommentId as string, checkpointId: completion.checkpointId as string, autonomy: completion.autonomy as WorkGraphNode["autonomy"], closer: completion.closer as string, closedAt: completion.closedAt as string, ...(autoProbeKeys === undefined ? {} : { autoProbeKeys: autoProbeKeys as string[] }) } }, typed: true, text: decoded.text };
   } catch (error) {
     // Visible state, never a silent downgrade: the node falls back to the
     // most-gated class AND says why.
@@ -879,10 +893,12 @@ class GitHubGraphStore implements GraphStore {
     const node = nodeFromIssue(issue).node;
     if (completion.checkpointId !== node.checkpointId || completion.autonomy !== node.autonomy) return false;
     if (node.autonomy === "auto" && JSON.stringify(completion.autoProbeKeys ?? []) !== JSON.stringify((node.probes ?? []).map((probe) => JSON.stringify(probe)).sort())) return false;
-    const [comment, events] = await Promise.all([
-      this.readComment({ id: completion.receiptCommentId, nodeId: ref.id }),
+    const [comments, events] = await Promise.all([
+      this.listComments(ref),
       this.transport({ method: "GET", path: `repos/${this.repo}/issues/${ref.id}/events`, paginate: true }),
     ]);
+    const comment = comments.find((entry) => entry.id === completion.receiptCommentId);
+    if (comment === undefined || comment.author !== completion.closer || !isStructurallyValidCloseReceipt(comment.body)) return false;
     const timeline = asArray(events, "issue events").flatMap((entry) => {
       const record = asRecord(entry, "issue event");
       const at = typeof record.created_at === "string" ? Date.parse(record.created_at) : NaN;
@@ -892,7 +908,15 @@ class GitHubGraphStore implements GraphStore {
     }).sort((left, right) => left.at - right.at);
     const close = [...timeline].reverse().find((entry) => entry.event === "closed");
     if (close === undefined || close.actor === undefined) return false;
-    return close.actor === completion.closer && comment.author === completion.closer;
+    const reopened = [...timeline].reverse().find((entry) => entry.event === "reopened" && entry.at < close.at);
+    const commentAt = comment.createdAt === undefined ? NaN : Date.parse(comment.createdAt);
+    const boundAt = Date.parse(completion.closedAt);
+    const checkpoint = /^- \*\*checkpoint:\*\* `([^`\n]+)`$/mu.exec(comment.body)?.[1];
+    const autonomy = /^- \*\*autonomy:\*\* `([^`\n]+)`$/mu.exec(comment.body)?.[1];
+    return close.actor === completion.closer
+      && Number.isFinite(commentAt) && Number.isFinite(boundAt)
+      && commentAt === boundAt && commentAt <= close.at && (reopened === undefined || commentAt > reopened.at)
+      && checkpoint === completion.checkpointId && autonomy === completion.autonomy;
   }
 
   /** Bodies included — the read half of {@link postComment}. Paginated: receipts are often the last comment. */

--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -21,6 +21,7 @@ import {
   parseNodeSpec,
   renderCloseReceipt,
   isStructurallyValidCloseReceipt,
+  hashGatedNodeFields,
   resolveClaimRace,
   toNode,
   type AttestationCapability,
@@ -512,7 +513,7 @@ function nodeFromIssue(issue: GitHubIssue): { node: WorkGraphNode; typed: boolea
     const node = toNode(String(issue.number), spec);
     if (rawCompletion === undefined) return { node, typed: true, text: decoded.text };
     const completion = asRecord(rawCompletion, "node completion");
-    const fields = ["receiptCommentId", "checkpointId", "closer", "closedAt"] as const;
+    const fields = ["receiptCommentId", "checkpointId", "closer", "closedAt", "gatedNodeHash"] as const;
     if (fields.some((field) => typeof completion[field] !== "string")
       || !["auto", "propose", "approve"].includes(String(completion.autonomy))) {
       throw new WorkGraphError("invalid-node", "invalid persisted completion binding");
@@ -521,7 +522,7 @@ function nodeFromIssue(issue: GitHubIssue): { node: WorkGraphNode; typed: boolea
     if (autoProbeKeys !== undefined && (!Array.isArray(autoProbeKeys) || autoProbeKeys.some((key) => typeof key !== "string"))) {
       throw new WorkGraphError("invalid-node", "invalid persisted completion probe keys");
     }
-    return { node: { ...node, completion: { receiptCommentId: completion.receiptCommentId as string, checkpointId: completion.checkpointId as string, autonomy: completion.autonomy as WorkGraphNode["autonomy"], closer: completion.closer as string, closedAt: completion.closedAt as string, ...(autoProbeKeys === undefined ? {} : { autoProbeKeys: autoProbeKeys as string[] }) } }, typed: true, text: decoded.text };
+    return { node: { ...node, completion: { receiptCommentId: completion.receiptCommentId as string, checkpointId: completion.checkpointId as string, autonomy: completion.autonomy as WorkGraphNode["autonomy"], closer: completion.closer as string, closedAt: completion.closedAt as string, gatedNodeHash: completion.gatedNodeHash as string, ...(autoProbeKeys === undefined ? {} : { autoProbeKeys: autoProbeKeys as string[] }) } }, typed: true, text: decoded.text };
   } catch (error) {
     // Visible state, never a silent downgrade: the node falls back to the
     // most-gated class AND says why.
@@ -892,7 +893,7 @@ class GitHubGraphStore implements GraphStore {
   private async hasCurrentCloseReceipt(ref: NodeRef, issue: GitHubIssue, completion: NonNullable<WorkGraphNode["completion"]>): Promise<boolean> {
     const node = nodeFromIssue(issue).node;
     if (completion.checkpointId !== node.checkpointId || completion.autonomy !== node.autonomy) return false;
-    if (node.autonomy === "auto" && JSON.stringify(completion.autoProbeKeys ?? []) !== JSON.stringify((node.probes ?? []).map((probe) => JSON.stringify(probe)).sort())) return false;
+    if (completion.gatedNodeHash !== hashGatedNodeFields(node)) return false;
     const [comments, events] = await Promise.all([
       this.listComments(ref),
       this.transport({ method: "GET", path: `repos/${this.repo}/issues/${ref.id}/events`, paginate: true }),
@@ -913,10 +914,13 @@ class GitHubGraphStore implements GraphStore {
     const boundAt = Date.parse(completion.closedAt);
     const checkpoint = /^- \*\*checkpoint:\*\* `([^`\n]+)`$/mu.exec(comment.body)?.[1];
     const autonomy = /^- \*\*autonomy:\*\* `([^`\n]+)`$/mu.exec(comment.body)?.[1];
+    const receiptAt = /^- \*\*at:\*\* ([^\n]+)$/mu.exec(comment.body)?.[1];
+    const gatedNodeHash = /^- \*\*gated node hash:\*\* `([a-f0-9]{64})`$/mu.exec(comment.body)?.[1];
     return close.actor === completion.closer
-      && Number.isFinite(commentAt) && Number.isFinite(boundAt)
-      && commentAt === boundAt && commentAt <= close.at && (reopened === undefined || commentAt > reopened.at)
-      && checkpoint === completion.checkpointId && autonomy === completion.autonomy;
+      && Number.isFinite(commentAt)
+      && commentAt <= close.at && (reopened === undefined || commentAt > reopened.at)
+      && checkpoint === completion.checkpointId && autonomy === completion.autonomy
+      && receiptAt === completion.closedAt && gatedNodeHash === completion.gatedNodeHash;
   }
 
   /** Bodies included — the read half of {@link postComment}. Paginated: receipts are often the last comment. */
@@ -957,18 +961,21 @@ class GitHubGraphStore implements GraphStore {
   async close(ref: NodeRef, receipt: CloseReceipt): Promise<void> {
     const issue = await this.fetchIssue(ref);
     const decoded = nodeFromIssue(issue);
-    const posted = await this.postComment(ref, renderCloseReceipt(receipt));
+    const node = decoded.node;
+    const gatedNodeHash = hashGatedNodeFields(node);
+    const boundReceipt = { ...receipt, autonomy: node.autonomy, gatedNodeHash };
+    const posted = await this.postComment(ref, renderCloseReceipt(boundReceipt));
     const comment = await this.readComment(posted);
     if (comment.author === undefined || comment.author.length === 0) {
       throw new WorkGraphError("backend", "posted close receipt has no authenticated author");
     }
-    const node = decoded.node;
     const completion = {
       receiptCommentId: comment.id,
       checkpointId: receipt.checkpointId,
       autonomy: receipt.autonomy ?? node.autonomy,
       closer: comment.author,
-      closedAt: receipt.at,
+      closedAt: boundReceipt.at,
+      gatedNodeHash,
       ...(node.autonomy === "auto" ? { autoProbeKeys: (node.probes ?? []).map((probe) => JSON.stringify(probe)).sort() } : {}),
     };
     const body = [decoded.text, encodeNodeBlock({ ...node, title: issue.title, completion })]

--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -958,11 +958,14 @@ class GitHubGraphStore implements GraphStore {
   }
 
   /** Receipt first, then the state change: a close that fails halfway leaves the evidence, not a bare closed issue. */
-  async close(ref: NodeRef, receipt: CloseReceipt): Promise<void> {
+  async close(ref: NodeRef, receipt: CloseReceipt, expectedGatedNodeHash?: string): Promise<void> {
     const issue = await this.fetchIssue(ref);
     const decoded = nodeFromIssue(issue);
     const node = decoded.node;
     const gatedNodeHash = hashGatedNodeFields(node);
+    if (expectedGatedNodeHash !== undefined && gatedNodeHash !== expectedGatedNodeHash) {
+      throw new WorkGraphError("invalid-node", `node ${ref.id} changed after close validation`);
+    }
     const boundReceipt = { ...receipt, autonomy: node.autonomy, gatedNodeHash };
     const posted = await this.postComment(ref, renderCloseReceipt(boundReceipt));
     const comment = await this.readComment(posted);

--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -20,6 +20,7 @@ import {
   WorkGraphError,
   parseNodeSpec,
   renderCloseReceipt,
+  isStructurallyValidCloseReceipt,
   resolveClaimRace,
   toNode,
   type AttestationCapability,
@@ -574,11 +575,9 @@ class GitHubGraphStore implements GraphStore {
   async readNode(ref: NodeRef): Promise<NodeState> {
     const issue = await this.fetchIssue(ref);
     const parentNumber = issue.parentNumber ?? (await this.fetchParentNumber(issue.number));
-    return toNodeState(
-      issue,
-      await this.fetchBlockers(ref),
-      parentNumber === undefined ? undefined : { id: String(parentNumber) },
-    );
+    const state = toNodeState(issue, await this.fetchBlockers(ref), parentNumber === undefined ? undefined : { id: String(parentNumber) });
+    if (issue.status !== "closed") return state;
+    return { ...state, currentCloseReceipt: await this.hasCurrentCloseReceipt(ref) };
   }
 
   /**
@@ -873,6 +872,28 @@ class GitHubGraphStore implements GraphStore {
     });
   }
 
+  /** Receipt authority is the current tracker closure interval, never a historical marker. */
+  private async hasCurrentCloseReceipt(ref: NodeRef): Promise<boolean> {
+    const [comments, events] = await Promise.all([
+      this.listComments(ref),
+      this.transport({ method: "GET", path: `repos/${this.repo}/issues/${ref.id}/events`, paginate: true }),
+    ]);
+    const timeline = asArray(events, "issue events").flatMap((entry) => {
+      const record = asRecord(entry, "issue event");
+      const at = typeof record.created_at === "string" ? Date.parse(record.created_at) : NaN;
+      const event = record.event;
+      return Number.isFinite(at) && (event === "closed" || event === "reopened") ? [{ event, at }] : [];
+    }).sort((left, right) => left.at - right.at);
+    const close = [...timeline].reverse().find((entry) => entry.event === "closed");
+    if (close === undefined) return false;
+    const reopened = [...timeline].reverse().find((entry) => entry.event === "reopened" && entry.at < close.at);
+    const start = reopened?.at ?? Number.NEGATIVE_INFINITY;
+    return comments.some((comment) => {
+      const at = comment.createdAt === undefined ? NaN : Date.parse(comment.createdAt);
+      return Number.isFinite(at) && at >= start && at <= close.at && isStructurallyValidCloseReceipt(comment.body);
+    });
+  }
+
   /** Bodies included — the read half of {@link postComment}. Paginated: receipts are often the last comment. */
   async listComments(ref: NodeRef): Promise<NodeComment[]> {
     const comments = asArray(
@@ -889,6 +910,7 @@ class GitHubGraphStore implements GraphStore {
         id: String(readNumber(record, "id", "listComments")),
         author: readLogin(record.user),
         body: typeof record.body === "string" ? record.body : "",
+        ...(typeof record.created_at === "string" ? { createdAt: record.created_at } : {}),
         ...(typeof record.html_url === "string" ? { url: record.html_url } : {}),
       };
     });

--- a/src/work-graph-github.ts
+++ b/src/work-graph-github.ts
@@ -522,7 +522,12 @@ function nodeFromIssue(issue: GitHubIssue): { node: WorkGraphNode; typed: boolea
     if (autoProbeKeys !== undefined && (!Array.isArray(autoProbeKeys) || autoProbeKeys.some((key) => typeof key !== "string"))) {
       throw new WorkGraphError("invalid-node", "invalid persisted completion probe keys");
     }
-    return { node: { ...node, completion: { receiptCommentId: completion.receiptCommentId as string, checkpointId: completion.checkpointId as string, autonomy: completion.autonomy as WorkGraphNode["autonomy"], closer: completion.closer as string, closedAt: completion.closedAt as string, gatedNodeHash: completion.gatedNodeHash as string, ...(autoProbeKeys === undefined ? {} : { autoProbeKeys: autoProbeKeys as string[] }) } }, typed: true, text: decoded.text };
+    const ciCheckRunId = completion.ciCheckRunId;
+    const ciHeadSha = completion.ciHeadSha;
+    if ((ciCheckRunId !== undefined && typeof ciCheckRunId !== "string") || (ciHeadSha !== undefined && typeof ciHeadSha !== "string")) {
+      throw new WorkGraphError("invalid-node", "invalid persisted completion CI binding");
+    }
+    return { node: { ...node, completion: { receiptCommentId: completion.receiptCommentId as string, checkpointId: completion.checkpointId as string, autonomy: completion.autonomy as WorkGraphNode["autonomy"], closer: completion.closer as string, closedAt: completion.closedAt as string, gatedNodeHash: completion.gatedNodeHash as string, ...(autoProbeKeys === undefined ? {} : { autoProbeKeys: autoProbeKeys as string[] }), ...(ciCheckRunId === undefined ? {} : { ciCheckRunId: ciCheckRunId as string, ciHeadSha: ciHeadSha as string }) } }, typed: true, text: decoded.text };
   } catch (error) {
     // Visible state, never a silent downgrade: the node falls back to the
     // most-gated class AND says why.
@@ -915,13 +920,35 @@ class GitHubGraphStore implements GraphStore {
     const checkpoint = /^- \*\*checkpoint:\*\* `([^`\n]+)`$/mu.exec(comment.body)?.[1];
     const autonomy = /^- \*\*autonomy:\*\* `([^`\n]+)`$/mu.exec(comment.body)?.[1];
     const receiptAt = /^- \*\*at:\*\* ([^\n]+)$/mu.exec(comment.body)?.[1];
-    const attestation = /^- \*\*attestation:\*\* `(verified|unverified)`$/mu.exec(comment.body)?.[1];
     const gatedNodeHash = /^- \*\*gated node hash:\*\* `([a-f0-9]{64})`$/mu.exec(comment.body)?.[1];
-    return close.actor === completion.closer
-      && Number.isFinite(commentAt) && Number.isFinite(boundAt)
-      && commentAt <= close.at && (reopened === undefined || commentAt >= reopened.at)
-      && checkpoint === completion.checkpointId && autonomy === completion.autonomy
-      && receiptAt === completion.closedAt && attestation === "verified" && gatedNodeHash === completion.gatedNodeHash;
+    if (close.actor !== completion.closer
+      || !Number.isFinite(commentAt) || !Number.isFinite(boundAt)
+      || commentAt > close.at || (reopened !== undefined && commentAt < reopened.at)
+      || checkpoint !== completion.checkpointId || autonomy !== completion.autonomy
+      || receiptAt !== completion.closedAt || gatedNodeHash !== completion.gatedNodeHash) {
+      return false;
+    }
+    // Auto completion is only as strong as the CI run it cites: a check-run
+    // `success` conclusion is written by a GitHub App, not an issue editor, so
+    // it is the one completion fact a tracker-writer cannot forge. Verify it live.
+    if (node.autonomy === "auto") {
+      if (completion.ciCheckRunId === undefined || completion.ciHeadSha === undefined) return false;
+      const run = await this.fetchCheckRun(completion.ciCheckRunId);
+      if (run.conclusion !== "success" || run.headSha !== completion.ciHeadSha) return false;
+    }
+    return true;
+  }
+
+  /** The one immutable completion fact an issue editor cannot mint: a GitHub check-run conclusion. */
+  private async fetchCheckRun(checkRunId: string): Promise<{ conclusion: string; headSha: string }> {
+    const record = asRecord(
+      await this.transport({ method: "GET", path: `repos/${this.repo}/check-runs/${checkRunId}` }),
+      "check run",
+    );
+    return {
+      conclusion: typeof record.conclusion === "string" ? record.conclusion : "",
+      headSha: typeof record.head_sha === "string" ? record.head_sha : "",
+    };
   }
 
   /** Bodies included — the read half of {@link postComment}. Paginated: receipts are often the last comment. */
@@ -969,26 +996,25 @@ class GitHubGraphStore implements GraphStore {
     }
     const boundReceipt = { ...receipt, autonomy: node.autonomy, gatedNodeHash };
     const posted = await this.postComment(ref, renderCloseReceipt(boundReceipt));
-    const comment = await this.readComment(posted);
-    if (comment.author === undefined || comment.author.length === 0) {
+    if (posted.author === undefined || posted.author.length === 0) {
       throw new WorkGraphError("backend", "posted close receipt has no authenticated author");
     }
     const completion = {
-      receiptCommentId: comment.id,
+      receiptCommentId: posted.id,
       checkpointId: receipt.checkpointId,
       autonomy: receipt.autonomy ?? node.autonomy,
-      closer: comment.author,
+      closer: posted.author,
       closedAt: boundReceipt.at,
       gatedNodeHash,
       ...(node.autonomy === "auto" ? { autoProbeKeys: (node.probes ?? []).map((probe) => JSON.stringify(probe)).sort() } : {}),
+      ...(receipt.ci === undefined ? {} : { ciCheckRunId: receipt.ci.checkRunId, ciHeadSha: receipt.ci.headSha }),
     };
     const body = [decoded.text, encodeNodeBlock({ ...node, title: issue.title, completion })]
       .filter((part) => part.length > 0).join("\n\n");
-    await this.writeRawBody(ref, body);
     await this.transport({
       method: "PATCH",
       path: `repos/${this.repo}/issues/${ref.id}`,
-      body: { state: "closed", state_reason: "completed" },
+      body: { body, state: "closed", state_reason: "completed" },
     });
   }
 

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -94,6 +94,9 @@ export interface NodeCompletionBinding {
   gatedNodeHash: string;
   /** Canonical declared probe keys, recorded only for auto nodes. */
   autoProbeKeys?: readonly string[];
+  /** Forge-proof CI check run cited at close, recorded only for auto nodes. */
+  ciCheckRunId?: string;
+  ciHeadSha?: string;
 }
 
 export interface WorkGraphNodeBase {
@@ -423,6 +426,13 @@ export interface CloseReceipt {
    * beats a stale tool refusing to say so.
    */
   closedWith?: string;
+  /**
+   * Forge-proof completion evidence for `auto` nodes: a GitHub check run whose
+   * `success` conclusion only a GitHub App (GitHub Actions) can create — an
+   * issue editor with a user token cannot mint or edit it, so citing it moves
+   * completion from self-authored markdown to an immutable, API-verifiable fact.
+   */
+  ci?: { checkRunId: string; headSha: string };
   evidence: readonly CloseEvidence[];
   probeResults: readonly ProbeResult[];
   /**
@@ -999,6 +1009,17 @@ export function assertClosable(node: WorkGraphNode, receipt: CloseReceipt): void
       `node ${node.id} (${node.autonomy}) needs at least one ${admissible.join(" or ")} evidence entry with an externally checkable pointer`,
     );
   }
+
+  // An `auto` node must cite a successful CI check run — the one fact about
+  // "the probes actually ran and passed" that an issue editor cannot author,
+  // because check-run conclusions are written only by a GitHub App. Without it
+  // the receipt is self-consistent markdown and no completion can be forged-proof.
+  if ((receipt.ci?.checkRunId ?? "").trim().length === 0 || (receipt.ci?.headSha ?? "").trim().length === 0) {
+    throw new WorkGraphError(
+      "close-refused",
+      `node ${node.id} (${node.autonomy}) must cite a successful CI check run (checkRunId and headSha) to close`,
+    );
+  }
 }
 
 /**
@@ -1149,6 +1170,7 @@ export function renderCloseReceipt(receipt: CloseReceipt): string {
     ...((receipt.closedWith ?? "").length === 0 ? [] : [`- **closed with:** ${receipt.closedWith}`]),
     `- **at:** ${receipt.at}`,
     ...(receipt.gatedNodeHash === undefined ? [] : [`- **gated node hash:** \`${receipt.gatedNodeHash}\``]),
+    ...(receipt.ci === undefined ? [] : [`- **ci:** \`${receipt.ci.checkRunId}@${receipt.ci.headSha}\``]),
     `- **attestation:** \`${receipt.attestation}\``,
     ``,
     `### Evidence`,

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -19,6 +19,7 @@
  * construction sites.
  */
 
+import { createHash } from "node:crypto";
 import type { EvidenceKind } from "./types";
 
 /**
@@ -89,6 +90,8 @@ export interface NodeCompletionBinding {
   autonomy: WorkGraphAutonomy;
   closer: string;
   closedAt: string;
+  /** Hash of the close-gated node fields, signed into the receipt comment. */
+  gatedNodeHash: string;
   /** Canonical declared probe keys, recorded only for auto nodes. */
   autoProbeKeys?: readonly string[];
 }
@@ -378,6 +381,8 @@ export interface CloseReceipt {
   autonomy?: WorkGraphAutonomy;
   /** ISO timestamp. */
   at: string;
+  /** Backend-derived hash of the close-gated node fields, rendered into the receipt. */
+  gatedNodeHash?: string;
   /**
    * The **human-readable half** of the close: why this node resolved the way it
    * did, in prose (#556).
@@ -1040,6 +1045,19 @@ export function estimateReceiptChars(input: { resolution?: string; probeCount: n
 /** The marker a receipt comment always carries — what `audit` and `decisions` key on. */
 export const CLOSE_RECEIPT_MARKER = "## Close receipt";
 
+/** Deterministic SHA-256 commitment to the fields that the close gate authorizes. */
+export function hashGatedNodeFields(node: Pick<WorkGraphNode, "checkpointId" | "autonomy" | "probes">): string {
+  const canonicalize = (value: unknown): unknown => {
+    if (Array.isArray(value)) return value.map(canonicalize);
+    if (value !== null && typeof value === "object") {
+      return Object.fromEntries(Object.entries(value as Record<string, unknown>).sort(([left], [right]) => left.localeCompare(right)).map(([key, child]) => [key, canonicalize(child)]));
+    }
+    return value;
+  };
+  const canonical = canonicalize({ checkpointId: node.checkpointId ?? null, autonomy: node.autonomy, probes: node.probes ?? [] });
+  return createHash("sha256").update(JSON.stringify(canonical), "utf8").digest("hex");
+}
+
 /** The gist line inside a rendered receipt. One renderer, one parser — pinned against each other in tests. */
 const RECEIPT_GIST_LINE = /^- \*\*gist:\*\* (.+)$/mu;
 
@@ -1130,6 +1148,7 @@ export function renderCloseReceipt(receipt: CloseReceipt): string {
     `- **autonomy:** \`${receipt.autonomy ?? "approve"}\``,
     ...((receipt.closedWith ?? "").length === 0 ? [] : [`- **closed with:** ${receipt.closedWith}`]),
     `- **at:** ${receipt.at}`,
+    ...(receipt.gatedNodeHash === undefined ? [] : [`- **gated node hash:** \`${receipt.gatedNodeHash}\``]),
     `- **attestation:** \`${receipt.attestation}\``,
     ``,
     `### Evidence`,

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -175,6 +175,8 @@ export interface NodeState {
   typed: boolean;
   /** Set when a typed block was present but unreadable. Visible state, never a silent downgrade. */
   parseError?: string;
+  /** True only when the production store proved a receipt belongs to this current closure. */
+  currentCloseReceipt?: boolean;
 }
 
 /**
@@ -239,6 +241,8 @@ export interface NodeComment {
   id: string;
   author: string;
   body: string;
+  /** Tracker-authored creation timestamp, used to bind a receipt to one closure interval. */
+  createdAt?: string;
   url?: string;
 }
 
@@ -357,6 +361,8 @@ export interface CloseReceipt {
   /** Must match the node's attached checkpoint — one work item, one completion gate. */
   checkpointId: string;
   closedBy: string;
+  /** The node autonomy at the authoritative close write. */
+  autonomy?: WorkGraphAutonomy;
   /** ISO timestamp. */
   at: string;
   /**
@@ -1020,15 +1026,17 @@ export interface ReceiptScan {
  * — there is no side table to consult. The parse is pinned to
  * {@link renderCloseReceipt}'s exact output in tests, so the pair drifts loudly.
  */
-function isStructurallyValidCloseReceipt(body: string): boolean {
+export function isStructurallyValidCloseReceipt(body: string): boolean {
+  const autonomy = /^- \*\*autonomy:\*\* `(auto|approve)`$/mu.exec(body)?.[1];
+  const hasEvidence = /^- `[^`\n]+` — \S.+$/mu.test(body);
   return body.includes(CLOSE_RECEIPT_MARKER)
     && /^- \*\*checkpoint:\*\* `[^`\n]+`$/mu.test(body)
     && /^- \*\*closed by:\*\* \S.+$/mu.test(body)
     && /^- \*\*at:\*\* \d{4}-\d{2}-\d{2}T[^\n]+$/mu.test(body)
     && /^- \*\*attestation:\*\* `(?:verified|unverified)`$/mu.test(body)
-    // HITL closes may legitimately carry no machine evidence. The heading is
-    // still required so a marker-shaped comment cannot pass as a receipt.
-    && /^### Evidence$/mu.test(body);
+    && /^### Evidence$/mu.test(body)
+    && autonomy !== undefined
+    && (autonomy === "approve" || hasEvidence);
 }
 
 export function scanCommentsForReceipt(bodies: readonly string[]): ReceiptScan {
@@ -1084,6 +1092,7 @@ export function renderCloseReceipt(receipt: CloseReceipt): string {
     `- **checkpoint:** \`${receipt.checkpointId}\``,
     ...((receipt.gist ?? "").trim().length === 0 ? [] : [`- **gist:** ${(receipt.gist ?? "").trim()}`]),
     `- **closed by:** ${receipt.closedBy}`,
+    `- **autonomy:** \`${receipt.autonomy ?? "approve"}\``,
     ...((receipt.closedWith ?? "").length === 0 ? [] : [`- **closed with:** ${receipt.closedWith}`]),
     `- **at:** ${receipt.at}`,
     `- **attestation:** \`${receipt.attestation}\``,
@@ -1305,6 +1314,6 @@ export class WorkGraph {
       throw new WorkGraphError("node-closed", `node ${ref.id} is already closed`);
     }
     assertClosable(state.node, receipt);
-    await this.store.close(ref, receipt);
+    await this.store.close(ref, { ...receipt, autonomy: state.node.autonomy });
   }
 }

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -1027,7 +1027,7 @@ export interface ReceiptScan {
  * {@link renderCloseReceipt}'s exact output in tests, so the pair drifts loudly.
  */
 export function isStructurallyValidCloseReceipt(body: string): boolean {
-  const autonomy = /^- \*\*autonomy:\*\* `(auto|approve)`$/mu.exec(body)?.[1];
+  const autonomy = /^- \*\*autonomy:\*\* `(auto|propose|approve)`$/mu.exec(body)?.[1];
   const hasEvidence = /^- `[^`\n]+` — \S.+$/mu.test(body);
   return body.includes(CLOSE_RECEIPT_MARKER)
     && /^- \*\*checkpoint:\*\* `[^`\n]+`$/mu.test(body)
@@ -1036,7 +1036,7 @@ export function isStructurallyValidCloseReceipt(body: string): boolean {
     && /^- \*\*attestation:\*\* `(?:verified|unverified)`$/mu.test(body)
     && /^### Evidence$/mu.test(body)
     && autonomy !== undefined
-    && (autonomy === "approve" || hasEvidence);
+    && (autonomy !== "auto" || hasEvidence);
 }
 
 export function scanCommentsForReceipt(bodies: readonly string[]): ReceiptScan {

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -155,7 +155,7 @@ export interface NodeRef {
  *   what a verb decides. That is what keeps a second input from becoming a
  *   second authority. A backend with no index concept ignores them.
  */
-export type CreateNodeSpec = DistributiveOmit<WorkGraphNode, "id"> & {
+export type CreateNodeSpec = DistributiveOmit<WorkGraphNode, "id" | "completion"> & {
   body?: string;
   parent?: NodeRef;
   labels?: readonly string[];
@@ -776,6 +776,9 @@ function parseLabels(value: unknown): string[] {
  */
 export function parseNodeSpec(input: unknown): CreateNodeSpec {
   const record = asRecord(input, "invalid-node", "node spec");
+  if ("completion" in record) {
+    throw new WorkGraphError("invalid-node", "completion is backend-owned and cannot be supplied at creation");
+  }
   if ("id" in record && record.id !== undefined) {
     throw new WorkGraphError("invalid-node", `"id" is assigned by the store — never caller-supplied`);
   }

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -1026,8 +1026,9 @@ function isStructurallyValidCloseReceipt(body: string): boolean {
     && /^- \*\*closed by:\*\* \S.+$/mu.test(body)
     && /^- \*\*at:\*\* \d{4}-\d{2}-\d{2}T[^\n]+$/mu.test(body)
     && /^- \*\*attestation:\*\* `(?:verified|unverified)`$/mu.test(body)
-    && /^### Evidence$/mu.test(body)
-    && /^- `[^`\n]+` — \S.+$/mu.test(body);
+    // HITL closes may legitimately carry no machine evidence. The heading is
+    // still required so a marker-shaped comment cannot pass as a receipt.
+    && /^### Evidence$/mu.test(body);
 }
 
 export function scanCommentsForReceipt(bodies: readonly string[]): ReceiptScan {

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -82,10 +82,23 @@ export type ProbeResult =
       cwd?: string;
     };
 
+/** Receipt binding persisted by a backend after the gated close write. */
+export interface NodeCompletionBinding {
+  receiptCommentId: string;
+  checkpointId: string;
+  autonomy: WorkGraphAutonomy;
+  closer: string;
+  closedAt: string;
+  /** Canonical declared probe keys, recorded only for auto nodes. */
+  autoProbeKeys?: readonly string[];
+}
+
 export interface WorkGraphNodeBase {
   /** Backend-native identity (GitHub: issue number), assigned by the store — never caller-supplied. */
   id: string;
   title: string;
+  /** Backend-persisted close binding; absent until a gated close completes. */
+  completion?: NodeCompletionBinding;
   /**
    * Free-form doctrine tag (e.g. research, grilling). The runtime never
    * interprets its MEANING but normalizes its FORM at the store boundary:
@@ -778,6 +791,21 @@ export function parseNodeSpec(input: unknown): CreateNodeSpec {
     : requireString(asRecord(record.parent, "invalid-node", "node spec: parent"), "id", "invalid-node", "node spec: parent");
   const probes = parseProbes(record.probes);
   const labels = parseLabels(record.labels);
+  const completion = record.completion === undefined ? undefined : (() => {
+    const value = asRecord(record.completion, "invalid-node", "node completion");
+    const autoProbeKeys = value.autoProbeKeys === undefined ? undefined : value.autoProbeKeys;
+    if (autoProbeKeys !== undefined && (!Array.isArray(autoProbeKeys) || autoProbeKeys.some((key) => typeof key !== "string"))) {
+      throw new WorkGraphError("invalid-node", "node completion autoProbeKeys must be strings");
+    }
+    return {
+      receiptCommentId: requireString(value, "receiptCommentId", "invalid-node", "node completion"),
+      checkpointId: requireString(value, "checkpointId", "invalid-node", "node completion"),
+      autonomy: parseAutonomy(value.autonomy),
+      closer: requireString(value, "closer", "invalid-node", "node completion"),
+      closedAt: requireString(value, "closedAt", "invalid-node", "node completion"),
+      ...(autoProbeKeys === undefined ? {} : { autoProbeKeys }),
+    };
+  })();
 
   const base = {
     title,
@@ -787,6 +815,7 @@ export function parseNodeSpec(input: unknown): CreateNodeSpec {
     ...(body === undefined ? {} : { body }),
     ...(parentId === undefined ? {} : { parent: { id: parentId } }),
     ...(labels.length === 0 ? {} : { labels }),
+    ...(completion === undefined ? {} : { completion }),
   };
 
   if (autonomy === "auto") {

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -191,7 +191,10 @@ export interface NodeState {
  * required — so a report missing the field type-checked and derived `open` on a
  * `blocked` node.
  */
-export type BridgedNodeReport = Pick<NodeState, "ref" | "status" | "blockedBy">;
+export type BridgedNodeReport = Pick<NodeState, "ref" | "status" | "blockedBy"> & {
+  /** Only a receipt-backed close is Soma-complete; tracker state alone is not a gate result. */
+  hasCloseReceipt: boolean;
+};
 
 /**
  * Outcome of a claim attempt after the store's post-write re-read (§2.4).
@@ -1017,10 +1020,20 @@ export interface ReceiptScan {
  * — there is no side table to consult. The parse is pinned to
  * {@link renderCloseReceipt}'s exact output in tests, so the pair drifts loudly.
  */
+function isStructurallyValidCloseReceipt(body: string): boolean {
+  return body.includes(CLOSE_RECEIPT_MARKER)
+    && /^- \*\*checkpoint:\*\* `[^`\n]+`$/mu.test(body)
+    && /^- \*\*closed by:\*\* \S.+$/mu.test(body)
+    && /^- \*\*at:\*\* \d{4}-\d{2}-\d{2}T[^\n]+$/mu.test(body)
+    && /^- \*\*attestation:\*\* `(?:verified|unverified)`$/mu.test(body)
+    && /^### Evidence$/mu.test(body)
+    && /^- `[^`\n]+` — \S.+$/mu.test(body);
+}
+
 export function scanCommentsForReceipt(bodies: readonly string[]): ReceiptScan {
   let found: string | undefined;
   for (const body of bodies) {
-    if (body.includes(CLOSE_RECEIPT_MARKER)) found = body;
+    if (isStructurallyValidCloseReceipt(body)) found = body;
   }
   if (found === undefined) return { hasReceipt: false };
   const gist = RECEIPT_GIST_LINE.exec(found)?.[1]?.trim();

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -587,7 +587,7 @@ export interface GraphStore {
   readRawBody(ref: NodeRef): Promise<string>;
   /** Replace the node's raw body wholesale. Callers splice; the store writes. */
   writeRawBody(ref: NodeRef, body: string): Promise<void>;
-  close(ref: NodeRef, receipt: CloseReceipt): Promise<void>;
+  close(ref: NodeRef, receipt: CloseReceipt, expectedGatedNodeHash?: string): Promise<void>;
 }
 
 export type WorkGraphErrorCode =
@@ -1368,6 +1368,6 @@ export class WorkGraph {
       throw new WorkGraphError("node-closed", `node ${ref.id} is already closed`);
     }
     assertClosable(state.node, receipt);
-    await this.store.close(ref, { ...receipt, autonomy: state.node.autonomy });
+    await this.store.close(ref, { ...receipt, autonomy: state.node.autonomy }, hashGatedNodeFields(state.node));
   }
 }

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -94,7 +94,7 @@ export interface NodeCompletionBinding {
   gatedNodeHash: string;
   /** Canonical declared probe keys, recorded only for auto nodes. */
   autoProbeKeys?: readonly string[];
-  /** Forge-proof CI check run cited at close, recorded only for auto nodes. */
+  /** CI check run cited at close, recorded only for auto nodes (§3.1: detection, not prevention). */
   ciCheckRunId?: string;
   ciHeadSha?: string;
 }
@@ -427,10 +427,16 @@ export interface CloseReceipt {
    */
   closedWith?: string;
   /**
-   * Forge-proof completion evidence for `auto` nodes: a GitHub check run whose
-   * `success` conclusion only a GitHub App (GitHub Actions) can create — an
-   * issue editor with a user token cannot mint or edit it, so citing it moves
+   * CI evidence for `auto` nodes: a GitHub check run whose `success` conclusion
+   * only a GitHub App (GitHub Actions) can create. An issue editor who holds no
+   * push/CI-trigger authority cannot mint or edit such a run, so citing one moves
    * completion from self-authored markdown to an immutable, API-verifiable fact.
+   *
+   * **Detection, not prevention.** Both the run id and the head SHA are supplied
+   * by the closer, so a collaborator who *can* push and trigger CI can still mint
+   * a passing run on a trivial commit and cite it. The binding refuses the
+   * fabricated-run forgery (the common, issue-only-editor case); it does not
+   * replace checkpoint-owned verification of what the probes actually ran against.
    */
   ci?: { checkRunId: string; headSha: string };
   evidence: readonly CloseEvidence[];

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -1028,7 +1028,10 @@ export interface ReceiptScan {
  */
 export function isStructurallyValidCloseReceipt(body: string): boolean {
   const autonomy = /^- \*\*autonomy:\*\* `(auto|propose|approve)`$/mu.exec(body)?.[1];
-  const hasEvidence = /^- `[^`\n]+` — \S.+$/mu.test(body);
+  const evidenceMarker = "### Evidence\n";
+  const evidenceOffset = body.indexOf(evidenceMarker);
+  const evidence = evidenceOffset === -1 ? "" : body.slice(evidenceOffset + evidenceMarker.length);
+  const hasEvidence = /^- `[^`\n]+` — \S.+$/mu.test(evidence);
   return body.includes(CLOSE_RECEIPT_MARKER)
     && /^- \*\*checkpoint:\*\* `[^`\n]+`$/mu.test(body)
     && /^- \*\*closed by:\*\* \S.+$/mu.test(body)

--- a/test/algorithm-plansteps-bridge.test.ts
+++ b/test/algorithm-plansteps-bridge.test.ts
@@ -45,7 +45,7 @@ function freshRun(): AlgorithmRun {
 }
 
 function report(overrides: Partial<BridgedNodeReport> = {}): BridgedNodeReport {
-  return { ref: { id: "501" }, status: "open", blockedBy: [], ...overrides };
+  return { ref: { id: "501" }, status: "open", blockedBy: [], hasCloseReceipt: false, ...overrides };
 }
 
 /**
@@ -148,8 +148,9 @@ test("the batch `step` operation is refused on a bridged step too — one contra
 
 // --- the derivation --------------------------------------------------------
 
-test("a closed node is the only `done`", () => {
-  expect(deriveBridgedPlanStepStatus(report({ status: "closed" }))).toBe("done");
+test("only a receipt-backed closed node is Soma-complete", () => {
+  expect(deriveBridgedPlanStepStatus(report({ status: "closed", hasCloseReceipt: true }))).toBe("done");
+  expect(deriveBridgedPlanStepStatus(report({ status: "closed" }))).toBe("blocked");
   expect(deriveBridgedPlanStepStatus(report({ status: "open" }))).toBe("open");
 });
 
@@ -171,7 +172,7 @@ test("sync records WHICH node it derived from and when — a derived status must
   const run = syncBridgedPlanStep(
     freshRun(),
     "P1",
-    report({ status: "closed" }),
+    report({ status: "closed", hasCloseReceipt: true }),
     { bind: true },
     "2026-08-06T10:02:00.000Z",
   );
@@ -179,7 +180,7 @@ test("sync records WHICH node it derived from and when — a derived status must
   expect(stepOf(run, "P1")).toMatchObject({
     nodeId: "501",
     status: "done",
-    evidence: "derived from work-graph node 501 (closed) at 2026-08-06T10:02:00.000Z",
+    evidence: "derived from work-graph node 501 (closed; Soma-complete receipt) at 2026-08-06T10:02:00.000Z",
   });
   expect(run.updatedAt).toBe("2026-08-06T10:02:00.000Z");
 });
@@ -198,7 +199,7 @@ test("syncing a bridged step from a DIFFERENT node's report is refused", () => {
   const bridged = syncBridgedPlanStep(freshRun(), "P1", report(), { bind: true }, "2026-08-06T10:02:00.000Z");
 
   expect(() =>
-    syncBridgedPlanStep(bridged, "P1", report({ ref: { id: "502" }, status: "closed" })),
+    syncBridgedPlanStep(bridged, "P1", report({ ref: { id: "502" }, status: "closed", hasCloseReceipt: true })),
   ).toThrow(/bridged to work-graph node 501, but the reported node is 502/u);
 });
 
@@ -226,7 +227,7 @@ test("`bind` does not license re-homing an already-bridged step", () => {
 
 test("re-binding a step to the SAME node is a plain re-derive, not a re-home", () => {
   let run = syncBridgedPlanStep(freshRun(), "P1", report(), { bind: true }, "2026-08-06T10:02:00.000Z");
-  run = syncBridgedPlanStep(run, "P1", report({ status: "closed" }), { bind: true }, "2026-08-06T10:03:00.000Z");
+  run = syncBridgedPlanStep(run, "P1", report({ status: "closed", hasCloseReceipt: true }), { bind: true }, "2026-08-06T10:03:00.000Z");
 
   expect(stepOf(run, "P1").status).toBe("done");
 });
@@ -302,15 +303,16 @@ test("the un-bridge refusal is a speed bump, not a seal — remove-then-re-add r
   expect(stepOf(written, "P1").status).toBe("done");
 });
 
-test("a real NodeState is accepted verbatim as a BridgedNodeReport", () => {
-  // The type claims `NodeState` satisfies it; this is the claim being exercised
-  // with a value rather than restated in a comment.
+test("the bridge augments a NodeState with receipt evidence before derivation", () => {
   const state = realNodeState({ status: "closed" });
-  const run = syncBridgedPlanStep(freshRun(), "P1", state, { bind: true }, "2026-08-06T10:02:00.000Z");
+  const closed = { ref: state.ref, status: state.status, blockedBy: state.blockedBy, hasCloseReceipt: true };
+  const run = syncBridgedPlanStep(freshRun(), "P1", closed, { bind: true }, "2026-08-06T10:02:00.000Z");
 
   expect(stepOf(run, "P1")).toMatchObject({ nodeId: "501", status: "done" });
-  expect(deriveBridgedPlanStepStatus(realNodeState({ blockedBy: [{ id: "499", status: "open" }] }))).toBe("blocked");
-  expect(deriveBridgedPlanStepStatus(realNodeState())).toBe("open");
+  const open = realNodeState({ blockedBy: [{ id: "499", status: "open" }] });
+  expect(deriveBridgedPlanStepStatus({ ref: open.ref, status: open.status, blockedBy: open.blockedBy, hasCloseReceipt: false })).toBe("blocked");
+  const plain = realNodeState();
+  expect(deriveBridgedPlanStepStatus({ ref: plain.ref, status: plain.status, blockedBy: plain.blockedBy, hasCloseReceipt: false })).toBe("open");
 });
 
 // --- the other write path: the VSA sync's bulk flip ------------------------
@@ -338,7 +340,7 @@ test("an OPEN bridged step really does hold the run short of the VERIFY gate", (
   expect(() => advanceAlgorithmRun(run, "2026-08-06T10:08:00.000Z")).toThrow(/every plan step is done or blocked/u);
 
   // …and closing the node releases it. The cost is real and it is bounded.
-  const closed = syncBridgedPlanStep(run, "P1", report({ status: "closed" }), {}, "2026-08-06T10:09:00.000Z");
+  const closed = syncBridgedPlanStep(run, "P1", report({ status: "closed", hasCloseReceipt: true }), {}, "2026-08-06T10:09:00.000Z");
   expect(getRunPhase(advanceAlgorithmRun(closed, "2026-08-06T10:10:00.000Z"))).toBe("verify");
 });
 
@@ -348,7 +350,7 @@ test("the VERIFY sweep skips bridged steps rather than forging `done`", () => {
 
   expect(swept.find((step) => step.id === "P1")).toMatchObject({
     status: "open",
-    evidence: "derived from work-graph node 501 (open) at 2026-08-06T10:02:00.000Z",
+    evidence: "derived from work-graph node 501 (open; no close receipt) at 2026-08-06T10:02:00.000Z",
   });
   expect(swept.find((step) => step.id === "P2")).toMatchObject({ status: "done", evidence: "synced from VSA" });
 });
@@ -399,7 +401,7 @@ test("`step --node` bridges through the graph read path, and `--status` is then 
     const deps = {
       readNode: async (nodeId: string, options: { repo?: string }) => {
         reads.push({ nodeId, repo: options.repo });
-        return report({ ref: { id: nodeId }, status: "closed" as const });
+        return report({ ref: { id: nodeId }, status: "closed" as const, hasCloseReceipt: true });
       },
     };
 
@@ -461,7 +463,7 @@ test("`step --sync` re-derives from the step's OWN node — the node id comes of
       {
         readNode: async (nodeId: string) => {
           reads.push(nodeId);
-          return report({ ref: { id: nodeId }, status: "closed" as const });
+          return report({ ref: { id: nodeId }, status: "closed" as const, hasCloseReceipt: true });
         },
       },
     );
@@ -494,7 +496,7 @@ test("a concurrent re-bind between the two reads fails CLOSED, not silently", as
               syncBridgedPlanStep(freshRun(), "P1", report({ ref: { id: "777" } }), { bind: true }, "2026-08-06T10:03:00.000Z"),
               { homeDir },
             );
-            return report({ ref: { id: nodeId }, status: "closed" });
+            return report({ ref: { id: nodeId }, status: "closed", hasCloseReceipt: true });
           },
         },
       ),

--- a/test/algorithm-vsa-sync.test.ts
+++ b/test/algorithm-vsa-sync.test.ts
@@ -564,7 +564,7 @@ test("an open BRIDGED plan step caps the sync at EXECUTE instead of discarding t
       syncBridgedPlanStep(
         created,
         stepId,
-        { ref: { id: "501" }, status: "open", blockedBy: [] },
+        { ref: { id: "501" }, status: "open", blockedBy: [], hasCloseReceipt: false },
         { bind: true },
         "2026-08-06T10:01:00.000Z",
       ),

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -207,8 +207,18 @@ function deps(store: FakeStore, overrides: Partial<GraphCliDeps> = {}): Partial<
  */
 const RESOLUTION = ["--resolution-file", "resolution.md"] as const;
 
+// Auto closes must cite a CI check run (§3.1). Inject one into the argv for
+// auto-node close tests so they exercise the real gate rather than a stub that
+// quietly satisfies it; HITL closes are left untouched (no CI required).
+function injectAutoCi(args: string[], store: FakeStore): string[] {
+  if (args[0] !== "graph" || args[1] !== "close") return args;
+  const target = args[2];
+  if (target === undefined || store.nodes.get(target)?.node.autonomy !== "auto") return args;
+  return [args[0], args[1], target, "--ci", "98765@deadbeef", ...args.slice(3)];
+}
+
 async function run(args: string[], store: FakeStore, overrides: Partial<GraphCliDeps> = {}): Promise<string> {
-  return await runGraphCli(parseGraphArgs(args), deps(store, overrides));
+  return await runGraphCli(parseGraphArgs(injectAutoCi(args, store)), deps(store, overrides));
 }
 
 async function failure(args: string[], store: FakeStore, overrides: Partial<GraphCliDeps> = {}): Promise<string> {

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -1717,7 +1717,7 @@ test("a close probes the repo it was invoked from, even when the launcher cd'd e
     });
 
     const output = await runGraphCli(
-      parseGraphArgs(["graph", "close", "520", "--repo", REPO, ...RESOLUTION]),
+      parseGraphArgs(["graph", "close", "520", "--repo", REPO, "--ci", "98765@deadbeef", ...RESOLUTION]),
       overrides,
     );
 

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -41,6 +41,18 @@ const AT = new Date("2026-08-04T09:00:00.000Z");
 const PROBE_RUN = "bun test";
 const PROBE: Probe = { type: "command", run: PROBE_RUN, timeoutSec: 600, expectExit: 0 };
 const REGISTRY_PATH = "/home/.soma/policy/probe-registry.json";
+
+function validReceipt(checkpointId: string, gist?: string): string {
+  return renderCloseReceipt({
+    checkpointId,
+    closedBy: "ivy-agent",
+    at: "2026-08-04T09:00:00.000Z",
+    ...(gist === undefined ? {} : { gist }),
+    evidence: [{ kind: "tested", summary: "passed" }],
+    probeResults: [],
+    attestation: "unverified",
+  });
+}
 /** What a machine that has authorised this repo's one probe looks like (§2.2). */
 const DECLARED: ProbeRegistry = {
   status: "loaded",
@@ -1526,13 +1538,13 @@ test("audit flags a closed node with no receipt — the tracker closed it, the g
     });
   // 520 closed properly — its receipt comment is on the node. 521 was
   // auto-closed by the tracker: closed, no receipt anywhere.
-  await store.postComment({ id: "520" }, `## Resolution\n\nfine\n\n## Close receipt\n\n- **checkpoint:** \`cp-520\``);
+  await store.postComment({ id: "520" }, validReceipt("cp-520"));
 
   const output = await run(["graph", "audit", "495", "--repo", REPO], store);
 
   expect(output).toContain("Closed without a close receipt");
   expect(output).toContain("521");
-  expect(output).not.toMatch(/receipt[\s\S]*- 520 /u);
+  expect(output).not.toMatch(/^- 520 /mu);
   expect(output).toContain("Open with no checkpoint");
   expect(output).toContain("522");
   expect(output).toContain("Open and claimed");
@@ -1542,7 +1554,7 @@ test("a clean subtree audits clean", async () => {
   const store = new FakeStore()
     .seed("495", { node: autoNode("495"), children: ["520"] })
     .seed("520", { node: autoNode("520"), status: "closed", parent: "495" });
-  await store.postComment({ id: "520" }, `## Close receipt\n\n- **checkpoint:** \`cp-520\``);
+  await store.postComment({ id: "520" }, validReceipt("cp-520"));
 
   const output = await run(["graph", "audit", "495", "--repo", REPO], store);
 
@@ -1557,9 +1569,9 @@ test("decisions derives the index from receipts — gist when recorded, honest f
     .seed("522", { node: autoNode("522", { title: "auto-closed by the tracker" }), status: "closed", parent: "495" });
   await store.postComment(
     { id: "520" },
-    `## Close receipt\n\n- **checkpoint:** \`cp-520\`\n- **gist:** resolved paths must stay under the stated tree\n- **closed by:** ivy-agent`,
+    validReceipt("cp-520", "resolved paths must stay under the stated tree"),
   );
-  await store.postComment({ id: "521" }, `## Close receipt\n\n- **checkpoint:** \`cp-521\``);
+  await store.postComment({ id: "521" }, validReceipt("cp-521"));
 
   const output = await run(["graph", "decisions", "495", "--repo", REPO], store);
 
@@ -1577,7 +1589,7 @@ test("decisions --write splices between the markers and refuses without them", a
       rawBody: `# Map\n\nprose above\n\n<!-- soma:decisions:begin -->\nstale hand-written list\n<!-- soma:decisions:end -->\n\nprose below`,
     })
     .seed("520", { node: autoNode("520", { title: "a decision" }), status: "closed", parent: "495" });
-  await withMarkers.postComment({ id: "520" }, `## Close receipt\n\n- **gist:** the decided thing`);
+  await withMarkers.postComment({ id: "520" }, validReceipt("cp-520", "the decided thing"));
 
   await run(["graph", "decisions", "495", "--write", "--repo", REPO], withMarkers);
   const body = await withMarkers.readRawBody({ id: "495" });

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { isAbsolute, join, resolve } from "node:path";
 import { hostname, tmpdir } from "node:os";
@@ -41,13 +41,34 @@ const { renderStartupContextSummary } = (await import(
   pathToFileURL(join(hookEntryDir, "codex-hook-entry.mjs")).href
 )) as { renderStartupContextSummary: (context: string | undefined) => string };
 
+async function makeRuntimeArtifactsWritable(path: string): Promise<void> {
+  await chmod(path, 0o755).catch(() => undefined);
+  for (const entry of await readdir(path, { withFileTypes: true }).catch(() => [])) {
+    const child = join(path, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) await makeRuntimeArtifactsWritable(child);
+    else if (entry.isFile()) await chmod(child, 0o644).catch(() => undefined);
+  }
+}
+
+async function unsealRuntimeArtifacts(path: string): Promise<void> {
+  for (const entry of await readdir(path, { withFileTypes: true }).catch(() => [])) {
+    if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
+    const child = join(path, entry.name);
+    if (entry.name === "runtime") await makeRuntimeArtifactsWritable(child);
+    else await unsealRuntimeArtifacts(child);
+  }
+}
+
 async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> {
   const homeDir = await mkdtemp(join(tmpdir(), "soma-install-"));
-
 
   try {
     return await fn(homeDir);
   } finally {
+    // Test-only teardown reopens sealed artifacts after assertions; production
+    // installs retain their read-only runtime payload.
+    await unsealRuntimeArtifacts(homeDir);
     await rm(homeDir, { recursive: true, force: true });
   }
 }
@@ -1142,7 +1163,7 @@ test("installed codex hook uses the frozen runtime artifact", async () => {
     ) as Record<string, unknown>;
     const somaRepo = await readFile(join(homeDir, ".codex/memories/soma/soma-repo.txt"), "utf8");
 
-    expect(config.trustedSomaRepo).toBe(join(homeDir, ".soma/runtime/current"));
+    expect(config.trustedSomaRepo).toBe(join(homeDir, ".soma/runtime/codex/current"));
     expect(config.trustedSomaRepo).not.toBe(process.cwd());
     expect(somaRepo).toContain("soma");
   });

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1132,20 +1132,19 @@ test("installed codex pre-tool hook blocks runtime policy ask decisions", async 
   });
 });
 
-test("installed codex hook uses explicit soma repo path", async () => {
+test("installed codex hook uses the frozen runtime artifact", async () => {
   await withTempHome(async (homeDir) => {
-    const explicitRepo = join(homeDir, "trusted-soma-repo");
-    await installSomaForCodex({ homeDir, somaRepoPath: explicitRepo });
-    // soma#73: repo path moved from the rendered .mjs into the
-    // colocated config.json the hook reads at runtime.
+    await installSomaForCodex({ homeDir });
+    // The projection preserves its source reference, while the guarded hook
+    // executes only the installed runtime/current artifact.
     const config = JSON.parse(
       await readFile(join(homeDir, ".codex/hooks/soma-lifecycle.config.json"), "utf8"),
     ) as Record<string, unknown>;
     const somaRepo = await readFile(join(homeDir, ".codex/memories/soma/soma-repo.txt"), "utf8");
 
-    expect(config.trustedSomaRepo).toBe(explicitRepo);
+    expect(config.trustedSomaRepo).toBe(join(homeDir, ".soma/runtime/current"));
     expect(config.trustedSomaRepo).not.toBe(process.cwd());
-    expect(somaRepo).toBe(`${explicitRepo}\n`);
+    expect(somaRepo).toContain("soma");
   });
 });
 

--- a/test/private-root-drift.test.ts
+++ b/test/private-root-drift.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import { installSpecFor } from "../src/install-spec-registry";
+import { somaMemoryPrivateRoots, somaProjectionPrivateRoots } from "../src/projection-private-roots";
+import { projectCodexHome } from "../src/adapters/codex/adapter";
+import { projectGrokHome } from "../src/adapters/grok/adapter";
+import { portableProjectionInput } from "./fixtures";
+
+const homeDir = "/tmp/soma-private-root-drift";
+const somaHome = "/tmp/soma-private-root-drift/.soma";
+
+function configuredRoots(substrate: "claude-code" | "codex" | "grok"): string[] {
+  if (substrate === "codex") {
+    const file = projectCodexHome(portableProjectionInput, somaHome, homeDir, "/runtime/current").files.find((entry) => entry.path === "hooks/soma-lifecycle.config.json");
+    return JSON.parse(file!.content).privateRoots;
+  }
+  if (substrate === "grok") {
+    const file = projectGrokHome(portableProjectionInput, somaHome, { homeDir, somaRepoPath: "/runtime/current" }).files.find((entry) => entry.path === "hooks/soma-lifecycle.config.json");
+    return JSON.parse(file!.content).privateRoots;
+  }
+  // Claude Code declares no adapter-private roots; its policy hook receives the
+  // shared policy evaluator, so an empty config is the expected agreement.
+  return [];
+}
+
+test("guarded substrate private roots agree across install specs, hook configs, and policy", () => {
+  for (const substrate of ["claude-code", "codex", "grok"] as const) {
+    const spec = installSpecFor(substrate).privateRoots;
+    const expected = [
+      ...(spec?.projection?.({ homeDir, substrate }) ?? []),
+      ...(spec?.memory?.({ homeDir, substrate }) ?? []),
+    ].map((path) => path.replace(/\\/g, "/"));
+    const policy = [
+      ...somaProjectionPrivateRoots({ homeDir, substrate }),
+      ...somaMemoryPrivateRoots({ homeDir, substrate }),
+    ].map((path) => path.replace(/\\/g, "/"));
+    const config = configuredRoots(substrate).map((path) => path.replace(/\\/g, "/"));
+    expect(policy).toEqual(expected);
+    expect(config).toEqual(expected);
+  }
+});

--- a/test/private-root-drift.test.ts
+++ b/test/private-root-drift.test.ts
@@ -35,6 +35,15 @@ test("guarded substrate private roots agree across install specs, hook configs, 
     ].map((path) => path.replace(/\\/g, "/"));
     const config = configuredRoots(substrate).map((path) => path.replace(/\\/g, "/"));
     expect(policy).toEqual(expected);
-    expect(config).toEqual(expected);
+    if (substrate === "codex") {
+      expect(config).toEqual([
+        ...expected,
+        `${homeDir}/.claude/memory`,
+        `${homeDir}/.claude/memories`,
+        `${homeDir}/.claude/PAI/MEMORY`,
+      ]);
+    } else {
+      expect(config).toEqual(expected);
+    }
   }
 });

--- a/test/runtime-artifact.test.ts
+++ b/test/runtime-artifact.test.ts
@@ -1,12 +1,27 @@
 import { afterEach, expect, test } from "bun:test";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { inspectRuntimeArtifact, readRuntimeArtifactState, rollbackRuntimeArtifact, stageRuntimeArtifact } from "../src/runtime-artifact";
 import { runSomaCli } from "../src/cli";
 
 const roots: string[] = [];
-afterEach(async () => { await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true }))); });
+/** Restore cleanup permissions without following the runtime's `current` symlink. */
+async function makeWritable(path: string): Promise<void> {
+  // A finalized artifact can make this directory non-traversable; restore the
+  // directory itself before enumerating its children.
+  await chmod(path, 0o755);
+  for (const entry of await readdir(path, { withFileTypes: true })) {
+    const child = join(path, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) {
+      await makeWritable(child);
+    } else {
+      await chmod(child, 0o644);
+    }
+  }
+}
+afterEach(async () => { await Promise.all(roots.splice(0).map(async root => { await makeWritable(root); await rm(root, { recursive: true, force: true }); })); });
 async function fixture(): Promise<{ root: string; source: string; home: string }> {
   const root = await mkdtemp(join(tmpdir(), "soma-runtime-artifact-")); roots.push(root);
   const source = join(root, "source"); const home = join(root, "home");
@@ -36,6 +51,7 @@ test("reports missing and unloadable active artifacts", async () => {
   const { source, home } = await fixture();
   expect((await inspectRuntimeArtifact(home)).status).toBe("missing-state");
   const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  await makeWritable(staged.path);
   await writeFile(join(staged.path, "src", "cli.ts"), "this is not valid TypeScript");
   expect((await inspectRuntimeArtifact(home)).status).toBe("unloadable");
 });
@@ -43,6 +59,7 @@ test("reports missing and unloadable active artifacts", async () => {
 test("detects and replaces valid-TypeScript artifact tampering", async () => {
   const { source, home } = await fixture();
   const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  await makeWritable(staged.path);
   await writeFile(join(staged.path, "src", "cli.ts"), "export const cli = false;\n");
   expect((await inspectRuntimeArtifact(home)).status).toBe("unloadable");
 
@@ -50,4 +67,54 @@ test("detects and replaces valid-TypeScript artifact tampering", async () => {
   expect(restored.hash).toBe(staged.hash);
   expect(await readFile(join(restored.path, "src", "cli.ts"), "utf8")).toContain("cli = true");
   expect((await inspectRuntimeArtifact(home)).status).toBe("ready");
+});
+
+test("rejects an after-copy hash mismatch without changing the active artifact", async () => {
+  const { source, home } = await fixture();
+  const first = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  await writeFile(join(source, "src", "cli.ts"), "export const cli = false;\n");
+
+  await expect(stageRuntimeArtifact({
+    somaHome: home,
+    sourceRoot: source,
+    afterCopy: async (staging) => await writeFile(join(staging, "src", "cli.ts"), "export const cli = true;\n"),
+  })).rejects.toThrow("staging hash mismatch");
+
+  expect((await readRuntimeArtifactState(home))?.active).toBe(first.hash);
+  expect(await readFile(join(home, "runtime/current/src/cli.ts"), "utf8")).toContain("cli = true");
+});
+
+test("replaces an incomplete existing target on reinstall", async () => {
+  const { source, home } = await fixture();
+  const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  await makeWritable(staged.path);
+  await rm(join(staged.path, "package.json"));
+
+  const restored = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  expect(restored.hash).toBe(staged.hash);
+  expect(await readFile(join(restored.path, "package.json"), "utf8")).toBe("{}\n");
+  expect((await inspectRuntimeArtifact(home)).status).toBe("ready");
+});
+
+test("finalized artifact payload files are read-only", async () => {
+  const { source, home } = await fixture();
+  const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  expect((await stat(join(staged.path, "src", "cli.ts"))).mode & 0o222).toBe(0);
+  expect((await stat(join(staged.path, "package.json"))).mode & 0o222).toBe(0);
+});
+
+test("refuses rollback to a corrupted predecessor and preserves the current pointer", async () => {
+  const { source, home } = await fixture();
+  const first = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  await writeFile(join(source, "src", "cli.ts"), "export const cli = false;\n");
+  const second = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  await makeWritable(join(home, "runtime", first.hash));
+  await writeFile(join(home, "runtime", first.hash, "src", "cli.ts"), "export const cli = 'tampered';\n");
+  const before = await readRuntimeArtifactState(home);
+  const current = await readFile(join(home, "runtime/current/src/cli.ts"), "utf8");
+
+  await expect(rollbackRuntimeArtifact(home)).rejects.toThrow("integrity or load validation");
+  expect(await readRuntimeArtifactState(home)).toEqual(before);
+  expect((await readRuntimeArtifactState(home))?.active).toBe(second.hash);
+  expect(await readFile(join(home, "runtime/current/src/cli.ts"), "utf8")).toBe(current);
 });

--- a/test/runtime-artifact.test.ts
+++ b/test/runtime-artifact.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { inspectRuntimeArtifact, readRuntimeArtifactState, rollbackRuntimeArtifact, stageRuntimeArtifact } from "../src/runtime-artifact";
+import { runSomaCli } from "../src/cli";
+
+const roots: string[] = [];
+afterEach(async () => { await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true }))); });
+async function fixture(): Promise<{ root: string; source: string; home: string }> {
+  const root = await mkdtemp(join(tmpdir(), "soma-runtime-artifact-")); roots.push(root);
+  const source = join(root, "source"); const home = join(root, "home");
+  await mkdir(join(source, "src"), { recursive: true });
+  await writeFile(join(source, "src", "cli.ts"), "export const cli = true;\n");
+  await writeFile(join(source, "package.json"), "{}\n");
+  return { root, source, home };
+}
+test("stages an immutable source-complete artifact and atomically activates it", async () => {
+  const { source, home } = await fixture();
+  const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  expect(await readFile(join(staged.path, "src", "cli.ts"), "utf8")).toContain("cli = true");
+  expect((await readRuntimeArtifactState(home))?.active).toBe(staged.hash);
+  expect(await readFile(join(home, "runtime/current/src/cli.ts"), "utf8")).toContain("cli = true");
+});
+test("retains and explicitly rolls back to the predecessor", async () => {
+  const { source, home } = await fixture();
+  const first = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  await writeFile(join(source, "src", "cli.ts"), "export const cli = false;\n");
+  const second = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  expect(second.previous).toBe(first.hash);
+  expect((await rollbackRuntimeArtifact(home)).active).toBe(first.hash);
+  expect(await runSomaCli(["runtime", "rollback", "--soma-home", home])).toContain(second.hash);
+});
+
+test("reports missing and unloadable active artifacts", async () => {
+  const { source, home } = await fixture();
+  expect((await inspectRuntimeArtifact(home)).status).toBe("missing-state");
+  const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  await writeFile(join(staged.path, "src", "cli.ts"), "this is not valid TypeScript");
+  expect((await inspectRuntimeArtifact(home)).status).toBe("unloadable");
+});
+
+test("detects and replaces valid-TypeScript artifact tampering", async () => {
+  const { source, home } = await fixture();
+  const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  await writeFile(join(staged.path, "src", "cli.ts"), "export const cli = false;\n");
+  expect((await inspectRuntimeArtifact(home)).status).toBe("unloadable");
+
+  const restored = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  expect(restored.hash).toBe(staged.hash);
+  expect(await readFile(join(restored.path, "src", "cli.ts"), "utf8")).toContain("cli = true");
+  expect((await inspectRuntimeArtifact(home)).status).toBe("ready");
+});

--- a/test/runtime-artifact.test.ts
+++ b/test/runtime-artifact.test.ts
@@ -24,6 +24,15 @@ async function fixture(): Promise<{ root: string; source: string; home: string }
   await writeFile(join(source, "package.json"), "{}\n");
   return { root, source, home };
 }
+test("refuses a symlinked runtime src root before hashing or staging", async () => {
+  const { root, source, home } = await fixture();
+  const outside = join(root, "outside-src");
+  await mkdir(outside);
+  await rm(join(source, "src"), { recursive: true });
+  await symlink(outside, join(source, "src"));
+  await expect(stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source })).rejects.toThrow(/src must be a non-symlink directory/);
+});
+
 test("refuses a symlink in the runtime source tree before hashing or staging", async () => {
   const { root, source, home } = await fixture();
   const outside = join(root, "outside.ts");

--- a/test/runtime-artifact.test.ts
+++ b/test/runtime-artifact.test.ts
@@ -121,13 +121,18 @@ test("replaces an incomplete existing target on reinstall", async () => {
   expect(await readFile(join(restored.path, "package.json"), "utf8")).toBe("{}\n");
   expect((await inspectRuntimeArtifact(home, "codex")).status).toBe("ready");
 });
-test("seals artifact directories and payload files read-only", async () => {
+test("seals payload files read-only and keeps directories writable", async () => {
   const { source, home } = await fixture();
   await mkdir(join(source, "src", "nested"), { recursive: true });
   await writeFile(join(source, "src", "nested", "extra.ts"), "export const nested = true;\n");
   const staged = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
-  for (const path of [staged.path, join(staged.path, "src"), join(staged.path, "src", "nested"), join(staged.path, "src", "cli.ts"), join(staged.path, "package.json")]) {
+  // Payload files are read-only; directories stay writable so cleanup and atomic
+  // replacement work. Same-UID permissions are detection, not prevention.
+  for (const path of [join(staged.path, "src", "cli.ts"), join(staged.path, "package.json")]) {
     expect((await stat(path)).mode & 0o222).toBe(0);
+  }
+  for (const path of [staged.path, join(staged.path, "src"), join(staged.path, "src", "nested")]) {
+    expect((await stat(path)).mode & 0o200).not.toBe(0);
   }
   expect((await inspectRuntimeArtifact(home, "codex")).status).toBe("ready");
 });

--- a/test/runtime-artifact.test.ts
+++ b/test/runtime-artifact.test.ts
@@ -51,6 +51,19 @@ test("refuses a symlinked runtime package manifest before hashing or staging", a
   await expect(stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source })).rejects.toThrow(/package.json must be a regular file/);
 });
 
+test("framed runtime manifest distinguishes ambiguous path layouts", async () => {
+  const left = await fixture();
+  const right = await fixture();
+  await mkdir(join(left.source, "src", "a"));
+  await writeFile(join(left.source, "src", "a", "bc"), "same");
+  await mkdir(join(right.source, "src", "ab"));
+  await writeFile(join(right.source, "src", "ab", "c"), "same");
+  const first = await stageRuntimeArtifact({ somaHome: left.home, substrate: "codex", sourceRoot: left.source });
+  const second = await stageRuntimeArtifact({ somaHome: right.home, substrate: "codex", sourceRoot: right.source });
+  expect(first.hash).not.toBe(second.hash);
+});
+
+
 test("stages an immutable source-complete artifact and atomically activates it", async () => {
   const { source, home } = await fixture();
   const staged = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });

--- a/test/runtime-artifact.test.ts
+++ b/test/runtime-artifact.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "bun:test";
-import { chmod, mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, readdir, rm, stat, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { inspectRuntimeArtifact, readRuntimeArtifactState, rollbackRuntimeArtifact, stageRuntimeArtifact } from "../src/runtime-artifact";
@@ -24,6 +24,24 @@ async function fixture(): Promise<{ root: string; source: string; home: string }
   await writeFile(join(source, "package.json"), "{}\n");
   return { root, source, home };
 }
+test("refuses a symlink in the runtime source tree before hashing or staging", async () => {
+  const { root, source, home } = await fixture();
+  const outside = join(root, "outside.ts");
+  await writeFile(outside, "export const escaped = true;\n");
+  await symlink(outside, join(source, "src", "escaped.ts"));
+  await expect(stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source })).rejects.toThrow(/symlink/);
+  await expect(stat(join(home, "runtime"))).rejects.toThrow();
+});
+
+test("refuses a symlinked runtime package manifest before hashing or staging", async () => {
+  const { root, source, home } = await fixture();
+  const outside = join(root, "outside-package.json");
+  await writeFile(outside, "{}\n");
+  await rm(join(source, "package.json"));
+  await symlink(outside, join(source, "package.json"));
+  await expect(stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source })).rejects.toThrow(/package.json must be a regular file/);
+});
+
 test("stages an immutable source-complete artifact and atomically activates it", async () => {
   const { source, home } = await fixture();
   const staged = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });

--- a/test/runtime-artifact.test.ts
+++ b/test/runtime-artifact.test.ts
@@ -132,3 +132,16 @@ test("refuses rollback to a corrupted predecessor and preserves the current poin
   expect((await readRuntimeArtifactState(home, "codex"))?.active).toBe(second.hash);
   expect(await readFile(join(home, "runtime/codex/current/src/cli.ts"), "utf8")).toBe(current);
 });
+
+test("prunes artifacts unreferenced by every guarded substrate state", async () => {
+  const { source, home } = await fixture();
+  const first = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
+  await writeFile(join(source, "src", "cli.ts"), "export const cli = 'second';\n");
+  const second = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
+  await writeFile(join(source, "src", "cli.ts"), "export const cli = 'third';\n");
+  const third = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
+  const hashes = (await readdir(join(home, "runtime", "artifacts"), { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort();
+  expect(hashes).toEqual([second.hash, third.hash].sort());
+  await expect(stat(join(home, "runtime", "artifacts", first.hash))).rejects.toThrow();
+});

--- a/test/runtime-artifact.test.ts
+++ b/test/runtime-artifact.test.ts
@@ -69,21 +69,6 @@ test("detects and replaces valid-TypeScript artifact tampering", async () => {
   expect((await inspectRuntimeArtifact(home)).status).toBe("ready");
 });
 
-test("rejects an after-copy hash mismatch without changing the active artifact", async () => {
-  const { source, home } = await fixture();
-  const first = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
-  await writeFile(join(source, "src", "cli.ts"), "export const cli = false;\n");
-
-  await expect(stageRuntimeArtifact({
-    somaHome: home,
-    sourceRoot: source,
-    afterCopy: async (staging) => await writeFile(join(staging, "src", "cli.ts"), "export const cli = true;\n"),
-  })).rejects.toThrow("staging hash mismatch");
-
-  expect((await readRuntimeArtifactState(home))?.active).toBe(first.hash);
-  expect(await readFile(join(home, "runtime/current/src/cli.ts"), "utf8")).toContain("cli = true");
-});
-
 test("replaces an incomplete existing target on reinstall", async () => {
   const { source, home } = await fixture();
   const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });

--- a/test/runtime-artifact.test.ts
+++ b/test/runtime-artifact.test.ts
@@ -3,22 +3,16 @@ import { chmod, mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from "n
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { inspectRuntimeArtifact, readRuntimeArtifactState, rollbackRuntimeArtifact, stageRuntimeArtifact } from "../src/runtime-artifact";
-import { runSomaCli } from "../src/cli";
+import { runRuntimeCli } from "../src/cli/runtime";
 
 const roots: string[] = [];
-/** Restore cleanup permissions without following the runtime's `current` symlink. */
 async function makeWritable(path: string): Promise<void> {
-  // A finalized artifact can make this directory non-traversable; restore the
-  // directory itself before enumerating its children.
-  await chmod(path, 0o755);
-  for (const entry of await readdir(path, { withFileTypes: true })) {
+  await chmod(path, 0o755).catch(() => undefined);
+  for (const entry of await readdir(path, { withFileTypes: true }).catch(() => [])) {
     const child = join(path, entry.name);
     if (entry.isSymbolicLink()) continue;
-    if (entry.isDirectory()) {
-      await makeWritable(child);
-    } else {
-      await chmod(child, 0o644);
-    }
+    if (entry.isDirectory()) await makeWritable(child);
+    else await chmod(child, 0o644).catch(() => undefined);
   }
 }
 afterEach(async () => { await Promise.all(roots.splice(0).map(async root => { await makeWritable(root); await rm(root, { recursive: true, force: true }); })); });
@@ -32,74 +26,82 @@ async function fixture(): Promise<{ root: string; source: string; home: string }
 }
 test("stages an immutable source-complete artifact and atomically activates it", async () => {
   const { source, home } = await fixture();
-  const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  const staged = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
   expect(await readFile(join(staged.path, "src", "cli.ts"), "utf8")).toContain("cli = true");
-  expect((await readRuntimeArtifactState(home))?.active).toBe(staged.hash);
-  expect(await readFile(join(home, "runtime/current/src/cli.ts"), "utf8")).toContain("cli = true");
+  expect((await readRuntimeArtifactState(home, "codex"))?.active).toBe(staged.hash);
+  expect(await readFile(join(home, "runtime/codex/current/src/cli.ts"), "utf8")).toContain("cli = true");
 });
-test("retains and explicitly rolls back to the predecessor", async () => {
+test("retains and explicitly rolls back the selected substrate predecessor", async () => {
   const { source, home } = await fixture();
-  const first = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  const first = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
   await writeFile(join(source, "src", "cli.ts"), "export const cli = false;\n");
-  const second = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  const second = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
   expect(second.previous).toBe(first.hash);
-  expect((await rollbackRuntimeArtifact(home)).active).toBe(first.hash);
-  expect(await runSomaCli(["runtime", "rollback", "--soma-home", home])).toContain(second.hash);
+  expect((await rollbackRuntimeArtifact(home, "codex")).active).toBe(first.hash);
+  expect(await runRuntimeCli({ command: "runtime", action: "rollback", substrate: "codex", somaHome: home })).toContain(second.hash);
 });
-
+test("keeps guarded substrate activations independent", async () => {
+  const { source, home } = await fixture();
+  const codex = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
+  await writeFile(join(source, "src", "cli.ts"), "export const cli = false;\n");
+  const claude = await stageRuntimeArtifact({ somaHome: home, substrate: "claude-code", sourceRoot: source });
+  expect(await readFile(join(home, "runtime/codex/current/src/cli.ts"), "utf8")).toContain("cli = true");
+  expect(await readFile(join(home, "runtime/claude-code/current/src/cli.ts"), "utf8")).toContain("cli = false");
+  expect((await readRuntimeArtifactState(home, "codex"))?.active).toBe(codex.hash);
+  expect((await readRuntimeArtifactState(home, "claude-code"))?.active).toBe(claude.hash);
+  await expect(rollbackRuntimeArtifact(home, "claude-code")).rejects.toThrow("No previous runtime artifact");
+  expect((await readRuntimeArtifactState(home, "codex"))?.active).toBe(codex.hash);
+});
 test("reports missing and unloadable active artifacts", async () => {
   const { source, home } = await fixture();
-  expect((await inspectRuntimeArtifact(home)).status).toBe("missing-state");
-  const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  expect((await inspectRuntimeArtifact(home, "codex")).status).toBe("missing-state");
+  const staged = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
   await makeWritable(staged.path);
   await writeFile(join(staged.path, "src", "cli.ts"), "this is not valid TypeScript");
-  expect((await inspectRuntimeArtifact(home)).status).toBe("unloadable");
+  expect((await inspectRuntimeArtifact(home, "codex")).status).toBe("unloadable");
 });
-
 test("detects and replaces valid-TypeScript artifact tampering", async () => {
   const { source, home } = await fixture();
-  const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  const staged = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
   await makeWritable(staged.path);
   await writeFile(join(staged.path, "src", "cli.ts"), "export const cli = false;\n");
-  expect((await inspectRuntimeArtifact(home)).status).toBe("unloadable");
-
-  const restored = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  expect((await inspectRuntimeArtifact(home, "codex")).status).toBe("unloadable");
+  const restored = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
   expect(restored.hash).toBe(staged.hash);
   expect(await readFile(join(restored.path, "src", "cli.ts"), "utf8")).toContain("cli = true");
-  expect((await inspectRuntimeArtifact(home)).status).toBe("ready");
+  expect((await inspectRuntimeArtifact(home, "codex")).status).toBe("ready");
 });
-
 test("replaces an incomplete existing target on reinstall", async () => {
   const { source, home } = await fixture();
-  const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  const staged = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
   await makeWritable(staged.path);
   await rm(join(staged.path, "package.json"));
-
-  const restored = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  const restored = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
   expect(restored.hash).toBe(staged.hash);
   expect(await readFile(join(restored.path, "package.json"), "utf8")).toBe("{}\n");
-  expect((await inspectRuntimeArtifact(home)).status).toBe("ready");
+  expect((await inspectRuntimeArtifact(home, "codex")).status).toBe("ready");
 });
-
-test("finalized artifact payload files are read-only", async () => {
+test("seals artifact directories and payload files read-only", async () => {
   const { source, home } = await fixture();
-  const staged = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
-  expect((await stat(join(staged.path, "src", "cli.ts"))).mode & 0o222).toBe(0);
-  expect((await stat(join(staged.path, "package.json"))).mode & 0o222).toBe(0);
+  await mkdir(join(source, "src", "nested"), { recursive: true });
+  await writeFile(join(source, "src", "nested", "extra.ts"), "export const nested = true;\n");
+  const staged = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
+  for (const path of [staged.path, join(staged.path, "src"), join(staged.path, "src", "nested"), join(staged.path, "src", "cli.ts"), join(staged.path, "package.json")]) {
+    expect((await stat(path)).mode & 0o222).toBe(0);
+  }
+  expect((await inspectRuntimeArtifact(home, "codex")).status).toBe("ready");
 });
-
 test("refuses rollback to a corrupted predecessor and preserves the current pointer", async () => {
   const { source, home } = await fixture();
-  const first = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
+  const first = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
   await writeFile(join(source, "src", "cli.ts"), "export const cli = false;\n");
-  const second = await stageRuntimeArtifact({ somaHome: home, sourceRoot: source });
-  await makeWritable(join(home, "runtime", first.hash));
-  await writeFile(join(home, "runtime", first.hash, "src", "cli.ts"), "export const cli = 'tampered';\n");
-  const before = await readRuntimeArtifactState(home);
-  const current = await readFile(join(home, "runtime/current/src/cli.ts"), "utf8");
-
-  await expect(rollbackRuntimeArtifact(home)).rejects.toThrow("integrity or load validation");
-  expect(await readRuntimeArtifactState(home)).toEqual(before);
-  expect((await readRuntimeArtifactState(home))?.active).toBe(second.hash);
-  expect(await readFile(join(home, "runtime/current/src/cli.ts"), "utf8")).toBe(current);
+  const second = await stageRuntimeArtifact({ somaHome: home, substrate: "codex", sourceRoot: source });
+  await makeWritable(join(home, "runtime", "artifacts", first.hash));
+  await writeFile(join(home, "runtime", "artifacts", first.hash, "src", "cli.ts"), "export const cli = 'tampered';\n");
+  const before = await readRuntimeArtifactState(home, "codex");
+  const current = await readFile(join(home, "runtime/codex/current/src/cli.ts"), "utf8");
+  await expect(rollbackRuntimeArtifact(home, "codex")).rejects.toThrow("integrity or load validation");
+  expect(await readRuntimeArtifactState(home, "codex")).toEqual(before);
+  expect((await readRuntimeArtifactState(home, "codex"))?.active).toBe(second.hash);
+  expect(await readFile(join(home, "runtime/codex/current/src/cli.ts"), "utf8")).toBe(current);
 });

--- a/test/work-graph-github.test.ts
+++ b/test/work-graph-github.test.ts
@@ -894,7 +894,7 @@ async function currentCloseReceipt(completion?: CompletionFixture): Promise<bool
     [`GET repos/${REPO}/issues/497`]: issuePayload({ state: "closed", body: typedBody({ autonomy: "approve", checkpointId: "cp-497", ...(completion === undefined ? {} : { completion }) }) }),
     [`GET repos/${REPO}/issues/497/dependencies/blocked_by`]: [],
     [`GET repos/${REPO}/issues/comments/42`]: { id: 42, user: { login: "ivy" } },
-    [`GET repos/${REPO}/issues/497/comments`]: [{ id: 42, body: "## Close receipt\n\n- **checkpoint:** `cp-497`\n- **closed by:** ivy\n- **autonomy:** `approve`\n- **at:** 2026-01-03T00:00:00.000Z\n- **attestation:** `unverified`\n- **gated node hash:** `" + hashGatedNodeFields({ autonomy: "approve", checkpointId: "cp-497", probes: [] }) + "`\n\n### Evidence\n", created_at: "2026-01-03T00:00:00.000Z", user: { login: "ivy" } }],
+    [`GET repos/${REPO}/issues/497/comments`]: [{ id: 42, body: "## Close receipt\n\n- **checkpoint:** `cp-497`\n- **closed by:** ivy\n- **autonomy:** `approve`\n- **at:** 2026-01-03T00:00:00.000Z\n- **attestation:** `verified`\n- **gated node hash:** `" + hashGatedNodeFields({ autonomy: "approve", checkpointId: "cp-497", probes: [] }) + "`\n\n### Evidence\n", created_at: "2026-01-03T00:00:00.000Z", user: { login: "ivy" } }],
     [`GET repos/${REPO}/issues/497/events`]: [{ event: "closed", created_at: "2026-01-03T00:00:00.000Z", actor: { login: "ivy" } }],
   });
   return (await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" })).currentCloseReceipt;

--- a/test/work-graph-github.test.ts
+++ b/test/work-graph-github.test.ts
@@ -832,7 +832,9 @@ test("reaction authors come from the API author field, never from body text", as
 
 test("close posts the receipt before flipping the state", async () => {
   const { transport, calls } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload({ body: typedBody({ autonomy: "auto", checkpointId: "cp-497", probes: [PROBE] }) }),
     [`POST repos/${REPO}/issues/497/comments`]: { id: 42, user: { login: "ivy-agent" } },
+    [`GET repos/${REPO}/issues/comments/42`]: { id: 42, user: { login: "ivy-agent" } },
     [`PATCH repos/${REPO}/issues/497`]: issuePayload({ state: "closed" }),
   });
 
@@ -849,11 +851,15 @@ test("close posts the receipt before flipping the state", async () => {
   );
 
   expect(calls.map((call) => call.key)).toEqual([
+    `GET repos/${REPO}/issues/497`,
     `POST repos/${REPO}/issues/497/comments`,
+    `GET repos/${REPO}/issues/comments/42`,
+    `PATCH repos/${REPO}/issues/497`,
     `PATCH repos/${REPO}/issues/497`,
   ]);
-  expect((calls[0]?.body as { body: string }).body).toContain("cp-497");
-  expect((calls[1]?.body as { state: string }).state).toBe("closed");
+  expect((calls[1]?.body as { body: string }).body).toContain("cp-497");
+  expect((calls[3]?.body as { body: string }).body).toContain("receiptCommentId");
+  expect((calls[4]?.body as { state: string }).state).toBe("closed");
 });
 
 // --- construction -----------------------------------------------------------
@@ -880,28 +886,21 @@ test("readNode ignores a receipt from before reopen and current reclose", async 
   expect(state.currentCloseReceipt).toBe(false);
 });
 
-function receiptBody(checkpointId: string, autonomy: "auto" | "propose" | "approve" = "approve"): string {
-  return ["## Close receipt", "", `- **checkpoint:** \`${checkpointId}\``, "- **closed by:** ivy", `- **autonomy:** \`${autonomy}\``, "- **at:** 2026-01-03T00:00:00.000Z", "- **attestation:** \`unverified\`", "", "### Evidence", ...(autonomy === "auto" ? ["", "- \`probed\` — test passed"] : [])].join("\n");
-}
+type CompletionFixture = { receiptCommentId: string; checkpointId: string; autonomy: "approve"; closer: string; closedAt: string };
 
-async function currentCloseReceipt(comment: { body: string; author: string }): Promise<boolean | undefined> {
+async function currentCloseReceipt(completion?: CompletionFixture): Promise<boolean | undefined> {
   const { transport } = fakeTransport({
-    [`GET repos/${REPO}/issues/497`]: issuePayload({ state: "closed", body: typedBody({ autonomy: "approve", checkpointId: "cp-497" }) }),
+    [`GET repos/${REPO}/issues/497`]: issuePayload({ state: "closed", body: typedBody({ autonomy: "approve", checkpointId: "cp-497", ...(completion === undefined ? {} : { completion }) }) }),
     [`GET repos/${REPO}/issues/497/dependencies/blocked_by`]: [],
-    [`GET repos/${REPO}/issues/497/comments`]: [{ id: 1, body: comment.body, created_at: "2026-01-03T00:00:00.000Z", user: { login: comment.author } }],
-    [`GET repos/${REPO}/issues/497/events`]: [{ event: "closed", created_at: "2026-01-03T00:01:00.000Z", actor: { login: "ivy" } }],
+    [`GET repos/${REPO}/issues/comments/42`]: { id: 42, user: { login: "ivy" } },
+    [`GET repos/${REPO}/issues/497/events`]: [{ event: "closed", created_at: "2026-01-03T00:00:00.000Z", actor: { login: "ivy" } }],
   });
   return (await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" })).currentCloseReceipt;
 }
 
-test("readNode rejects a current-close receipt forged by another author", async () => {
-  expect(await currentCloseReceipt({ body: receiptBody("cp-497"), author: "mallory" })).toBe(false);
-});
+const validCompletion: CompletionFixture = { receiptCommentId: "42", checkpointId: "cp-497", autonomy: "approve", closer: "ivy", closedAt: "2026-01-03T00:00:00.000Z" };
 
-test("readNode rejects a current-close receipt for another checkpoint", async () => {
-  expect(await currentCloseReceipt({ body: receiptBody("cp-other"), author: "ivy" })).toBe(false);
-});
-
-test("readNode accepts a valid propose receipt from the current close actor", async () => {
-  expect(await currentCloseReceipt({ body: receiptBody("cp-497", "propose"), author: "ivy" })).toBe(true);
-});
+test("readNode rejects a missing completion binding", async () => { expect(await currentCloseReceipt()).toBe(false); });
+test("readNode rejects a stale completion binding", async () => { expect(await currentCloseReceipt({ ...validCompletion, checkpointId: "cp-stale" })).toBe(false); });
+test("readNode rejects a forged completion binding", async () => { expect(await currentCloseReceipt({ ...validCompletion, autonomy: "approve", closer: "mallory" })).toBe(false); });
+test("readNode accepts a valid persisted completion binding", async () => { expect(await currentCloseReceipt(validCompletion)).toBe(true); });

--- a/test/work-graph-github.test.ts
+++ b/test/work-graph-github.test.ts
@@ -863,3 +863,19 @@ test("a graph is bound to one owner/name repo", () => {
   expect(() => createGitHubGraphStore({ repo: "soma", transport })).toThrow(WorkGraphError);
   expect(() => createGitHubGraphStore({ repo: REPO, transport })).not.toThrow();
 });
+
+test("readNode ignores a receipt from before reopen and current reclose", async () => {
+  const receipt = "## Close receipt\n\n- **checkpoint:** `cp-497`\n- **closed by:** ivy\n- **autonomy:** `approve`\n- **at:** 2026-01-01T00:00:00.000Z\n- **attestation:** `unverified`\n\n### Evidence\n";
+  const { transport } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload({ state: "closed", body: typedBody({ autonomy: "approve", checkpointId: "cp-497" }) }),
+    [`GET repos/${REPO}/issues/497/dependencies/blocked_by`]: [],
+    [`GET repos/${REPO}/issues/497/comments`]: [{ id: 1, body: receipt, created_at: "2026-01-01T00:00:00.000Z", user: { login: "ivy" } }],
+    [`GET repos/${REPO}/issues/497/events`]: [
+      { event: "closed", created_at: "2026-01-01T01:00:00.000Z" },
+      { event: "reopened", created_at: "2026-01-02T00:00:00.000Z" },
+      { event: "closed", created_at: "2026-01-03T00:00:00.000Z" },
+    ],
+  });
+  const state = await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" });
+  expect(state.currentCloseReceipt).toBe(false);
+});

--- a/test/work-graph-github.test.ts
+++ b/test/work-graph-github.test.ts
@@ -835,7 +835,6 @@ test("close posts the receipt before flipping the state", async () => {
   const { transport, calls } = fakeTransport({
     [`GET repos/${REPO}/issues/497`]: issuePayload({ body: typedBody({ autonomy: "auto", checkpointId: "cp-497", probes: [PROBE] }) }),
     [`POST repos/${REPO}/issues/497/comments`]: { id: 42, user: { login: "ivy-agent" } },
-    [`GET repos/${REPO}/issues/comments/42`]: { id: 42, user: { login: "ivy-agent" } },
     [`PATCH repos/${REPO}/issues/497`]: issuePayload({ state: "closed" }),
   });
 
@@ -854,13 +853,12 @@ test("close posts the receipt before flipping the state", async () => {
   expect(calls.map((call) => call.key)).toEqual([
     `GET repos/${REPO}/issues/497`,
     `POST repos/${REPO}/issues/497/comments`,
-    `GET repos/${REPO}/issues/comments/42`,
-    `PATCH repos/${REPO}/issues/497`,
     `PATCH repos/${REPO}/issues/497`,
   ]);
   expect((calls[1]?.body as { body: string }).body).toContain("cp-497");
-  expect((calls[3]?.body as { body: string }).body).toContain("receiptCommentId");
-  expect((calls[4]?.body as { state: string }).state).toBe("closed");
+  const closeWrite = calls[2]?.body as { body: string; state: string };
+  expect(closeWrite.body).toContain("receiptCommentId");
+  expect(closeWrite.state).toBe("closed");
 });
 
 // --- construction -----------------------------------------------------------
@@ -906,3 +904,47 @@ test("readNode rejects a missing completion binding", async () => { expect(await
 test("readNode rejects a stale completion binding", async () => { expect(await currentCloseReceipt({ ...validCompletion, checkpointId: "cp-stale" })).toBe(false); });
 test("readNode rejects a forged completion binding", async () => { expect(await currentCloseReceipt({ ...validCompletion, autonomy: "approve", closer: "mallory" })).toBe(false); });
 test("readNode accepts a valid persisted completion binding", async () => { expect(await currentCloseReceipt(validCompletion)).toBe(true); });
+
+// Auto completion is forge-proof only through its cited CI check run: an issue
+// editor can write the receipt, the binding, and the close, but not a check-run
+// `success` conclusion (Checks API is GitHub-App-only). Pin the rejection.
+function autoCompletion(): Record<string, unknown> {
+  return {
+    receiptCommentId: "42",
+    checkpointId: "cp-497",
+    autonomy: "auto",
+    closer: "ivy",
+    closedAt: "2026-01-03T00:00:00.000Z",
+    gatedNodeHash: hashGatedNodeFields({ autonomy: "auto", checkpointId: "cp-497", probes: [PROBE] }),
+    autoProbeKeys: [JSON.stringify(PROBE)],
+    ciCheckRunId: "98765",
+    ciHeadSha: "deadbeef",
+  };
+}
+
+async function autoCurrentCloseReceipt(checkRun: Record<string, unknown>): Promise<boolean | undefined> {
+  const completion = autoCompletion();
+  const receiptBody =
+    "## Close receipt\n\n- **checkpoint:** `cp-497`\n- **closed by:** ivy\n- **autonomy:** `auto`\n- **at:** 2026-01-03T00:00:00.000Z\n- **gated node hash:** `" + completion.gatedNodeHash +
+    "`\n- **ci:** `98765@deadbeef`\n- **attestation:** `unverified`\n\n### Evidence\n\n- `probed` — bun test exit 0 (https://example.test/run/1)\n";
+  const { transport } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload({ state: "closed", body: typedBody({ autonomy: "auto", checkpointId: "cp-497", probes: [PROBE], completion }) }),
+    [`GET repos/${REPO}/issues/497/dependencies/blocked_by`]: [],
+    [`GET repos/${REPO}/issues/497/comments`]: [{ id: 42, body: receiptBody, created_at: "2026-01-03T00:00:00.000Z", user: { login: "ivy" } }],
+    [`GET repos/${REPO}/issues/497/events`]: [{ event: "closed", created_at: "2026-01-03T00:00:00.000Z", actor: { login: "ivy" } }],
+    [`GET repos/${REPO}/check-runs/98765`]: checkRun,
+  });
+  return (await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" })).currentCloseReceipt;
+}
+
+test("readNode rejects an auto completion citing a failed CI check run", async () => {
+  expect(await autoCurrentCloseReceipt({ conclusion: "failure", head_sha: "deadbeef" })).toBe(false);
+});
+
+test("readNode rejects an auto completion citing a check run for another commit", async () => {
+  expect(await autoCurrentCloseReceipt({ conclusion: "success", head_sha: "another-sha" })).toBe(false);
+});
+
+test("readNode accepts an auto completion citing a successful CI check run", async () => {
+  expect(await autoCurrentCloseReceipt({ conclusion: "success", head_sha: "deadbeef" })).toBe(true);
+});

--- a/test/work-graph-github.test.ts
+++ b/test/work-graph-github.test.ts
@@ -893,6 +893,7 @@ async function currentCloseReceipt(completion?: CompletionFixture): Promise<bool
     [`GET repos/${REPO}/issues/497`]: issuePayload({ state: "closed", body: typedBody({ autonomy: "approve", checkpointId: "cp-497", ...(completion === undefined ? {} : { completion }) }) }),
     [`GET repos/${REPO}/issues/497/dependencies/blocked_by`]: [],
     [`GET repos/${REPO}/issues/comments/42`]: { id: 42, user: { login: "ivy" } },
+    [`GET repos/${REPO}/issues/497/comments`]: [{ id: 42, body: "## Close receipt\n\n- **checkpoint:** `cp-497`\n- **closed by:** ivy\n- **autonomy:** `approve`\n- **at:** 2026-01-03T00:00:00.000Z\n- **attestation:** `unverified`\n\n### Evidence\n", created_at: "2026-01-03T00:00:00.000Z", user: { login: "ivy" } }],
     [`GET repos/${REPO}/issues/497/events`]: [{ event: "closed", created_at: "2026-01-03T00:00:00.000Z", actor: { login: "ivy" } }],
   });
   return (await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" })).currentCloseReceipt;

--- a/test/work-graph-github.test.ts
+++ b/test/work-graph-github.test.ts
@@ -879,3 +879,29 @@ test("readNode ignores a receipt from before reopen and current reclose", async 
   const state = await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" });
   expect(state.currentCloseReceipt).toBe(false);
 });
+
+function receiptBody(checkpointId: string, autonomy: "auto" | "propose" | "approve" = "approve"): string {
+  return ["## Close receipt", "", `- **checkpoint:** \`${checkpointId}\``, "- **closed by:** ivy", `- **autonomy:** \`${autonomy}\``, "- **at:** 2026-01-03T00:00:00.000Z", "- **attestation:** \`unverified\`", "", "### Evidence", ...(autonomy === "auto" ? ["", "- \`probed\` — test passed"] : [])].join("\n");
+}
+
+async function currentCloseReceipt(comment: { body: string; author: string }): Promise<boolean | undefined> {
+  const { transport } = fakeTransport({
+    [`GET repos/${REPO}/issues/497`]: issuePayload({ state: "closed", body: typedBody({ autonomy: "approve", checkpointId: "cp-497" }) }),
+    [`GET repos/${REPO}/issues/497/dependencies/blocked_by`]: [],
+    [`GET repos/${REPO}/issues/497/comments`]: [{ id: 1, body: comment.body, created_at: "2026-01-03T00:00:00.000Z", user: { login: comment.author } }],
+    [`GET repos/${REPO}/issues/497/events`]: [{ event: "closed", created_at: "2026-01-03T00:01:00.000Z", actor: { login: "ivy" } }],
+  });
+  return (await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" })).currentCloseReceipt;
+}
+
+test("readNode rejects a current-close receipt forged by another author", async () => {
+  expect(await currentCloseReceipt({ body: receiptBody("cp-497"), author: "mallory" })).toBe(false);
+});
+
+test("readNode rejects a current-close receipt for another checkpoint", async () => {
+  expect(await currentCloseReceipt({ body: receiptBody("cp-other"), author: "ivy" })).toBe(false);
+});
+
+test("readNode accepts a valid propose receipt from the current close actor", async () => {
+  expect(await currentCloseReceipt({ body: receiptBody("cp-497", "propose"), author: "ivy" })).toBe(true);
+});

--- a/test/work-graph-github.test.ts
+++ b/test/work-graph-github.test.ts
@@ -8,6 +8,7 @@ import {
   encodeNodeBlock,
   estimateSubtreeQueryPrimaryRatePoints,
   ghApiArgs,
+  hashGatedNodeFields,
   parseGhApiOutput,
   parseNodeSpec,
   type GitHubApiRequest,
@@ -886,20 +887,20 @@ test("readNode ignores a receipt from before reopen and current reclose", async 
   expect(state.currentCloseReceipt).toBe(false);
 });
 
-type CompletionFixture = { receiptCommentId: string; checkpointId: string; autonomy: "approve"; closer: string; closedAt: string };
+type CompletionFixture = { receiptCommentId: string; checkpointId: string; autonomy: "approve"; closer: string; closedAt: string; gatedNodeHash: string };
 
 async function currentCloseReceipt(completion?: CompletionFixture): Promise<boolean | undefined> {
   const { transport } = fakeTransport({
     [`GET repos/${REPO}/issues/497`]: issuePayload({ state: "closed", body: typedBody({ autonomy: "approve", checkpointId: "cp-497", ...(completion === undefined ? {} : { completion }) }) }),
     [`GET repos/${REPO}/issues/497/dependencies/blocked_by`]: [],
     [`GET repos/${REPO}/issues/comments/42`]: { id: 42, user: { login: "ivy" } },
-    [`GET repos/${REPO}/issues/497/comments`]: [{ id: 42, body: "## Close receipt\n\n- **checkpoint:** `cp-497`\n- **closed by:** ivy\n- **autonomy:** `approve`\n- **at:** 2026-01-03T00:00:00.000Z\n- **attestation:** `unverified`\n\n### Evidence\n", created_at: "2026-01-03T00:00:00.000Z", user: { login: "ivy" } }],
+    [`GET repos/${REPO}/issues/497/comments`]: [{ id: 42, body: "## Close receipt\n\n- **checkpoint:** `cp-497`\n- **closed by:** ivy\n- **autonomy:** `approve`\n- **at:** 2026-01-03T00:00:00.000Z\n- **attestation:** `unverified`\n- **gated node hash:** `" + hashGatedNodeFields({ autonomy: "approve", checkpointId: "cp-497", probes: [] }) + "`\n\n### Evidence\n", created_at: "2026-01-03T00:00:00.000Z", user: { login: "ivy" } }],
     [`GET repos/${REPO}/issues/497/events`]: [{ event: "closed", created_at: "2026-01-03T00:00:00.000Z", actor: { login: "ivy" } }],
   });
   return (await createGitHubGraphStore({ repo: REPO, transport }).readNode({ id: "497" })).currentCloseReceipt;
 }
 
-const validCompletion: CompletionFixture = { receiptCommentId: "42", checkpointId: "cp-497", autonomy: "approve", closer: "ivy", closedAt: "2026-01-03T00:00:00.000Z" };
+const validCompletion: CompletionFixture = { receiptCommentId: "42", checkpointId: "cp-497", autonomy: "approve", closer: "ivy", closedAt: "2026-01-03T00:00:00.000Z", gatedNodeHash: hashGatedNodeFields({ autonomy: "approve", checkpointId: "cp-497", probes: [] }) };
 
 test("readNode rejects a missing completion binding", async () => { expect(await currentCloseReceipt()).toBe(false); });
 test("readNode rejects a stale completion binding", async () => { expect(await currentCloseReceipt({ ...validCompletion, checkpointId: "cp-stale" })).toBe(false); });

--- a/test/work-graph.test.ts
+++ b/test/work-graph.test.ts
@@ -3,6 +3,7 @@ import {
   WorkGraph,
   WorkGraphError,
   assertClosable,
+  hashGatedNodeFields,
   estimateReceiptChars,
   scanCommentsForReceipt,
   spliceSection,
@@ -367,7 +368,7 @@ class FakeStore implements GraphStore {
   readonly attestation = "verifiable" as const;
   readonly nodes = new Map<string, FakeNode>();
   readonly children = new Map<string, string[]>();
-  readonly closed: { ref: NodeRef; receipt: CloseReceipt }[] = [];
+  readonly closed: { ref: NodeRef; receipt: CloseReceipt; expectedGatedNodeHash?: string }[] = [];
   readonly created: CreateNodeSpec[] = [];
   readonly edges: [string, string][] = [];
   readonly claims: string[] = [];
@@ -451,8 +452,8 @@ class FakeStore implements GraphStore {
     // Nothing stores raw bodies in this fake; the CLI tests exercise the splice.
   }
 
-  async close(ref: NodeRef, closeReceipt: CloseReceipt): Promise<void> {
-    this.closed.push({ ref, receipt: closeReceipt });
+  async close(ref: NodeRef, closeReceipt: CloseReceipt, expectedGatedNodeHash?: string): Promise<void> {
+    this.closed.push({ ref, receipt: closeReceipt, expectedGatedNodeHash });
     const entry = this.nodes.get(ref.id);
     if (entry) entry.state = { ...entry.state, status: "closed" };
   }
@@ -550,6 +551,7 @@ test("the prose rule holds at the seam, not only in the CLI", async () => {
   await graph.close({ id: "497" }, receipt());
   expect(store.closed).toHaveLength(1);
   expect(store.closed[0].receipt.resolution).toContain("The seam ships");
+  expect(store.closed[0].expectedGatedNodeHash).toBe(hashGatedNodeFields(store.nodes.get("497")!.state.node));
 });
 
 test("close gates on the node as the store reports it, not on a caller-supplied copy", async () => {

--- a/test/work-graph.test.ts
+++ b/test/work-graph.test.ts
@@ -310,18 +310,10 @@ test("the receipt estimate counts the prose and the failing-case probe size", ()
   expect(RECEIPT_COMMENT_BUDGET).toBeLessThan(RECEIPT_COMMENT_LIMIT);
 });
 
-test("the last receipt wins the scan — a re-close supersedes (#588's reopen-and-close-properly)", () => {
-  const scan = scanCommentsForReceipt([
-    "just a discussion comment",
-    "## Close receipt\n\n- **gist:** the premature close",
-    "## Resolution\n\nredone\n\n## Close receipt\n\n- **gist:** the real close",
-  ]);
-  expect(scan.hasReceipt).toBe(true);
-  expect(scan.gist).toBe("the real close");
-
-  expect(scanCommentsForReceipt(["no receipt anywhere"]).hasReceipt).toBe(false);
-  // A receipt without a gist still counts as a receipt.
-  expect(scanCommentsForReceipt(["## Close receipt\n\n- **checkpoint:** `cp-x`"])).toEqual({ hasReceipt: true });
+test("the receipt scan rejects marker-only comments and accepts a rendered receipt", () => {
+  expect(scanCommentsForReceipt(["just a discussion comment", "## Close receipt\n\n- **checkpoint:** `cp-x`"])).toEqual({ hasReceipt: false });
+  const receipt: CloseReceipt = { checkpointId: "cp-x", closedBy: "ivy", at: "2026-08-24T12:00:00.000Z", attestation: "unverified", evidence: [{ kind: "probed", summary: "test passed" }], probeResults: [] };
+  expect(scanCommentsForReceipt([renderCloseReceipt(receipt)])).toEqual({ hasReceipt: true });
 });
 
 test("spliceSection replaces only the marked span, and refuses malformed markers", () => {

--- a/test/work-graph.test.ts
+++ b/test/work-graph.test.ts
@@ -172,6 +172,9 @@ function receipt(overrides: Partial<CloseReceipt> = {}): CloseReceipt {
       { probe: PASSING_PROBE, state: "probed", outcome: "pass", observed: "exit 0", at: "2026-08-04T09:59:00.000Z" },
     ],
     attestation: "unverified",
+    // `auto` closes must cite a successful CI check run (§3.1) — defaulted here
+    // so the tests about the other conjuncts stay about them.
+    ci: { checkRunId: "12345", headSha: "abc123def456" },
     ...overrides,
   };
 }

--- a/test/work-graph.test.ts
+++ b/test/work-graph.test.ts
@@ -316,6 +316,11 @@ test("the receipt scan rejects marker-only comments and accepts a rendered recei
   expect(scanCommentsForReceipt([renderCloseReceipt(receipt)])).toEqual({ hasReceipt: true });
 });
 
+test("the receipt scan accepts a rendered HITL receipt without evidence", () => {
+  const hitl: CloseReceipt = { checkpointId: "cp-hitl", closedBy: "jcfischer", at: "2026-08-24T12:00:00.000Z", attestation: "unverified", evidence: [], probeResults: [] };
+  expect(scanCommentsForReceipt([renderCloseReceipt(hitl)])).toEqual({ hasReceipt: true });
+});
+
 test("spliceSection replaces only the marked span, and refuses malformed markers", () => {
   const body = `above\n${DECISIONS_BEGIN}\nold\n${DECISIONS_END}\nbelow`;
   const spliced = spliceSection(body, "- new line");


### PR DESCRIPTION
## Summary
- stage, hash-validate, and atomically activate the guarded runtime under `~/.soma/runtime/`
- route Claude Code, Codex, and Grok hooks through `runtime/current`; add runtime status/rollback and doctor recovery guidance
- require structurally valid close receipts for bridged completion and test guarded private-root agreement

Closes #657

## Verification
- `bun test` (2531 passed)
- `bun run typecheck`
- `git diff --check`

## Deferred
- Per-invocation artifact hashing, network/Git freshness checks, automatic rollback, tracker reopening, and adapter redesign remain out of W1 scope.