### PR TITLE
chore(release): 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-08-27
+
+### Added
+
+- **Frozen, content-addressed runtime enforcement artifacts.** Guarded
+  substrates (`claude-code`, `codex`, `grok`) execute their policy hooks from a
+  sealed snapshot under `~/.soma/runtime/artifacts/<hash>`, atomically activated
+  per substrate via `runtime/<substrate>/current`, with `soma runtime status` and
+  `soma runtime rollback --substrate <name>`. Staged sources refuse symlinks,
+  payload files are read-only, and unreferenced artifacts are pruned. Read-only
+  permissions are best-effort hardening, not a tamper-proof boundary. ([#657])
+
+### Changed
+
+- **`auto` work-graph closes cite a CI check run.** `soma graph close` requires
+  `--ci <checkRunId>@<headSha>` for `auto` nodes, and the store verifies
+  `conclusion: success` at that SHA before the bridge reports completion — moving
+  completion from self-authored markdown to an immutable, API-verifiable fact.
+  Detection, not prevention: a collaborator who can push and trigger CI can still
+  mint a passing run. ([#661])
+
 ## [0.18.3] - 2026-08-26
 
 ### Fixed

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,6 +1,6 @@
 schema: arc/v1
 name: soma
-version: 0.18.3
+version: 0.19.0
 type: tool
 tier: community
 description: Substrate-portable Personal AI Assistant core for identity, memory, VSA, skills, learning, and adapters.

--- a/docs/soma-home-layout.md
+++ b/docs/soma-home-layout.md
@@ -29,8 +29,35 @@ re-projection rewrites.
 │   ├── behavior.md         # cross-substrate behavioral rules — NOT created by `soma init`
 │   └── probe-registry.json # work-graph probe authorisations (see docs/work-graph.md §2.2)
 ├── imports/                # migration manifests and portability reports
+├── runtime/                # frozen enforcement artifacts for guarded substrates
 └── projections/            # cached generated projections (codex, claude-code, …)
 ```
+
+### Frozen enforcement artifacts (`runtime/`)
+
+Guarded substrates (`claude-code`, `codex`, `grok`) execute their policy hooks
+from a **frozen, content-addressed runtime snapshot** rather than from the
+source tree:
+
+```text
+~/.soma/runtime/
+├── artifacts/<hash>/                # content-addressed frozen source snapshot
+└── <substrate>/
+    ├── current -> ../artifacts/<hash>  # atomic symlink the hook resolves
+    └── active.json                  # { active, previous } — active + rollback target
+```
+
+Installing a guarded substrate stages the snapshot under `artifacts/<hash>`,
+seals its payload files read-only, and atomically repoints
+`<substrate>/current`; `soma runtime rollback --substrate <name>` swaps back to
+the retained predecessor, and `soma runtime status` inspects the active state.
+Symlinked or special files in the staged source are refused, and unreferenced
+artifacts are pruned so the store does not grow without bound.
+
+Read-only payload permissions are **best-effort hardening, not a tamper-proof
+boundary** — a same-UID actor can `chmod` them back, and no hash runs on the
+hook path by design. They pin the snapshot against incidental edits, not
+against an actor who sets out to modify it.
 
 ## How the assistant talks, and what it may do
 

--- a/docs/work-graph.md
+++ b/docs/work-graph.md
@@ -806,6 +806,18 @@ never suffices alone. The receipt proves *existence + probe passage, not
 quality* — sound because `auto` work sits below the irreversibility line;
 quality ratifies when a downstream HITL node consumes the artifact (#485).
 
+An `auto` close must also cite a **successful CI check run** (`--ci
+<checkRunId>@<headSha>`): the receipt records the run, and the store verifies
+`conclusion: success` at the cited SHA when the bridge reads the node back.
+Check-run conclusions are written only by a GitHub App (GitHub Actions), so an
+issue editor who holds no push/CI-trigger authority cannot fabricate one.
+
+**Detection, not prevention.** Both the run id and the SHA are supplied by the
+closer, so a collaborator who *can* push and trigger CI can still mint a passing
+run on a trivial commit and cite it. The binding refuses the fabricated-run
+forgery (the common, issue-only-editor case); it does not replace
+checkpoint-owned verification of what the probes actually ran against.
+
 ### 3.2 HITL (`propose` / `approve`)
 
 A HITL node **closes on the closing session's say-so**. The human in the loop is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soma",
-  "version": "0.18.3",
+  "version": "0.19.0",
   "private": true,
   "type": "module",
   "description": "Substrate-portable Personal AI Assistant core.",


### PR DESCRIPTION
Release 0.19.0: frozen runtime enforcement artifacts and CI-bound auto completion.