### PR TITLE
fix(dsh): enable bounded graph closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+## [0.18.2] - 2026-08-26
+
+### Fixed
+
+- **DSH graph closure is available through a bounded host tool.** `soma_graph`
+  now exposes `close` with resolution prose or a workspace-relative resolution
+  file; traversal and symlink escapes are refused before the existing graph
+  closure gate runs. The tool also surfaces CLI stderr when a graph command
+  fails, while `decisions --write` remains limited to the derived map index.
+- **Portable-skill reconciliation preserves principal-replaced links.** A stale
+  manifest may remove a migrated loader slot only when that slot targets its
+  exact matching `~/.soma/skills/<name>` registry entry; links to other
+  principal-owned locations, including another registry skill, remain intact.
 
 ## [0.18.1] - 2026-08-25
 

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,6 +1,6 @@
 schema: arc/v1
 name: soma
-version: 0.18.1
+version: 0.18.2
 type: tool
 tier: community
 description: Substrate-portable Personal AI Assistant core for identity, memory, VSA, skills, learning, and adapters.

--- a/docs/dsh-substrate.md
+++ b/docs/dsh-substrate.md
@@ -6,8 +6,9 @@ it from the running soma package, wires the profile dependency, and patches the
 composition row. Verification state — **known to work live:** plugin apply in
 a booted `dsh web` server, session-start writeback (runtime skill visible in
 the session catalog; `lifecycle.session_start` events in the Soma event log).
-**Not yet observed live:** session-end writeback and the `soma_memory` tool —
-both are exercised only by the checked-in cordis smoke harness
+**Not yet observed live:** session-end writeback and host CLI tool execution —
+the `soma_memory`, `soma_algorithm`, and `soma_graph` registrations are
+exercised by the checked-in Cordis smoke harness
 (`integrations/dsh/soma-host/tools/cordis-smoke.mts`). The client-side
 `soma-dsh-hide-tools` remains a hand-installed prototype.
 
@@ -56,7 +57,7 @@ only visible surface.
 | Feedback | durable `feedback/record{text}`; `ctx.messageFeedback` sidecar | `soma feedback capture` |
 | Goals | durable `goal/change`; `ctx.goals` verbs | Soma Algorithm runs / active VSA |
 | Persistence | `ctx.storageDomain` domain/table KV store under `~/.dsh/storages` | Soma idempotency/state for the plugin |
-| External process | `ctx.subprocess.spawn` / `ctx.shell.run` (providers: `dsh-subprocess-local`, `dsh-bash-local`) | invoke the `soma` CLI |
+| External process | `ctx.subprocess.spawn` / `ctx.shell.run` (providers: `dsh-subprocess-local`, `dsh-bash-local`) | invoke the `soma` CLI; host tools can write the Soma home outside the model-facing workspace sandbox |
 | Model-facing tool presentation | `ctx.tools.presentAs('native'|'code'|'both')` | **model**-facing only |
 | Browser tool-card rendering | `dsh-client-ui-tool` registers the `tool-call` chat node; `dsh-client-ui-trajectory` is the audit tab | **UI**-facing: hide via a client plugin |
 
@@ -340,12 +341,19 @@ surface (against `@deepseek-ai/dsh*` 0.1.0-rc.8):
    - **Goals** = durable `goal/change` + `ctx.goals` verbs → mirror active
      Soma Algorithm runs / VSAs (optional, later).
 
-3. **Memory** — register the Soma memory route as a runtime skill via
-   `ctx.skills.register({ name, description, whenToUse, content })`
-   (`dsh-skill`), and/or project the CLI-facing tools.
-   `ctx.subprocess.spawn({ argv, cwd, stdio, graceMs })` / `ctx.shell.run`
-   invoke the `soma` CLI for `soma memory …`, `soma graph …`,
-   `soma algorithm …`, `soma vsa …`.
+3. **Memory and durable verbs** — register the Soma memory route as a runtime
+   skill via `ctx.skills.register({ name, description, whenToUse, content })`
+   (`dsh-skill`), and expose narrow host tools for mutable Soma CLI surfaces.
+   `soma_algorithm` invokes supported Algorithm verbs through
+   `ctx.subprocess.spawn({ argv, cwd, stdio, graceMs })` and forces
+   `--substrate dsh`, so it can persist under `~/.soma` without the
+   model-facing workspace sandbox. `soma_graph` likewise exposes bounded graph
+   verbs, including `close` and `decisions --write`. A close can receive
+   resolution prose (materialized as a temporary, mode-0600 file inside the
+   session workspace) or a workspace-relative `resolutionFile`; absolute paths,
+   traversal, and symlink escapes are refused before the existing close gate
+   runs. `decisions --write` remains bounded by the CLI to the map's marked
+   derived-index section.
 
 4. **Algorithm / orienteer** — the `the-algorithm` and `orienteer` skills are
    projected as files (the adapter) and auto-discovered; the plugin can

--- a/integrations/dsh/soma-host/README.md
+++ b/integrations/dsh/soma-host/README.md
@@ -13,7 +13,10 @@ It gives every live session:
    goes idle (deduped per session via `ctx.storageDomain`);
 3. a **runtime digest skill** (`soma-digest`) routing session wrap-up to
    `soma memory digest`;
-4. a **`soma_memory` tool** that shells out to `soma memory recall`.
+4. host CLI tools: **`soma_memory`** for recall, **`soma_algorithm`** for
+   durable Algorithm run reads/mutations, and **`soma_graph`** for bounded
+   work-graph reads/mutations. The latter two avoid the model-facing workspace
+   sandbox, which cannot write `~/.soma`.
 
 The plugin shells out to the `soma` CLI (raw `ctx.subprocess` argv, no shell
 interpolation) rather than re-implementing Soma — Soma stays the single source
@@ -88,6 +91,14 @@ preset get it; rows that publish a *service* must sit inside a
    `session_end`) rows with `substrate: dsh`.
 3. The system prompt contains the "You run on Soma" anchor.
 4. Ask the model to recall memory — it can use the `soma_memory` tool.
+5. Start or update an Algorithm run — the model uses `soma_algorithm`, not a
+   sandboxed shell command, and the run is written under `~/.soma`.
+6. Close a graph node with `soma_graph`: pass `resolution` prose or a
+   workspace-relative `resolutionFile`. The host rejects absolute paths,
+   traversal, and symlink escapes; direct prose is written as a temporary,
+   mode-0600 workspace file and removed after the CLI returns. `decisions
+   --write` is available because the CLI updates only the map's marker-bounded
+   derived index.
 
 ## License
 

--- a/integrations/dsh/soma-host/lib/index.js
+++ b/integrations/dsh/soma-host/lib/index.js
@@ -6,7 +6,7 @@
 //   1. an always-on Soma prompt section (identity / purpose / policy),
 //   2. lifecycle writeback to ~/.soma (session-start / session-end),
 //   3. a runtime digest skill,
-//   4. a `soma_memory` tool that shells out to the `soma` CLI.
+//   4. narrow host tools for Soma memory, Algorithm, and work-graph commands.
 //
 // Status: smoke-tested against the DSH checkout's own cordis (apply registers
 // the section/skill/tool; scoped emitAgentEvent dispatch fires both lifecycle
@@ -17,6 +17,9 @@
 // shell interpolation) rather than re-implementing Soma logic — Soma stays the
 // single source of truth.
 
+import { randomUUID } from "node:crypto";
+import { realpath, rm, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, relative, resolve } from "node:path";
 import { defineTool } from "@deepseek-ai/dsh-tools";
 
 const SOMA_SUBSTRATE = "dsh";
@@ -104,7 +107,11 @@ export function apply(ctx, config = {}) {
     });
   });
 
-  // ── 4. soma CLI tools ─────────────────────────────────────────────────────
+  // ── 4. Soma CLI tools ─────────────────────────────────────────────────────
+  // These run through the host's local subprocess provider, rather than the
+  // model-facing workspace sandbox. Keep the exposed verbs narrow: they may
+  // mutate the Soma home or the work graph, but cannot become an arbitrary
+  // host-shell or arbitrary-path capability.
   ctx.tools.register(
     defineTool({
       name: "soma_memory",
@@ -112,19 +119,164 @@ export function apply(ctx, config = {}) {
       parameters: {
         query: { type: "string", required: true, description: "Topic to recall from Soma memory." },
       },
-      output: {
-        schema: { type: "string" },
-        render: (_args, value) => [{ type: "text", text: value }],
-      },
+      output: textOutput(),
       async execute(args, exec) {
-        const { stdout } = await runSoma(ctx, somaPath, ["memory", "recall", "--query", args.query], cwdOf(exec));
-        return stdout;
+        return await runSomaChecked(ctx, somaPath, ["memory", "recall", "--query", args.query], cwdOf(exec));
+      },
+    }),
+  );
+
+  ctx.tools.register(
+    defineTool({
+      name: "soma_algorithm",
+      description:
+        "Read or update a durable Soma Algorithm run. This host tool writes through to the Soma home outside the workspace sandbox; use it instead of bash for `soma algorithm`.",
+      parameters: {
+        action: { type: "string", required: true, enum: ALGORITHM_ACTIONS, description: "The supported `soma algorithm` verb." },
+        arguments: { type: "array", required: true, items: { type: "string" }, description: "CLI arguments for the selected verb only, without `algorithm` or the action." },
+      },
+      output: textOutput(),
+      async execute(args, exec) {
+        const argv = algorithmArgv(args.action, args.arguments);
+        return await runSomaChecked(ctx, somaPath, argv, cwdOf(exec));
+      },
+    }),
+  );
+
+  ctx.tools.register(
+    defineTool({
+      name: "soma_graph",
+      description:
+        "Read or perform bounded work-graph operations through Soma. Use it instead of bash for graph frontier, claim, release, add, close, audit, or decisions. For close, provide resolution text or a workspace-relative resolutionFile; declared probes execute through the existing graph close gate.",
+      parameters: {
+        action: { type: "string", required: true, enum: GRAPH_ACTIONS, description: "The supported `soma graph` verb." },
+        arguments: { type: "array", required: true, items: { type: "string" }, description: "CLI arguments for the selected verb only, without `graph` or the action." },
+        resolution: { type: "string", description: "Close-resolution prose. The host writes it to a temporary file inside the current workspace, passes that file to the CLI, then removes it." },
+        resolutionFile: { type: "string", description: "Existing resolution prose file relative to the current workspace. Absolute paths, traversal, and symlink escapes are refused." },
+      },
+      output: textOutput(),
+      async execute(args, exec) {
+        const cwd = cwdOf(exec);
+        const prepared = await graphArgv(args, cwd);
+        try {
+          return await runSomaChecked(ctx, somaPath, prepared.argv, cwd);
+        } finally {
+          await prepared.dispose();
+        }
       },
     }),
   );
 }
 
 // ── helpers ─────────────────────────────────────────────────────────────────
+
+const ALGORITHM_ACTIONS = [
+  "new", "classify", "list", "show", "capabilities", "invoke", "remove-capability",
+  "plan", "observe", "decision", "change", "ref", "resolve", "step", "verify",
+  "learn", "reflect", "reflections", "batch", "advance", "resume",
+];
+const ALGORITHM_SUBSTRATE_ACTIONS = new Set([
+  "new", "capabilities", "invoke", "observe", "verify", "learn", "reflect", "batch", "advance", "resume",
+]);
+const GRAPH_ACTIONS = ["frontier", "node", "claim", "release", "add", "close", "audit", "decisions"];
+const FORBIDDEN_ARGUMENTS = new Set(["--home-dir", "--soma-home", "--isa", "--body-file", "--resolution-file"]);
+const TEMP_RESOLUTION_PREFIX = ".soma-graph-resolution-";
+
+function textOutput() {
+  return {
+    schema: { type: "string" },
+    render: (_args, value) => [{ type: "text", text: value }],
+  };
+}
+
+function validateArguments(action, args, forbidden = FORBIDDEN_ARGUMENTS) {
+  if (!Array.isArray(args) || !args.every((arg) => typeof arg === "string" && !arg.includes("\0"))) {
+    throw new Error(`${action}: arguments must be strings without NUL bytes.`);
+  }
+  for (const arg of args) {
+    if (forbidden.has(arg)) throw new Error(`${action}: ${arg} is not available through this host tool.`);
+  }
+}
+
+function algorithmArgv(action, args) {
+  validateArguments(`soma_algorithm ${action}`, args);
+  if (args.includes("--substrate")) {
+    throw new Error("soma_algorithm: --substrate is managed by the DSH host and must not be supplied.");
+  }
+  return ["algorithm", action, ...args, ...(ALGORITHM_SUBSTRATE_ACTIONS.has(action) ? ["--substrate", SOMA_SUBSTRATE] : [])];
+}
+
+async function graphArgv(input, cwd) {
+  const { action, arguments: args, resolution, resolutionFile } = input;
+  validateArguments(`soma_graph ${action}`, args);
+  if (action !== "close" && (resolution !== undefined || resolutionFile !== undefined)) {
+    throw new Error(`soma_graph ${action}: resolution inputs are available only for close.`);
+  }
+  if (resolution !== undefined && resolutionFile !== undefined) {
+    throw new Error("soma_graph close: supply either resolution or resolutionFile, not both.");
+  }
+  if (resolution !== undefined && (typeof resolution !== "string" || resolution.trim().length === 0)) {
+    throw new Error("soma_graph close: resolution must be non-empty prose.");
+  }
+  if (resolutionFile !== undefined && typeof resolutionFile !== "string") {
+    throw new Error("soma_graph close: resolutionFile must be a workspace-relative path.");
+  }
+
+  if (action !== "close") return { argv: ["graph", action, ...args], dispose: async () => {} };
+  if (args.includes("--propose") && (resolution !== undefined || resolutionFile !== undefined)) {
+    throw new Error("soma_graph close: resolution inputs cannot be combined with --propose; its body is the resolution.");
+  }
+
+  if (resolutionFile !== undefined) {
+    const path = await resolveWorkspaceFile(cwd, resolutionFile);
+    return { argv: ["graph", action, ...args, "--resolution-file", path], dispose: async () => {} };
+  }
+  if (resolution !== undefined) {
+    const path = await writeTemporaryResolution(cwd, resolution);
+    return {
+      argv: ["graph", action, ...args, "--resolution-file", path],
+      dispose: async () => { await rm(path, { force: true }); },
+    };
+  }
+  return { argv: ["graph", action, ...args], dispose: async () => {} };
+}
+
+async function resolveWorkspaceFile(cwd, file) {
+  if (file.trim().length === 0 || isAbsolute(file)) {
+    throw new Error("soma_graph close: resolutionFile must be a non-empty path relative to the current workspace.");
+  }
+  const workspace = await realpath(cwd);
+  const candidate = resolve(workspace, file);
+  if (!isWithin(workspace, candidate)) {
+    throw new Error("soma_graph close: resolutionFile must remain inside the current workspace.");
+  }
+  let resolved;
+  try {
+    resolved = await realpath(candidate);
+  } catch (error) {
+    throw new Error(`soma_graph close: resolutionFile could not be resolved: ${error instanceof Error ? error.message : String(error)}`);
+  }
+  if (!isWithin(workspace, resolved)) {
+    throw new Error("soma_graph close: resolutionFile resolves outside the current workspace.");
+  }
+  return resolved;
+}
+
+function isWithin(workspace, candidate) {
+  const path = relative(workspace, candidate);
+  return path === "" || (!path.startsWith("..") && !isAbsolute(path));
+}
+
+async function writeTemporaryResolution(cwd, resolution) {
+  const workspace = await realpath(cwd);
+  const file = resolve(workspace, `${TEMP_RESOLUTION_PREFIX}${randomUUID()}.md`);
+  // The generated basename is fixed here; reject any unexpected path before write.
+  if (dirname(file) !== workspace || !basename(file).startsWith(TEMP_RESOLUTION_PREFIX)) {
+    throw new Error("soma_graph close: could not prepare the workspace resolution file.");
+  }
+  await writeFile(file, resolution, { encoding: "utf8", flag: "wx", mode: 0o600 });
+  return file;
+}
 
 function renderSomaEntry() {
   // Compact static fallback. The projected `~/.dsh/AGENTS.md` and
@@ -186,6 +338,14 @@ async function ensureDigestTable(ctx) {
  * Run the soma CLI best-effort. Uses ctx.subprocess (raw argv, no shell) and
  * returns `{ exitCode, stdout }`; never throws for a non-zero exit.
  */
+async function runSomaChecked(ctx, somaPath, args, cwd) {
+  const outcome = await runSoma(ctx, somaPath, args, cwd);
+  if (outcome.exitCode !== 0) {
+    throw new Error(`Soma command failed (${outcome.exitCode ?? "could not start"}): ${[somaPath, ...args].join(" ")}`);
+  }
+  return outcome.stdout;
+}
+
 async function runSoma(ctx, somaPath, args, cwd) {
   const subprocess = ctx.subprocess;
   if (!subprocess) {

--- a/integrations/dsh/soma-host/lib/index.js
+++ b/integrations/dsh/soma-host/lib/index.js
@@ -336,12 +336,15 @@ async function ensureDigestTable(ctx) {
 
 /**
  * Run the soma CLI best-effort. Uses ctx.subprocess (raw argv, no shell) and
- * returns `{ exitCode, stdout }`; never throws for a non-zero exit.
+ * returns `{ exitCode, stdout, stderr }`; never throws for a non-zero exit.
  */
 async function runSomaChecked(ctx, somaPath, args, cwd) {
   const outcome = await runSoma(ctx, somaPath, args, cwd);
   if (outcome.exitCode !== 0) {
-    throw new Error(`Soma command failed (${outcome.exitCode ?? "could not start"}): ${[somaPath, ...args].join(" ")}`);
+    const stderr = outcome.stderr.trim();
+    throw new Error(
+      `Soma command failed (${outcome.exitCode ?? "could not start"}): ${[somaPath, ...args].join(" ")}${stderr ? `\n${stderr}` : ""}`,
+    );
   }
   return outcome.stdout;
 }
@@ -350,7 +353,7 @@ async function runSoma(ctx, somaPath, args, cwd) {
   const subprocess = ctx.subprocess;
   if (!subprocess) {
     console.warn("[soma-host] no subprocess provider mounted; skipping", args.join(" "));
-    return { exitCode: null, stdout: "" };
+    return { exitCode: null, stdout: "", stderr: "" };
   }
   const handle = subprocess.spawn({
     argv: [somaPath, ...args],
@@ -361,13 +364,13 @@ async function runSoma(ctx, somaPath, args, cwd) {
   try {
     const outcome = await handle.done;
     const stdout = handle.collected?.stdout?.readFrom?.(0)?.text ?? "";
+    const stderr = handle.collected?.stderr?.readFrom?.(0)?.text ?? "";
     if (outcome.exitCode !== 0) {
-      const stderr = handle.collected?.stderr?.readFrom?.(0)?.text ?? "";
       console.warn("[soma-host]", [somaPath, ...args].join(" "), "exited", outcome.exitCode, stderr.slice(0, 400));
     }
-    return { exitCode: outcome.exitCode, stdout };
+    return { exitCode: outcome.exitCode, stdout, stderr };
   } catch (error) {
     console.warn("[soma-host] spawn failed for", [somaPath, ...args].join(" "), error);
-    return { exitCode: null, stdout: "" };
+    return { exitCode: null, stdout: "", stderr: "" };
   }
 }

--- a/integrations/dsh/soma-host/tools/cordis-smoke.mts
+++ b/integrations/dsh/soma-host/tools/cordis-smoke.mts
@@ -59,10 +59,10 @@ app.provide("subprocess", {
   spawn: (opts: any) => {
     calls.push(`spawn[${scenario}]:${opts.argv.join(" ")}`);
     return {
-      done: Promise.resolve({ exitCode: scenario === "failing" && opts.argv.includes("session-end") ? 1 : 0 }),
+      done: Promise.resolve({ exitCode: (scenario === "failing" && opts.argv.includes("session-end")) || (scenario === "cli-failing" && opts.argv.includes("graph")) ? 1 : 0 }),
       collected: {
         stdout: { readFrom: () => ({ text: "" }) },
-        stderr: { readFrom: () => ({ text: "" }) },
+        stderr: { readFrom: () => ({ text: scenario === "cli-failing" ? "graph close refused by declared probe\n" : "" }) },
       },
     };
   },
@@ -124,6 +124,12 @@ try {
   await rm(resolutionFile, { force: true });
   await rm(escapingLink, { force: true });
 }
+
+scenario = "cli-failing";
+await tools.get("soma_graph").execute({ action: "claim", arguments: ["42"] }, toolExec)
+  .then(() => { throw new Error("failed graph command should surface stderr"); })
+  .catch((error) => assert(String(error).includes("graph close refused by declared probe"), "CLI stderr reaches the tool caller"));
+scenario = "happy";
 
 assert(calls.some((c) => c.includes("lifecycle session-start") && c.startsWith("spawn[happy]")), "session-start fired");
 assert(calls.some((c) => c.includes("lifecycle session-end") && c.startsWith("spawn[happy]")), "session-end fired");

--- a/integrations/dsh/soma-host/tools/cordis-smoke.mts
+++ b/integrations/dsh/soma-host/tools/cordis-smoke.mts
@@ -81,6 +81,13 @@ function assert(condition: boolean, message: string): void {
   if (!condition) throw new Error(`FAIL (${scenario}): ${message}`);
 }
 
+async function assertRejects(promise: Promise<unknown>, expectedText: string, message: string): Promise<void> {
+  await promise.then(
+    () => { throw new Error(`expected rejection containing ${expectedText}`); },
+    (error) => assert(String(error).includes(expectedText), message),
+  );
+}
+
 assert(calls.some((c) => c.startsWith("section:soma:core")), "prompt section registered");
 assert(calls.some((c) => c.startsWith("skill:soma-digest")), "runtime skill registered");
 assert(calls.some((c) => c.startsWith("tool:soma_memory")), "memory tool registered");
@@ -114,21 +121,27 @@ try {
   await tools.get("soma_graph").execute({ action: "close", arguments: ["42", "--dry-run"], resolutionFile: "soma-host-smoke-resolution.md" }, toolExec);
   const resolvedResolutionFile = await realpath(resolutionFile);
   assert(calls.some((c) => c.includes(`graph close 42 --dry-run --resolution-file ${resolvedResolutionFile}`)), "workspace-relative resolution file is accepted");
-  await tools.get("soma_graph").execute({ action: "close", arguments: ["42"], resolutionFile: "../etc/passwd" }, toolExec)
-    .then(() => { throw new Error("escaping resolution file should be refused"); })
-    .catch((error) => assert(String(error).includes("must remain inside"), "escaping path is refused"));
-  await tools.get("soma_graph").execute({ action: "close", arguments: ["42"], resolutionFile: "soma-host-smoke-escape.md" }, toolExec)
-    .then(() => { throw new Error("symlink escape should be refused"); })
-    .catch((error) => assert(String(error).includes("resolves outside"), "symlink escape is refused"));
+  await assertRejects(
+    tools.get("soma_graph").execute({ action: "close", arguments: ["42"], resolutionFile: "../etc/passwd" }, toolExec),
+    "must remain inside",
+    "escaping path is refused",
+  );
+  await assertRejects(
+    tools.get("soma_graph").execute({ action: "close", arguments: ["42"], resolutionFile: "soma-host-smoke-escape.md" }, toolExec),
+    "resolves outside",
+    "symlink escape is refused",
+  );
 } finally {
   await rm(resolutionFile, { force: true });
   await rm(escapingLink, { force: true });
 }
 
 scenario = "cli-failing";
-await tools.get("soma_graph").execute({ action: "claim", arguments: ["42"] }, toolExec)
-  .then(() => { throw new Error("failed graph command should surface stderr"); })
-  .catch((error) => assert(String(error).includes("graph close refused by declared probe"), "CLI stderr reaches the tool caller"));
+await assertRejects(
+  tools.get("soma_graph").execute({ action: "claim", arguments: ["42"] }, toolExec),
+  "graph close refused by declared probe",
+  "CLI stderr reaches the tool caller",
+);
 scenario = "happy";
 
 assert(calls.some((c) => c.includes("lifecycle session-start") && c.startsWith("spawn[happy]")), "session-start fired");

--- a/integrations/dsh/soma-host/tools/cordis-smoke.mts
+++ b/integrations/dsh/soma-host/tools/cordis-smoke.mts
@@ -18,6 +18,7 @@
 // under test defaults to the profile-installed copy and can be overridden
 // with DSH_PLUGIN_PATH.
 
+import { access, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -35,10 +36,17 @@ const plugin = await import(pluginPath);
 
 let scenario = "happy";
 const calls: string[] = [];
+const tools = new Map<string, any>();
 const app = new Context();
 app.provide("systemPrompt", { section: (s: any) => calls.push(`section:${s.name}:order=${s.order}`) });
 app.provide("skills", { register: (s: any) => calls.push(`skill:${s.name}`) });
-app.provide("tools", { register: (t: any) => calls.push(`tool:${typeof t === "function" ? t.name : t?.name ?? "?"}`) });
+app.provide("tools", {
+  register: (tool: any) => {
+    const name = typeof tool === "function" ? tool.name : tool?.name ?? "?";
+    calls.push(`tool:${name}`);
+    tools.set(name, tool);
+  },
+});
 app.provide("storageDomain", {
   open: async () => ({
     table: () => ({
@@ -49,7 +57,7 @@ app.provide("storageDomain", {
 });
 app.provide("subprocess", {
   spawn: (opts: any) => {
-    calls.push(`spawn[${scenario}]:${opts.argv.slice(0, 3).join(" ")}`);
+    calls.push(`spawn[${scenario}]:${opts.argv.join(" ")}`);
     return {
       done: Promise.resolve({ exitCode: scenario === "failing" && opts.argv.includes("session-end") ? 1 : 0 }),
       collected: {
@@ -75,7 +83,48 @@ function assert(condition: boolean, message: string): void {
 
 assert(calls.some((c) => c.startsWith("section:soma:core")), "prompt section registered");
 assert(calls.some((c) => c.startsWith("skill:soma-digest")), "runtime skill registered");
-assert(calls.some((c) => c.startsWith("tool:soma_memory")), "tool registered");
+assert(calls.some((c) => c.startsWith("tool:soma_memory")), "memory tool registered");
+assert(calls.some((c) => c.startsWith("tool:soma_algorithm")), "Algorithm tool registered");
+assert(calls.some((c) => c.startsWith("tool:soma_graph")), "work-graph tool registered");
+
+const toolExec = { session: { header: { cwd: "/tmp" } } };
+await tools.get("soma_algorithm").execute({ action: "advance", arguments: ["--id", "run-1"] }, toolExec);
+assert(calls.some((c) => c.includes("algorithm advance --id run-1 --substrate dsh")), "Algorithm tool invokes host CLI with DSH provenance");
+await tools.get("soma_graph").execute({ action: "claim", arguments: ["42"] }, toolExec);
+assert(calls.some((c) => c.includes("graph claim 42")), "graph tool invokes host CLI");
+await tools.get("soma_graph").execute({ action: "decisions", arguments: ["42", "--write"] }, toolExec);
+assert(calls.some((c) => c.includes("graph decisions 42 --write")), "derived decisions index write is permitted");
+await tools.get("soma_graph").execute(
+  { action: "close", arguments: ["42", "--dry-run"], resolution: "The node is complete." },
+  toolExec,
+);
+const workspace = await realpath("/tmp");
+const temporaryClose = calls.find((c) => c.includes(`graph close 42 --dry-run --resolution-file ${workspace}/.soma-graph-resolution-`));
+assert(temporaryClose !== undefined, "close writes only a temporary workspace resolution file");
+const temporaryPath = temporaryClose?.split("--resolution-file ")[1];
+await access(temporaryPath!).then(
+  () => { throw new Error("temporary resolution file should be removed"); },
+  () => undefined,
+);
+const resolutionFile = "/tmp/soma-host-smoke-resolution.md";
+const escapingLink = "/tmp/soma-host-smoke-escape.md";
+await writeFile(resolutionFile, "The existing workspace resolution is complete.\n");
+await symlink("/etc/passwd", escapingLink);
+try {
+  await tools.get("soma_graph").execute({ action: "close", arguments: ["42", "--dry-run"], resolutionFile: "soma-host-smoke-resolution.md" }, toolExec);
+  const resolvedResolutionFile = await realpath(resolutionFile);
+  assert(calls.some((c) => c.includes(`graph close 42 --dry-run --resolution-file ${resolvedResolutionFile}`)), "workspace-relative resolution file is accepted");
+  await tools.get("soma_graph").execute({ action: "close", arguments: ["42"], resolutionFile: "../etc/passwd" }, toolExec)
+    .then(() => { throw new Error("escaping resolution file should be refused"); })
+    .catch((error) => assert(String(error).includes("must remain inside"), "escaping path is refused"));
+  await tools.get("soma_graph").execute({ action: "close", arguments: ["42"], resolutionFile: "soma-host-smoke-escape.md" }, toolExec)
+    .then(() => { throw new Error("symlink escape should be refused"); })
+    .catch((error) => assert(String(error).includes("resolves outside"), "symlink escape is refused"));
+} finally {
+  await rm(resolutionFile, { force: true });
+  await rm(escapingLink, { force: true });
+}
+
 assert(calls.some((c) => c.includes("lifecycle session-start") && c.startsWith("spawn[happy]")), "session-start fired");
 assert(calls.some((c) => c.includes("lifecycle session-end") && c.startsWith("spawn[happy]")), "session-end fired");
 assert(calls.includes("dedup-put[happy]"), "dedup key written after successful session-end");
@@ -91,4 +140,4 @@ assert(
 assert(!calls.includes("dedup-put[failing]"), "dedup key NOT written when session-end fails (retryable)");
 
 console.log("CORDIS SMOKE OK");
-await app.destroy();
+await fiber.dispose();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soma",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "private": true,
   "type": "module",
   "description": "Substrate-portable Personal AI Assistant core.",

--- a/src/adapters/shared/portable-skill-manifest.ts
+++ b/src/adapters/shared/portable-skill-manifest.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { lstat, mkdir, readFile, rm, rmdir, unlink, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, readlink, rm, rmdir, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, resolve, sep } from "node:path";
 import { isEnoent } from "../../fs-errors";
 
@@ -138,6 +138,13 @@ async function symlinkAncestor(root: string, target: string): Promise<SymlinkIde
   return undefined;
 }
 
+/** A migrated loader slot is owned only when it still points into Soma's skill registry. */
+async function isSomaRegistryLink(linkPath: string, somaHome: string): Promise<boolean> {
+  const registryRoot = join(resolve(somaHome), "skills");
+  const target = resolve(dirname(linkPath), await readlink(linkPath));
+  return target !== registryRoot && target.startsWith(`${registryRoot}${sep}`);
+}
+
 export async function readPortableSkillManifest(
   somaHome: string,
   substrate: PortableSkillManifestSubstrate,
@@ -162,6 +169,7 @@ export async function readPortableSkillManifest(
  * a non-recursive rmdir, so principal-added files keep their dirs alive.
  */
 async function removeListedProjectionFiles(
+  somaHome: string,
   substrateHome: string,
   files: readonly { path: string; sha256: string }[],
 ): Promise<string[]> {
@@ -178,9 +186,9 @@ async function removeListedProjectionFiles(
     const linkedDir = await symlinkAncestor(substrateHome, target);
     if (linkedDir !== undefined) {
       // The substrate's top-level directories are shared surfaces, not
-      // manifest-owned skill slots. If one is itself a symlink, fail open for
-      // this entry rather than unlinking the whole shared loader root.
-      if (dirname(linkedDir.path) === substrateHome) continue;
+      // manifest-owned skill slots. A nested symlink is also principal state
+      // unless its target proves it is the loader link Soma projected.
+      if (dirname(linkedDir.path) === substrateHome || !(await isSomaRegistryLink(linkedDir.path, somaHome))) continue;
       try {
         // Narrow the lstat→unlink race: only unlink the same symlink inode we
         // classified. A swapped regular file or replacement link is user state,
@@ -250,7 +258,7 @@ export async function reconcilePortableSkillProjection(options: {
   if (resolve(manifest.substrateHome) !== substrateHome) return [];
   const current = new Set(options.currentPaths);
   const stale = manifest.files.filter((file) => !current.has(file.path));
-  return removeListedProjectionFiles(substrateHome, stale);
+  return removeListedProjectionFiles(options.somaHome, substrateHome, stale);
 }
 
 /**
@@ -278,7 +286,7 @@ export async function removePortableSkillProjection(options: {
   const substrateHome = resolve(options.substrateHome);
   if (resolve(manifest.substrateHome) !== substrateHome) return [];
 
-  const removed = await removeListedProjectionFiles(substrateHome, manifest.files);
+  const removed = await removeListedProjectionFiles(options.somaHome, substrateHome, manifest.files);
   const manifestPath = portableSkillManifestPath(options.somaHome, options.substrate, options.substrateHome);
   await rm(manifestPath, { force: true });
   removed.push(manifestPath);

--- a/src/adapters/shared/portable-skill-manifest.ts
+++ b/src/adapters/shared/portable-skill-manifest.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 import { lstat, mkdir, readFile, readlink, rm, rmdir, unlink, writeFile } from "node:fs/promises";
-import { dirname, join, resolve, sep } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import { isEnoent } from "../../fs-errors";
 
 /**
@@ -140,9 +140,8 @@ async function symlinkAncestor(root: string, target: string): Promise<SymlinkIde
 
 /** A migrated loader slot is owned only when it still points into Soma's skill registry. */
 async function isSomaRegistryLink(linkPath: string, somaHome: string): Promise<boolean> {
-  const registryRoot = join(resolve(somaHome), "skills");
   const target = resolve(dirname(linkPath), await readlink(linkPath));
-  return target !== registryRoot && target.startsWith(`${registryRoot}${sep}`);
+  return target === join(resolve(somaHome), "skills", basename(linkPath));
 }
 
 export async function readPortableSkillManifest(

--- a/test/portable-skill-manifest.test.ts
+++ b/test/portable-skill-manifest.test.ts
@@ -223,6 +223,32 @@ test("reconcile preserves a principal-replaced skill symlink", async () => {
   });
 });
 
+test("reconcile preserves a principal link to another Soma registry skill", async () => {
+  await withDirs(async (somaHome, substrateHome) => {
+    const files = [{ path: "skills/the-algorithm/SKILL.md", content: "algorithm body\n" }];
+    await project(substrateHome, files);
+    await writePortableSkillManifest({ somaHome, substrate: "claude-code", substrateHome, files });
+
+    const slot = join(substrateHome, "skills/the-algorithm");
+    const replacement = join(somaHome, "skills/principal-replacement");
+    await rm(slot, { recursive: true });
+    await mkdir(replacement, { recursive: true });
+    await writeFile(join(replacement, "SKILL.md"), "replacement body\n", "utf8");
+    await symlink(replacement, slot);
+
+    const removed = await reconcilePortableSkillProjection({
+      somaHome,
+      substrate: "claude-code",
+      substrateHome,
+      currentPaths: [],
+    });
+
+    expect(removed).not.toContain(slot);
+    expect((await lstat(slot)).isSymbolicLink()).toBe(true);
+    expect(await readFile(join(slot, "SKILL.md"), "utf8")).toBe("replacement body\n");
+  });
+});
+
 test("reconcile never unlinks a shared top-level directory symlink", async () => {
   await withDirs(async (somaHome, substrateHome) => {
     const files = [{ path: "skills/Memory/SKILL.md", content: "memory body\n" }];

--- a/test/portable-skill-manifest.test.ts
+++ b/test/portable-skill-manifest.test.ts
@@ -174,9 +174,12 @@ test("reconcile removes a migrated symlink slot without touching its target (#65
     await writePortableSkillManifest({ somaHome, substrate: "claude-code", substrateHome, files });
 
     const slot = join(substrateHome, "skills/the-algorithm");
-    const registrySkill = join(substrateHome, "registry/the-algorithm");
+    const registrySkill = join(somaHome, "skills/the-algorithm");
     await rm(slot, { recursive: true });
-    await project(substrateHome, files.map((file) => ({ ...file, path: file.path.replace("skills/", "registry/") })));
+    await mkdir(registrySkill, { recursive: true });
+    await writeFile(join(registrySkill, "SKILL.md"), "algorithm body\n", "utf8");
+    await mkdir(join(registrySkill, "Workflows"), { recursive: true });
+    await writeFile(join(registrySkill, "Workflows/Run.md"), "workflow body\n", "utf8");
     await symlink(registrySkill, slot);
 
     const removed = await reconcilePortableSkillProjection({
@@ -192,6 +195,31 @@ test("reconcile removes a migrated symlink slot without touching its target (#65
     expect(await gone(join(substrateHome, "skills/gone"))).toBe(true);
     expect(await readFile(join(registrySkill, "SKILL.md"), "utf8")).toBe("algorithm body\n");
     expect(await readFile(join(registrySkill, "Workflows/Run.md"), "utf8")).toBe("workflow body\n");
+  });
+});
+
+test("reconcile preserves a principal-replaced skill symlink", async () => {
+  await withDirs(async (somaHome, substrateHome) => {
+    const files = [{ path: "skills/the-algorithm/SKILL.md", content: "algorithm body\n" }];
+    await project(substrateHome, files);
+    await writePortableSkillManifest({ somaHome, substrate: "claude-code", substrateHome, files });
+
+    const slot = join(substrateHome, "skills/the-algorithm");
+    const principalSkill = join(substrateHome, "principal-skills/the-algorithm");
+    await rm(slot, { recursive: true });
+    await project(substrateHome, [{ path: "principal-skills/the-algorithm/SKILL.md", content: "principal body\n" }]);
+    await symlink(principalSkill, slot);
+
+    const removed = await reconcilePortableSkillProjection({
+      somaHome,
+      substrate: "claude-code",
+      substrateHome,
+      currentPaths: [],
+    });
+
+    expect(removed).not.toContain(slot);
+    expect((await lstat(slot)).isSymbolicLink()).toBe(true);
+    expect(await readFile(join(slot, "SKILL.md"), "utf8")).toBe("principal body\n");
   });
 });
 


### PR DESCRIPTION
## Summary
- expose `soma_graph close` through controlled resolution inputs
- confine resolution files to the workspace and reject traversal/symlink escapes
- allow bounded `decisions --write` and add smoke coverage

## Verification
- Cordis smoke test
- `bun test test/cli-graph.test.ts`
- `bun run typecheck`