### PR TITLE
fix(graph): redact all probe observations

### DIFF
--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -245,6 +245,11 @@ function resolveDeps(options: ProbeRunnerOptions): ProbeRunnerDeps {
   };
 }
 
+/** The sole publication boundary for probe observations: close receipts use this value verbatim. */
+function publishObserved(observed: string): string {
+  return redactHome(observed);
+}
+
 function probed(
   probe: Probe,
   outcome: "pass" | "fail",
@@ -252,7 +257,7 @@ function probed(
   at: string,
   cwd?: string,
 ): ProbeResult {
-  return { probe, state: "probed", outcome, observed, at, ...(cwd === undefined ? {} : { cwd }) };
+  return { probe, state: "probed", outcome, observed: publishObserved(observed), at, ...(cwd === undefined ? {} : { cwd }) };
 }
 
 /**
@@ -279,7 +284,9 @@ function describeCommand(
       : `timed out after ${timeoutSec}s (killed)`;
   }
   const limit = passed ? OBSERVED_PASS_TAIL_LIMIT : OBSERVED_TAIL_LIMIT;
-  const tail = boundObserved([outcome.stdout, outcome.stderr].filter((part) => part.trim().length > 0).join("\n"), limit);
+  // Redact before bounding: a tail cut inside a home path would otherwise sever
+  // its prefix and make the later publication chokepoint unable to recognise it.
+  const tail = boundObserved(redactHome([outcome.stdout, outcome.stderr].filter((part) => part.trim().length > 0).join("\n")), limit);
   return tail.length === 0 ? `exit ${outcome.exitCode}` : `exit ${outcome.exitCode}: ${tail}`;
 }
 
@@ -611,7 +618,10 @@ export async function runProbe(probe: Probe, options: ProbeRunnerOptions): Promi
   // Every result carries the same probe, timestamp, and directory; only the
   // outcome and the observation differ. Binding them once keeps a branch from
   // quietly omitting one — which is how `cwd` would go missing on the path that
-  // needs it most.
+  // needs it most. `probed` is the sole publication chokepoint, so every
+  // result constructor redacts before its observation can reach a close receipt.
+  // `describeCommand` redacts earlier too, before its tail bound can split a
+  // home path and make it unrecognisable at that boundary.
   const finish = (outcome: "pass" | "fail", observed: string): ProbeResult =>
     probed(probe, outcome, observed, at, ranIn);
 

--- a/src/work-graph-probes.ts
+++ b/src/work-graph-probes.ts
@@ -284,9 +284,11 @@ function describeCommand(
       : `timed out after ${timeoutSec}s (killed)`;
   }
   const limit = passed ? OBSERVED_PASS_TAIL_LIMIT : OBSERVED_TAIL_LIMIT;
-  // Redact before bounding: a tail cut inside a home path would otherwise sever
-  // its prefix and make the later publication chokepoint unable to recognise it.
-  const tail = boundObserved(redactHome([outcome.stdout, outcome.stderr].filter((part) => part.trim().length > 0).join("\n")), limit);
+  // Sanitize before bounding: a tail cut inside a home path would otherwise sever
+  // its prefix and make the result-construction boundary unable to recognise it.
+  // `publishObserved` is idempotent, so `probed` applies the same boundary again
+  // when it constructs the result.
+  const tail = boundObserved(publishObserved([outcome.stdout, outcome.stderr].filter((part) => part.trim().length > 0).join("\n")), limit);
   return tail.length === 0 ? `exit ${outcome.exitCode}` : `exit ${outcome.exitCode}: ${tail}`;
 }
 

--- a/test/work-graph-probes.test.ts
+++ b/test/work-graph-probes.test.ts
@@ -985,3 +985,64 @@ test("redaction runs before the tail bound, or a cut inside the home path defeat
     else process.env.HOME = previousHome;
   }
 });
+
+// --- published observation redaction (#666) ----------------------------------
+
+test("a real command subprocess cannot publish its home path in observed output", async () => {
+  const home = process.env.HOME;
+  if (home === undefined || home.length === 0) throw new Error("test requires HOME");
+  const cwd = process.cwd();
+  const run = "ls \"$HOME/.tmp-nonexistent-dir\"";
+
+  // Use the production command seam rather than a synthetic outcome: shell
+  // stderr is the data source that reaches a real close receipt.
+  const result = requireProbed(
+    await runProbe(
+      { type: "command", run, timeoutSec: 10, expectExit: 0 },
+      { cwd, registry: registry([{ run, cwd }]), deps: { now: () => AT } },
+    ),
+  );
+  expect(result.outcome).toBe("fail");
+  expect(result.observed).toContain("~/.tmp-nonexistent-dir");
+  expect(result.observed).not.toContain(home);
+});
+
+test("a real command redacts before its output tail can split a home path", async () => {
+  const home = process.env.HOME;
+  if (home === undefined || home.length === 0) throw new Error("test requires HOME");
+  const cwd = process.cwd();
+  // The output is 1,255 bytes: its 1,200-byte failure tail starts five bytes
+  // into the home path. A post-bound-only sanitizer cannot recognise that tail.
+  const run = "p=\"$HOME/.tmp-nonexistent-dir\"; printf '%050d%s' 0 \"$p\"; yes y | head -c $((1205 - ${#p})); false";
+  const result = requireProbed(
+    await runProbe(
+      { type: "command", run, timeoutSec: 10, expectExit: 0 },
+      { cwd, registry: registry([{ run, cwd }]), deps: { now: () => AT } },
+    ),
+  );
+  expect(result.outcome).toBe("fail");
+  expect(result.observed).toContain("~/.tmp-nonexistent-dir");
+  expect(result.observed).not.toContain(home);
+});
+
+test("the observation chokepoint redacts registry paths in refusal messages", async () => {
+  const home = process.env.HOME;
+  if (home === undefined || home.length === 0) throw new Error("test requires HOME");
+  const path = `${home}/.soma/policy/probe-registry.json`;
+  const registries: ProbeRegistry[] = [
+    { status: "absent", repo: REPO, path },
+    { status: "invalid", repo: REPO, path, reason: "is not valid JSON" },
+  ];
+
+  for (const registry of registries) {
+    const result = requireProbed(
+      await runProbe(
+        { type: "command", run: "bun test", timeoutSec: 10, expectExit: 0 },
+        { cwd: "/repo", registry, deps: { now: () => AT } },
+      ),
+    );
+    expect(result.outcome).toBe("fail");
+    expect(result.observed).toContain("~/.soma/policy/probe-registry.json");
+    expect(result.observed).not.toContain(home);
+  }
+});


### PR DESCRIPTION
Fixes #666.

## Summary
- Route every `ProbeResult.observed` through a home-path redaction boundary.
- Redact command text before tail truncation, preventing a truncated home path from leaking.
- Add focused coverage for command output and probe-registry refusal text.

## Verification
- `bun test test/work-graph-probes.test.ts` (43 focused tests)
- `bun run typecheck`
- `git diff --check`