### PR TITLE
fix(graph): run close probes in the tree the operator invoked from (#662)

### DIFF
--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -152,11 +152,35 @@ Runner semantics settled while implementing #498:
   wanted, a launcher that `cd`s made probes execute in the install tree, so
   `bun test` passed against a commit that did not contain the work and the
   receipt said only `HEAD <sha>` — a true fact about the wrong tree.
-  **This is detection, not prevention.** The stated value still originates as the
-  process's cwd, so a launcher that `cd`s still moves it; what the receipt buys
-  is that the substituted tree is now named rather than silent. Refusing a probe
-  tree that does not contain the work is the preventive version, and it needs to
-  know which commit a node claims — #579 named it and left it out of scope.
+  **The base is the *invocation* directory, not the process's cwd**
+  ([#662](https://github.com/the-metafactory/soma/issues/662)). #579 read
+  `process.cwd()` and called a `cd`-ing launcher an unfixable limit; arc then
+  regenerated its shim with a `cd` into the install tree, reintroducing #579 on
+  every arc install regardless of what a hand-edited launcher did. A shim that
+  `cd`s exports where it came from first, so the close resolves its base from
+  `ARC_INVOCATION_CWD` when that names an absolute directory and from
+  `process.cwd()` otherwise — one rule, shared with `soma export --out` (#315),
+  since two expressions of it is the drift #579 already cost this spec once. A
+  relative or empty value is *not* trusted: resolving it against the moved cwd
+  would name a third directory that is neither the caller's nor the install
+  tree's.
+  What is still **detection, not prevention**: a launcher that `cd`s without
+  exporting the caller's directory moves the base and nothing here can tell.
+  The receipt still buys that the substituted tree is named rather than silent.
+  Refusing a probe tree that does not contain the work is the preventive version,
+  and it needs to know which commit a node claims — #579 named it and left it out
+  of scope.
+- **"I could not look" is not "it is not there"** (#662). Git plumbing answers a
+  question with exit 0 or 1 and reports that it could not answer with 128, and a
+  runner that folds the two together publishes `<path> absent at <ref>` for a
+  directory that is not a repository at all — the diagnosis a reader most needs
+  is the one the message hides. On the three git probes the `observed` for a
+  non-answering command (any exit but 0/1, a timeout included) MUST say the
+  repository or ref could not be reached and MUST name the resolved directory,
+  rather than assert absence or non-ancestry. It is still `outcome: "fail"` —
+  fail-closed is the runner's rule, and "could not reach the tree" is no more a
+  pass than "not there" is. The classification reads the **exit code**, never the
+  stderr text, which is localizable and has been reworded across git versions.
   A **dirty** probe tree is likewise *recorded, never refused*: it is a fact
   about the evidence, and refusing it would change what closes an `auto` node.
   A close whose probes are **all `url`** records no tree at all — it tested a

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -170,17 +170,32 @@ Runner semantics settled while implementing #498:
   Refusing a probe tree that does not contain the work is the preventive version,
   and it needs to know which commit a node claims — #579 named it and left it out
   of scope.
-- **"I could not look" is not "it is not there"** (#662). Git plumbing answers a
-  question with exit 0 or 1 and reports that it could not answer with 128, and a
-  runner that folds the two together publishes `<path> absent at <ref>` for a
-  directory that is not a repository at all — the diagnosis a reader most needs
-  is the one the message hides. On the three git probes the `observed` for a
-  non-answering command (any exit but 0/1, a timeout included) MUST say the
-  repository or ref could not be reached and MUST name the resolved directory,
-  rather than assert absence or non-ancestry. It is still `outcome: "fail"` —
-  fail-closed is the runner's rule, and "could not reach the tree" is no more a
-  pass than "not there" is. The classification reads the **exit code**, never the
-  stderr text, which is localizable and has been reworded across git versions.
+- **"I could not look" is not "it is not there"** (#662). A runner that folds the
+  two together publishes `<path> absent at <ref>` for a directory that is not a
+  repository at all — the diagnosis a reader most needs is the one the message
+  hides. On the three git probes, a failure that means *the repository or ref
+  could not be reached* MUST say so and MUST name the resolved directory, rather
+  than assert absence or non-ancestry. It is still `outcome: "fail"` — fail-closed
+  is the runner's rule, and "could not reach the tree" is no more a pass than
+  "not there" is.
+
+  **Which exit code carries that distinction depends on the argv, and assuming
+  otherwise is a defect** (#662 review B1). Verified on git 2.40.0:
+  `rev-parse --verify --quiet <ref>^{commit}` and `merge-base --is-ancestor`
+  answer "no" with **1** and report failure with **128**, so for those two the
+  boundary is exactly 0/1-answered. `cat-file -e <ref>:<path>` does **not**:
+  object-name syntax makes a genuinely missing path a *fatal*, so an absent file
+  at a valid ref exits **128**, indistinguishable from a missing tree. An
+  `artifact-exists` probe with `atRef` MUST therefore establish reachability with
+  a separate ref resolution first, after which any non-zero from the path lookup
+  is the path's answer. One extra spawn; a published attestation that states a
+  falsehood costs more.
+
+  The classification reads the **exit code**, never the stderr text, which is
+  localizable and has been reworded across git versions. Any path echoed into
+  `observed` — the resolved directory and git's own stderr alike — is
+  home-collapsed before publication, because git names paths it was *redirected*
+  to (a `.git` gitfile) that containment never bounded.
   A **dirty** probe tree is likewise *recorded, never refused*: it is a fact
   about the evidence, and refusing it would change what closes an `auto` node.
   A close whose probes are **all `url`** records no tree at all — it tested a

--- a/src/cli/graph.ts
+++ b/src/cli/graph.ts
@@ -86,6 +86,7 @@ import {
 // to re-implement it, becoming the second reader §2.7 forbids. No re-export — the
 // other importers point at core directly, so there is one path to each symbol.
 import { resolveGraphRepo } from "../work-graph-bridge";
+import { invocationCwd } from "../path-utils";
 import { SomaCliError } from "./errors";
 import { readOption } from "./parse-utils";
 
@@ -508,16 +509,23 @@ export interface GraphCliDeps {
    * The directory the probes run in, resolved **once** per close and passed
    * everywhere it is needed — the runner, the registry match, and the receipt.
    *
-   * The default is still the process's cwd, and that is the honest limit of this
-   * fix: **soma cannot tell which tree you meant.** A launcher that `cd`s before
-   * `exec` still moves it, exactly as `~/bin/soma` did in #579 — which is why
-   * that launcher no longer carries a `cd`, and why nothing here can stop the
-   * next one that does. What changed is that the value is read *once* and
-   * *recorded*: a substituted tree now shows up in the receipt as a directory
-   * and a HEAD that are not the ones under review, where before it was silent.
-   * Detection, not prevention. Refusing a probe tree that does not contain the
-   * work is the prevention, and it needs to know which commit a node claims —
-   * #579 named it and left it out of scope.
+   * The default is the *invocation* cwd, not the process's ({@link invocationCwd}).
+   * #579 read `process.cwd()` here and called a `cd`-ing launcher an unfixable
+   * limit — "nothing here can stop the next one that does" — and #662 was that
+   * next one: arc regenerates its shim with a `cd` into the install tree, so
+   * every arc install silently reintroduced #579 no matter what a hand-edited
+   * launcher did. The premise was wrong rather than the reasoning. A shim that
+   * `cd`s exports where it came from first, and soma already read that value on
+   * another path (#315); reading it here is the difference between detecting a
+   * substituted tree in the receipt and never substituting one.
+   *
+   * What stays true: a launcher that `cd`s *without* exporting the caller's
+   * directory still moves this, and nothing here can tell. That case is still
+   * detection-only — the value is read once and recorded, so the substituted
+   * tree shows up in the receipt as a directory and a HEAD that are not the ones
+   * under review. Refusing a probe tree that does not contain the work is the
+   * prevention, and it needs to know which commit a node claims — #579 named it
+   * and left it out of scope.
    */
   probeCwd: () => string;
   /**
@@ -725,7 +733,7 @@ function defaultDeps(): GraphCliDeps {
         platform: process.platform,
         now: () => new Date(),
       }),
-    probeCwd: () => resolve(process.cwd()),
+    probeCwd: () => invocationCwd(),
     describeProbeTree: defaultDescribeProbeTree,
     readTextFile: async (path) => await Bun.file(path).text(),
     describeTool: defaultDescribeTool,

--- a/src/cli/substrate-lifecycle.ts
+++ b/src/cli/substrate-lifecycle.ts
@@ -38,6 +38,7 @@ import {
 import type { ClaudeCodeInstallOptions } from "../adapters/claude-code/install-options";
 import { projectVsaSkillBundleFiles } from "../vsa-skill-installer";
 import { defaultSubstrateHome, installSpecFor } from "../install-spec-registry";
+import { invocationCwd } from "../path-utils";
 import { loadSomaHome } from "../soma-home";
 import { scanRegistrySkills, type UnprojectableRegistrySkill } from "../skill-projection";
 import type {
@@ -673,12 +674,11 @@ function resolveAbsolute(path: string): string {
   if (path.startsWith("/")) return path;
   // soma#315: when soma is launched through an arc-generated shim, the
   // shim `cd`s into the repo before exec, so process.cwd() is the repo
-  // root — not the directory the user ran `soma export` from. The shim
-  // exports the caller's directory as ARC_INVOCATION_CWD; resolve a
-  // relative --out against it, falling back to process.cwd() for direct
-  // (non-shim) invocations.
-  const base = process.env.ARC_INVOCATION_CWD ?? process.cwd();
-  return resolveJoin(base, path);
+  // root — not the directory the user ran `soma export` from. The rule
+  // for recovering the caller's directory lives in {@link invocationCwd},
+  // shared with `soma graph close`'s probe base since #662 — one
+  // expression, so the two cannot drift apart.
+  return resolveJoin(invocationCwd(), path);
 }
 
 async function writeProjectionExportFile(

--- a/src/path-utils.ts
+++ b/src/path-utils.ts
@@ -1,3 +1,4 @@
+import { statSync } from "node:fs";
 import { isAbsolute, relative, resolve } from "node:path";
 
 export function isInsidePath(path: string, root: string): boolean {
@@ -12,30 +13,54 @@ export function isInsidePath(path: string, root: string): boolean {
  * An arc-generated launcher shim `cd`s into the install tree before `exec`, so
  * inside the process `process.cwd()` is soma's own checkout rather than the
  * caller's directory. The shim exports the caller's directory as
- * `ARC_INVOCATION_CWD` before that `cd`, and it is the only value left that
- * still knows where the operator actually stood.
+ * `ARC_INVOCATION_CWD` before that `cd`.
  *
  * **One expression, two callers**, and deliberately so. `soma export --out`
  * learned this in [#315](https://github.com/the-metafactory/soma/issues/315);
  * `soma graph close`'s probe base never did, so under an arc install every
  * declared probe resolved against the install tree and a close receipt named a
  * checkout the operator had never opened
- * ([#662](https://github.com/the-metafactory/soma/issues/662)) — including a
- * `git cat-file` that reported an artifact "absent" while it sat in the tree the
- * close was run from. Two `??` expressions of one rule is the shape #579 already
- * cost this module once, so the rule lives here and both callers read it.
+ * ([#662](https://github.com/the-metafactory/soma/issues/662)). Two `??`
+ * expressions of one rule is the shape #579 already cost this module once.
  *
- * **Only an absolute value is trusted.** A relative or empty `ARC_INVOCATION_CWD`
+ * **What this value actually states, and what it does not.** arc's generator
+ * writes `export ARC_INVOCATION_CWD="${ARC_INVOCATION_CWD:-$(pwd)}"` — the `:-`
+ * deliberately preserves an outer value so that nested arc CLIs agree on one
+ * directory. So it names where the **outermost** arc caller stood, not where
+ * *this* process was invoked. An arc-launched tool that starts in one repo,
+ * `cd`s to another and runs `soma graph close` there gets the first repo's tree:
+ * #662 one level up. That is a real residual limit, and it is sharper than it
+ * looks, because for the three ungated probes this same value is the containment
+ * boundary — so under nesting a probe may be confined to a tree that is not the
+ * one being closed. Detection still holds (the receipt names the directory and
+ * its HEAD, so a substituted tree is visible rather than silent); prevention does
+ * not. Fixing it needs a way for the caller to state the tree per invocation,
+ * which is a feature and tracked separately.
+ *
+ * **Only an absolute, existing directory is trusted.** A relative or empty value
  * would resolve against `process.cwd()` — the very directory the shim moved —
  * producing a third location that is neither the caller's nor the install tree's.
- * Falling back is the honest answer: the variable is a launcher's statement of
- * where it was called from, and a relative one is not one.
+ * A value naming something that is not a directory is not a statement of where
+ * anyone stood either, and under an arc install the base used to be pinned while
+ * this makes it environment-settable, so it gets a floor rather than the benefit
+ * of the doubt (#662 review m2). Note what the floor does *not* do: `/` is an
+ * existing directory and still passes, exactly as `cd / && soma graph close`
+ * always could. This closes a new way in, not an old one.
  *
  * @param env Environment to read. Injected so a test can state the launcher's
  *   half of the contract without mutating the process's own.
  */
 export function invocationCwd(env: Readonly<Record<string, string | undefined>> = process.env): string {
   const declared = env.ARC_INVOCATION_CWD;
-  if (declared !== undefined && isAbsolute(declared)) return resolve(declared);
+  if (declared !== undefined && isAbsolute(declared) && isDirectory(declared)) return resolve(declared);
   return resolve(process.cwd());
+}
+
+/** Best-effort: an unreadable or missing path is simply not a directory we will resolve against. */
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
 }

--- a/src/path-utils.ts
+++ b/src/path-utils.ts
@@ -1,6 +1,41 @@
-import { isAbsolute, relative } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 
 export function isInsidePath(path: string, root: string): boolean {
   const rel = relative(root, path);
   return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+/**
+ * The directory the operator ran soma *from* — which is not always
+ * `process.cwd()`.
+ *
+ * An arc-generated launcher shim `cd`s into the install tree before `exec`, so
+ * inside the process `process.cwd()` is soma's own checkout rather than the
+ * caller's directory. The shim exports the caller's directory as
+ * `ARC_INVOCATION_CWD` before that `cd`, and it is the only value left that
+ * still knows where the operator actually stood.
+ *
+ * **One expression, two callers**, and deliberately so. `soma export --out`
+ * learned this in [#315](https://github.com/the-metafactory/soma/issues/315);
+ * `soma graph close`'s probe base never did, so under an arc install every
+ * declared probe resolved against the install tree and a close receipt named a
+ * checkout the operator had never opened
+ * ([#662](https://github.com/the-metafactory/soma/issues/662)) — including a
+ * `git cat-file` that reported an artifact "absent" while it sat in the tree the
+ * close was run from. Two `??` expressions of one rule is the shape #579 already
+ * cost this module once, so the rule lives here and both callers read it.
+ *
+ * **Only an absolute value is trusted.** A relative or empty `ARC_INVOCATION_CWD`
+ * would resolve against `process.cwd()` — the very directory the shim moved —
+ * producing a third location that is neither the caller's nor the install tree's.
+ * Falling back is the honest answer: the variable is a launcher's statement of
+ * where it was called from, and a relative one is not one.
+ *
+ * @param env Environment to read. Injected so a test can state the launcher's
+ *   half of the contract without mutating the process's own.
+ */
+export function invocationCwd(env: Readonly<Record<string, string | undefined>> = process.env): string {
+  const declared = env.ARC_INVOCATION_CWD;
+  if (declared !== undefined && isAbsolute(declared)) return resolve(declared);
+  return resolve(process.cwd());
 }

--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -314,23 +314,48 @@ async function runGit(
 }
 
 /**
+ * The one shape a "could not look" reads as, so the three git probes cannot
+ * describe the same condition three ways.
+ *
+ * Both echoed values are **published**: an `observed` string rides the close
+ * receipt onto a tracker whose visibility soma cannot know. So the directory is
+ * home-collapsed for the reason {@link authorizeProbeTree} already collapses its
+ * refusal paths — the account name is the one part that does not help a reader
+ * tell one checkout from another — and git's own stderr is collapsed *as well as*
+ * bounded. The stderr needs it more than the directory does: a directory whose
+ * `.git` is a gitfile makes git name the path it was redirected to, which is not
+ * the containment-checked tree and can sit anywhere on the machine
+ * (`fatal: not a git repository: /Users/<account>/…/.git`, reproduced on git
+ * 2.40.0). Containment bounds where a probe *reads*; it does not bound what git
+ * *says about* the read, and those are different questions.
+ */
+function unreachable(cwd: string, target: string, reason: string, detail = ""): string {
+  const shown = detail.length === 0 ? "" : `: ${collapseHome(boundObserved(detail))}`;
+  return `could not reach ${target} in ${collapseHome(cwd)} — ${reason}${shown}`;
+}
+
+/**
  * Did this git command actually *answer the question*, or could it not look?
  *
- * Git plumbing says "no" with exit 1 and "I could not look" with 128, and before
- * #662 the runner collapsed the two: `git cat-file -e HEAD:docs/x.md` in a
- * directory that is not a repository exits 128, and the receipt read
- * `docs/x.md absent at HEAD` — sending an operator to hunt for a file that was
- * sitting, present, in the tree they ran the close from. The probe base being
- * wrong is a *different defect* from the artifact being missing, and a receipt
- * that cannot tell them apart makes the first one unfindable.
+ * **Only for argv whose 1-vs-128 boundary is clean**, which is the correction
+ * #662's first fix needed. Two of git's plumbing commands answer "no" with exit
+ * 1 and report "I could not look" with 128, verified on 2.40.0:
  *
- * **The exit code, not the stderr text.** Git's messages are localizable and
- * have been reworded across versions; the 0/1-answered, everything-else-failed
- * contract has not. Matching on "not a git repository" would be a probe that
- * passes in English and misreports in German.
+ * - `rev-parse --verify --quiet <ref>^{commit}` — 1 for an unknown ref in a valid
+ *   repository, 128 for a non-repository.
+ * - `merge-base --is-ancestor` — 1 for a genuine non-ancestor, 128 for a bad
+ *   object.
  *
- * A timeout is unreachable too — a killed spawn reports `exitCode: null`, which
- * would otherwise render as a confident "absent" for a question nobody asked.
+ * `cat-file -e <ref>:<path>` does **not** belong here and calling it through this
+ * predicate is a defect: object-name syntax makes a genuinely missing path a
+ * *fatal*, so a plainly absent file exits 128 exactly like a missing tree does.
+ * That branch establishes reachability with a separate `rev-parse` first — see
+ * the `artifact-exists` case.
+ *
+ * **The exit code, not the stderr text.** Git's messages are localizable and have
+ * been reworded across versions; the exit-code contract has not. Matching on
+ * "not a git repository" would be a probe that passes in English and misreports
+ * in German.
  *
  * Still a **fail** either way (§2.2's fail-closed rule): this changes what the
  * receipt *says*, never what the close gate *does*. A new outcome would mean a
@@ -338,14 +363,25 @@ async function runGit(
  * a pass than "not there" is.
  */
 function gitUnreachable(outcome: CommandOutcome, cwd: string, target: string): string | undefined {
-  if (!outcome.timedOut && (outcome.exitCode === 0 || outcome.exitCode === 1)) return undefined;
-  const reason = outcome.timedOut ? "git timed out (killed)" : `git exited ${outcome.exitCode}`;
-  // The stderr tail carries the actual reason (`fatal: not a git repository`,
-  // `fatal: bad object`), and it is safe to echo *here specifically*: the three
-  // git probes are containment-checked before dispatch, so this directory is
-  // already inside the stated probe tree and already named on the line above.
-  const detail = boundObserved(outcome.stderr.trim().length > 0 ? outcome.stderr : outcome.stdout);
-  return `could not reach ${target} in ${cwd} — ${reason}${detail.length === 0 ? "" : `: ${detail}`}`;
+  const killed = gitTimedOut(outcome, cwd, target);
+  if (killed !== undefined) return killed;
+  if (outcome.exitCode === 0 || outcome.exitCode === 1) return undefined;
+  return unreachable(cwd, target, `git exited ${outcome.exitCode}`, outcome.stderr.trim().length > 0 ? outcome.stderr : outcome.stdout);
+}
+
+/**
+ * The timeout arm of {@link gitUnreachable}, on its own.
+ *
+ * A killed spawn reports `exitCode: null`, and every git branch has to rule that
+ * out before reading an exit code as an answer — otherwise a probe the deadline
+ * killed renders as a confident "absent" for a question git never got to. The
+ * `artifact-exists` branch needs *only* this half, because once its ref has been
+ * shown to resolve, every remaining non-zero exit is the path's answer rather
+ * than the tree's. Split rather than forced out of the wider helper with a
+ * non-null assertion: the narrower question has a narrower predicate.
+ */
+function gitTimedOut(outcome: CommandOutcome, cwd: string, target: string): string | undefined {
+  return outcome.timedOut ? unreachable(cwd, target, "git timed out (killed)") : undefined;
 }
 
 /**
@@ -601,7 +637,7 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions): Promi
         if (unreachable !== undefined) return finish("fail", unreachable);
         const sha = outcome.stdout.trim();
         const passed = outcome.exitCode === 0 && sha.length > 0;
-        return finish(passed ? "pass" : "fail", passed ? `${probe.ref} → ${sha}` : `${probe.ref} does not resolve in ${resolvedCwd}`);
+        return finish(passed ? "pass" : "fail", passed ? `${probe.ref} → ${sha}` : `${probe.ref} does not resolve in ${collapseHome(resolvedCwd)}`);
       }
 
       case "git-merged-into": {
@@ -610,7 +646,7 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions): Promi
         if (refUnreachable !== undefined) return finish("fail", refUnreachable);
         const sha = resolvedRef.stdout.trim();
         if (resolvedRef.exitCode !== 0 || sha.length === 0) {
-          return finish("fail", `${probe.ref} does not resolve in ${resolvedCwd}`);
+          return finish("fail", `${probe.ref} does not resolve in ${collapseHome(resolvedCwd)}`);
         }
         const ancestor = await runGit(deps, resolvedCwd, ["merge-base", "--is-ancestor", probe.ref, probe.into], options.remainingSec);
         // Checked on `into` as well as on `ref`: `merge-base --is-ancestor` exits
@@ -627,13 +663,39 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions): Promi
           // Same expression the containment check used — see {@link artifactFilePath}.
           const full = artifactFilePath(probe.path, resolvedCwd);
           const passed = deps.pathExists(full);
-          return finish(passed ? "pass" : "fail", `${full} ${passed ? "exists" : "is absent"}`);
+          // Home-collapsed like every other published path in this switch (#662
+          // review m1). `full` itself stays absolute — it is what `pathExists`
+          // was handed, and a display convention must not become a comparison
+          // one, which is the rule {@link collapseHome} already states.
+          return finish(passed ? "pass" : "fail", `${collapseHome(full)} ${passed ? "exists" : "is absent"}`);
         }
+        // Two commands, and the first one is the whole point. `cat-file -e` reads
+        // *object-name syntax*, where a missing path is a fatal rather than a
+        // "no": on git 2.40.0 an absent `docs/x.md` at a perfectly valid HEAD
+        // exits 128, byte-identical in exit code to a directory that is not a
+        // repository at all. So this branch cannot ask `cat-file` whether the
+        // tree was reachable — the answer is the same either way, and reading it
+        // as reachability makes every genuine absence claim the repo could not be
+        // reached (#662 review B1: the first fix had this inverted, and it shipped
+        // green because the tests asserted an exit code real git never returns
+        // for this argv).
+        //
+        // `rev-parse --verify --quiet <ref>^{object}` *does* have the clean
+        // boundary — 0 resolved, 1 unknown ref in a valid repo, 128 no repo — so
+        // reachability is established there, and after it every non-zero from
+        // `cat-file` is the path's answer rather than the tree's. Costs one extra
+        // spawn on this branch; a published attestation that states a falsehood
+        // costs more.
+        const ref = await runGit(deps, resolvedCwd, ["rev-parse", "--verify", "--quiet", `${probe.atRef}^{object}`], options.remainingSec);
+        const treeUnreachable = gitUnreachable(ref, resolvedCwd, probe.atRef);
+        if (treeUnreachable !== undefined) return finish("fail", treeUnreachable);
+        if (ref.exitCode !== 0) return finish("fail", `${probe.atRef} does not resolve in ${collapseHome(resolvedCwd)}`);
+
         const outcome = await runGit(deps, resolvedCwd, ["cat-file", "-e", `${probe.atRef}:${probe.path}`], options.remainingSec);
-        // #662's reported symptom lives on this line: the probe base was the
-        // install tree, `cat-file` exited 128, and the receipt said `absent`.
-        const unreachable = gitUnreachable(outcome, resolvedCwd, probe.atRef);
-        if (unreachable !== undefined) return finish("fail", unreachable);
+        // The ref resolved, so the only thing left that is not the path's answer
+        // is the deadline killing the spawn.
+        const killed = gitTimedOut(outcome, resolvedCwd, probe.atRef);
+        if (killed !== undefined) return finish("fail", killed);
         const passed = outcome.exitCode === 0;
         return finish(passed ? "pass" : "fail", `${probe.path} ${passed ? "present" : "absent"} at ${probe.atRef}`);
       }

--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -744,6 +744,17 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions): Promi
     }
   } catch (error) {
     // Fail-closed: an unrunnable probe is a failed probe, never a skipped one.
+    //
+    // Unredacted, and checked rather than assumed (#662 review): this publishes a
+    // thrown message, and every way `runSpawned` throws names the *binary*, never
+    // a path from the environment — measured on Bun 1.3.6:
+    //   `Executable not found in $PATH: "definitely-not-a-real-binary-xyz"`
+    //   `ENOENT: no such file or directory, posix_spawn '/no/such/dir/git'`
+    // A cwd that does not exist throws the third form, naming `git` and not the
+    // cwd, so even a probe directory under `$HOME` discloses nothing here. If a
+    // future runtime starts echoing the cwd, this line needs {@link redactHome}
+    // — it is a publication site like the others, currently harmless by accident
+    // of the message format rather than by construction.
     return finish("fail", `probe runner error: ${error instanceof Error ? error.message : String(error)}`);
   }
 }

--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -314,6 +314,41 @@ async function runGit(
 }
 
 /**
+ * Did this git command actually *answer the question*, or could it not look?
+ *
+ * Git plumbing says "no" with exit 1 and "I could not look" with 128, and before
+ * #662 the runner collapsed the two: `git cat-file -e HEAD:docs/x.md` in a
+ * directory that is not a repository exits 128, and the receipt read
+ * `docs/x.md absent at HEAD` — sending an operator to hunt for a file that was
+ * sitting, present, in the tree they ran the close from. The probe base being
+ * wrong is a *different defect* from the artifact being missing, and a receipt
+ * that cannot tell them apart makes the first one unfindable.
+ *
+ * **The exit code, not the stderr text.** Git's messages are localizable and
+ * have been reworded across versions; the 0/1-answered, everything-else-failed
+ * contract has not. Matching on "not a git repository" would be a probe that
+ * passes in English and misreports in German.
+ *
+ * A timeout is unreachable too — a killed spawn reports `exitCode: null`, which
+ * would otherwise render as a confident "absent" for a question nobody asked.
+ *
+ * Still a **fail** either way (§2.2's fail-closed rule): this changes what the
+ * receipt *says*, never what the close gate *does*. A new outcome would mean a
+ * new branch in {@link assertClosable}, and "could not reach the tree" is no more
+ * a pass than "not there" is.
+ */
+function gitUnreachable(outcome: CommandOutcome, cwd: string, target: string): string | undefined {
+  if (!outcome.timedOut && (outcome.exitCode === 0 || outcome.exitCode === 1)) return undefined;
+  const reason = outcome.timedOut ? "git timed out (killed)" : `git exited ${outcome.exitCode}`;
+  // The stderr tail carries the actual reason (`fatal: not a git repository`,
+  // `fatal: bad object`), and it is safe to echo *here specifically*: the three
+  // git probes are containment-checked before dispatch, so this directory is
+  // already inside the stated probe tree and already named on the line above.
+  const detail = boundObserved(outcome.stderr.trim().length > 0 ? outcome.stderr : outcome.stdout);
+  return `could not reach ${target} in ${cwd} — ${reason}${detail.length === 0 ? "" : `: ${detail}`}`;
+}
+
+/**
  * `repo` on the git/artifact probes is a **local working tree path**, defaulting
  * to the runner's cwd — the reading `artifact-exists`'s `path` + `atRef` pair
  * forces (`git cat-file -e <atRef>:<path>` needs a checkout, not an API).
@@ -562,6 +597,8 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions): Promi
 
       case "git-ref-exists": {
         const outcome = await runGit(deps, resolvedCwd, ["rev-parse", "--verify", "--quiet", `${probe.ref}^{commit}`], options.remainingSec);
+        const unreachable = gitUnreachable(outcome, resolvedCwd, probe.ref);
+        if (unreachable !== undefined) return finish("fail", unreachable);
         const sha = outcome.stdout.trim();
         const passed = outcome.exitCode === 0 && sha.length > 0;
         return finish(passed ? "pass" : "fail", passed ? `${probe.ref} → ${sha}` : `${probe.ref} does not resolve in ${resolvedCwd}`);
@@ -569,11 +606,18 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions): Promi
 
       case "git-merged-into": {
         const resolvedRef = await runGit(deps, resolvedCwd, ["rev-parse", "--verify", "--quiet", `${probe.ref}^{commit}`], options.remainingSec);
+        const refUnreachable = gitUnreachable(resolvedRef, resolvedCwd, probe.ref);
+        if (refUnreachable !== undefined) return finish("fail", refUnreachable);
         const sha = resolvedRef.stdout.trim();
         if (resolvedRef.exitCode !== 0 || sha.length === 0) {
           return finish("fail", `${probe.ref} does not resolve in ${resolvedCwd}`);
         }
         const ancestor = await runGit(deps, resolvedCwd, ["merge-base", "--is-ancestor", probe.ref, probe.into], options.remainingSec);
+        // Checked on `into` as well as on `ref`: `merge-base --is-ancestor` exits
+        // 128 for an `into` that does not resolve, and "is not an ancestor of
+        // main" is a plausible-sounding way to say "there is no main here".
+        const intoUnreachable = gitUnreachable(ancestor, resolvedCwd, probe.into);
+        if (intoUnreachable !== undefined) return finish("fail", intoUnreachable);
         const passed = ancestor.exitCode === 0;
         return finish(passed ? "pass" : "fail", `${probe.ref} (${sha}) ${passed ? "is" : "is not"} an ancestor of ${probe.into}`);
       }
@@ -586,6 +630,10 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions): Promi
           return finish(passed ? "pass" : "fail", `${full} ${passed ? "exists" : "is absent"}`);
         }
         const outcome = await runGit(deps, resolvedCwd, ["cat-file", "-e", `${probe.atRef}:${probe.path}`], options.remainingSec);
+        // #662's reported symptom lives on this line: the probe base was the
+        // install tree, `cat-file` exited 128, and the receipt said `absent`.
+        const unreachable = gitUnreachable(outcome, resolvedCwd, probe.atRef);
+        if (unreachable !== undefined) return finish("fail", unreachable);
         const passed = outcome.exitCode === 0;
         return finish(passed ? "pass" : "fail", `${probe.path} ${passed ? "present" : "absent"} at ${probe.atRef}`);
       }

--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -33,7 +33,7 @@ import {
   type ProbeAuthorization,
   type ProbeRegistry,
 } from "./work-graph-probe-registry";
-import { collapseHome, type Probe, type ProbeResult } from "./work-graph";
+import { collapseHome, redactHome, type Probe, type ProbeResult } from "./work-graph";
 
 /**
  * How much of a *failing* command's output survives into the receipt (§2.2: a
@@ -318,19 +318,24 @@ async function runGit(
  * describe the same condition three ways.
  *
  * Both echoed values are **published**: an `observed` string rides the close
- * receipt onto a tracker whose visibility soma cannot know. So the directory is
- * home-collapsed for the reason {@link authorizeProbeTree} already collapses its
- * refusal paths — the account name is the one part that does not help a reader
- * tell one checkout from another — and git's own stderr is collapsed *as well as*
- * bounded. The stderr needs it more than the directory does: a directory whose
- * `.git` is a gitfile makes git name the path it was redirected to, which is not
- * the containment-checked tree and can sit anywhere on the machine
+ * receipt onto a tracker whose visibility soma cannot know. The account name is
+ * the one part of a path that does not help a reader tell one checkout from
+ * another, so it goes — but the two halves need *different* functions, which is
+ * the correction #662 review B2 made.
+ *
+ * The directory is a bare path, so {@link collapseHome} is exactly its contract.
+ * Git's stderr is a **sentence with a path inside it**, where `collapseHome` is
+ * prefix-only and therefore inert — measured, not assumed. It needs
+ * {@link redactHome}, which replaces home wherever it appears. The stderr needs
+ * it more than the directory does: a directory whose `.git` is a gitfile makes
+ * git name the path it was *redirected to*, which is not the containment-checked
+ * tree and can sit anywhere on the machine
  * (`fatal: not a git repository: /Users/<account>/…/.git`, reproduced on git
  * 2.40.0). Containment bounds where a probe *reads*; it does not bound what git
  * *says about* the read, and those are different questions.
  */
 function unreachable(cwd: string, target: string, reason: string, detail = ""): string {
-  const shown = detail.length === 0 ? "" : `: ${collapseHome(boundObserved(detail))}`;
+  const shown = detail.length === 0 ? "" : `: ${redactHome(boundObserved(detail))}`;
   return `could not reach ${target} in ${collapseHome(cwd)} — ${reason}${shown}`;
 }
 

--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -335,9 +335,23 @@ async function runGit(
  * *says about* the read, and those are different questions.
  */
 function unreachable(cwd: string, target: string, reason: string, detail = ""): string {
-  const shown = detail.length === 0 ? "" : `: ${redactHome(boundObserved(detail))}`;
+  // Redact **then** bound, never the reverse (#662 review n1). The tail cut can
+  // land *inside* a home path, severing `/Users/` from `s/fischer/.ssh/…` — after
+  // which the prefix no longer matches and the account name survives redaction.
+  // Measured on a constructed boundary case, so this order is load-bearing rather
+  // than stylistic. Strictly better on content too: `~` is shorter than the path
+  // it replaces, so more of the message fits under the same bound.
+  const shown = detail.length === 0 ? "" : `: ${boundObserved(redactHome(detail))}`;
   return `could not reach ${target} in ${collapseHome(cwd)} — ${reason}${shown}`;
 }
+
+/**
+ * The exit codes `cat-file -e` uses to *answer*, measured on git 2.40.0: 0 for a
+ * resolvable object, 128 for a missing path in object-name form, and 1 for a raw
+ * sha that is not present. Every other code — a signal kill's 137/139 included —
+ * means the question went unanswered (#662 review mm1).
+ */
+const CAT_FILE_ANSWERS: ReadonlySet<number> = new Set([0, 1, 128]);
 
 /**
  * Did this git command actually *answer the question*, or could it not look?
@@ -687,20 +701,43 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions): Promi
         //
         // `rev-parse --verify --quiet <ref>^{object}` *does* have the clean
         // boundary — 0 resolved, 1 unknown ref in a valid repo, 128 no repo — so
-        // reachability is established there, and after it every non-zero from
-        // `cat-file` is the path's answer rather than the tree's. Costs one extra
-        // spawn on this branch; a published attestation that states a falsehood
-        // costs more.
+        // reachability is established there.
         const ref = await runGit(deps, resolvedCwd, ["rev-parse", "--verify", "--quiet", `${probe.atRef}^{object}`], options.remainingSec);
         const treeUnreachable = gitUnreachable(ref, resolvedCwd, probe.atRef);
         if (treeUnreachable !== undefined) return finish("fail", treeUnreachable);
-        if (ref.exitCode !== 0) return finish("fail", `${probe.atRef} does not resolve in ${collapseHome(resolvedCwd)}`);
+        const sha = ref.stdout.trim();
+        if (ref.exitCode !== 0 || sha.length === 0) {
+          return finish("fail", `${probe.atRef} does not resolve in ${collapseHome(resolvedCwd)}`);
+        }
 
-        const outcome = await runGit(deps, resolvedCwd, ["cat-file", "-e", `${probe.atRef}:${probe.path}`], options.remainingSec);
-        // The ref resolved, so the only thing left that is not the path's answer
-        // is the deadline killing the spawn.
-        const killed = gitTimedOut(outcome, resolvedCwd, probe.atRef);
-        if (killed !== undefined) return finish("fail", killed);
+        // The lookup is bound to the **sha** `rev-parse` just printed, not to the
+        // ref name a second time. `rev-parse` already paid for the resolution, so
+        // this is free — and resolving one ref twice and trusting the answers to
+        // match is the two-equivalent-expressions shape this module refuses
+        // everywhere else ({@link probeDirectory}, {@link artifactFilePath}, the
+        // single `ranIn`). Verified equivalent to `<ref>:<path>` across every
+        // shape `^{object}` accepts — branch, lightweight tag, annotated tag,
+        // a tag pointing at a tree, and a bare tree-ish — for present and absent
+        // paths alike; git peels the tag object in `<object>:<path>` form.
+        // The message still names `probe.atRef`: the binding is an implementation
+        // guarantee, not something to make a reader decode a sha for.
+        const outcome = await runGit(deps, resolvedCwd, ["cat-file", "-e", `${sha}:${probe.path}`], options.remainingSec);
+
+        // The object resolved, so a *lookup answer* is 0 (present), or 1/128
+        // (absent — 128 is the object-name form, 1 the raw-sha form; both
+        // measured). Anything else did not answer, and `timedOut` is not the only
+        // way that happens: a child killed by an external signal reports a
+        // NUMBER — 137 for SIGKILL, 139 for SIGSEGV — which would sail through a
+        // null check into `passed = false` and publish a confident "absent"
+        // (#662 review mm1). That is B1's class re-opened one notch down, and it
+        // is exactly what an OOM killer or a cgroup limit produces on a loaded
+        // box. An allowlist rather than a denylist: a code this argv is not known
+        // to return is a code we cannot interpret, and fail-closed means saying
+        // so rather than guessing.
+        if (outcome.timedOut || !CAT_FILE_ANSWERS.has(outcome.exitCode ?? -1)) {
+          const reason = outcome.timedOut ? "git timed out (killed)" : `git exited ${outcome.exitCode}`;
+          return finish("fail", unreachable(resolvedCwd, probe.atRef, reason, outcome.stderr.trim().length > 0 ? outcome.stderr : outcome.stdout));
+        }
         const passed = outcome.exitCode === 0;
         return finish(passed ? "pass" : "fail", `${probe.path} ${passed ? "present" : "absent"} at ${probe.atRef}`);
       }

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -468,6 +468,13 @@ export function collapseHome(dir: string, home: string | undefined = process.env
  * whitespace, and the punctuation git wraps paths in. Anything else after the
  * home prefix is treated as *continuing a directory name*, so `/Users/fischer`
  * is not redacted out of `/Users/fischerson/x`.
+ *
+ * **`.` `!` and `?` are omitted deliberately** (#662 review n2), even though a
+ * sentence can end `…: /Users/me.` — they are legal in a directory name, and
+ * adding `.` would rewrite `/Users/me.bak/x` to `~bak/x`: a different directory,
+ * silently corrupted, to redact an account name that a trailing separator already
+ * covers in every real message. Under-redacting a bare home at the end of a
+ * sentence is recoverable; corrupting a path a reader is trying to act on is not.
  */
 const PATH_TOKEN_DELIMITERS = new Set(["'", '"', "`", " ", "\t", "\n", "\r", ":", ",", ";", ")", "]", "}", ">", "<"]);
 

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -464,6 +464,78 @@ export function collapseHome(dir: string, home: string | undefined = process.env
 }
 
 /**
+ * Characters that end a path token in the kind of text this redacts — quotes,
+ * whitespace, and the punctuation git wraps paths in. Anything else after the
+ * home prefix is treated as *continuing a directory name*, so `/Users/fischer`
+ * is not redacted out of `/Users/fischerson/x`.
+ */
+const PATH_TOKEN_DELIMITERS = new Set(["'", '"', "`", " ", "\t", "\n", "\r", ":", ",", ";", ")", "]", "}", ">", "<"]);
+
+/**
+ * {@link collapseHome}'s sibling, for text that *contains* paths rather than text
+ * that *is* one.
+ *
+ * `collapseHome` is prefix-only — it asks whether the whole string starts at
+ * home — which is exactly right for a `ProbeTree.dir` and inert on a sentence.
+ * Measured, because assuming otherwise is what made this a second finding
+ * (#662 review B2):
+ *
+ * ```
+ * collapseHome("/Users/me/secret/.git")                              → "~/secret/.git"
+ * collapseHome("fatal: not a git repository: /Users/me/secret/.git") → unchanged
+ * ```
+ *
+ * Subprocess output is the second shape, and git reaches paths containment never
+ * bounded: a `.git` *gitfile* redirects it anywhere on the machine, so
+ * `fatal: not a git repository: /Users/<account>/…/.git` is a published receipt
+ * naming a directory no probe was ever allowed to read. Hence a separate
+ * function rather than widening the first: `collapseHome` has callers whose
+ * contract is a bare path, and a global replace would change what they publish
+ * (`/Users/me/x/Users/me/y` collapses at the front but redacts twice).
+ *
+ * **No regex, deliberately.** A home directory is a *filesystem* string and may
+ * hold regex metacharacters; building a pattern from it means an escaping bug
+ * either corrupts the output or silently stops redacting, and a redaction that
+ * fails open is worse than none because the call site looks handled. Literal
+ * scanning cannot have that bug at all — the hazard is removed rather than
+ * managed.
+ *
+ * Separator-agnostic for the reason `collapseHome` argues: the runner has a
+ * `win32` branch, so both spellings of home are redacted.
+ *
+ * **Published text only.** Every value the runner *compares* — containment
+ * bases, resolved probe directories — stays absolute. A display convention must
+ * not become a comparison one.
+ */
+export function redactHome(text: string, home: string | undefined = process.env.HOME): string {
+  if (home === undefined || home.length === 0) return text;
+  const trimmed = home.replace(/[/\\]+$/u, "");
+  if (trimmed.length === 0) return text;
+  const spellings = new Set([trimmed, trimmed.replace(/\//gu, "\\"), trimmed.replace(/\\/gu, "/")]);
+  let out = text;
+  for (const spelling of spellings) out = redactAll(out, spelling);
+  return out;
+}
+
+/** Every boundaried occurrence of one home spelling, replaced by `~`. */
+function redactAll(text: string, root: string): string {
+  let out = "";
+  let from = 0;
+  for (;;) {
+    const at = text.indexOf(root, from);
+    if (at === -1) return out + text.slice(from);
+    const after = at + root.length;
+    // End-of-string tested by length rather than an `undefined` compare: without
+    // `noUncheckedIndexedAccess` the index signature claims `string`, so the
+    // compare reads as impossible to the linter while being live at runtime.
+    const next = after >= text.length ? "" : text.slice(after, after + 1);
+    const boundary = next === "" || next === "/" || next === "\\" || PATH_TOKEN_DELIMITERS.has(next);
+    out += text.slice(from, at) + (boundary ? "~" : root);
+    from = after;
+  }
+}
+
+/**
  * The store seam (§2.5): pure I/O, no contract logic. The tracker is the *sole*
  * authoritative store for topology, claims, and status; soma-home holds at most
  * a disposable derived cache and `nodeId` references, and no sync contract

--- a/src/work-graph.ts
+++ b/src/work-graph.ts
@@ -513,6 +513,25 @@ const PATH_TOKEN_DELIMITERS = new Set(["'", '"', "`", " ", "\t", "\n", "\r", ":"
  * **Published text only.** Every value the runner *compares* — containment
  * bases, resolved probe directories — stays absolute. A display convention must
  * not become a comparison one.
+ *
+ * **The input is not pre-bounded.** Its caller in `work-graph-probes.ts` redacts
+ * *before* applying the tail bound, deliberately — a cut landing inside a home
+ * path severs the prefix and defeats redaction (#662 review n1) — so this is
+ * handed raw subprocess output of whatever size the child produced. That is safe
+ * because the scan is linear: `out +=` totals one copy of the input and `from`
+ * advances by at least `root.length` each iteration. Measured, best-of-7 across
+ * doublings on a dense worst case (a hit every ~17 chars): 1.7M chars 4.5ms,
+ * 3.4M 7.9ms, 6.8M 15.1ms, 13.6M 35.8ms — ratios 1.75x/1.93x/2.37x, the drift at
+ * the top being GC on the accumulating result rather than super-linear scanning.
+ * Anyone changing this algorithm should keep that property, because the bound no
+ * longer protects it.
+ *
+ * **Known limitation: matching is case-sensitive**, inherited from
+ * {@link collapseHome} and not introduced here — on a case-insensitive
+ * filesystem `/users/me/x` names the same directory as `/Users/me/x` and is not
+ * redacted. Deliberately left: a case-insensitive match has its own corruption
+ * risk on case-sensitive filesystems, where those genuinely are different
+ * directories, so it belongs in its own change rather than #662's.
  */
 export function redactHome(text: string, home: string | undefined = process.env.HOME): string {
   if (home === undefined || home.length === 0) return text;

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -16,10 +16,11 @@ import { parseRepoFromRemote } from "../src/work-graph-bridge";
 // Receipt-rendering helpers are deliberately not on the public barrel (sage on
 // #584): they are internals of `renderCloseReceipt`, so the test reaches for
 // them where they live.
-import { describeProbeTree } from "../src/work-graph";
+import { collapseHome, describeProbeTree } from "../src/work-graph";
 import {
   WorkGraphError,
   renderCloseReceipt,
+  runProbe,
   runProbes,
   scanCommentsForReceipt,
   type ClaimResult,
@@ -1750,6 +1751,51 @@ test("the same close, run from a directory that is not a repository, says so ins
   } finally {
     if (previous === undefined) delete process.env.ARC_INVOCATION_CWD;
     else process.env.ARC_INVOCATION_CWD = previous;
+    await rm(notARepo, { recursive: true, force: true });
+  }
+});
+
+test("artifact-exists at a ref: the four outcomes, against real git (#662 review B1/m3)", async () => {
+  // The test whose absence let B1 ship green. Every other assertion about this
+  // branch's exit codes runs against a stub, and the stub encoded a value real
+  // git never returns: `cat-file -e <ref>:<path>` reports a MISSING PATH as a
+  // fatal (128), not as exit 1 — the same code a missing repository gives. A
+  // split that read reachability off that call therefore called every genuine
+  // absence "unreachable". Only real git can hold this contract honest.
+  const repoDir = await repoContaining("docs/only-here.md");
+  const notARepo = await realpath(await mkdtemp(join(tmpdir(), "soma-662-nonrepo-")));
+
+  const run = async (dir: string, path: string, atRef: string) => {
+    const result = await runProbe({ type: "artifact-exists", path, atRef }, { cwd: dir, deps: { now: () => AT } });
+    if (result.state !== "probed") throw new Error("the runner must always run the probe");
+    return result;
+  };
+
+  try {
+    // 1. Present at a valid ref.
+    const present = await run(repoDir, "docs/only-here.md", "HEAD");
+    expect(present.outcome).toBe("pass");
+    expect(present.observed).toBe("docs/only-here.md present at HEAD");
+
+    // 2. Genuinely absent at a valid ref, in a reachable repo. This is the one
+    //    B1 broke: real git exits 128 here.
+    const absent = await run(repoDir, "docs/never-committed.md", "HEAD");
+    expect(absent.outcome).toBe("fail");
+    expect(absent.observed).toBe("docs/never-committed.md absent at HEAD");
+    expect(absent.observed).not.toContain("could not reach");
+
+    // 3. Reachable repo, ref that does not resolve.
+    const badRef = await run(repoDir, "docs/only-here.md", "nosuchref");
+    expect(badRef.outcome).toBe("fail");
+    expect(badRef.observed).toBe(`nosuchref does not resolve in ${collapseHome(repoDir)}`);
+
+    // 4. Not a repository at all — #662's reported symptom.
+    const unreachable = await run(notARepo, "docs/only-here.md", "HEAD");
+    expect(unreachable.outcome).toBe("fail");
+    expect(unreachable.observed).toContain(`could not reach HEAD in ${collapseHome(notARepo)}`);
+    expect(unreachable.observed).not.toContain("absent");
+  } finally {
+    await rm(repoDir, { recursive: true, force: true });
     await rm(notARepo, { recursive: true, force: true });
   }
 });

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { expect, test } from "bun:test";
 import { SomaCliError } from "../src/cli/errors";
 import {
@@ -1632,5 +1635,121 @@ test("SomaCliError carries a non-zero exit for a lost claim", async () => {
   } catch (error) {
     expect(error).toBeInstanceOf(SomaCliError);
     expect((error as SomaCliError).exitCode).toBe(1);
+  }
+});
+
+// --- the probe tree is the tree soma was invoked from (#662) ----------------
+
+/**
+ * A real git repository, somewhere that is emphatically not soma's own tree,
+ * with one committed artifact.
+ *
+ * Real rather than stubbed because the failure being closed lives *inside* git:
+ * `git cat-file -e HEAD:<path>` run in the wrong directory exits 128, and a fake
+ * runner returning a chosen exit code would be asserting the fix on the way in.
+ */
+async function repoContaining(path: string): Promise<string> {
+  // `realpath` because $TMPDIR is a symlink on macOS and every comparison below
+  // is string equality against a path the CLI resolved lexically.
+  const dir = await realpath(await mkdtemp(join(tmpdir(), "soma-662-")));
+  await mkdir(join(dir, "docs"), { recursive: true });
+  await writeFile(join(dir, path), "the artifact the node claims\n", "utf8");
+  for (const argv of [
+    ["init", "--initial-branch=main"],
+    ["config", "user.email", "test@example.test"],
+    ["config", "user.name", "soma test"],
+    ["add", "."],
+    ["commit", "-m", "seed"],
+  ]) {
+    const proc = Bun.spawn(["git", "-C", dir, ...argv], { stdout: "pipe", stderr: "pipe" });
+    expect(await proc.exited).toBe(0);
+  }
+  return dir;
+}
+
+test("a close probes the repo it was invoked from, even when the launcher cd'd elsewhere (#662)", async () => {
+  // AC-2. The failure: an arc-generated shim `cd`s into soma's install tree
+  // before `exec`, so `process.cwd()` is that tree and every declared probe
+  // resolved against it — `git cat-file` reported the node's artifact "absent"
+  // while it sat, committed, in the checkout the operator ran the close from.
+  //
+  // Falsifiable by construction: `docs/only-here.md` exists in the temp repo and
+  // in no soma checkout, so a probe base that fell back to `process.cwd()` (this
+  // test file's own tree) fails the probe and the close refuses.
+  const repoDir = await repoContaining("docs/only-here.md");
+  const previous = process.env.ARC_INVOCATION_CWD;
+  process.env.ARC_INVOCATION_CWD = repoDir;
+
+  try {
+    const probe: Probe = { type: "artifact-exists", path: "docs/only-here.md", atRef: "HEAD" };
+    const store = new FakeStore()
+      .seed("495", { node: autoNode("495"), author: "jcfischer" })
+      .seed("520", { node: autoNode("520", { probes: [probe] }), parent: "495", author: "ivy-agent" });
+
+    // `probeCwd` and `describeProbeTree` are dropped rather than stubbed: the
+    // thing under test *is* the default `probeCwd`, and a test that injected one
+    // would pass against the broken code. Everything else stays hermetic.
+    const { probeCwd: _useTheDefault, describeProbeTree: _readTheRealTree, ...overrides } = deps(store, {
+      runProbes: async (probes, registry, cwd) => await runProbes(probes, { cwd, registry, deps: { now: () => AT } }),
+    });
+
+    const output = await runGraphCli(
+      parseGraphArgs(["graph", "close", "520", "--repo", REPO, ...RESOLUTION]),
+      overrides,
+    );
+
+    expect(output).toContain("Closed node 520");
+    const receipt = store.closed[0].receipt;
+    // Where it ran …
+    const [result] = receipt.probeResults;
+    if (result.state !== "probed") throw new Error("the runner returned a specified result — it must run the probe");
+    expect(result.outcome).toBe("pass");
+    expect(result.cwd).toBe(repoDir);
+    // … and what the receipt says about it, read from the real tree.
+    const [tree] = receipt.probeTrees ?? [];
+    expect(tree?.dir).toBe(repoDir);
+    expect(tree?.head).toMatch(/^[0-9a-f]{4,40}$/u);
+  } finally {
+    if (previous === undefined) delete process.env.ARC_INVOCATION_CWD;
+    else process.env.ARC_INVOCATION_CWD = previous;
+    await rm(repoDir, { recursive: true, force: true });
+  }
+});
+
+test("the same close, run from a directory that is not a repository, says so instead of 'absent' (#662)", async () => {
+  // AC-3 at the CLI seam. The half of #662 that cost the reporter the most time
+  // was not the wrong directory — it was the receipt describing the wrong
+  // directory in the vocabulary of a missing file.
+  const notARepo = await realpath(await mkdtemp(join(tmpdir(), "soma-662-bare-")));
+  const previous = process.env.ARC_INVOCATION_CWD;
+  process.env.ARC_INVOCATION_CWD = notARepo;
+
+  try {
+    const probe: Probe = { type: "artifact-exists", path: "docs/only-here.md", atRef: "HEAD" };
+    const store = new FakeStore()
+      .seed("495", { node: autoNode("495"), author: "jcfischer" })
+      .seed("520", { node: autoNode("520", { probes: [probe] }), parent: "495", author: "ivy-agent" });
+
+    const { probeCwd: _useTheDefault, ...overrides } = deps(store, {
+      runProbes: async (probes, registry, cwd) => await runProbes(probes, { cwd, registry, deps: { now: () => AT } }),
+    });
+
+    // `--dry-run` rather than the refusal: the refusal message summarises
+    // ("ran and failed"), and the string the operator actually reads their
+    // diagnosis out of is the rendered receipt.
+    const output = await runGraphCli(
+      parseGraphArgs(["graph", "close", "520", "--dry-run", "--repo", REPO]),
+      overrides,
+    );
+
+    expect(store.closed).toHaveLength(0);
+    expect(output).toContain("would be REFUSED");
+    expect(output).toContain(`could not reach HEAD in ${notARepo}`);
+    expect(output).toContain("not a git repository");
+    expect(output).not.toContain("absent");
+  } finally {
+    if (previous === undefined) delete process.env.ARC_INVOCATION_CWD;
+    else process.env.ARC_INVOCATION_CWD = previous;
+    await rm(notARepo, { recursive: true, force: true });
   }
 });

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -1746,7 +1746,12 @@ test("the same close, run from a directory that is not a repository, says so ins
     expect(store.closed).toHaveLength(0);
     expect(output).toContain("would be REFUSED");
     expect(output).toContain(`could not reach HEAD in ${notARepo}`);
-    expect(output).toContain("not a git repository");
+    // Our wording and a verified exit code, never git's prose. This line used to
+    // assert `not a git repository` — real git's phrasing, in a real-git test,
+    // which is the same assumption class that turned the B2 arm red on CI. It
+    // happens to hold on both platforms; it is still the wrong thing to depend
+    // on, since git reworders and localises its messages and we control neither.
+    expect(output).toContain("git exited 128");
     expect(output).not.toContain("absent");
   } finally {
     if (previous === undefined) delete process.env.ARC_INVOCATION_CWD;
@@ -1800,49 +1805,119 @@ test("artifact-exists at a ref: the four outcomes, against real git (#662 review
   }
 });
 
-test("a probe failure never publishes the operator's home path, even when git names one (#662 review B2)", async () => {
-  // Real git, because this is the second finding where a helper was adopted for
-  // what its name implies rather than what it does to the input in hand. A stub
-  // would assert my model of git's stderr; only git produces the actual string.
-  //
-  // The shape that beats containment: a `.git` GITFILE redirects git to an
-  // arbitrary path, so `fatal: not a git repository: <that path>` names a
-  // directory no probe was allowed to read — and it rides the close receipt onto
-  // a tracker whose visibility soma cannot know.
-  //
-  // `HOME` is pointed at a temp directory for the duration (#662 review n3):
-  // the fixture has to live *under* home for the redaction to have anything to
-  // do, and creating it in the operator's real home means an interrupted run
-  // leaves litter there. Nothing is weakened by this — `redactHome` reads `HOME`
-  // at call time through the same ambient default it uses in production, so the
-  // assertion still exercises the real lookup, and git is told nothing about it.
-  const previousHome = process.env.HOME;
-  const home = await realpath(await mkdtemp(join(tmpdir(), "soma-662-home-")));
+/** Run `body` with `HOME` pointed somewhere else, restoring it whatever happens. */
+async function withHome<T>(home: string, body: () => Promise<T>): Promise<T> {
+  const previous = process.env.HOME;
   process.env.HOME = home;
+  try {
+    return await body();
+  } finally {
+    if (previous === undefined) delete process.env.HOME;
+    else process.env.HOME = previous;
+  }
+}
 
+test("a probe failure never publishes the operator's home path — deterministic arm (#662 review B2)", async () => {
+  // THE POSITIVE PROOF LIVES HERE, on injected deps, because it is the only arm
+  // that behaves the same on every git.
+  //
+  // The first version of this test asserted `~/…` against REAL git's stderr and
+  // went red on CI: a gitfile whose target is missing makes Linux git say
+  // `fatal: not a git repository: (null)` while macOS git names the path. So
+  // there was nothing to redact there and the assertion waited for a string that
+  // could not appear. That is this branch's own lesson one layer out — I asserted
+  // a git MESSAGE FORMAT, having spent four rounds learning not to assume git's
+  // exit codes.
+  //
+  // A crafted stderr is honest here in a way it was not for B1: the unit under
+  // test is *our redaction of arbitrary subprocess text*, not git's phrasing, so
+  // the stub encodes no belief about git at all.
+  const home = "/Users/tester";
+  const leaked = `${home}/.ssh/secret/.git`;
+
+  const result = await withHome(home, async () =>
+    await runProbe(
+      { type: "artifact-exists", path: "docs/x.md", atRef: "HEAD" },
+      {
+        cwd: "/repo",
+        deps: {
+          runCommand: async () => ({
+            exitCode: 128,
+            stdout: "",
+            stderr: `fatal: not a git repository: ${leaked}\n`,
+            timedOut: false,
+          }),
+          now: () => AT,
+        },
+      },
+    ),
+  );
+  if (result.state !== "probed") throw new Error("the runner must always run the probe");
+
+  expect(result.outcome).toBe("fail");
+  // The negative — the property we actually care about.
+  expect(result.observed).not.toContain(home);
+  // …and the positive: the redirect is still named, wearing `~`, so the redaction
+  // is proved to have FIRED rather than the message merely having lost its path.
+  expect(result.observed).toContain("~/.ssh/secret/.git");
+});
+
+test("…and the same holds against real git, when this git names the path at all (#662 review B2)", async () => {
+  // The real-git arm, kept but made SELF-CHECKING rather than assuming.
+  //
+  // Kept, rather than dropped, because the gitfile redirect is the shape that
+  // beats containment — git reaching a path no probe was allowed to read — and
+  // retiring it would leave that scenario covered only by a string I wrote
+  // myself. Made conditional because whether git echoes the target is a message
+  // format, and this branch's whole subject is not assuming those.
+  //
+  // `HOME` points at a temp directory (#662 review n3) so an interrupted run
+  // cannot litter the operator's real home. `redactHome` reads `HOME` at call
+  // time through the same ambient default it uses in production, so the real
+  // lookup is still exercised; git is told nothing about the swap.
+  const home = await realpath(await mkdtemp(join(tmpdir(), "soma-662-home-")));
+  const elsewhere = await realpath(await mkdtemp(join(tmpdir(), "soma-662-notahome-")));
   const redirected = join(home, ".soma-662-b2-fixture");
   const probeTree = await realpath(await mkdtemp(join(tmpdir(), "soma-662-gitfile-")));
-  await mkdir(redirected, { recursive: true });
-  await writeFile(join(probeTree, ".git"), `gitdir: ${join(redirected, ".git")}\n`, "utf8");
 
   try {
-    const result = await runProbe(
-      { type: "artifact-exists", path: "docs/x.md", atRef: "HEAD" },
-      { cwd: probeTree, deps: { now: () => AT } },
-    );
-    if (result.state !== "probed") throw new Error("the runner must always run the probe");
+    await mkdir(redirected, { recursive: true });
+    await writeFile(join(probeTree, ".git"), `gitdir: ${join(redirected, ".git")}\n`, "utf8");
 
-    expect(result.outcome).toBe("fail");
-    // Asserted on the ABSENCE of the raw home prefix rather than on an exact
-    // string, so this keeps its meaning if the message wording changes.
-    expect(result.observed).not.toContain(home);
-    // …and it is still a useful message: the redirect is named, just wearing `~`.
-    expect(result.observed).toContain("~/.soma-662-b2-fixture");
-    expect(result.observed).toContain("could not reach HEAD");
+    const probe = async (): Promise<string> => {
+      const result = await runProbe(
+        { type: "artifact-exists", path: "docs/x.md", atRef: "HEAD" },
+        { cwd: probeTree, deps: { now: () => AT } },
+      );
+      if (result.state !== "probed") throw new Error("the runner must always run the probe");
+      expect(result.outcome).toBe("fail");
+      return result.observed;
+    };
+
+    // Control: HOME somewhere unrelated, so nothing is redacted and the raw
+    // message is visible. This is how we learn what THIS git says, instead of
+    // deciding in advance.
+    const control = await withHome(elsewhere, probe);
+    const namesThePath = control.includes(redirected);
+
+    const observed = await withHome(home, probe);
+
+    // Unconditional, true on every git: the raw home prefix is never published.
+    expect(observed).not.toContain(home);
+
+    if (namesThePath) {
+      // This git echoes the gitfile target, so redaction had something to do and
+      // must be seen to have done it.
+      expect(observed).toContain("~/.soma-662-b2-fixture");
+    } else {
+      // This git does not name the path (Linux says `(null)`), so there is
+      // nothing to redact. Assert the message is still the useful one rather than
+      // letting the test pass vacuously.
+      expect(observed).toContain("could not reach HEAD");
+    }
   } finally {
-    if (previousHome === undefined) delete process.env.HOME;
-    else process.env.HOME = previousHome;
     await rm(probeTree, { recursive: true, force: true });
     await rm(home, { recursive: true, force: true });
+    await rm(elsewhere, { recursive: true, force: true });
   }
 });

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -1809,8 +1809,16 @@ test("a probe failure never publishes the operator's home path, even when git na
   // arbitrary path, so `fatal: not a git repository: <that path>` names a
   // directory no probe was allowed to read — and it rides the close receipt onto
   // a tracker whose visibility soma cannot know.
-  const home = process.env.HOME;
-  if (home === undefined || home.length === 0) throw new Error("this test needs HOME set");
+  //
+  // `HOME` is pointed at a temp directory for the duration (#662 review n3):
+  // the fixture has to live *under* home for the redaction to have anything to
+  // do, and creating it in the operator's real home means an interrupted run
+  // leaves litter there. Nothing is weakened by this — `redactHome` reads `HOME`
+  // at call time through the same ambient default it uses in production, so the
+  // assertion still exercises the real lookup, and git is told nothing about it.
+  const previousHome = process.env.HOME;
+  const home = await realpath(await mkdtemp(join(tmpdir(), "soma-662-home-")));
+  process.env.HOME = home;
 
   const redirected = join(home, ".soma-662-b2-fixture");
   const probeTree = await realpath(await mkdtemp(join(tmpdir(), "soma-662-gitfile-")));
@@ -1832,7 +1840,9 @@ test("a probe failure never publishes the operator's home path, even when git na
     expect(result.observed).toContain("~/.soma-662-b2-fixture");
     expect(result.observed).toContain("could not reach HEAD");
   } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
     await rm(probeTree, { recursive: true, force: true });
-    await rm(redirected, { recursive: true, force: true });
+    await rm(home, { recursive: true, force: true });
   }
 });

--- a/test/cli-graph.test.ts
+++ b/test/cli-graph.test.ts
@@ -1799,3 +1799,40 @@ test("artifact-exists at a ref: the four outcomes, against real git (#662 review
     await rm(notARepo, { recursive: true, force: true });
   }
 });
+
+test("a probe failure never publishes the operator's home path, even when git names one (#662 review B2)", async () => {
+  // Real git, because this is the second finding where a helper was adopted for
+  // what its name implies rather than what it does to the input in hand. A stub
+  // would assert my model of git's stderr; only git produces the actual string.
+  //
+  // The shape that beats containment: a `.git` GITFILE redirects git to an
+  // arbitrary path, so `fatal: not a git repository: <that path>` names a
+  // directory no probe was allowed to read — and it rides the close receipt onto
+  // a tracker whose visibility soma cannot know.
+  const home = process.env.HOME;
+  if (home === undefined || home.length === 0) throw new Error("this test needs HOME set");
+
+  const redirected = join(home, ".soma-662-b2-fixture");
+  const probeTree = await realpath(await mkdtemp(join(tmpdir(), "soma-662-gitfile-")));
+  await mkdir(redirected, { recursive: true });
+  await writeFile(join(probeTree, ".git"), `gitdir: ${join(redirected, ".git")}\n`, "utf8");
+
+  try {
+    const result = await runProbe(
+      { type: "artifact-exists", path: "docs/x.md", atRef: "HEAD" },
+      { cwd: probeTree, deps: { now: () => AT } },
+    );
+    if (result.state !== "probed") throw new Error("the runner must always run the probe");
+
+    expect(result.outcome).toBe("fail");
+    // Asserted on the ABSENCE of the raw home prefix rather than on an exact
+    // string, so this keeps its meaning if the message wording changes.
+    expect(result.observed).not.toContain(home);
+    // …and it is still a useful message: the redirect is named, just wearing `~`.
+    expect(result.observed).toContain("~/.soma-662-b2-fixture");
+    expect(result.observed).toContain("could not reach HEAD");
+  } finally {
+    await rm(probeTree, { recursive: true, force: true });
+    await rm(redirected, { recursive: true, force: true });
+  }
+});

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -1,6 +1,9 @@
 import { join, resolve } from "node:path";
 import { expect, test } from "bun:test";
 import { createPaths, type SomaPaths } from "../src/index";
+// Not on the public barrel — a launcher-contract detail two CLI paths share,
+// so the test reaches for it where it lives.
+import { invocationCwd } from "../src/path-utils";
 
 test("createPaths defaults under a home directory", () => {
   const homeDir = "/tmp/soma-paths-home";
@@ -121,4 +124,30 @@ test("store accessors refuse to escape the Soma root", () => {
   expect(() => paths.episodic("sessions", "..", "..", "..", "..", "escape.md")).toThrow("escapes root");
   // `state()` prepends 2 segments ("memory","STATE"); 3 levels of ".." escapes.
   expect(() => paths.state("..", "..", "..", "escape.json")).toThrow("escapes root");
+});
+
+// --- the invocation cwd (#315, #662) ---------------------------------------
+
+test("invocationCwd prefers the launcher's absolute invocation directory over the process cwd", () => {
+  // The only falsifiable shape: the two directories must differ, because on a
+  // machine where soma is run directly they are the same value and a broken
+  // implementation passes. This is #662 — an arc shim `cd`s into the install
+  // tree, so process.cwd() is soma's own checkout and the exported variable is
+  // the only thing left that knows where the operator stood.
+  const invoked = "/work/tree-under-review";
+  expect(invoked).not.toBe(process.cwd());
+
+  expect(invocationCwd({ ARC_INVOCATION_CWD: invoked })).toBe(invoked);
+});
+
+test("invocationCwd falls back to the process cwd when the launcher states nothing usable", () => {
+  const here = resolve(process.cwd());
+
+  // Direct invocation: no shim, no variable, nothing moved.
+  expect(invocationCwd({})).toBe(here);
+  // A relative or empty value is not a statement of where the caller stood.
+  // Resolving it against process.cwd() would produce a third directory that is
+  // neither the caller's nor the install tree's, so it falls back instead.
+  expect(invocationCwd({ ARC_INVOCATION_CWD: "../elsewhere" })).toBe(here);
+  expect(invocationCwd({ ARC_INVOCATION_CWD: "" })).toBe(here);
 });

--- a/test/paths.test.ts
+++ b/test/paths.test.ts
@@ -1,3 +1,5 @@
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { expect, test } from "bun:test";
 import { createPaths, type SomaPaths } from "../src/index";
@@ -128,19 +130,25 @@ test("store accessors refuse to escape the Soma root", () => {
 
 // --- the invocation cwd (#315, #662) ---------------------------------------
 
-test("invocationCwd prefers the launcher's absolute invocation directory over the process cwd", () => {
+test("invocationCwd prefers the launcher's absolute invocation directory over the process cwd", async () => {
   // The only falsifiable shape: the two directories must differ, because on a
   // machine where soma is run directly they are the same value and a broken
   // implementation passes. This is #662 — an arc shim `cd`s into the install
   // tree, so process.cwd() is soma's own checkout and the exported variable is
-  // the only thing left that knows where the operator stood.
-  const invoked = "/work/tree-under-review";
-  expect(invoked).not.toBe(process.cwd());
-
-  expect(invocationCwd({ ARC_INVOCATION_CWD: invoked })).toBe(invoked);
+  // where the operator stood.
+  //
+  // A real directory, not a plausible string: since #662 review m2 the value has
+  // to name one, so a fictional path would be testing the fallback.
+  const invoked = await realpath(await mkdtemp(join(tmpdir(), "soma-invocation-")));
+  try {
+    expect(invoked).not.toBe(process.cwd());
+    expect(invocationCwd({ ARC_INVOCATION_CWD: invoked })).toBe(invoked);
+  } finally {
+    await rm(invoked, { recursive: true, force: true });
+  }
 });
 
-test("invocationCwd falls back to the process cwd when the launcher states nothing usable", () => {
+test("invocationCwd falls back to the process cwd when the launcher states nothing usable", async () => {
   const here = resolve(process.cwd());
 
   // Direct invocation: no shim, no variable, nothing moved.
@@ -150,4 +158,19 @@ test("invocationCwd falls back to the process cwd when the launcher states nothi
   // neither the caller's nor the install tree's, so it falls back instead.
   expect(invocationCwd({ ARC_INVOCATION_CWD: "../elsewhere" })).toBe(here);
   expect(invocationCwd({ ARC_INVOCATION_CWD: "" })).toBe(here);
+
+  // #662 review m2: absolute is not enough. Under an arc install the probe base
+  // used to be pinned to the process cwd and is now environment-settable, so a
+  // value naming nothing — or naming a file — gets the floor rather than the
+  // benefit of the doubt. It would otherwise become the containment base for
+  // every ungated probe.
+  const dir = await realpath(await mkdtemp(join(tmpdir(), "soma-invocation-floor-")));
+  try {
+    const file = join(dir, "not-a-directory");
+    await writeFile(file, "x", "utf8");
+    expect(invocationCwd({ ARC_INVOCATION_CWD: join(dir, "no-such-subdir") })).toBe(here);
+    expect(invocationCwd({ ARC_INVOCATION_CWD: file })).toBe(here);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/test/work-graph-probes.test.ts
+++ b/test/work-graph-probes.test.ts
@@ -666,3 +666,107 @@ test("resolvedProbePaths names every path a probe touches, and the field it came
   ]);
   expect(resolvedProbePaths({ type: "url", target: "https://example.test/", expectStatus: 200 }, "/repo")).toEqual([]);
 });
+
+// --- "could not reach the tree" is not "the artifact is absent" (#662) ------
+
+test("an artifact-exists atRef in a directory git cannot read says so, and names the directory", async () => {
+  // #662's reported symptom. The probe base was the install tree, `git cat-file`
+  // exited 128, and the receipt said `docs/x.md absent at main` — so the reporter
+  // went hunting for a file that was present in the tree they ran the close from.
+  // The two failures have different fixes, so they must read differently.
+  const unreadable = requireProbed(
+    await runProbe(
+      { type: "artifact-exists", path: "docs/x.md", atRef: "main" },
+      deps({
+        command: () => ({
+          exitCode: 128,
+          stdout: "",
+          stderr: "fatal: not a git repository (or any of the parent directories): .git\n",
+          timedOut: false,
+        }),
+      }),
+    ),
+  );
+
+  expect(unreadable.outcome).toBe("fail");
+  expect(unreadable.observed).toContain("could not reach main in /repo");
+  expect(unreadable.observed).toContain("git exited 128");
+  expect(unreadable.observed).toContain("not a git repository");
+  // The word that sent the reporter to the wrong place must not appear.
+  expect(unreadable.observed).not.toContain("absent");
+
+  // And the genuine answer still reads exactly as it did: exit 1 is git saying
+  // "I looked, it is not there", which is a real absence.
+  const absent = requireProbed(
+    await runProbe(
+      { type: "artifact-exists", path: "docs/x.md", atRef: "main" },
+      deps({ command: () => ({ exitCode: 1, stdout: "", stderr: "", timedOut: false }) }),
+    ),
+  );
+  expect(absent.outcome).toBe("fail");
+  expect(absent.observed).toBe("docs/x.md absent at main");
+});
+
+test("the reachability split covers the other two git probes, on both of git-merged-into's refs", async () => {
+  // Same helper, three call sites: `does not resolve in /repo` is a plausible
+  // way to say "this is not a repository", and `is not an ancestor of main` is a
+  // plausible way to say "there is no main here". Both would send a reader after
+  // the wrong defect.
+  const refExists = requireProbed(
+    await runProbe(
+      { type: "git-ref-exists", ref: "main" },
+      deps({ command: () => ({ exitCode: 128, stdout: "", stderr: "fatal: not a git repository\n", timedOut: false }) }),
+    ),
+  );
+  expect(refExists.outcome).toBe("fail");
+  expect(refExists.observed).toContain("could not reach main in /repo");
+  expect(refExists.observed).not.toContain("does not resolve");
+
+  // An `into` that does not resolve fails on the second git call, after the ref
+  // itself resolved fine.
+  const badInto = requireProbed(
+    await runProbe(
+      { type: "git-merged-into", ref: "feat/x", into: "main" },
+      deps({
+        command: (request) =>
+          request.argv?.includes("merge-base") === true
+            ? { exitCode: 128, stdout: "", stderr: "fatal: Not a valid object name main\n", timedOut: false }
+            : { exitCode: 0, stdout: "abc1234\n", stderr: "", timedOut: false },
+      }),
+    ),
+  );
+  expect(badInto.outcome).toBe("fail");
+  expect(badInto.observed).toContain("could not reach main in /repo");
+  expect(badInto.observed).not.toContain("is not an ancestor");
+
+  // Exit 1 on the same call is the honest "no", and keeps its message.
+  const notAncestor = requireProbed(
+    await runProbe(
+      { type: "git-merged-into", ref: "feat/x", into: "main" },
+      deps({
+        command: (request) =>
+          request.argv?.includes("merge-base") === true
+            ? { exitCode: 1, stdout: "", stderr: "", timedOut: false }
+            : { exitCode: 0, stdout: "abc1234\n", stderr: "", timedOut: false },
+      }),
+    ),
+  );
+  expect(notAncestor.observed).toContain("is not an ancestor of main");
+});
+
+test("a git probe killed by a timeout reads as unreachable, never as a confident answer", async () => {
+  // A killed spawn reports `exitCode: null`; before #662 that fell through the
+  // `exitCode === 0` comparison and rendered as `absent`, which is a claim about
+  // a question git never got to answer.
+  const result = requireProbed(
+    await runProbe(
+      { type: "artifact-exists", path: "docs/x.md", atRef: "main" },
+      deps({ command: () => ({ exitCode: null, stdout: "", stderr: "", timedOut: true }) }),
+    ),
+  );
+
+  expect(result.outcome).toBe("fail");
+  expect(result.observed).toContain("could not reach main in /repo");
+  expect(result.observed).toContain("git timed out (killed)");
+  expect(result.observed).not.toContain("absent");
+});

--- a/test/work-graph-probes.test.ts
+++ b/test/work-graph-probes.test.ts
@@ -192,17 +192,27 @@ test("artifact-exists checks the filesystem without atRef and the tree with it",
       {
         cwd: "/repo",
         deps: {
+          // Real-git-shaped (#662 review m3): the ref resolves, and the absent
+          // path comes back 128, because `cat-file -e <ref>:<path>` reports a
+          // missing path as a fatal rather than as exit 1. This stub used to
+          // return 1 for both calls — a value real git never produces for this
+          // argv, which is how the inverted split shipped green.
           runCommand: async (request) => {
             seen.push(request);
-            return { exitCode: 1, stdout: "", stderr: "", timedOut: false };
+            return request.argv?.includes("cat-file") === true
+              ? { exitCode: 128, stdout: "", stderr: "fatal: path 'src/work-graph.ts' does not exist in 'main'\n", timedOut: false }
+              : { exitCode: 0, stdout: "abc1234\n", stderr: "", timedOut: false };
           },
           now: () => AT,
         },
       },
     ),
   );
-  expect(seen[0].argv).toEqual(["git", "-C", "/repo", "cat-file", "-e", "main:src/work-graph.ts"]);
+  // Reachability first, then the path lookup.
+  expect(seen[0].argv).toEqual(["git", "-C", "/repo", "rev-parse", "--verify", "--quiet", "main^{object}"]);
+  expect(seen[1].argv).toEqual(["git", "-C", "/repo", "cat-file", "-e", "main:src/work-graph.ts"]);
   expect(atRef.outcome).toBe("fail");
+  expect(atRef.observed).toBe("src/work-graph.ts absent at main");
 });
 
 test("runProbes runs every probe in order and allProbesPassed needs all of them", async () => {
@@ -606,9 +616,13 @@ test("an atRef artifact-exists reads through git, so only its directory is conta
       {
         cwd: "/repo",
         deps: {
+          // Real-git-shaped (#662 review m3): the ref resolves, the object name
+          // does not exist, and `cat-file -e` reports that with 128.
           runCommand: async (request) => {
             seen.push(request);
-            return { exitCode: 1, stdout: "", stderr: "", timedOut: false };
+            return request.argv?.includes("cat-file") === true
+              ? { exitCode: 128, stdout: "", stderr: "fatal: path '/etc/passwd' does not exist in 'main'\n", timedOut: false }
+              : { exitCode: 0, stdout: "abc1234\n", stderr: "", timedOut: false };
           },
           now: () => AT,
         },
@@ -617,7 +631,9 @@ test("an atRef artifact-exists reads through git, so only its directory is conta
   );
 
   expect(result.observed).not.toContain(PROBE_ESCAPED_PREFIX);
-  expect(seen[0].argv).toEqual(["git", "-C", "/repo", "cat-file", "-e", "main:/etc/passwd"]);
+  // The path still reaches git verbatim as an object name — the reachability
+  // call added in #662 review B1 runs ahead of it and does not touch `path`.
+  expect(seen[1].argv).toEqual(["git", "-C", "/repo", "cat-file", "-e", "main:/etc/passwd"]);
   expect(result.outcome).toBe("fail");
 });
 
@@ -695,16 +711,34 @@ test("an artifact-exists atRef in a directory git cannot read says so, and names
   // The word that sent the reporter to the wrong place must not appear.
   expect(unreadable.observed).not.toContain("absent");
 
-  // And the genuine answer still reads exactly as it did: exit 1 is git saying
-  // "I looked, it is not there", which is a real absence.
+  // And a genuine absence still reads as absence. `cat-file -e` reports a
+  // missing path with 128, the SAME code a missing tree gives, so this case is
+  // separated by the ref resolving first — never by the path lookup's own exit
+  // code (#662 review B1).
   const absent = requireProbed(
     await runProbe(
       { type: "artifact-exists", path: "docs/x.md", atRef: "main" },
-      deps({ command: () => ({ exitCode: 1, stdout: "", stderr: "", timedOut: false }) }),
+      deps({
+        command: (request) =>
+          request.argv?.includes("cat-file") === true
+            ? { exitCode: 128, stdout: "", stderr: "fatal: path 'docs/x.md' does not exist in 'main'\n", timedOut: false }
+            : { exitCode: 0, stdout: "abc1234\n", stderr: "", timedOut: false },
+      }),
     ),
   );
   expect(absent.outcome).toBe("fail");
   expect(absent.observed).toBe("docs/x.md absent at main");
+
+  // A ref that does not resolve in a valid repository is a third thing again:
+  // not the tree being unreachable, not the path being absent.
+  const badRef = requireProbed(
+    await runProbe(
+      { type: "artifact-exists", path: "docs/x.md", atRef: "nosuchref" },
+      deps({ command: () => ({ exitCode: 1, stdout: "", stderr: "", timedOut: false }) }),
+    ),
+  );
+  expect(badRef.outcome).toBe("fail");
+  expect(badRef.observed).toBe("nosuchref does not resolve in /repo");
 });
 
 test("the reachability split covers the other two git probes, on both of git-merged-into's refs", async () => {
@@ -758,15 +792,35 @@ test("a git probe killed by a timeout reads as unreachable, never as a confident
   // A killed spawn reports `exitCode: null`; before #662 that fell through the
   // `exitCode === 0` comparison and rendered as `absent`, which is a claim about
   // a question git never got to answer.
-  const result = requireProbed(
+  const onReachability = requireProbed(
     await runProbe(
       { type: "artifact-exists", path: "docs/x.md", atRef: "main" },
       deps({ command: () => ({ exitCode: null, stdout: "", stderr: "", timedOut: true }) }),
     ),
   );
 
-  expect(result.outcome).toBe("fail");
-  expect(result.observed).toContain("could not reach main in /repo");
-  expect(result.observed).toContain("git timed out (killed)");
-  expect(result.observed).not.toContain("absent");
+  expect(onReachability.outcome).toBe("fail");
+  expect(onReachability.observed).toContain("could not reach main in /repo");
+  expect(onReachability.observed).toContain("git timed out (killed)");
+  expect(onReachability.observed).not.toContain("absent");
+
+  // The deadline can also land on the *second* call, after the ref has resolved.
+  // That path reads only the timeout — every other non-zero there is the path's
+  // answer — so it needs its own case or the narrower predicate goes untested.
+  const onLookup = requireProbed(
+    await runProbe(
+      { type: "artifact-exists", path: "docs/x.md", atRef: "main" },
+      deps({
+        command: (request) =>
+          request.argv?.includes("cat-file") === true
+            ? { exitCode: null, stdout: "", stderr: "", timedOut: true }
+            : { exitCode: 0, stdout: "abc1234\n", stderr: "", timedOut: false },
+      }),
+    ),
+  );
+
+  expect(onLookup.outcome).toBe("fail");
+  expect(onLookup.observed).toContain("could not reach main in /repo");
+  expect(onLookup.observed).toContain("git timed out (killed)");
+  expect(onLookup.observed).not.toContain("absent");
 });

--- a/test/work-graph-probes.test.ts
+++ b/test/work-graph-probes.test.ts
@@ -211,9 +211,10 @@ test("artifact-exists checks the filesystem without atRef and the tree with it",
       },
     ),
   );
-  // Reachability first, then the path lookup.
+  // Reachability first, then the path lookup — bound to the sha the first call
+  // resolved rather than to the ref name a second time (#662 review, SHA binding).
   expect(seen[0].argv).toEqual(["git", "-C", "/repo", "rev-parse", "--verify", "--quiet", "main^{object}"]);
-  expect(seen[1].argv).toEqual(["git", "-C", "/repo", "cat-file", "-e", "main:src/work-graph.ts"]);
+  expect(seen[1].argv).toEqual(["git", "-C", "/repo", "cat-file", "-e", "abc1234:src/work-graph.ts"]);
   expect(atRef.outcome).toBe("fail");
   expect(atRef.observed).toBe("src/work-graph.ts absent at main");
 });
@@ -636,7 +637,8 @@ test("an atRef artifact-exists reads through git, so only its directory is conta
   expect(result.observed).not.toContain(PROBE_ESCAPED_PREFIX);
   // The path still reaches git verbatim as an object name — the reachability
   // call added in #662 review B1 runs ahead of it and does not touch `path`.
-  expect(seen[1].argv).toEqual(["git", "-C", "/repo", "cat-file", "-e", "main:/etc/passwd"]);
+  // Only the ref half is replaced by the resolved sha.
+  expect(seen[1].argv).toEqual(["git", "-C", "/repo", "cat-file", "-e", "abc1234:/etc/passwd"]);
   expect(result.outcome).toBe("fail");
 });
 
@@ -874,4 +876,112 @@ test("redactHome does not redact a different account whose name merely starts wi
   // different user's tree, and mangling it would corrupt the message without
   // protecting anything.
   expect(redactHome("/Users/testerson/x", "/Users/tester")).toBe("/Users/testerson/x");
+});
+
+test("a signal-killed git lookup is unreachable, not a confident absence (#662 review mm1)", async () => {
+  // The hairline B1 re-opened. `timedOut` is not the only non-answer: a child
+  // killed by an EXTERNAL signal reports a number, not null — measured, 137 for
+  // SIGKILL and 139 for SIGSEGV — so a guard narrowed to the timeout lets 137
+  // fall through to `passed = (137 === 0)` and publish `absent`. An OOM killer
+  // or a cgroup limit on a loaded box produces exactly this.
+  for (const exitCode of [137, 139]) {
+    const result = requireProbed(
+      await runProbe(
+        { type: "artifact-exists", path: "docs/x.md", atRef: "main" },
+        deps({
+          command: (request) =>
+            request.argv?.includes("cat-file") === true
+              ? { exitCode, stdout: "", stderr: "", timedOut: false }
+              : { exitCode: 0, stdout: "abc1234\n", stderr: "", timedOut: false },
+        }),
+      ),
+    );
+
+    expect(result.outcome).toBe("fail");
+    expect(result.observed).toContain("could not reach main in /repo");
+    expect(result.observed).toContain(`git exited ${exitCode}`);
+    expect(result.observed).not.toContain("absent");
+  }
+
+  // The codes `cat-file -e` genuinely answers with still read as answers: 128 is
+  // the object-name form of "missing path", 1 the raw-sha form.
+  for (const exitCode of [1, 128]) {
+    const result = requireProbed(
+      await runProbe(
+        { type: "artifact-exists", path: "docs/x.md", atRef: "main" },
+        deps({
+          command: (request) =>
+            request.argv?.includes("cat-file") === true
+              ? { exitCode, stdout: "", stderr: "", timedOut: false }
+              : { exitCode: 0, stdout: "abc1234\n", stderr: "", timedOut: false },
+        }),
+      ),
+    );
+    expect(result.observed).toBe("docs/x.md absent at main");
+  }
+});
+
+test("the artifact lookup is bound to the sha rev-parse resolved, not to the ref name twice", async () => {
+  // Resolving one ref twice and trusting the answers to agree is the shape this
+  // module refuses everywhere else (#579). `rev-parse` already printed the sha,
+  // so binding costs nothing.
+  const seen: CommandRequest[] = [];
+  await runProbe(
+    { type: "artifact-exists", path: "docs/x.md", atRef: "main" },
+    {
+      cwd: "/repo",
+      deps: {
+        runCommand: async (request) => {
+          seen.push(request);
+          return request.argv?.includes("cat-file") === true
+            ? { exitCode: 0, stdout: "", stderr: "", timedOut: false }
+            : { exitCode: 0, stdout: "fa70972eff31c0ffee\n", stderr: "", timedOut: false };
+        },
+        now: () => AT,
+      },
+    },
+  );
+
+  expect(seen[0].argv).toEqual(["git", "-C", "/repo", "rev-parse", "--verify", "--quiet", "main^{object}"]);
+  expect(seen[1].argv).toEqual(["git", "-C", "/repo", "cat-file", "-e", "fa70972eff31c0ffee:docs/x.md"]);
+});
+
+test("redaction runs before the tail bound, or a cut inside the home path defeats it (#662 review n1)", async () => {
+  // Constructed so the cut PROVABLY lands inside the home path rather than
+  // trusting a long blob to hit it: `boundObserved` keeps the last LIMIT chars,
+  // so the cut index is N - LIMIT, and the suffix is sized to put that index 5
+  // characters into the home prefix.
+  const home = "/Users/tester";
+  const LIMIT = 1_200;
+  const path = `${home}/.ssh/secret/.git`;
+  const suffix = "y".repeat(LIMIT + 5 - path.length);
+  const stderr = `${"x".repeat(50)}${path}${suffix}`;
+
+  const cut = stderr.length - LIMIT;
+  const at = stderr.indexOf(home);
+  expect(cut).toBeGreaterThan(at);
+  expect(cut).toBeLessThan(at + home.length);
+
+  // Composed the wrong way round, the cut severs `/Users/` from the prefix, so it
+  // no longer matches and the account name survives. This is the failure, pinned.
+  expect(redactHome(boundObserved(stderr), home)).toContain("tester");
+
+  // …and asserted through the RUNNER, not just as an expression. A test that
+  // only compared the two orderings would pass whichever one the call site used,
+  // which is a test that documents a rule without guarding it.
+  const previousHome = process.env.HOME;
+  process.env.HOME = home;
+  try {
+    const result = requireProbed(
+      await runProbe(
+        { type: "artifact-exists", path: "docs/x.md", atRef: "main" },
+        deps({ command: () => ({ exitCode: 128, stdout: "", stderr, timedOut: false }) }),
+      ),
+    );
+    expect(result.outcome).toBe("fail");
+    expect(result.observed).not.toContain("tester");
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+  }
 });

--- a/test/work-graph-probes.test.ts
+++ b/test/work-graph-probes.test.ts
@@ -18,6 +18,9 @@ import {
   type ProbeRunnerOptions,
   type WorkGraphNode,
 } from "../src/index";
+// Not on the public barrel — publication-rendering helpers, reached for where
+// they live, the way `cli-graph.test.ts` reaches for the receipt internals.
+import { collapseHome, redactHome } from "../src/work-graph";
 
 const AT = new Date("2026-08-04T09:00:00.000Z");
 const REPO = "the-metafactory/soma";
@@ -823,4 +826,52 @@ test("a git probe killed by a timeout reads as unreachable, never as a confident
   expect(onLookup.observed).toContain("could not reach main in /repo");
   expect(onLookup.observed).toContain("git timed out (killed)");
   expect(onLookup.observed).not.toContain("absent");
+});
+
+// --- redaction of published subprocess text (#662 review B2) ----------------
+
+test("redactHome replaces home wherever it appears, which is where collapseHome does not", () => {
+  const home = "/Users/tester";
+
+  // The distinction the whole finding turns on, asserted side by side so the
+  // next reader cannot mistake one for the other. `collapseHome` asks whether
+  // the string STARTS at home; a sentence with a path inside it does not, and
+  // passes through untouched.
+  expect(collapseHome(`${home}/secret/.git`, home)).toBe("~/secret/.git");
+  expect(collapseHome(`fatal: not a git repository: ${home}/secret/.git`, home)).toBe(
+    `fatal: not a git repository: ${home}/secret/.git`,
+  );
+  expect(redactHome(`fatal: not a git repository: ${home}/secret/.git`, home)).toBe(
+    "fatal: not a git repository: ~/secret/.git",
+  );
+
+  // Prefix, several occurrences, and none at all.
+  expect(redactHome(`${home}/secret/.git`, home)).toBe("~/secret/.git");
+  expect(redactHome(`a ${home}/x and ${home}/y`, home)).toBe("a ~/x and ~/y");
+  expect(redactHome("nothing to see here", home)).toBe("nothing to see here");
+
+  // Bare home ending a quoted token — git writes this shape too.
+  expect(redactHome(`cannot change to '${home}': nope`, home)).toBe("cannot change to '~': nope");
+});
+
+test("redactHome is a no-op without a home, and cannot be broken by one containing regex metacharacters", () => {
+  expect(redactHome("fatal: /Users/tester/x", undefined)).toBe("fatal: /Users/tester/x");
+  expect(redactHome("fatal: /Users/tester/x", "")).toBe("fatal: /Users/tester/x");
+
+  // A home directory is a filesystem string and may hold `+ ( ) . *`. Building a
+  // pattern from it would either corrupt the output or silently stop redacting —
+  // a redaction that fails open is worse than none, because the call site looks
+  // handled. Literal scanning cannot have that bug; this pins it.
+  const spicy = "/Users/fisch+er(1).x";
+  expect(redactHome(`fatal: ${spicy}/secret`, spicy)).toBe("fatal: ~/secret");
+
+  // Separator-agnostic, for the reason collapseHome already argues.
+  expect(redactHome("fatal: C:\\Users\\tester\\secret", "C:\\Users\\tester")).toBe("fatal: ~\\secret");
+});
+
+test("redactHome does not redact a different account whose name merely starts with ours", () => {
+  // `/Users/tester` must not turn `/Users/testerson/x` into `~son/x` — that is a
+  // different user's tree, and mangling it would corrupt the message without
+  // protecting anything.
+  expect(redactHome("/Users/testerson/x", "/Users/tester")).toBe("/Users/testerson/x");
 });


### PR DESCRIPTION
Fixes #662.

## The gap

`soma graph close` resolved its probe base directory from raw `process.cwd()` (`src/cli/graph.ts`). The arc-generated launcher shim `cd`s into the install tree **before** `exec` and hands the caller's directory over in `ARC_INVOCATION_CWD`:

```bash
export ARC_INVOCATION_CWD="${ARC_INVOCATION_CWD:-$(pwd)}"
cd "/Users/…/.claude/bin/soma" && exec bun run src/cli.ts "$@"
```

So every declared probe resolved against soma's own arc clone, and a close receipt named a checkout the operator had never opened. `soma export --out` already honoured that variable (#315); the graph probe path never learned the rule.

This is why #662 presents as a 0.18.0 regression: #579 was fixed in a hand-edited shim rather than in soma, so every arc install reintroduced it, and `~/.local/bin` precedes `~/bin` on PATH.

## What changed

**`invocationCwd()` — one expression, both callers** (`src/path-utils.ts`). Trusts `ARC_INVOCATION_CWD` only when it names an absolute, existing directory; otherwise falls back to `process.cwd()`. `substrate-lifecycle.ts` now reads it too instead of carrying its own `??`. Incidentally closes a latent #315 bug: `env.X ?? process.cwd()` did not catch the empty string, so `ARC_INVOCATION_CWD=""` resolved `--out` to the filesystem root.

**`artifact-exists` distinguishes unreachable from absent** (#662 AC-3). Previously `git cat-file -e <ref>:<path>` rendered every failure as `absent at <ref>` — which is what sent the reporter chasing a file that was present.

The subtlety, measured rather than assumed: `cat-file -e` takes an **object name**, not a path, so a genuinely missing path is a *fatal* (128), not a "no" (1). There is no clean 1-vs-128 boundary to predicate on. The branch establishes reachability with `rev-parse --verify --quiet <atRef>^{object}` (whose boundary *is* clean), then reads the second call as a pure answer, accepting only the codes that argv actually returns — `{0, 1, 128}` — and treating anything else as unreachable. A signal-killed child returns `137`/`139` with `timedOut: false`, so a bare timeout check would publish "absent" for a question git never answered.

Both calls bind to the **same object**: `rev-parse` already prints the resolved sha, so `cat-file -e <sha>:<path>` costs no extra spawn and removes a second resolution of one value — the `#579` shape this module forbids everywhere else. Verified across branch, annotated tag, lightweight tag, tag-pointing-at-a-tree, and tree-ish.

**`redactHome()`** (`src/work-graph.ts`). `collapseHome` is prefix-only, so it is inert on a path embedded mid-sentence — which is the shape git's stderr always has. A probe failure was publishing the operator's home path into a receipt on a tracker of unknown visibility. `redactHome` scans literally (no regex, so no escaping bug that could fail open), is boundary-aware so `/Users/me.bak/x` is not corrupted into `~bak/x`, and is separator-agnostic. Redaction runs **before** the tail bound — the other order leaks when the cut lands inside the home path.

`docs/work-graph.md` §2.2 updated: the normative message contract no longer claims a single exit-code rule holds across argv.

## Verification

- `bun test` — 2541 pass / 0 fail
- `bunx tsc --noEmit` — exit 0
- eslint — 72 problems, identical file set and per-file counts to `origin/main`; every touched `src/` file clean
- Every new test verified to **fail** against `origin/main`, and each fix verified falsifiable by reverting its call site
- Behaviour confirmed against real git 2.40.0, not only through stubs

## Review

Four rounds with an independent reviewer. Findings that mattered, each fixed before merge:

- **B1** — the AC-3 split shipped *inverted* for the one probe #662 is about. Caught because the exit-code contract was asserted entirely against stubs written from the same wrong model, so the stubs could not disagree with it. Two of those impossible stubs **predate this branch**.
- **B2** — the first redaction fix was inert; `collapseHome` looked like it handled the leak and did not.
- **mm1** — B1's fix narrowed a guard and re-opened its own class one notch down, for signal-killed children.

## Follow-ups filed, deliberately not fixed here

- #664 — `--probe-cwd` override. `ARC_INVOCATION_CWD` is inherited (`${VAR:-$(pwd)}` preserves an outer value), so it names where the *outermost* arc caller stood. A nested launcher hits #662 one level up.
- #665 — `substrate-lifecycle.ts:229` still resolves the dsh substrate home from bare `process.cwd()`.
- #666 — two further sites publish the operator's home path into receipts: `describeCommand` (subprocess output) and the registry refusal messages (soma's own path). Carries the design question this fix keeps running into — every probe branch assembles its own `observed` and re-decides redaction, which is why the same defect recurred twice.

## Note on AC-1

AC-1 as written ("`--repo <owner/name>` runs probes against `<owner/name>`") specifies a mechanism that cannot be built. `--repo` is a tracker coordinate; probe `repo` is a local working-tree path, because `artifact-exists` with `atRef` needs a checkout rather than an API. There is no mapping, and inferring one would have soma choosing a tree the operator did not — #579 relocated. AC-1's *intent* is satisfied here, because the operator runs the close from the node's checkout. Restatement posted on #662.