### PR TITLE
refactor: move home projection facts into adapters

### DIFF
--- a/src/adapters/anthropic-cowork/install.ts
+++ b/src/adapters/anthropic-cowork/install.ts
@@ -13,6 +13,7 @@ import {
   ANTHROPIC_COWORK_HOME_FILE_PATHS,
   ANTHROPIC_COWORK_SKILLS_ROOT_PATH,
 } from "../anthropic-cowork";
+import { isAnthropicCoworkSkillProjectionPath, projectAnthropicCoworkHome } from "../anthropic-cowork";
 
 type CoworkRemovalTargetKind = "entrypoint" | "projection-file" | "vsa-skill";
 
@@ -92,6 +93,10 @@ export const anthropicCoworkInstallSpec: SubstrateInstallSpec<"anthropic-cowork"
   substrate: "anthropic-cowork",
   defaultHome: ANTHROPIC_COWORK_DEFAULT_HOME,
   homeFiles: ANTHROPIC_COWORK_HOME_FILE_PATHS,
+  homeProjection: {
+    build: (input) => projectAnthropicCoworkHome(input),
+    isSkillProjectionPath: isAnthropicCoworkSkillProjectionPath,
+  },
   skillsLoaderDir: skillsLoaderUnder(ANTHROPIC_COWORK_SKILLS_ROOT_PATH),
   skillsLoading: "on-demand",
   skillsDiscovery: "catalog",

--- a/src/adapters/claude-code/install.ts
+++ b/src/adapters/claude-code/install.ts
@@ -22,6 +22,9 @@ import {
 } from "./hooks";
 import { CLAUDE_CODE_CLAUDE_MD_RELATIVE_PATH, installClaudeCodeClaudeMd } from "./claude-md";
 import { isClaudeCodeInstallOptions } from "./install-options";
+import { projectClaudeCodeHome, isClaudeCodeSkillProjectionPath } from "../claude-code";
+import { reconcilePortableSkillProjection, writePortableSkillManifest } from "../shared/portable-skill-manifest";
+import { writeProjection } from "../../projection";
 
 export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
   substrate: "claude-code",
@@ -32,6 +35,28 @@ export const claudeCodeInstallSpec: SubstrateInstallSpec<"claude-code"> = {
     SOMA_CLAUDE_HOOK_CONFIG_RELATIVE_PATH,
     "settings.json",
   ],
+  homeProjection: {
+    build: (input) => projectClaudeCodeHome(input),
+    isSkillProjectionPath: isClaudeCodeSkillProjectionPath,
+    write: async (projection, options) => {
+      const portableFiles = projection.bundle.files.filter((file) => isClaudeCodeSkillProjectionPath(file.path));
+      const written = await writeProjection(projection.bundle, projection.substrateHome);
+      if (options.codeOnly === true) return written;
+      await reconcilePortableSkillProjection({
+        somaHome: projection.somaHome,
+        substrate: "claude-code",
+        substrateHome: projection.substrateHome,
+        currentPaths: portableFiles.map((file) => file.path),
+      });
+      await writePortableSkillManifest({
+        somaHome: projection.somaHome,
+        substrate: "claude-code",
+        substrateHome: projection.substrateHome,
+        files: portableFiles,
+      });
+      return written;
+    },
+  },
   // Owned (Soma-exclusive) dirs — see ownedSubtrees JSDoc. Subsumes the former
   // obsoleteHomeFiles for TELOS.md/ACTIVE_ISA.md, which live under rules/soma.
   ownedSubtrees: ["rules/soma", "hooks/soma"],

--- a/src/adapters/codex/install.ts
+++ b/src/adapters/codex/install.ts
@@ -4,6 +4,7 @@ import { configureCodexInstall } from "./config";
 import { skillsLoaderUnder, vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
 import { vsaSiblingPrunePrepare } from "../../legacy-skill-prune";
 import { CODEX_DEFAULT_HOME, codexMemoryPrivateRoots, codexProjectionPrivateRoots } from "../private-roots";
+import { isCodexSkillProjectionPath, projectCodexHome } from "./adapter";
 
 export const CODEX_HOME_FILES = [
   "rules/soma.rules",
@@ -52,6 +53,10 @@ export const codexInstallSpec: SubstrateInstallSpec<"codex"> = {
   substrate: "codex",
   defaultHome: CODEX_DEFAULT_HOME,
   homeFiles: CODEX_HOME_FILES,
+  homeProjection: {
+    build: (input, context) => projectCodexHome(input, context.somaHome, context.homeDir, context.somaRepoPath),
+    isSkillProjectionPath: isCodexSkillProjectionPath,
+  },
   // Owned (Soma-exclusive) dir — see ownedSubtrees JSDoc. (hooks/ + skills/ are shared.)
   ownedSubtrees: ["memories/soma"],
   skillsLoaderDir: skillsLoaderUnder(),

--- a/src/adapters/content-compare-doctor.ts
+++ b/src/adapters/content-compare-doctor.ts
@@ -1,6 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { CURSOR_RULES_BLOCK_BEGIN, buildSubstrateHomeProjection, mergeCursorRulesContent } from "../home-projection";
+import { buildSubstrateHomeProjection } from "../home-projection";
+import { CURSOR_RULES_BLOCK_BEGIN } from "./cursor";
+import { mergeCursorRulesContent } from "./cursor/install";
 import { SomaHomeNotLoadableError, loadProjectionInputForDoctor } from "../doctor-projection-input";
 import { defaultSomaRepoPath } from "../repo-path";
 import { isEnoent, pathExists } from "../fs-utils";

--- a/src/adapters/cursor/install.ts
+++ b/src/adapters/cursor/install.ts
@@ -1,9 +1,41 @@
-import { readFile, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
 import { isEnoent } from "../../fs-errors";
 import { skillsLoaderUnder, vsaSkillUnder, type SubstrateInstallSpec } from "../../install-spec";
-import { CURSOR_HOME_FILE_PATHS, CURSOR_RULES_BLOCK_BEGIN, CURSOR_RULES_BLOCK_END, CURSOR_RULES_PATH } from "../cursor";
+import { writeProjection } from "../../projection";
+import { CURSOR_HOME_FILE_PATHS, CURSOR_RULES_BLOCK_BEGIN, CURSOR_RULES_BLOCK_END, CURSOR_RULES_PATH, isCursorSkillProjectionPath, projectCursorHome } from "../cursor";
 import { stripProvenance } from "../shared";
+
+function renderCursorRulesBlock(content: string): string {
+  return `${CURSOR_RULES_BLOCK_BEGIN}\n${content.trimEnd()}\n${CURSOR_RULES_BLOCK_END}`;
+}
+
+function replaceCursorRulesBlock(existing: string, generated: string): string {
+  const start = existing.indexOf(CURSOR_RULES_BLOCK_BEGIN);
+  if (start === -1) return `${existing.trimEnd()}\n\n${renderCursorRulesBlock(generated)}\n`;
+  const end = existing.indexOf(CURSOR_RULES_BLOCK_END, start);
+  if (end === -1) return `${existing.trimEnd()}\n\n${renderCursorRulesBlock(generated)}\n`;
+  const before = existing.slice(0, start).trimEnd();
+  const after = existing.slice(end + CURSOR_RULES_BLOCK_END.length).trimStart();
+  const next = [before, renderCursorRulesBlock(generated), after.trimEnd()].filter((part) => part.length > 0).join("\n\n");
+  return `${next}\n`;
+}
+
+/** The Cursor-managed block definition shared by the writer and doctor. */
+export function mergeCursorRulesContent(existing: string, generated: string): string {
+  if (existing.length === 0 || existing.startsWith("# Soma Cursor Projection")) {
+    return `${generated.trimEnd()}\n`;
+  }
+  return replaceCursorRulesBlock(existing, generated);
+}
+
+async function mergeCursorRulesFile(target: string, generated: string): Promise<string> {
+  const existing = await readFile(target, "utf8").catch((error: unknown) => {
+    if (typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT") return "";
+    throw error;
+  });
+  return mergeCursorRulesContent(existing, generated);
+}
 
 async function shouldRemoveSomaRulesDir(target: string): Promise<boolean> {
   const markerFile = join(target, "README.md");
@@ -53,6 +85,25 @@ export const cursorInstallSpec: SubstrateInstallSpec<"cursor"> = {
   substrate: "cursor",
   defaultHome: ".",
   homeFiles: CURSOR_HOME_FILE_PATHS,
+  homeProjection: {
+    build: (input) => projectCursorHome(input),
+    isSkillProjectionPath: isCursorSkillProjectionPath,
+    write: async (projection) => {
+      const cursorRules = projection.bundle.files.find((file) => file.path === CURSOR_RULES_PATH);
+      const projectionWithoutCursorRules = {
+        ...projection.bundle,
+        files: projection.bundle.files.filter((file) => file.path !== CURSOR_RULES_PATH),
+      };
+      const written = await writeProjection(projectionWithoutCursorRules, projection.substrateHome);
+      if (cursorRules) {
+        const target = resolve(projection.substrateHome, CURSOR_RULES_PATH);
+        await mkdir(dirname(target), { recursive: true });
+        await writeFile(target, await mergeCursorRulesFile(target, cursorRules.content), "utf8");
+        written.files.push(target);
+      }
+      return written;
+    },
+  },
   // Owned (Soma-exclusive) dir — see ownedSubtrees JSDoc. Subsumes the former
   // obsoleteHomeFiles for TELOS.md/ACTIVE_ISA.md under .cursor/rules/soma.
   ownedSubtrees: [".cursor/rules/soma"],

--- a/src/adapters/dsh/install.ts
+++ b/src/adapters/dsh/install.ts
@@ -2,6 +2,7 @@ import { skillsLoaderUnder, vsaSkillUnder, type SubstrateInstallSpec } from "../
 import { DSH_DEFAULT_HOME } from "../private-roots";
 import { configureDshAgentsPointer } from "./config-patch";
 import { DSH_HOST_PLUGIN_ID, installDshHostPlugin } from "./plugin";
+import { isDshSkillProjectionPath, projectDshHome } from "./adapter";
 
 /**
  * Static file set emitted by `projectDshHome`, relative to `~/.dsh` — the
@@ -58,6 +59,10 @@ export const dshInstallSpec: SubstrateInstallSpec<"dsh"> = {
   substrate: "dsh",
   defaultHome: DSH_DEFAULT_HOME,
   homeFiles: DSH_HOME_FILES,
+  homeProjection: {
+    build: (input, context) => projectDshHome(input, context.somaHome, context.homeDir, context.somaRepoPath),
+    isSkillProjectionPath: isDshSkillProjectionPath,
+  },
   // Soma-exclusive dir under the DSH home. `skills/` itself is SHARED (the
   // loader holds registry symlinks + the principal's own skills), so only the
   // soma skill dir is owned — the reconcile prunes it to the projected set

--- a/src/adapters/grok/install.ts
+++ b/src/adapters/grok/install.ts
@@ -21,6 +21,9 @@ import {
 import { smokeTestInstalledGrokHookCommand } from "./hook-smoke";
 import { removeGrokPortableSkillProjection } from "./install-manifest";
 import { validateGrokInstallRuntime } from "./version";
+import { isGrokSkillProjectionPath, projectGrokHome } from "./adapter";
+import { reconcileGrokPortableSkillProjection, writeGrokInstallManifest } from "./install-manifest";
+import { writeProjection } from "../../projection";
 
 /**
  * Static file set emitted by `projectGrokHome`, relative to `~/.grok` —
@@ -172,6 +175,30 @@ export const grokInstallSpec: SubstrateInstallSpec<"grok"> = {
   substrate: "grok",
   defaultHome: GROK_DEFAULT_HOME,
   homeFiles: GROK_HOME_FILES,
+  homeProjection: {
+    build: (input, context) => projectGrokHome(input, context.somaHome, {
+      homeDir: context.homeDir,
+      somaRepoPath: context.somaRepoPath,
+      grokHome: context.substrateHome,
+    }),
+    isSkillProjectionPath: isGrokSkillProjectionPath,
+    write: async (projection, options) => {
+      const portableFiles = projection.bundle.files.filter((file) => isGrokPortableSkillProjectionPath(file.path));
+      const written = await writeProjection(projection.bundle, projection.substrateHome);
+      if (options.codeOnly === true) return written;
+      await reconcileGrokPortableSkillProjection({
+        somaHome: projection.somaHome,
+        substrateHome: projection.substrateHome,
+        currentPaths: portableFiles.map((file) => file.path),
+      });
+      await writeGrokInstallManifest({
+        somaHome: projection.somaHome,
+        substrateHome: projection.substrateHome,
+        files: portableFiles,
+      });
+      return written;
+    },
+  },
   // refuse to install against an unsupported Grok runtime —
   // the whole adapter is a set of version-pinned assumptions (doctor
   // inspect shape, hook event set, enumerated tool names). Reads

--- a/src/adapters/pi-dev/install.ts
+++ b/src/adapters/pi-dev/install.ts
@@ -6,6 +6,7 @@ import {
   removeLegacyPiDevVsaSkillProjection,
 } from "./skill-projection";
 import { validatePiDevInstallRuntime } from "./version";
+import { isPiDevSkillProjectionPath, projectPiDevHome } from "./adapter";
 
 export const PI_DEV_HOME_FILES = [
   "agent/extensions/soma.ts",
@@ -29,6 +30,10 @@ export const piDevInstallSpec: SubstrateInstallSpec<"pi-dev"> = {
   substrate: "pi-dev",
   defaultHome: PI_DEV_DEFAULT_HOME,
   homeFiles: PI_DEV_HOME_FILES,
+  homeProjection: {
+    build: (input, context) => projectPiDevHome(input, context.somaHome),
+    isSkillProjectionPath: isPiDevSkillProjectionPath,
+  },
   // Owned (Soma-exclusive) dir — see ownedSubtrees JSDoc. (agent/extensions + agent/skills shared.)
   ownedSubtrees: ["agent/soma"],
   skillsLoaderDir: skillsLoaderUnder("agent"),

--- a/src/home-projection.ts
+++ b/src/home-projection.ts
@@ -1,327 +1,131 @@
 import { homedir } from "node:os";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join, resolve } from "node:path";
-import { dirname } from "node:path";
-import { CURSOR_RULES_BLOCK_BEGIN, CURSOR_RULES_BLOCK_END, CURSOR_RULES_PATH } from "./adapters/cursor";
-import { projectClaudeCodeHome, projectCodexHome, projectCursorHome, projectDshHome, projectGrokHome, projectPiDevHome } from "./adapters";
-import { isAnthropicCoworkSkillProjectionPath, projectAnthropicCoworkHome } from "./adapters/anthropic-cowork";
-import { isClaudeCodeSkillProjectionPath } from "./adapters/claude-code";
-import { isCodexSkillProjectionPath } from "./adapters/codex/adapter";
-import { isCursorSkillProjectionPath } from "./adapters/cursor";
-import { isDshSkillProjectionPath } from "./adapters/dsh/adapter";
-import { isGrokSkillProjectionPath } from "./adapters/grok/adapter";
-import { isGrokPortableSkillProjectionPath } from "./adapters/grok/install";
-import { reconcileGrokPortableSkillProjection, writeGrokInstallManifest } from "./adapters/grok/install-manifest";
-import { reconcilePortableSkillProjection, writePortableSkillManifest } from "./adapters/shared/portable-skill-manifest";
-import { isPiDevSkillProjectionPath } from "./adapters/pi-dev/adapter";
+import { installSpecFor, isRegisteredInstallSubstrate } from "./install-spec-registry";
+import type { HomeProjectionBuildContext } from "./install-spec";
 import { writeProjection } from "./projection";
 import { defaultSomaRepoPath } from "./repo-path";
-import { defaultSubstrateHome } from "./install-spec-registry";
 import type { InstallSubstrate, Projection, ProjectionInput, ProjectionSubstrate, SomaHomeProjection, SomaHomeProjectionOptions, WrittenProjection } from "./types";
-
-const HOME_PROJECTION_INSTALL_SUBSTRATES = ["codex", "pi-dev", "claude-code", "cursor", "grok", "dsh", "anthropic-cowork"] as const satisfies readonly InstallSubstrate[];
-
-function isHomeProjectionInstallSubstrate(substrate: ProjectionSubstrate): substrate is InstallSubstrate {
-  return (HOME_PROJECTION_INSTALL_SUBSTRATES as readonly ProjectionSubstrate[]).includes(substrate);
-}
 
 export function resolveHomeProjectionPaths(
   substrate: ProjectionSubstrate,
   options: SomaHomeProjectionOptions = {},
 ): Omit<SomaHomeProjection, "bundle"> {
-  if (!isHomeProjectionInstallSubstrate(substrate)) {
+  if (!isRegisteredInstallSubstrate(substrate)) {
     throw new Error(`Home projection is not implemented for substrate: ${substrate}`);
   }
 
   const homeDir = resolve(options.homeDir ?? homedir());
-  const defaultHome = defaultSubstrateHome(substrate);
+  const spec = installSpecFor(substrate);
 
   return {
     substrate,
     somaHome: resolve(options.somaHome ?? join(homeDir, ".soma")),
-    substrateHome: resolve(options.substrateHome ?? join(homeDir, defaultHome)),
+    substrateHome: resolve(options.substrateHome ?? join(homeDir, spec.defaultHome)),
   };
 }
-
-function buildHomeProjectionFor(
-  substrate: InstallSubstrate,
-  options: SomaHomeProjectionOptions,
-  project: (paths: Omit<SomaHomeProjection, "bundle">) => Projection,
-): SomaHomeProjection {
-  const paths = resolveHomeProjectionPaths(substrate, options);
-
-  return {
-    ...paths,
-    bundle: project(paths),
-  };
-}
-
-type SkillProjectionPathPredicate = (path: string) => boolean;
 
 function maybeCodeOnlyProjection(
   projection: Projection,
   options: SomaHomeProjectionOptions,
-  isSkillProjectionPath: SkillProjectionPathPredicate,
+  isSkillProjectionPath: (path: string) => boolean,
 ): Projection {
   if (options.codeOnly !== true) return projection;
-  return {
-    ...projection,
-    files: projection.files.filter((file) => !isSkillProjectionPath(file.path)),
-  };
+  return { ...projection, files: projection.files.filter((file) => !isSkillProjectionPath(file.path)) };
 }
 
-export function buildCodexHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
-  const homeDir = resolve(options.homeDir ?? homedir());
-  const somaRepoPath = resolve(options.somaRepoPath ?? defaultSomaRepoPath());
-
-  return buildHomeProjectionFor("codex", options, (paths) =>
-    maybeCodeOnlyProjection(projectCodexHome(input, paths.somaHome, homeDir, somaRepoPath), options, isCodexSkillProjectionPath),
-  );
-}
-
-export async function installCodexHomeProjection(
-  input: ProjectionInput,
-  options: SomaHomeProjectionOptions = {},
-): Promise<WrittenProjection> {
-  const projection = buildCodexHomeProjection(input, options);
-  return writeProjection(projection.bundle, projection.substrateHome);
-}
-
-export function buildPiDevHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
-  return buildHomeProjectionFor("pi-dev", options, (paths) =>
-    maybeCodeOnlyProjection(projectPiDevHome(input, paths.somaHome), options, isPiDevSkillProjectionPath),
-  );
-}
-
-export async function installPiDevHomeProjection(
-  input: ProjectionInput,
-  options: SomaHomeProjectionOptions = {},
-): Promise<WrittenProjection> {
-  const projection = buildPiDevHomeProjection(input, options);
-  return writeProjection(projection.bundle, projection.substrateHome);
-}
-
-/**
- * Claude Code home projection (#37 minimal). For now this bundle is
- * just the active-VSA file at `PAI/ACTIVE_VSA.md`; the full home
- * install lands in #29 with the `.claude/rules/` pivot.
- */
-export function buildClaudeCodeHomeProjection(
+function buildHomeProjectionFor<S extends InstallSubstrate>(
+  substrate: S,
   input: ProjectionInput,
   options: SomaHomeProjectionOptions = {},
 ): SomaHomeProjection {
-  return buildHomeProjectionFor("claude-code", options, () =>
-    maybeCodeOnlyProjection(projectClaudeCodeHome(input), options, isClaudeCodeSkillProjectionPath),
-  );
+  const paths = resolveHomeProjectionPaths(substrate, options);
+  const homeDir = resolve(options.homeDir ?? homedir());
+  const context: HomeProjectionBuildContext<S> = {
+    substrate,
+    homeDir,
+    somaHome: paths.somaHome,
+    substrateHome: paths.substrateHome,
+    somaRepoPath: resolve(options.somaRepoPath ?? defaultSomaRepoPath()),
+  };
+  const spec = installSpecFor(substrate);
+
+  return {
+    ...paths,
+    bundle: maybeCodeOnlyProjection(spec.homeProjection.build(input, context), options, spec.homeProjection.isSkillProjectionPath),
+  };
 }
 
-export async function installClaudeCodeHomeProjection(
+async function installHomeProjectionFor<S extends InstallSubstrate>(
+  substrate: S,
   input: ProjectionInput,
   options: SomaHomeProjectionOptions = {},
 ): Promise<WrittenProjection> {
-  const projection = buildClaudeCodeHomeProjection(input, options);
-  // Portable skills land under the SHARED `skills/` dir, so the owned-subtree
-  // reconcile (rules/soma, hooks/soma) cannot prune stale ones. Mirror grok:
-  // record the dynamically-named portable-skill files (path + content hash) in
-  // an install manifest on the Soma side so uninstall round-trips them, and
-  // reconcile away files a previous install recorded that this projection no
-  // longer contains (a skill removed/renamed in the profile).
-  const portableFiles = projection.bundle.files.filter((file) => isClaudeCodeSkillProjectionPath(file.path));
-  const written = await writeProjection(projection.bundle, projection.substrateHome);
-  if (options.codeOnly === true) {
-    return written;
-  }
-  await reconcilePortableSkillProjection({
-    somaHome: projection.somaHome,
-    substrate: "claude-code",
-    substrateHome: projection.substrateHome,
-    currentPaths: portableFiles.map((file) => file.path),
-  });
-  await writePortableSkillManifest({
-    somaHome: projection.somaHome,
-    substrate: "claude-code",
-    substrateHome: projection.substrateHome,
-    files: portableFiles,
-  });
-  return written;
+  const projection = buildHomeProjectionFor(substrate, input, options);
+  return (await installSpecFor(substrate).homeProjection.write?.(projection, options)) ?? writeProjection(projection.bundle, projection.substrateHome);
+}
+
+// Public compatibility interfaces. Native build/write facts live with the adapter install specs.
+export function buildCodexHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
+  return buildHomeProjectionFor("codex", input, options);
+}
+
+export async function installCodexHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): Promise<WrittenProjection> {
+  return installHomeProjectionFor("codex", input, options);
+}
+
+export function buildPiDevHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
+  return buildHomeProjectionFor("pi-dev", input, options);
+}
+
+export async function installPiDevHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): Promise<WrittenProjection> {
+  return installHomeProjectionFor("pi-dev", input, options);
+}
+
+export function buildClaudeCodeHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
+  return buildHomeProjectionFor("claude-code", input, options);
+}
+
+export async function installClaudeCodeHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): Promise<WrittenProjection> {
+  return installHomeProjectionFor("claude-code", input, options);
 }
 
 export function buildCursorHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
-  return buildHomeProjectionFor("cursor", options, () => maybeCodeOnlyProjection(projectCursorHome(input), options, isCursorSkillProjectionPath));
+  return buildHomeProjectionFor("cursor", input, options);
+}
+
+export async function installCursorHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): Promise<WrittenProjection> {
+  return installHomeProjectionFor("cursor", input, options);
 }
 
 export function buildGrokHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
-  const homeDir = resolve(options.homeDir ?? homedir());
-  const somaRepoPath = resolve(options.somaRepoPath ?? defaultSomaRepoPath());
-
-  // The hook surface embeds install-time absolutes, so the
-  // resolved substrate home — including a substrateHome override — and
-  // the trusted repo path flow into the projection.
-  return buildHomeProjectionFor("grok", options, (paths) =>
-    maybeCodeOnlyProjection(
-      projectGrokHome(input, paths.somaHome, { homeDir, somaRepoPath, grokHome: paths.substrateHome }),
-      options,
-      isGrokSkillProjectionPath,
-    ),
-  );
+  return buildHomeProjectionFor("grok", input, options);
 }
 
-export function buildAnthropicCoworkHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
-  return buildHomeProjectionFor("anthropic-cowork", options, () =>
-    maybeCodeOnlyProjection(projectAnthropicCoworkHome(input), options, isAnthropicCoworkSkillProjectionPath),
-  );
+export async function installGrokHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): Promise<WrittenProjection> {
+  return installHomeProjectionFor("grok", input, options);
 }
 
 export function buildDshHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
-  const homeDir = resolve(options.homeDir ?? homedir());
-  const somaRepoPath = resolve(options.somaRepoPath ?? defaultSomaRepoPath());
-
-  return buildHomeProjectionFor("dsh", options, (paths) =>
-    maybeCodeOnlyProjection(projectDshHome(input, paths.somaHome, homeDir, somaRepoPath), options, isDshSkillProjectionPath),
-  );
+  return buildHomeProjectionFor("dsh", input, options);
 }
 
-export async function installDshHomeProjection(
-  input: ProjectionInput,
-  options: SomaHomeProjectionOptions = {},
-): Promise<WrittenProjection> {
-  const projection = buildDshHomeProjection(input, options);
-  // No portable-skill manifest here: DSH is a `loader` substrate, so the
-  // bundle carries no portable-skill copies for the manifest to track — the
-  // loader holds install-created registry symlinks instead (claude-code's
-  // removeProjectedSkillLinks owns those on uninstall).
-  return writeProjection(projection.bundle, projection.substrateHome);
+export async function installDshHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): Promise<WrittenProjection> {
+  return installHomeProjectionFor("dsh", input, options);
 }
 
-/**
- * Central substrate → home-projection dispatcher. soma#356: a single owner of
- * the substrate-to-builder mapping so callers (e.g. `project-skill`'s catalog
- * refresh) do not each maintain a parallel hard-coded map.
- */
+export function buildAnthropicCoworkHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): SomaHomeProjection {
+  return buildHomeProjectionFor("anthropic-cowork", input, options);
+}
+
+export async function installAnthropicCoworkHomeProjection(input: ProjectionInput, options: SomaHomeProjectionOptions = {}): Promise<WrittenProjection> {
+  return installHomeProjectionFor("anthropic-cowork", input, options);
+}
+
+/** Generic caller surface; lookup is through adapter-owned install facts. */
 export function buildSubstrateHomeProjection(
   substrate: InstallSubstrate,
   input: ProjectionInput,
   options: SomaHomeProjectionOptions = {},
 ): SomaHomeProjection {
-  switch (substrate) {
-    case "codex":
-      return buildCodexHomeProjection(input, options);
-    case "pi-dev":
-      return buildPiDevHomeProjection(input, options);
-    case "claude-code":
-      return buildClaudeCodeHomeProjection(input, options);
-    case "cursor":
-      return buildCursorHomeProjection(input, options);
-    case "grok":
-      return buildGrokHomeProjection(input, options);
-    case "dsh":
-      return buildDshHomeProjection(input, options);
-    case "anthropic-cowork":
-      return buildAnthropicCoworkHomeProjection(input, options);
-  }
-}
-
-export async function installAnthropicCoworkHomeProjection(
-  input: ProjectionInput,
-  options: SomaHomeProjectionOptions = {},
-): Promise<WrittenProjection> {
-  const projection = buildAnthropicCoworkHomeProjection(input, options);
-  return writeProjection(projection.bundle, projection.substrateHome);
-}
-
-export async function installGrokHomeProjection(
-  input: ProjectionInput,
-  options: SomaHomeProjectionOptions = {},
-): Promise<WrittenProjection> {
-  const projection = buildGrokHomeProjection(input, options);
-  const portableFiles = projection.bundle.files.filter((file) => isGrokPortableSkillProjectionPath(file.path));
-  const written = await writeProjection(projection.bundle, projection.substrateHome);
-  if (options.codeOnly === true) {
-    return written;
-  }
-  // U6 follow-up: the manifest records the dynamically-named
-  // portable-skill files (path + content hash) on the Soma side so
-  // uninstall can round-trip them. Before refreshing it, reconcile:
-  // files the previous install recorded that this projection no longer
-  // contains (skill removed/renamed in the profile) are removed with the
-  // same user-edit-preserving guards uninstall uses — otherwise they
-  // stay orphaned in ~/.grok. Reproject/upgrade reuse this installer.
-  await reconcileGrokPortableSkillProjection({
-    somaHome: projection.somaHome,
-    substrateHome: projection.substrateHome,
-    currentPaths: portableFiles.map((file) => file.path),
-  });
-  await writeGrokInstallManifest({
-    somaHome: projection.somaHome,
-    substrateHome: projection.substrateHome,
-    files: portableFiles,
-  });
-  return written;
-}
-
-export async function installCursorHomeProjection(
-  input: ProjectionInput,
-  options: SomaHomeProjectionOptions = {},
-): Promise<WrittenProjection> {
-  const projection = buildCursorHomeProjection(input, options);
-  const cursorRules = projection.bundle.files.find((file) => file.path === CURSOR_RULES_PATH);
-  const projectionWithoutCursorRules = {
-    ...projection.bundle,
-    files: projection.bundle.files.filter((file) => file.path !== CURSOR_RULES_PATH),
-  };
-  const written = await writeProjection(projectionWithoutCursorRules, projection.substrateHome);
-
-  if (cursorRules) {
-    const target = resolve(projection.substrateHome, CURSOR_RULES_PATH);
-    await mkdir(dirname(target), { recursive: true });
-    await writeFile(target, await mergeCursorRulesFile(target, cursorRules.content), "utf8");
-    written.files.push(target);
-  }
-
-  return written;
-}
-
-export { CURSOR_RULES_BLOCK_BEGIN, CURSOR_RULES_BLOCK_END };
-
-function renderCursorRulesBlock(content: string): string {
-  return `${CURSOR_RULES_BLOCK_BEGIN}\n${content.trimEnd()}\n${CURSOR_RULES_BLOCK_END}`;
-}
-
-function replaceCursorRulesBlock(existing: string, generated: string): string {
-  const start = existing.indexOf(CURSOR_RULES_BLOCK_BEGIN);
-  if (start === -1) return `${existing.trimEnd()}\n\n${renderCursorRulesBlock(generated)}\n`;
-  const end = existing.indexOf(CURSOR_RULES_BLOCK_END, start);
-  if (end === -1) return `${existing.trimEnd()}\n\n${renderCursorRulesBlock(generated)}\n`;
-  const before = existing.slice(0, start).trimEnd();
-  const after = existing.slice(end + CURSOR_RULES_BLOCK_END.length).trimStart();
-  const next = [before, renderCursorRulesBlock(generated), after.trimEnd()].filter((part) => part.length > 0).join("\n\n");
-  return `${next}\n`;
-}
-
-/**
- * Pure merge decision for `.cursorrules`: given whatever currently sits on
- * disk (empty string when the file does not exist yet) and the freshly
- * rendered Soma block body, compute the byte content the file SHOULD have.
- * Exported so `soma doctor`'s content-compare (soma#370) can ask "does the
- * on-disk file already reflect a fresh render" without duplicating the
- * merge/patch semantics `mergeCursorRulesFile` writes to disk — the doctor
- * and the writer must never drift apart on what "managed" means here.
- */
-export function mergeCursorRulesContent(existing: string, generated: string): string {
-  if (existing.length === 0 || existing.startsWith("# Soma Cursor Projection")) {
-    return `${generated.trimEnd()}\n`;
-  }
-
-  return replaceCursorRulesBlock(existing, generated);
-}
-
-async function mergeCursorRulesFile(target: string, generated: string): Promise<string> {
-  const existing = await readFile(target, "utf8").catch((error: unknown) => {
-    if (typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT") {
-      return "";
-    }
-    throw error;
-  });
-
-  return mergeCursorRulesContent(existing, generated);
+  return buildHomeProjectionFor(substrate, input, options);
 }

--- a/src/install-spec.ts
+++ b/src/install-spec.ts
@@ -1,5 +1,13 @@
 import { resolve } from "node:path";
-import type { InstallSubstrate, ProjectionSubstrate } from "./types";
+import type {
+  InstallSubstrate,
+  Projection,
+  ProjectionInput,
+  ProjectionSubstrate,
+  SomaHomeProjection,
+  SomaHomeProjectionOptions,
+  WrittenProjection,
+} from "./types";
 
 export type { InstallSubstrate } from "./types";
 
@@ -25,6 +33,22 @@ export interface VsaSkillProjectionSpec {
   destinationDir(substrateHome: string): string;
   skillNameOverride?: string;
   prepare?(substrateHome: string): Promise<void>;
+}
+
+/** Resolved values an adapter needs to build its native home projection. */
+export interface HomeProjectionBuildContext<S extends InstallSubstrate = InstallSubstrate> {
+  substrate: S;
+  homeDir: string;
+  somaHome: string;
+  substrateHome: string;
+  somaRepoPath: string;
+}
+
+/** Adapter-owned native projection facts; the installer retains orchestration. */
+export interface HomeProjectionSpec<S extends InstallSubstrate = InstallSubstrate> {
+  build(input: ProjectionInput, context: HomeProjectionBuildContext<S>): Projection;
+  isSkillProjectionPath(path: string): boolean;
+  write?(projection: SomaHomeProjection, options: SomaHomeProjectionOptions): Promise<WrittenProjection>;
 }
 
 export function vsaSkillUnder(...pathSegments: string[]): (substrateHome: string) => string {
@@ -121,6 +145,7 @@ export interface SubstrateInstallSpec<S extends InstallSubstrate = InstallSubstr
   substrate: S;
   defaultHome: string;
   homeFiles: readonly string[];
+  homeProjection: HomeProjectionSpec<S>;
   /**
    * Files this substrate used to manage but no longer writes (e.g. a renamed
    * projection). Removed under the substrate home on every install/reproject/

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -319,12 +319,19 @@ test("install spec registry has adapter-owned facts for every install substrate"
   const substrates = ["codex", "pi-dev", "claude-code", "cursor", "grok", "dsh", "anthropic-cowork"] as const;
 
   expect(allInstallSpecs().map((spec) => spec.substrate).sort()).toEqual([...substrates].sort());
+  expect(allInstallSpecs().flatMap((spec) => spec.homeProjection.write ? [spec.substrate] : []).sort()).toEqual([
+    "claude-code",
+    "cursor",
+    "grok",
+  ]);
 
   for (const substrate of substrates) {
     const spec = installSpecFor(substrate);
     expect(spec.substrate).toBe(substrate);
     expect(spec.defaultHome.length).toBeGreaterThan(0);
     expect(spec.homeFiles.length).toBeGreaterThan(0);
+    expect(spec.homeProjection.build).toBeDefined();
+    expect(spec.homeProjection.isSkillProjectionPath).toBeDefined();
     expect(spec.vsaSkillProjection.destinationDir("/tmp/substrate-home")).toContain("/tmp/substrate-home");
     expect(spec.uninstall.kind).toMatch(/implemented|reserved/);
   }


### PR DESCRIPTION
## Summary
- move native home-projection build, path predicate, and custom write facts into each adapter install spec
- retain generic installer orchestration and public compatibility projection APIs
- preserve Cursor rules merging and portable manifest reconciliation in their adapters

## Verification
- bun run typecheck
- bun test --timeout 10000 (2570 pass, 0 fail)
- git diff --check

The full suite's default timeout exposed one timing-sensitive test under suite contention; rerunning the full suite with the explicit 10s timeout passed.