### PR TITLE
refactor: expose installation partial receipts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -384,6 +384,8 @@ export {
 // runtime shape in the follow-up PR. Tests can import the helpers
 // directly from the substrate path.
 export { writeProjection } from "./projection";
+export { SomaInstallError, SomaInstallExecution } from "./installation-execution";
+export type { SomaInstallOperation, SomaPartialInstallResult } from "./installation-execution";
 export { createPaths, type SomaPathsOptions } from "./paths";
 export {
   advisor,

--- a/src/index.ts
+++ b/src/index.ts
@@ -384,7 +384,7 @@ export {
 // runtime shape in the follow-up PR. Tests can import the helpers
 // directly from the substrate path.
 export { writeProjection } from "./projection";
-export { SomaInstallError, SomaInstallExecution } from "./installation-execution";
+export { SomaInstallError } from "./installation-execution";
 export type { SomaInstallOperation, SomaPartialInstallResult } from "./installation-execution";
 export { createPaths, type SomaPathsOptions } from "./paths";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -385,7 +385,7 @@ export {
 // directly from the substrate path.
 export { writeProjection } from "./projection";
 export { SomaInstallError } from "./installation-execution";
-export type { SomaInstallOperation, SomaPartialInstallResult } from "./installation-execution";
+export type { SomaHomeInstallReceipt, SomaInstallStage, SomaPartialInstallResult } from "./installation-execution";
 export { createPaths, type SomaPathsOptions } from "./paths";
 export {
   advisor,

--- a/src/index.ts
+++ b/src/index.ts
@@ -385,7 +385,7 @@ export {
 // directly from the substrate path.
 export { writeProjection } from "./projection";
 export { SomaInstallError } from "./installation-execution";
-export type { SomaHomeInstallReceipt, SomaInstallStage, SomaPartialInstallResult } from "./installation-execution";
+export type { SomaHomeInstallReceipt, SomaInstallStage, SomaPartialInstallResult, SomaSubstrateInstallReceipt } from "./installation-execution";
 export { createPaths, type SomaPathsOptions } from "./paths";
 export {
   advisor,

--- a/src/index.ts
+++ b/src/index.ts
@@ -385,7 +385,7 @@ export {
 // directly from the substrate path.
 export { writeProjection } from "./projection";
 export { SomaInstallError } from "./installation-execution";
-export type { SomaHomeInstallReceipt, SomaInstallStage, SomaPartialInstallResult, SomaSubstrateInstallReceipt } from "./installation-execution";
+export type { SomaHomeInstallReceipt, SomaInstallStage, SomaPartialInstallResult, SomaRuntimeArtifactReceipt, SomaSubstrateInstallReceipt } from "./installation-execution";
 export { createPaths, type SomaPathsOptions } from "./paths";
 export {
   advisor,

--- a/src/install.ts
+++ b/src/install.ts
@@ -24,7 +24,7 @@ import { loadMemoryIndexForProjection } from "./memory-index";
 import { isUnderOrEqual, reconcileOwnedDir } from "./projection-reconcile";
 import { isEnoent } from "./fs-errors";
 import { isGuardedRuntimeSubstrate, stageRuntimeArtifact } from "./runtime-artifact";
-import { SomaInstallExecution } from "./installation-execution";
+import { SomaInstallExecution } from "./installation-executor";
 import {
   type ImplementedUninstallSpec,
   type InstallSubstrate,
@@ -180,10 +180,10 @@ async function installSomaForSubstrate(
     // stale ISA here would re-propagate to every substrate on each install. Cheap +
     // idempotent (a no-op readdir+gate once ISA is gone). Provenance-gated
     // (frontmatter name: ISA + identity marker) — a user "ISA" skill is preserved.
-    await execution.run("prepare-soma-home-skills", () => pruneLegacyVsaSkill(createPaths(somaHome.somaHome).skills()));
+    await execution.run("prune-legacy-vsa-skill", () => pruneLegacyVsaSkill(createPaths(somaHome.somaHome).skills()));
     // Install VSA skill into Soma home (canonical baseline) so other
     // tooling reading <somaHome>/skills/VSA continues to work.
-    await execution.run("prepare-soma-home-skills", () => installVsaSkillProjection({
+    await execution.run("install-soma-home-vsa-skill", () => installVsaSkillProjection({
       homeDir: options.homeDir,
       somaHome: somaHome.somaHome,
       somaRepoPath,
@@ -195,7 +195,7 @@ async function installSomaForSubstrate(
     // installer above owns its baseline). Placed before the loadSomaHome reload
     // below so install #1 already lists + projects them. Idempotent + byte-for-
     // byte from the repo source; user-added files under a skill dir survive.
-    bundledSkillNames = (await execution.run("prepare-soma-home-skills", () => installBundledSkillsIntoHome({
+    bundledSkillNames = (await execution.run("install-bundled-skills", () => installBundledSkillsIntoHome({
       homeDir: options.homeDir,
       somaHome: somaHome.somaHome,
       somaRepoPath,
@@ -207,7 +207,7 @@ async function installSomaForSubstrate(
     // were declared." and only the second install converges. Reloading makes
     // the very first projection already list the VSA skill — install #1 is
     // correct and byte-identical to every re-run.
-    projectionContext = await execution.run("prepare-soma-home-skills", () => loadSomaHome(somaHome.somaHome));
+    projectionContext = await execution.run("reload-soma-home-context", () => loadSomaHome(somaHome.somaHome));
   }
   const projectionOptions = {
     homeDir: options.homeDir,
@@ -224,8 +224,8 @@ async function installSomaForSubstrate(
   const substrateRoot = resolve(options.substrateHome ?? join(resolvedHomeDir, spec.defaultHome));
   await execution.run("validate-substrate", () => spec.validator?.(substrateRoot));
   if (!codeOnly) {
-    await execution.run("install-vsa-skill", () => spec.vsaSkillProjection.prepare?.(substrateRoot));
-    await execution.run("install-vsa-skill", () => installVsaSkillProjection({
+    await execution.run("prepare-substrate-vsa-skill", () => spec.vsaSkillProjection.prepare?.(substrateRoot));
+    await execution.run("install-substrate-vsa-skill", () => installVsaSkillProjection({
       homeDir: options.homeDir,
       somaHome: somaHome.somaHome,
       somaRepoPath,
@@ -263,6 +263,8 @@ async function installSomaForSubstrate(
     substrateHome: substrateHome.rootDir,
     options,
   }));
+  substrateHome = { ...substrateHome, files: [...substrateHome.files, ...postProjectionFiles] };
+  execution.record({ substrateHome });
   const lifecycleSpec = spec.lifecycleProjection;
   const lifecycleFiles = lifecycleSpec
     ? await execution.run("install-lifecycle-projection", () => installLifecycleProjection(lifecycleSpec, substrateHome.rootDir, {
@@ -273,7 +275,7 @@ async function installSomaForSubstrate(
       }))
     : [];
 
-  const allProjectedFiles = [...substrateHome.files, ...postProjectionFiles, ...lifecycleFiles];
+  const allProjectedFiles = [...substrateHome.files, ...lifecycleFiles];
   substrateHome = { ...substrateHome, files: allProjectedFiles };
   execution.record({ substrateHome });
   await execution.run("reconcile-owned-subtrees", () => reconcileOwnedSubtrees(spec, substrateHome.rootDir, allProjectedFiles));

--- a/src/install.ts
+++ b/src/install.ts
@@ -24,6 +24,7 @@ import { loadMemoryIndexForProjection } from "./memory-index";
 import { isUnderOrEqual, reconcileOwnedDir } from "./projection-reconcile";
 import { isEnoent } from "./fs-errors";
 import { isGuardedRuntimeSubstrate, stageRuntimeArtifact } from "./runtime-artifact";
+import { SomaInstallExecution } from "./installation-execution";
 import {
   type ImplementedUninstallSpec,
   type InstallSubstrate,
@@ -141,6 +142,7 @@ async function installSomaForSubstrate(
   substrate: InstallSubstrate,
   options: SomaInstallOptions = {},
 ): Promise<SomaInstallResult> {
+  const execution = new SomaInstallExecution(substrate);
   const spec = installSpecFor(substrate);
   // soma#73 pre-flight: every soma substrate hook now runs under Bun
   // (#!/usr/bin/env bun shebang). The adopter rejects loud + early
@@ -148,18 +150,22 @@ async function installSomaForSubstrate(
   // that fails at hook fire time. Always probes `which bun` — sage
   // r1 caught a bypass that trusted `process.versions.bun`, which
   // doesn't prove anything about the hook's later spawn environment.
-  requireBunInPath();
+  await execution.run("require-bun", () => {
+    requireBunInPath();
+  });
   const codeOnly = options.codeOnly === true;
-  const somaHome = await bootstrapSomaHome({
+  const somaHome = await execution.run("bootstrap-soma-home", () => bootstrapSomaHome({
     homeDir: options.homeDir,
     somaHome: options.somaHome,
     includeSkills: !codeOnly,
-  });
+  }));
+  execution.record({ somaHome });
   const somaRepoPath = options.somaRepoPath ?? defaultSomaRepoPath();
   // Guarded substrates execute only the immutable artifact, never this editable checkout.
   const guardedRuntime = isGuardedRuntimeSubstrate(substrate)
-    ? await stageRuntimeArtifact({ somaHome: somaHome.somaHome, substrate, sourceRoot: somaRepoPath })
+    ? await execution.run("stage-runtime-artifact", () => stageRuntimeArtifact({ somaHome: somaHome.somaHome, substrate, sourceRoot: somaRepoPath }))
     : undefined;
+  if (guardedRuntime) execution.record({ runtimeArtifact: guardedRuntime });
   const runtimeRepoPath = guardedRuntime?.path ?? somaRepoPath;
   let projectionContext = somaHome.context;
   // Repo-bundled skill dir names — set from installBundledSkillsIntoHome below
@@ -174,14 +180,14 @@ async function installSomaForSubstrate(
     // stale ISA here would re-propagate to every substrate on each install. Cheap +
     // idempotent (a no-op readdir+gate once ISA is gone). Provenance-gated
     // (frontmatter name: ISA + identity marker) — a user "ISA" skill is preserved.
-    await pruneLegacyVsaSkill(createPaths(somaHome.somaHome).skills());
+    await execution.run("prepare-soma-home-skills", () => pruneLegacyVsaSkill(createPaths(somaHome.somaHome).skills()));
     // Install VSA skill into Soma home (canonical baseline) so other
     // tooling reading <somaHome>/skills/VSA continues to work.
-    await installVsaSkillProjection({
+    await execution.run("prepare-soma-home-skills", () => installVsaSkillProjection({
       homeDir: options.homeDir,
       somaHome: somaHome.somaHome,
       somaRepoPath,
-    });
+    }));
     // Copy the repo-bundled skills (src/skills/* except VSA — the-algorithm,
     // Memory) into <somaHome>/skills so they enter the Soma catalog (SKILLS.md)
     // and profile.skills, and therefore project to every substrate through the
@@ -189,11 +195,11 @@ async function installSomaForSubstrate(
     // installer above owns its baseline). Placed before the loadSomaHome reload
     // below so install #1 already lists + projects them. Idempotent + byte-for-
     // byte from the repo source; user-added files under a skill dir survive.
-    bundledSkillNames = (await installBundledSkillsIntoHome({
+    bundledSkillNames = (await execution.run("prepare-soma-home-skills", () => installBundledSkillsIntoHome({
       homeDir: options.homeDir,
       somaHome: somaHome.somaHome,
       somaRepoPath,
-    })).names;
+    }))).names;
     // bootstrapSomaHome captured its context snapshot BEFORE the VSA skill
     // baseline above existed, so its skill list is empty on a first install.
     // Re-read the Soma home now that <somaHome>/skills/VSA is on disk: without
@@ -201,7 +207,7 @@ async function installSomaForSubstrate(
     // were declared." and only the second install converges. Reloading makes
     // the very first projection already list the VSA skill — install #1 is
     // correct and byte-identical to every re-run.
-    projectionContext = await loadSomaHome(somaHome.somaHome);
+    projectionContext = await execution.run("prepare-soma-home-skills", () => loadSomaHome(somaHome.somaHome));
   }
   const projectionOptions = {
     homeDir: options.homeDir,
@@ -216,56 +222,61 @@ async function installSomaForSubstrate(
   // inherits installVsaSkill's local-edits-preserved contract.
   const resolvedHomeDir = resolve(options.homeDir ?? homedir());
   const substrateRoot = resolve(options.substrateHome ?? join(resolvedHomeDir, spec.defaultHome));
-  await spec.validator?.(substrateRoot);
+  await execution.run("validate-substrate", () => spec.validator?.(substrateRoot));
   if (!codeOnly) {
-    await spec.vsaSkillProjection.prepare?.(substrateRoot);
-    await installVsaSkillProjection({
+    await execution.run("install-vsa-skill", () => spec.vsaSkillProjection.prepare?.(substrateRoot));
+    await execution.run("install-vsa-skill", () => installVsaSkillProjection({
       homeDir: options.homeDir,
       somaHome: somaHome.somaHome,
       somaRepoPath,
       skillDestinationDir: spec.vsaSkillProjection.destinationDir(substrateRoot),
       skillNameOverride: spec.vsaSkillProjection.skillNameOverride,
       projectionSubstrate: substrate,
-    });
+    }));
   }
   // Populate the projection input with the active VSA so each substrate writes its
   // `active-vsa.md` file (#37 AC-1/AC-2), and with the memory index (M4) so
   // memory-aware substrates project their always-loaded memory file. Both are
   // soft: absent source → the file is simply omitted.
-  const memoryIndexContent = await loadMemoryIndexForProjection({ somaHome: somaHome.somaHome });
-  const contextWithActiveVsa: ProjectionInput = {
-    ...projectionContext,
-    activeVsa: (await loadActiveVsaForBundle({ somaHome: somaHome.somaHome })) ?? undefined,
-    memory: memoryIndexContent !== undefined ? { indexContent: memoryIndexContent } : undefined,
+  const contextWithActiveVsa: ProjectionInput = await execution.run("build-projection-input", async () => {
+    const memoryIndexContent = await loadMemoryIndexForProjection({ somaHome: somaHome.somaHome });
+    return {
+      ...projectionContext,
+      activeVsa: (await loadActiveVsaForBundle({ somaHome: somaHome.somaHome })) ?? undefined,
+      memory: memoryIndexContent !== undefined ? { indexContent: memoryIndexContent } : undefined,
     // The repo-bundled skills (src/skills/*) copied into the home above scope
     // the portable-skill loop: only these project as invocable dirs, so a
     // 100-skill migrated home projects the bundle, not everything, and never
     // collides with the `--skills` selective symlink flow. Captured from the
     // home-copy step above (undefined under codeOnly — no copy, profile.skills
     // is empty, so this list is inert).
-    bundledSkillNames,
-  };
-  const substrateHome = await installHomeProjectionFor(substrate, contextWithActiveVsa, projectionOptions);
-  await removeObsoleteHomeFiles(spec, substrateHome.rootDir);
-  const postProjectionFiles = await runPostProjectionSteps(spec, {
+      bundledSkillNames,
+    };
+  });
+  let substrateHome = await execution.run("write-home-projection", () => installHomeProjectionFor(substrate, contextWithActiveVsa, projectionOptions));
+  execution.record({ substrateHome });
+  await execution.run("remove-obsolete-home-files", () => removeObsoleteHomeFiles(spec, substrateHome.rootDir));
+  const postProjectionFiles = await execution.run("run-post-projection", () => runPostProjectionSteps(spec, {
     homeDir: options.homeDir,
     somaHome: somaHome.somaHome,
     somaRepoPath: projectionOptions.somaRepoPath,
     substrateHome: substrateHome.rootDir,
     options,
-  });
+  }));
   const lifecycleSpec = spec.lifecycleProjection;
   const lifecycleFiles = lifecycleSpec
-    ? await installLifecycleProjection(lifecycleSpec, substrateHome.rootDir, {
+    ? await execution.run("install-lifecycle-projection", () => installLifecycleProjection(lifecycleSpec, substrateHome.rootDir, {
         homeDir: options.homeDir,
         somaHome: somaHome.somaHome,
         somaRepoPath: projectionOptions.somaRepoPath,
-        substrate: substrate as SubstrateId,
-      })
+        substrate,
+      }))
     : [];
 
   const allProjectedFiles = [...substrateHome.files, ...postProjectionFiles, ...lifecycleFiles];
-  await reconcileOwnedSubtrees(spec, substrateHome.rootDir, allProjectedFiles);
+  substrateHome = { ...substrateHome, files: allProjectedFiles };
+  execution.record({ substrateHome });
+  await execution.run("reconcile-owned-subtrees", () => reconcileOwnedSubtrees(spec, substrateHome.rootDir, allProjectedFiles));
 
   // soma#638: link the curated registry into the substrate's loader. This lives
   // in the install layer, not the CLI, because for a `loader` substrate the
@@ -279,25 +290,16 @@ async function installSomaForSubstrate(
   // subtree — ordering keeps that from being a silent trap.)
   const { projectedSkills, unprojectableSkills } = codeOnly
     ? { projectedSkills: [], unprojectableSkills: [] }
-    : await projectRegistrySkills(spec, {
+    : await execution.run("project-registry-skills", () => projectRegistrySkills(spec, {
         substrate,
         substrateRoot,
         somaHome: somaHome.somaHome,
         homeDir: options.homeDir,
         selected: options.skills ?? [],
-      });
+      }));
+  execution.record({ projectedSkills, unprojectableSkills });
 
-  return {
-    substrate,
-    ...(guardedRuntime ? { runtimeArtifact: guardedRuntime } : {}),
-    somaHome,
-    substrateHome: {
-      ...substrateHome,
-      files: allProjectedFiles,
-    },
-    projectedSkills,
-    unprojectableSkills,
-  };
+  return execution.result();
 }
 
 /**

--- a/src/installation-execution.ts
+++ b/src/installation-execution.ts
@@ -1,41 +1,34 @@
-import type { InstallSubstrate, SomaHomeBootstrapResult, WrittenProjection } from "./types";
-import type { InstalledSkill, UninstallableSkillReport } from "./types";
+import type { InstalledSkill, InstallSubstrate, UninstallableSkillReport, WrittenProjection } from "./types";
 
-/** Exact ordered operation currently performed by the substrate-neutral installer. */
-export type SomaInstallOperation =
-  | "require-bun"
-  | "bootstrap-soma-home"
-  | "stage-runtime-artifact"
-  | "prune-legacy-vsa-skill"
-  | "install-soma-home-vsa-skill"
-  | "install-bundled-skills"
-  | "reload-soma-home-context"
-  | "validate-substrate"
-  | "prepare-substrate-vsa-skill"
-  | "install-substrate-vsa-skill"
-  | "build-projection-input"
-  | "write-home-projection"
-  | "remove-obsolete-home-files"
-  | "run-post-projection"
-  | "install-lifecycle-projection"
-  | "reconcile-owned-subtrees"
-  | "project-registry-skills";
+/** Stable category for an installation failure. */
+export type SomaInstallStage = "environment" | "soma-home" | "substrate" | "projection" | "skills";
 
-/** Durable prefix of an installation, suitable for safe re-run recovery. */
+/** Safe-to-report details of a completed Soma-home bootstrap. */
+export interface SomaHomeInstallReceipt {
+  somaHome: string;
+  files: string[];
+}
+
+/**
+ * Safe-to-report evidence from operations completed before an installation
+ * failure. It intentionally does not claim to inventory writes from the
+ * operation that threw; installations converge by safe re-run instead.
+ */
 export interface SomaPartialInstallResult {
   substrate: InstallSubstrate;
   runtimeArtifact?: { path: string; hash: string; previous?: string };
-  somaHome?: SomaHomeBootstrapResult;
+  somaHome?: SomaHomeInstallReceipt;
   substrateHome?: WrittenProjection;
   projectedSkills?: InstalledSkill[];
   unprojectableSkills?: UninstallableSkillReport[];
 }
 
-function snapshotPartial(result: SomaPartialInstallResult): SomaPartialInstallResult {
+/** Return an immutable, safe-to-report copy of completed-operation evidence. */
+export function snapshotSomaPartialInstallResult(result: SomaPartialInstallResult): SomaPartialInstallResult {
   return {
     ...result,
     runtimeArtifact: result.runtimeArtifact ? { ...result.runtimeArtifact } : undefined,
-    somaHome: result.somaHome ? { ...result.somaHome, files: [...result.somaHome.files] } : undefined,
+    somaHome: result.somaHome ? { somaHome: result.somaHome.somaHome, files: [...result.somaHome.files] } : undefined,
     substrateHome: result.substrateHome ? { ...result.substrateHome, files: [...result.substrateHome.files] } : undefined,
     projectedSkills: result.projectedSkills?.map((skill) => ({ ...skill })),
     unprojectableSkills: result.unprojectableSkills?.map((report) => ({ ...report })),
@@ -43,19 +36,23 @@ function snapshotPartial(result: SomaPartialInstallResult): SomaPartialInstallRe
 }
 
 /**
- * An installation failed after an earlier operation made state durable. The
- * partial result is intentionally a recovery receipt, not a rollback promise:
- * callers can inspect it, report it, and safely re-run installation.
+ * An installation failed after earlier operations completed. The partial result
+ * is completed-operation evidence, not a rollback promise or an inventory of
+ * failed-operation writes. Callers can report it and safely re-run the
+ * convergent installation.
  */
 export class SomaInstallError extends Error {
-  readonly operation: SomaInstallOperation;
+  /** Exact internal label for diagnosis; intentionally not a public enum. */
+  readonly operation: string;
+  readonly stage: SomaInstallStage;
   readonly partial: SomaPartialInstallResult;
 
-  constructor(input: { operation: SomaInstallOperation; partial: SomaPartialInstallResult; cause: unknown }) {
+  constructor(input: { operation: string; stage: SomaInstallStage; partial: SomaPartialInstallResult; cause: unknown }) {
     const detail = input.cause instanceof Error && input.cause.message.length > 0 ? ` ${input.cause.message}` : "";
     super(`Soma install failed during ${input.operation}.${detail}`, { cause: input.cause });
     this.name = "SomaInstallError";
     this.operation = input.operation;
-    this.partial = snapshotPartial(input.partial);
+    this.stage = input.stage;
+    this.partial = snapshotSomaPartialInstallResult(input.partial);
   }
 }

--- a/src/installation-execution.ts
+++ b/src/installation-execution.ts
@@ -60,8 +60,7 @@ export class SomaInstallError extends Error {
   readonly partial: SomaPartialInstallResult;
 
   constructor(input: { operation: string; stage: SomaInstallStage; partial: SomaPartialInstallResult; cause: unknown }) {
-    const detail = input.cause instanceof Error && input.cause.message.length > 0 ? ` ${input.cause.message}` : "";
-    super(`Soma install failed during ${input.operation}.${detail}`, { cause: input.cause });
+    super(`Soma install failed during ${input.operation}.`);
     this.name = "SomaInstallError";
     this.operation = input.operation;
     this.stage = input.stage;

--- a/src/installation-execution.ts
+++ b/src/installation-execution.ts
@@ -1,18 +1,22 @@
-import type { InstalledSkill, InstallSubstrate, UninstallableSkillReport } from "./types";
+import type { InstallSubstrate } from "./types";
 
 /** Stable category for an installation failure. */
 export type SomaInstallStage = "environment" | "soma-home" | "substrate" | "projection" | "skills";
 
 /** Safe-to-report details of a completed Soma-home bootstrap. */
 export interface SomaHomeInstallReceipt {
-  readonly somaHome: string;
-  readonly files: readonly string[];
+  readonly filesWritten: number;
 }
 
 /** Safe-to-report details of a completed substrate projection. */
 export interface SomaSubstrateInstallReceipt {
-  readonly rootDir: string;
-  readonly files: readonly string[];
+  readonly filesWritten: number;
+}
+
+/** Safe-to-report details of a completed guarded runtime update. */
+export interface SomaRuntimeArtifactReceipt {
+  readonly hash: string;
+  readonly replacedPrevious: boolean;
 }
 
 /**
@@ -22,11 +26,11 @@ export interface SomaSubstrateInstallReceipt {
  */
 export interface SomaPartialInstallResult {
   readonly substrate: InstallSubstrate;
-  readonly runtimeArtifact?: Readonly<{ path: string; hash: string; previous?: string }>;
+  readonly runtimeArtifact?: SomaRuntimeArtifactReceipt;
   readonly somaHome?: SomaHomeInstallReceipt;
   readonly substrateHome?: SomaSubstrateInstallReceipt;
-  readonly projectedSkills?: readonly InstalledSkill[];
-  readonly unprojectableSkills?: readonly UninstallableSkillReport[];
+  readonly projectedSkillCount?: number;
+  readonly unprojectableSkillCount?: number;
 }
 
 /** Return an immutable, safe-to-report copy of completed-operation evidence. */
@@ -35,14 +39,10 @@ export function snapshotSomaPartialInstallResult(result: SomaPartialInstallResul
     ...result,
     runtimeArtifact: result.runtimeArtifact ? Object.freeze({ ...result.runtimeArtifact }) : undefined,
     somaHome: result.somaHome
-      ? Object.freeze({ somaHome: result.somaHome.somaHome, files: Object.freeze([...result.somaHome.files]) })
+      ? Object.freeze({ filesWritten: result.somaHome.filesWritten })
       : undefined,
     substrateHome: result.substrateHome
-      ? Object.freeze({ ...result.substrateHome, files: Object.freeze([...result.substrateHome.files]) })
-      : undefined,
-    projectedSkills: result.projectedSkills ? Object.freeze(result.projectedSkills.map((skill) => Object.freeze({ ...skill }))) : undefined,
-    unprojectableSkills: result.unprojectableSkills
-      ? Object.freeze(result.unprojectableSkills.map((report) => Object.freeze({ ...report })))
+      ? Object.freeze({ filesWritten: result.substrateHome.filesWritten })
       : undefined,
   });
 }

--- a/src/installation-execution.ts
+++ b/src/installation-execution.ts
@@ -1,12 +1,18 @@
-import type { InstalledSkill, InstallSubstrate, UninstallableSkillReport, WrittenProjection } from "./types";
+import type { InstalledSkill, InstallSubstrate, UninstallableSkillReport } from "./types";
 
 /** Stable category for an installation failure. */
 export type SomaInstallStage = "environment" | "soma-home" | "substrate" | "projection" | "skills";
 
 /** Safe-to-report details of a completed Soma-home bootstrap. */
 export interface SomaHomeInstallReceipt {
-  somaHome: string;
-  files: string[];
+  readonly somaHome: string;
+  readonly files: readonly string[];
+}
+
+/** Safe-to-report details of a completed substrate projection. */
+export interface SomaSubstrateInstallReceipt {
+  readonly rootDir: string;
+  readonly files: readonly string[];
 }
 
 /**
@@ -15,24 +21,30 @@ export interface SomaHomeInstallReceipt {
  * operation that threw; installations converge by safe re-run instead.
  */
 export interface SomaPartialInstallResult {
-  substrate: InstallSubstrate;
-  runtimeArtifact?: { path: string; hash: string; previous?: string };
-  somaHome?: SomaHomeInstallReceipt;
-  substrateHome?: WrittenProjection;
-  projectedSkills?: InstalledSkill[];
-  unprojectableSkills?: UninstallableSkillReport[];
+  readonly substrate: InstallSubstrate;
+  readonly runtimeArtifact?: Readonly<{ path: string; hash: string; previous?: string }>;
+  readonly somaHome?: SomaHomeInstallReceipt;
+  readonly substrateHome?: SomaSubstrateInstallReceipt;
+  readonly projectedSkills?: readonly InstalledSkill[];
+  readonly unprojectableSkills?: readonly UninstallableSkillReport[];
 }
 
 /** Return an immutable, safe-to-report copy of completed-operation evidence. */
 export function snapshotSomaPartialInstallResult(result: SomaPartialInstallResult): SomaPartialInstallResult {
-  return {
+  return Object.freeze({
     ...result,
-    runtimeArtifact: result.runtimeArtifact ? { ...result.runtimeArtifact } : undefined,
-    somaHome: result.somaHome ? { somaHome: result.somaHome.somaHome, files: [...result.somaHome.files] } : undefined,
-    substrateHome: result.substrateHome ? { ...result.substrateHome, files: [...result.substrateHome.files] } : undefined,
-    projectedSkills: result.projectedSkills?.map((skill) => ({ ...skill })),
-    unprojectableSkills: result.unprojectableSkills?.map((report) => ({ ...report })),
-  };
+    runtimeArtifact: result.runtimeArtifact ? Object.freeze({ ...result.runtimeArtifact }) : undefined,
+    somaHome: result.somaHome
+      ? Object.freeze({ somaHome: result.somaHome.somaHome, files: Object.freeze([...result.somaHome.files]) })
+      : undefined,
+    substrateHome: result.substrateHome
+      ? Object.freeze({ ...result.substrateHome, files: Object.freeze([...result.substrateHome.files]) })
+      : undefined,
+    projectedSkills: result.projectedSkills ? Object.freeze(result.projectedSkills.map((skill) => Object.freeze({ ...skill }))) : undefined,
+    unprojectableSkills: result.unprojectableSkills
+      ? Object.freeze(result.unprojectableSkills.map((report) => Object.freeze({ ...report })))
+      : undefined,
+  });
 }
 
 /**

--- a/src/installation-execution.ts
+++ b/src/installation-execution.ts
@@ -1,4 +1,4 @@
-import type { InstallSubstrate, SomaHomeBootstrapResult, SomaInstallResult, WrittenProjection } from "./types";
+import type { InstallSubstrate, SomaHomeBootstrapResult, WrittenProjection } from "./types";
 import type { InstalledSkill, UninstallableSkillReport } from "./types";
 
 /** Exact ordered operation currently performed by the substrate-neutral installer. */
@@ -6,9 +6,13 @@ export type SomaInstallOperation =
   | "require-bun"
   | "bootstrap-soma-home"
   | "stage-runtime-artifact"
-  | "prepare-soma-home-skills"
+  | "prune-legacy-vsa-skill"
+  | "install-soma-home-vsa-skill"
+  | "install-bundled-skills"
+  | "reload-soma-home-context"
   | "validate-substrate"
-  | "install-vsa-skill"
+  | "prepare-substrate-vsa-skill"
+  | "install-substrate-vsa-skill"
   | "build-projection-input"
   | "write-home-projection"
   | "remove-obsolete-home-files"
@@ -31,6 +35,7 @@ function snapshotPartial(result: SomaPartialInstallResult): SomaPartialInstallRe
   return {
     ...result,
     runtimeArtifact: result.runtimeArtifact ? { ...result.runtimeArtifact } : undefined,
+    somaHome: result.somaHome ? { ...result.somaHome, files: [...result.somaHome.files] } : undefined,
     substrateHome: result.substrateHome ? { ...result.substrateHome, files: [...result.substrateHome.files] } : undefined,
     projectedSkills: result.projectedSkills?.map((skill) => ({ ...skill })),
     unprojectableSkills: result.unprojectableSkills?.map((report) => ({ ...report })),
@@ -52,50 +57,5 @@ export class SomaInstallError extends Error {
     this.name = "SomaInstallError";
     this.operation = input.operation;
     this.partial = snapshotPartial(input.partial);
-  }
-}
-
-/**
- * Substrate-neutral installation execution. Adapter facts stay in each
- * SubstrateInstallSpec; this module owns ordered operations and their failure
- * receipt at the installer seam.
- */
-export class SomaInstallExecution {
-  private partial: SomaPartialInstallResult;
-
-  constructor(substrate: InstallSubstrate) {
-    this.partial = { substrate };
-  }
-
-  record(result: Omit<Partial<SomaPartialInstallResult>, "substrate">): void {
-    this.partial = { ...this.partial, ...result };
-  }
-
-  snapshot(): SomaPartialInstallResult {
-    return snapshotPartial(this.partial);
-  }
-
-  async run<T>(operation: SomaInstallOperation, work: () => Promise<T> | T): Promise<T> {
-    try {
-      return await work();
-    } catch (error) {
-      if (error instanceof SomaInstallError) throw error;
-      throw new SomaInstallError({ operation, partial: this.snapshot(), cause: error });
-    }
-  }
-
-  result(): SomaInstallResult {
-    const { somaHome, substrateHome, projectedSkills, unprojectableSkills } = this.partial;
-    if (!somaHome || !substrateHome || !projectedSkills || !unprojectableSkills) {
-      throw new Error("Soma installation result is incomplete.");
-    }
-    return {
-      substrate: this.partial.substrate,
-      ...(this.partial.runtimeArtifact ? { runtimeArtifact: { ...this.partial.runtimeArtifact } } : {}),
-      somaHome,
-      substrateHome: { ...substrateHome, files: [...substrateHome.files] },
-      projectedSkills: projectedSkills.map((skill) => ({ ...skill })),
-      unprojectableSkills: unprojectableSkills.map((report) => ({ ...report })),
-    };
   }
 }

--- a/src/installation-execution.ts
+++ b/src/installation-execution.ts
@@ -1,0 +1,101 @@
+import type { InstallSubstrate, SomaHomeBootstrapResult, SomaInstallResult, WrittenProjection } from "./types";
+import type { InstalledSkill, UninstallableSkillReport } from "./types";
+
+/** Exact ordered operation currently performed by the substrate-neutral installer. */
+export type SomaInstallOperation =
+  | "require-bun"
+  | "bootstrap-soma-home"
+  | "stage-runtime-artifact"
+  | "prepare-soma-home-skills"
+  | "validate-substrate"
+  | "install-vsa-skill"
+  | "build-projection-input"
+  | "write-home-projection"
+  | "remove-obsolete-home-files"
+  | "run-post-projection"
+  | "install-lifecycle-projection"
+  | "reconcile-owned-subtrees"
+  | "project-registry-skills";
+
+/** Durable prefix of an installation, suitable for safe re-run recovery. */
+export interface SomaPartialInstallResult {
+  substrate: InstallSubstrate;
+  runtimeArtifact?: { path: string; hash: string; previous?: string };
+  somaHome?: SomaHomeBootstrapResult;
+  substrateHome?: WrittenProjection;
+  projectedSkills?: InstalledSkill[];
+  unprojectableSkills?: UninstallableSkillReport[];
+}
+
+function snapshotPartial(result: SomaPartialInstallResult): SomaPartialInstallResult {
+  return {
+    ...result,
+    runtimeArtifact: result.runtimeArtifact ? { ...result.runtimeArtifact } : undefined,
+    substrateHome: result.substrateHome ? { ...result.substrateHome, files: [...result.substrateHome.files] } : undefined,
+    projectedSkills: result.projectedSkills?.map((skill) => ({ ...skill })),
+    unprojectableSkills: result.unprojectableSkills?.map((report) => ({ ...report })),
+  };
+}
+
+/**
+ * An installation failed after an earlier operation made state durable. The
+ * partial result is intentionally a recovery receipt, not a rollback promise:
+ * callers can inspect it, report it, and safely re-run installation.
+ */
+export class SomaInstallError extends Error {
+  readonly operation: SomaInstallOperation;
+  readonly partial: SomaPartialInstallResult;
+
+  constructor(input: { operation: SomaInstallOperation; partial: SomaPartialInstallResult; cause: unknown }) {
+    const detail = input.cause instanceof Error && input.cause.message.length > 0 ? ` ${input.cause.message}` : "";
+    super(`Soma install failed during ${input.operation}.${detail}`, { cause: input.cause });
+    this.name = "SomaInstallError";
+    this.operation = input.operation;
+    this.partial = snapshotPartial(input.partial);
+  }
+}
+
+/**
+ * Substrate-neutral installation execution. Adapter facts stay in each
+ * SubstrateInstallSpec; this module owns ordered operations and their failure
+ * receipt at the installer seam.
+ */
+export class SomaInstallExecution {
+  private partial: SomaPartialInstallResult;
+
+  constructor(substrate: InstallSubstrate) {
+    this.partial = { substrate };
+  }
+
+  record(result: Omit<Partial<SomaPartialInstallResult>, "substrate">): void {
+    this.partial = { ...this.partial, ...result };
+  }
+
+  snapshot(): SomaPartialInstallResult {
+    return snapshotPartial(this.partial);
+  }
+
+  async run<T>(operation: SomaInstallOperation, work: () => Promise<T> | T): Promise<T> {
+    try {
+      return await work();
+    } catch (error) {
+      if (error instanceof SomaInstallError) throw error;
+      throw new SomaInstallError({ operation, partial: this.snapshot(), cause: error });
+    }
+  }
+
+  result(): SomaInstallResult {
+    const { somaHome, substrateHome, projectedSkills, unprojectableSkills } = this.partial;
+    if (!somaHome || !substrateHome || !projectedSkills || !unprojectableSkills) {
+      throw new Error("Soma installation result is incomplete.");
+    }
+    return {
+      substrate: this.partial.substrate,
+      ...(this.partial.runtimeArtifact ? { runtimeArtifact: { ...this.partial.runtimeArtifact } } : {}),
+      somaHome,
+      substrateHome: { ...substrateHome, files: [...substrateHome.files] },
+      projectedSkills: projectedSkills.map((skill) => ({ ...skill })),
+      unprojectableSkills: unprojectableSkills.map((report) => ({ ...report })),
+    };
+  }
+}

--- a/src/installation-executor.ts
+++ b/src/installation-executor.ts
@@ -1,27 +1,28 @@
 import { SomaInstallError, snapshotSomaPartialInstallResult, type SomaInstallStage, type SomaPartialInstallResult } from "./installation-execution";
 import type { InstallSubstrate, SomaHomeBootstrapResult, SomaInstallResult, WrittenProjection } from "./types";
 
-export const SOMA_INSTALL_OPERATIONS = [
-  "require-bun",
-  "bootstrap-soma-home",
-  "stage-runtime-artifact",
-  "prune-legacy-vsa-skill",
-  "install-soma-home-vsa-skill",
-  "install-bundled-skills",
-  "reload-soma-home-context",
-  "validate-substrate",
-  "prepare-substrate-vsa-skill",
-  "install-substrate-vsa-skill",
-  "build-projection-input",
-  "write-home-projection",
-  "remove-obsolete-home-files",
-  "run-post-projection",
-  "install-lifecycle-projection",
-  "reconcile-owned-subtrees",
-  "project-registry-skills",
-] as const;
+export const SOMA_INSTALL_OPERATION_STAGES = {
+  "require-bun": "environment",
+  "bootstrap-soma-home": "soma-home",
+  "stage-runtime-artifact": "environment",
+  "prune-legacy-vsa-skill": "soma-home",
+  "install-soma-home-vsa-skill": "soma-home",
+  "install-bundled-skills": "soma-home",
+  "reload-soma-home-context": "soma-home",
+  "validate-substrate": "substrate",
+  "prepare-substrate-vsa-skill": "substrate",
+  "install-substrate-vsa-skill": "substrate",
+  "build-projection-input": "projection",
+  "write-home-projection": "projection",
+  "remove-obsolete-home-files": "projection",
+  "run-post-projection": "projection",
+  "install-lifecycle-projection": "projection",
+  "reconcile-owned-subtrees": "projection",
+  "project-registry-skills": "skills",
+} as const satisfies Record<string, SomaInstallStage>;
 
-type SomaInstallOperation = typeof SOMA_INSTALL_OPERATIONS[number];
+type SomaInstallOperation = keyof typeof SOMA_INSTALL_OPERATION_STAGES;
+export const SOMA_INSTALL_OPERATIONS = Object.keys(SOMA_INSTALL_OPERATION_STAGES) as SomaInstallOperation[];
 
 type SomaInstallExecutionRecord = Omit<Partial<SomaPartialInstallResult>, "substrate" | "somaHome"> & {
   somaHome?: SomaHomeBootstrapResult;
@@ -30,7 +31,7 @@ type SomaInstallExecutionRecord = Omit<Partial<SomaPartialInstallResult>, "subst
 
 /**
  * Internal substrate-neutral installer coordinator. Adapter facts stay in
- * SubstrateInstallSpec; this records the durable prefix at the installer seam.
+ * SubstrateInstallSpec; this records completed-operation evidence at the installer seam.
  */
 export class SomaInstallExecution {
   private partial: SomaPartialInstallResult;
@@ -83,9 +84,5 @@ export class SomaInstallExecution {
 }
 
 function stageFor(operation: SomaInstallOperation): SomaInstallStage {
-  if (operation === "require-bun" || operation === "stage-runtime-artifact") return "environment";
-  if (operation === "bootstrap-soma-home" || operation.includes("soma-home")) return "soma-home";
-  if (operation === "validate-substrate" || operation.includes("substrate-vsa")) return "substrate";
-  if (operation === "project-registry-skills") return "skills";
-  return "projection";
+  return SOMA_INSTALL_OPERATION_STAGES[operation];
 }

--- a/src/installation-executor.ts
+++ b/src/installation-executor.ts
@@ -37,35 +37,24 @@ interface SomaInstallExecutionRecord {
  * SubstrateInstallSpec; this records completed-operation evidence at the installer seam.
  */
 export class SomaInstallExecution {
-  private partial: SomaPartialInstallResult;
-  private somaHome?: SomaHomeBootstrapResult;
-  private substrateHome?: WrittenProjection;
-  private runtimeArtifact?: { path: string; hash: string; previous?: string };
-  private projectedSkills?: InstalledSkill[];
-  private unprojectableSkills?: UninstallableSkillReport[];
+  private completed: SomaInstallExecutionRecord = {};
 
-  constructor(substrate: InstallSubstrate) {
-    this.partial = { substrate };
-  }
+  constructor(private readonly substrate: InstallSubstrate) {}
 
   record(result: SomaInstallExecutionRecord): void {
-    if (result.somaHome) this.somaHome = result.somaHome;
-    if (result.substrateHome) this.substrateHome = result.substrateHome;
-    if (result.runtimeArtifact) this.runtimeArtifact = result.runtimeArtifact;
-    if (result.projectedSkills) this.projectedSkills = result.projectedSkills;
-    if (result.unprojectableSkills) this.unprojectableSkills = result.unprojectableSkills;
-    this.partial = {
-      ...this.partial,
-      ...(result.runtimeArtifact ? { runtimeArtifact: { hash: result.runtimeArtifact.hash, replacedPrevious: result.runtimeArtifact.previous !== undefined } } : {}),
-      ...(result.somaHome ? { somaHome: { filesWritten: result.somaHome.files.length } } : {}),
-      ...(result.substrateHome ? { substrateHome: { filesWritten: result.substrateHome.files.length } } : {}),
-      ...(result.projectedSkills ? { projectedSkillCount: result.projectedSkills.length } : {}),
-      ...(result.unprojectableSkills ? { unprojectableSkillCount: result.unprojectableSkills.length } : {}),
-    };
+    this.completed = { ...this.completed, ...result };
   }
 
   snapshot(): SomaPartialInstallResult {
-    return snapshotSomaPartialInstallResult(this.partial);
+    const { runtimeArtifact, somaHome, substrateHome, projectedSkills, unprojectableSkills } = this.completed;
+    return snapshotSomaPartialInstallResult({
+      substrate: this.substrate,
+      ...(runtimeArtifact ? { runtimeArtifact: { hash: runtimeArtifact.hash, replacedPrevious: runtimeArtifact.previous !== undefined } } : {}),
+      ...(somaHome ? { somaHome: { filesWritten: somaHome.files.length } } : {}),
+      ...(substrateHome ? { substrateHome: { filesWritten: substrateHome.files.length } } : {}),
+      ...(projectedSkills ? { projectedSkillCount: projectedSkills.length } : {}),
+      ...(unprojectableSkills ? { unprojectableSkillCount: unprojectableSkills.length } : {}),
+    });
   }
 
   async run<T>(operation: SomaInstallOperation, work: () => Promise<T> | T): Promise<T> {
@@ -78,16 +67,13 @@ export class SomaInstallExecution {
   }
 
   result(): SomaInstallResult {
-    const somaHome = this.somaHome;
-    const substrateHome = this.substrateHome;
-    const projectedSkills = this.projectedSkills;
-    const unprojectableSkills = this.unprojectableSkills;
+    const { runtimeArtifact, somaHome, substrateHome, projectedSkills, unprojectableSkills } = this.completed;
     if (!somaHome || !substrateHome || !projectedSkills || !unprojectableSkills) {
       throw new Error("Soma installation result is incomplete.");
     }
     return {
-      substrate: this.partial.substrate,
-      ...(this.runtimeArtifact ? { runtimeArtifact: { ...this.runtimeArtifact } } : {}),
+      substrate: this.substrate,
+      ...(runtimeArtifact ? { runtimeArtifact: { ...runtimeArtifact } } : {}),
       somaHome,
       substrateHome: { ...substrateHome, files: [...substrateHome.files] },
       projectedSkills: projectedSkills.map((skill) => ({ ...skill })),

--- a/src/installation-executor.ts
+++ b/src/installation-executor.ts
@@ -1,27 +1,31 @@
 import { SomaInstallError, snapshotSomaPartialInstallResult, type SomaInstallStage, type SomaPartialInstallResult } from "./installation-execution";
-import type { InstallSubstrate, SomaHomeBootstrapResult, SomaInstallResult } from "./types";
+import type { InstallSubstrate, SomaHomeBootstrapResult, SomaInstallResult, WrittenProjection } from "./types";
 
-type SomaInstallOperation =
-  | "require-bun"
-  | "bootstrap-soma-home"
-  | "stage-runtime-artifact"
-  | "prune-legacy-vsa-skill"
-  | "install-soma-home-vsa-skill"
-  | "install-bundled-skills"
-  | "reload-soma-home-context"
-  | "validate-substrate"
-  | "prepare-substrate-vsa-skill"
-  | "install-substrate-vsa-skill"
-  | "build-projection-input"
-  | "write-home-projection"
-  | "remove-obsolete-home-files"
-  | "run-post-projection"
-  | "install-lifecycle-projection"
-  | "reconcile-owned-subtrees"
-  | "project-registry-skills";
+export const SOMA_INSTALL_OPERATIONS = [
+  "require-bun",
+  "bootstrap-soma-home",
+  "stage-runtime-artifact",
+  "prune-legacy-vsa-skill",
+  "install-soma-home-vsa-skill",
+  "install-bundled-skills",
+  "reload-soma-home-context",
+  "validate-substrate",
+  "prepare-substrate-vsa-skill",
+  "install-substrate-vsa-skill",
+  "build-projection-input",
+  "write-home-projection",
+  "remove-obsolete-home-files",
+  "run-post-projection",
+  "install-lifecycle-projection",
+  "reconcile-owned-subtrees",
+  "project-registry-skills",
+] as const;
+
+type SomaInstallOperation = typeof SOMA_INSTALL_OPERATIONS[number];
 
 type SomaInstallExecutionRecord = Omit<Partial<SomaPartialInstallResult>, "substrate" | "somaHome"> & {
   somaHome?: SomaHomeBootstrapResult;
+  substrateHome?: WrittenProjection;
 };
 
 /**
@@ -31,6 +35,7 @@ type SomaInstallExecutionRecord = Omit<Partial<SomaPartialInstallResult>, "subst
 export class SomaInstallExecution {
   private partial: SomaPartialInstallResult;
   private somaHome?: SomaHomeBootstrapResult;
+  private substrateHome?: WrittenProjection;
 
   constructor(substrate: InstallSubstrate) {
     this.partial = { substrate };
@@ -38,6 +43,7 @@ export class SomaInstallExecution {
 
   record(result: SomaInstallExecutionRecord): void {
     if (result.somaHome) this.somaHome = result.somaHome;
+    if (result.substrateHome) this.substrateHome = result.substrateHome;
     this.partial = {
       ...this.partial,
       ...result,
@@ -59,8 +65,9 @@ export class SomaInstallExecution {
   }
 
   result(): SomaInstallResult {
-    const { substrateHome, projectedSkills, unprojectableSkills } = this.partial;
+    const { projectedSkills, unprojectableSkills } = this.partial;
     const somaHome = this.somaHome;
+    const substrateHome = this.substrateHome;
     if (!somaHome || !substrateHome || !projectedSkills || !unprojectableSkills) {
       throw new Error("Soma installation result is incomplete.");
     }

--- a/src/installation-executor.ts
+++ b/src/installation-executor.ts
@@ -1,0 +1,57 @@
+import { SomaInstallError, type SomaInstallOperation, type SomaPartialInstallResult } from "./installation-execution";
+import type { InstallSubstrate, SomaInstallResult } from "./types";
+
+/**
+ * Internal substrate-neutral installer coordinator. Adapter facts stay in
+ * SubstrateInstallSpec; this records the durable prefix at the installer seam.
+ */
+export class SomaInstallExecution {
+  private partial: SomaPartialInstallResult;
+
+  constructor(substrate: InstallSubstrate) {
+    this.partial = { substrate };
+  }
+
+  record(result: Omit<Partial<SomaPartialInstallResult>, "substrate">): void {
+    this.partial = { ...this.partial, ...result };
+  }
+
+  snapshot(): SomaPartialInstallResult {
+    return snapshotPartial(this.partial);
+  }
+
+  async run<T>(operation: SomaInstallOperation, work: () => Promise<T> | T): Promise<T> {
+    try {
+      return await work();
+    } catch (error) {
+      if (error instanceof SomaInstallError) throw error;
+      throw new SomaInstallError({ operation, partial: this.snapshot(), cause: error });
+    }
+  }
+
+  result(): SomaInstallResult {
+    const { somaHome, substrateHome, projectedSkills, unprojectableSkills } = this.partial;
+    if (!somaHome || !substrateHome || !projectedSkills || !unprojectableSkills) {
+      throw new Error("Soma installation result is incomplete.");
+    }
+    return {
+      substrate: this.partial.substrate,
+      ...(this.partial.runtimeArtifact ? { runtimeArtifact: { ...this.partial.runtimeArtifact } } : {}),
+      somaHome,
+      substrateHome: { ...substrateHome, files: [...substrateHome.files] },
+      projectedSkills: projectedSkills.map((skill) => ({ ...skill })),
+      unprojectableSkills: unprojectableSkills.map((report) => ({ ...report })),
+    };
+  }
+}
+
+function snapshotPartial(result: SomaPartialInstallResult): SomaPartialInstallResult {
+  return {
+    ...result,
+    runtimeArtifact: result.runtimeArtifact ? { ...result.runtimeArtifact } : undefined,
+    somaHome: result.somaHome ? { ...result.somaHome, files: [...result.somaHome.files] } : undefined,
+    substrateHome: result.substrateHome ? { ...result.substrateHome, files: [...result.substrateHome.files] } : undefined,
+    projectedSkills: result.projectedSkills?.map((skill) => ({ ...skill })),
+    unprojectableSkills: result.unprojectableSkills?.map((report) => ({ ...report })),
+  };
+}

--- a/src/installation-executor.ts
+++ b/src/installation-executor.ts
@@ -1,5 +1,5 @@
 import { SomaInstallError, snapshotSomaPartialInstallResult, type SomaInstallStage, type SomaPartialInstallResult } from "./installation-execution";
-import type { InstallSubstrate, SomaHomeBootstrapResult, SomaInstallResult, WrittenProjection } from "./types";
+import type { InstalledSkill, InstallSubstrate, SomaHomeBootstrapResult, SomaInstallResult, UninstallableSkillReport, WrittenProjection } from "./types";
 
 export const SOMA_INSTALL_OPERATION_STAGES = {
   "require-bun": "environment",
@@ -24,10 +24,13 @@ export const SOMA_INSTALL_OPERATION_STAGES = {
 type SomaInstallOperation = keyof typeof SOMA_INSTALL_OPERATION_STAGES;
 export const SOMA_INSTALL_OPERATIONS = Object.keys(SOMA_INSTALL_OPERATION_STAGES) as SomaInstallOperation[];
 
-type SomaInstallExecutionRecord = Omit<Partial<SomaPartialInstallResult>, "substrate" | "somaHome"> & {
+interface SomaInstallExecutionRecord {
+  runtimeArtifact?: { path: string; hash: string; previous?: string };
   somaHome?: SomaHomeBootstrapResult;
   substrateHome?: WrittenProjection;
-};
+  projectedSkills?: InstalledSkill[];
+  unprojectableSkills?: UninstallableSkillReport[];
+}
 
 /**
  * Internal substrate-neutral installer coordinator. Adapter facts stay in
@@ -37,6 +40,9 @@ export class SomaInstallExecution {
   private partial: SomaPartialInstallResult;
   private somaHome?: SomaHomeBootstrapResult;
   private substrateHome?: WrittenProjection;
+  private runtimeArtifact?: { path: string; hash: string; previous?: string };
+  private projectedSkills?: InstalledSkill[];
+  private unprojectableSkills?: UninstallableSkillReport[];
 
   constructor(substrate: InstallSubstrate) {
     this.partial = { substrate };
@@ -45,10 +51,16 @@ export class SomaInstallExecution {
   record(result: SomaInstallExecutionRecord): void {
     if (result.somaHome) this.somaHome = result.somaHome;
     if (result.substrateHome) this.substrateHome = result.substrateHome;
+    if (result.runtimeArtifact) this.runtimeArtifact = result.runtimeArtifact;
+    if (result.projectedSkills) this.projectedSkills = result.projectedSkills;
+    if (result.unprojectableSkills) this.unprojectableSkills = result.unprojectableSkills;
     this.partial = {
       ...this.partial,
-      ...result,
-      ...(result.somaHome ? { somaHome: { somaHome: result.somaHome.somaHome, files: [...result.somaHome.files] } } : {}),
+      ...(result.runtimeArtifact ? { runtimeArtifact: { hash: result.runtimeArtifact.hash, replacedPrevious: result.runtimeArtifact.previous !== undefined } } : {}),
+      ...(result.somaHome ? { somaHome: { filesWritten: result.somaHome.files.length } } : {}),
+      ...(result.substrateHome ? { substrateHome: { filesWritten: result.substrateHome.files.length } } : {}),
+      ...(result.projectedSkills ? { projectedSkillCount: result.projectedSkills.length } : {}),
+      ...(result.unprojectableSkills ? { unprojectableSkillCount: result.unprojectableSkills.length } : {}),
     };
   }
 
@@ -66,15 +78,16 @@ export class SomaInstallExecution {
   }
 
   result(): SomaInstallResult {
-    const { projectedSkills, unprojectableSkills } = this.partial;
     const somaHome = this.somaHome;
     const substrateHome = this.substrateHome;
+    const projectedSkills = this.projectedSkills;
+    const unprojectableSkills = this.unprojectableSkills;
     if (!somaHome || !substrateHome || !projectedSkills || !unprojectableSkills) {
       throw new Error("Soma installation result is incomplete.");
     }
     return {
       substrate: this.partial.substrate,
-      ...(this.partial.runtimeArtifact ? { runtimeArtifact: { ...this.partial.runtimeArtifact } } : {}),
+      ...(this.runtimeArtifact ? { runtimeArtifact: { ...this.runtimeArtifact } } : {}),
       somaHome,
       substrateHome: { ...substrateHome, files: [...substrateHome.files] },
       projectedSkills: projectedSkills.map((skill) => ({ ...skill })),

--- a/src/installation-executor.ts
+++ b/src/installation-executor.ts
@@ -1,5 +1,28 @@
-import { SomaInstallError, type SomaInstallOperation, type SomaPartialInstallResult } from "./installation-execution";
-import type { InstallSubstrate, SomaInstallResult } from "./types";
+import { SomaInstallError, snapshotSomaPartialInstallResult, type SomaInstallStage, type SomaPartialInstallResult } from "./installation-execution";
+import type { InstallSubstrate, SomaHomeBootstrapResult, SomaInstallResult } from "./types";
+
+type SomaInstallOperation =
+  | "require-bun"
+  | "bootstrap-soma-home"
+  | "stage-runtime-artifact"
+  | "prune-legacy-vsa-skill"
+  | "install-soma-home-vsa-skill"
+  | "install-bundled-skills"
+  | "reload-soma-home-context"
+  | "validate-substrate"
+  | "prepare-substrate-vsa-skill"
+  | "install-substrate-vsa-skill"
+  | "build-projection-input"
+  | "write-home-projection"
+  | "remove-obsolete-home-files"
+  | "run-post-projection"
+  | "install-lifecycle-projection"
+  | "reconcile-owned-subtrees"
+  | "project-registry-skills";
+
+type SomaInstallExecutionRecord = Omit<Partial<SomaPartialInstallResult>, "substrate" | "somaHome"> & {
+  somaHome?: SomaHomeBootstrapResult;
+};
 
 /**
  * Internal substrate-neutral installer coordinator. Adapter facts stay in
@@ -7,17 +30,23 @@ import type { InstallSubstrate, SomaInstallResult } from "./types";
  */
 export class SomaInstallExecution {
   private partial: SomaPartialInstallResult;
+  private somaHome?: SomaHomeBootstrapResult;
 
   constructor(substrate: InstallSubstrate) {
     this.partial = { substrate };
   }
 
-  record(result: Omit<Partial<SomaPartialInstallResult>, "substrate">): void {
-    this.partial = { ...this.partial, ...result };
+  record(result: SomaInstallExecutionRecord): void {
+    if (result.somaHome) this.somaHome = result.somaHome;
+    this.partial = {
+      ...this.partial,
+      ...result,
+      ...(result.somaHome ? { somaHome: { somaHome: result.somaHome.somaHome, files: [...result.somaHome.files] } } : {}),
+    };
   }
 
   snapshot(): SomaPartialInstallResult {
-    return snapshotPartial(this.partial);
+    return snapshotSomaPartialInstallResult(this.partial);
   }
 
   async run<T>(operation: SomaInstallOperation, work: () => Promise<T> | T): Promise<T> {
@@ -25,12 +54,13 @@ export class SomaInstallExecution {
       return await work();
     } catch (error) {
       if (error instanceof SomaInstallError) throw error;
-      throw new SomaInstallError({ operation, partial: this.snapshot(), cause: error });
+      throw new SomaInstallError({ operation, stage: stageFor(operation), partial: this.snapshot(), cause: error });
     }
   }
 
   result(): SomaInstallResult {
-    const { somaHome, substrateHome, projectedSkills, unprojectableSkills } = this.partial;
+    const { substrateHome, projectedSkills, unprojectableSkills } = this.partial;
+    const somaHome = this.somaHome;
     if (!somaHome || !substrateHome || !projectedSkills || !unprojectableSkills) {
       throw new Error("Soma installation result is incomplete.");
     }
@@ -45,13 +75,10 @@ export class SomaInstallExecution {
   }
 }
 
-function snapshotPartial(result: SomaPartialInstallResult): SomaPartialInstallResult {
-  return {
-    ...result,
-    runtimeArtifact: result.runtimeArtifact ? { ...result.runtimeArtifact } : undefined,
-    somaHome: result.somaHome ? { ...result.somaHome, files: [...result.somaHome.files] } : undefined,
-    substrateHome: result.substrateHome ? { ...result.substrateHome, files: [...result.substrateHome.files] } : undefined,
-    projectedSkills: result.projectedSkills?.map((skill) => ({ ...skill })),
-    unprojectableSkills: result.unprojectableSkills?.map((report) => ({ ...report })),
-  };
+function stageFor(operation: SomaInstallOperation): SomaInstallStage {
+  if (operation === "require-bun" || operation === "stage-runtime-artifact") return "environment";
+  if (operation === "bootstrap-soma-home" || operation.includes("soma-home")) return "soma-home";
+  if (operation === "validate-substrate" || operation.includes("substrate-vsa")) return "substrate";
+  if (operation === "project-registry-skills") return "skills";
+  return "projection";
 }

--- a/test/grok-install.test.ts
+++ b/test/grok-install.test.ts
@@ -3,7 +3,7 @@ import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { bootstrapSomaHome, installSomaForGrok, planSomaForGrokInstall, projectGrokHome, activeVsaProjectionPath } from "../src/index";
+import { bootstrapSomaHome, installSomaForGrok, planSomaForGrokInstall, projectGrokHome, activeVsaProjectionPath, SomaInstallError } from "../src/index";
 import { smokeTestInstalledGrokHookCommand } from "../src/adapters/grok/hook-smoke";
 import { GROK_INSTALL_MANIFEST_SCHEMA, grokInstallManifestPath } from "../src/adapters/grok/install-manifest";
 import { allInstallSpecs, installSpecFor } from "../src/install-spec-registry";
@@ -303,8 +303,12 @@ test("grok install refuses a runtime below the minimum with upgrade guidance", a
     await mkdir(grokHome, { recursive: true });
     await writeFile(join(grokHome, "version.json"), JSON.stringify({ version: "0.2.10" }), "utf8");
 
-    await expect(installSomaForGrok({ homeDir })).rejects.toThrow("Unsupported grok version 0.2.10");
-    await expect(installSomaForGrok({ homeDir })).rejects.toThrow("0.2.38");
+    await expect(installSomaForGrok({ homeDir })).rejects.toMatchObject({
+      name: "SomaInstallError",
+      operation: "validate-substrate",
+      stage: "substrate",
+      message: "Soma install failed during validate-substrate.",
+    });
   });
 });
 
@@ -314,7 +318,12 @@ test("grok install refuses a prerelease runtime", async () => {
     await mkdir(grokHome, { recursive: true });
     await writeFile(join(grokHome, "version.json"), JSON.stringify({ version: "0.2.40-rc.1" }), "utf8");
 
-    await expect(installSomaForGrok({ homeDir })).rejects.toThrow("Unsupported grok version 0.2.40-rc.1");
+    await expect(installSomaForGrok({ homeDir })).rejects.toMatchObject({
+      name: "SomaInstallError",
+      operation: "validate-substrate",
+      stage: "substrate",
+      message: "Soma install failed during validate-substrate.",
+    });
   });
 });
 
@@ -324,7 +333,12 @@ test("grok install refuses malformed version metadata", async () => {
     await mkdir(grokHome, { recursive: true });
     await writeFile(join(grokHome, "version.json"), JSON.stringify({ version: "banana" }), "utf8");
 
-    await expect(installSomaForGrok({ homeDir })).rejects.toThrow("Unable to read grok version");
+    await expect(installSomaForGrok({ homeDir })).rejects.toMatchObject({
+      name: "SomaInstallError",
+      operation: "validate-substrate",
+      stage: "substrate",
+      message: "Soma install failed during validate-substrate.",
+    });
   });
 });
 
@@ -464,7 +478,12 @@ test("grok install never emits a whitespace hook command for a spaced home (8.3 
       await installSomaForGrok({ homeDir });
     } catch (err) {
       installed = false;
-      expect(String(err)).toMatch(/whitespace in the (grok hooks path|bun path)/i);
+      expect(err).toBeInstanceOf(SomaInstallError);
+      expect(err).toMatchObject({
+        operation: "write-home-projection",
+        stage: "projection",
+        message: "Soma install failed during write-home-projection.",
+      });
     }
 
     if (installed) {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -4,7 +4,7 @@ import { isAbsolute, join, resolve } from "node:path";
 import { hostname, tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { expect, test } from "bun:test";
-import { bootstrapSomaHome, experimentalAnthropicCowork, installSomaForClaudeCode, installSomaForCodex, installSomaForCursor, installSomaForPiDev, planSomaForCodexInstall, planSomaForPiDevInstall, somaWorkRegistryPaths } from "../src/index";
+import { bootstrapSomaHome, experimentalAnthropicCowork, installSomaForClaudeCode, installSomaForCodex, installSomaForCursor, installSomaForPiDev, planSomaForCodexInstall, planSomaForPiDevInstall, SomaInstallError, somaWorkRegistryPaths } from "../src/index";
 import { codexInstallSpec } from "../src/adapters/codex/install";
 import { ANTHROPIC_COWORK_ACTIVE_VSA_MARKER, isAnthropicCoworkSkillProjectionPath } from "../src/adapters/anthropic-cowork";
 import { removeLegacyPiDevVsaSkillProjection } from "../src/adapters/pi-dev/skill-projection";
@@ -219,6 +219,32 @@ test("installs soma source home and codex home projection", async () => {
     expect(algorithmSkill).toContain("Start with `Workflows/RunAlgorithm.md`");
     expect(algorithmSkill).toContain("The harness is mutable run state");
     expect(startupContext).toContain("Soma Startup Context");
+  });
+});
+
+test("a failed lifecycle projection reports its durable prefix and converges on re-run", async () => {
+  await withTempHome(async (homeDir) => {
+    const blockedStartupContext = join(homeDir, ".codex/memories/soma/startup-context.md");
+    await mkdir(blockedStartupContext, { recursive: true });
+
+    const failure = await installSomaForCodex({ homeDir }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(SomaInstallError);
+    expect(failure).toMatchObject({
+      operation: "install-lifecycle-projection",
+      partial: {
+        substrate: "codex",
+        substrateHome: {
+          files: expect.arrayContaining([join(homeDir, ".codex/AGENTS.md")]),
+        },
+      },
+    });
+
+    await rm(blockedStartupContext, { recursive: true, force: true });
+    const recovered = await installSomaForCodex({ homeDir });
+
+    expect(recovered.substrateHome.files).toContain(join(homeDir, ".codex/memories/soma/startup-context.md"));
+    await expect(readFile(join(homeDir, ".codex/memories/soma/startup-context.md"), "utf8")).resolves.toContain("Soma");
   });
 });
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -233,13 +233,12 @@ test("a failed lifecycle projection reports completed projection evidence and co
     expect(failure).toMatchObject({
       operation: "install-lifecycle-projection",
       stage: "projection",
-      partial: {
-        substrate: "codex",
-        substrateHome: {
-          files: expect.arrayContaining([join(homeDir, ".codex/AGENTS.md")]),
-        },
-      },
+      partial: { substrate: "codex" },
     });
+    const receipt = (failure as SomaInstallError).partial.substrateHome;
+    expect(typeof receipt?.filesWritten).toBe("number");
+    expect(receipt?.filesWritten).toBeGreaterThan(0);
+    expect(Object.keys(receipt ?? {})).toEqual(["filesWritten"]);
 
     await rm(blockedStartupContext, { recursive: true, force: true });
     const recovered = await installSomaForCodex({ homeDir });

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1728,7 +1728,12 @@ test("#85: pi.dev install refuses explicitly unsupported runtime versions", asyn
     await mkdir(agentDir, { recursive: true });
     await writeFile(join(agentDir, "package.json"), JSON.stringify({ version: "0.0.1" }), "utf8");
 
-    await expect(installSomaForPiDev({ homeDir })).rejects.toThrow("Unsupported pi.dev version 0.0.1");
+    await expect(installSomaForPiDev({ homeDir })).rejects.toMatchObject({
+      name: "SomaInstallError",
+      operation: "validate-substrate",
+      stage: "substrate",
+      message: "Soma install failed during validate-substrate.",
+    });
   });
 });
 
@@ -1738,7 +1743,12 @@ test("#85: pi.dev install refuses prerelease versions at the stable minimum", as
     await mkdir(agentDir, { recursive: true });
     await writeFile(join(agentDir, "package.json"), JSON.stringify({ version: "0.10.0-beta.1" }), "utf8");
 
-    await expect(installSomaForPiDev({ homeDir })).rejects.toThrow("Unsupported pi.dev version 0.10.0-beta.1");
+    await expect(installSomaForPiDev({ homeDir })).rejects.toMatchObject({
+      name: "SomaInstallError",
+      operation: "validate-substrate",
+      stage: "substrate",
+      message: "Soma install failed during validate-substrate.",
+    });
   });
 });
 
@@ -1748,7 +1758,12 @@ test("#85: pi.dev install refuses malformed runtime versions as invalid metadata
     await mkdir(agentDir, { recursive: true });
     await writeFile(join(agentDir, "package.json"), JSON.stringify({ version: "banana" }), "utf8");
 
-    await expect(installSomaForPiDev({ homeDir })).rejects.toThrow("Unable to read pi.dev version");
+    await expect(installSomaForPiDev({ homeDir })).rejects.toMatchObject({
+      name: "SomaInstallError",
+      operation: "validate-substrate",
+      stage: "substrate",
+      message: "Soma install failed during validate-substrate.",
+    });
   });
 });
 
@@ -1758,7 +1773,12 @@ test("#85: pi.dev install refuses partial runtime versions as invalid metadata",
     await mkdir(agentDir, { recursive: true });
     await writeFile(join(agentDir, "package.json"), JSON.stringify({ version: "1" }), "utf8");
 
-    await expect(installSomaForPiDev({ homeDir })).rejects.toThrow("Unable to read pi.dev version");
+    await expect(installSomaForPiDev({ homeDir })).rejects.toMatchObject({
+      name: "SomaInstallError",
+      operation: "validate-substrate",
+      stage: "substrate",
+      message: "Soma install failed during validate-substrate.",
+    });
   });
 });
 

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -222,7 +222,7 @@ test("installs soma source home and codex home projection", async () => {
   });
 });
 
-test("a failed lifecycle projection reports its durable prefix and converges on re-run", async () => {
+test("a failed lifecycle projection reports completed projection evidence and converges on re-run", async () => {
   await withTempHome(async (homeDir) => {
     const blockedStartupContext = join(homeDir, ".codex/memories/soma/startup-context.md");
     await mkdir(blockedStartupContext, { recursive: true });
@@ -232,6 +232,7 @@ test("a failed lifecycle projection reports its durable prefix and converges on 
     expect(failure).toBeInstanceOf(SomaInstallError);
     expect(failure).toMatchObject({
       operation: "install-lifecycle-projection",
+      stage: "projection",
       partial: {
         substrate: "codex",
         substrateHome: {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1,6 +1,6 @@
 import { chmod, copyFile, mkdir, mkdtemp, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
-import { isAbsolute, join, resolve } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 import { hostname, tmpdir } from "node:os";
 import { pathToFileURL } from "node:url";
 import { expect, test } from "bun:test";
@@ -71,6 +71,17 @@ async function withTempHome<T>(fn: (homeDir: string) => Promise<T>): Promise<T> 
     await unsealRuntimeArtifacts(homeDir);
     await rm(homeDir, { recursive: true, force: true });
   }
+}
+
+async function readProjectionSnapshot(root: string, files: readonly string[]): Promise<Record<string, string>> {
+  return Object.fromEntries(
+    await Promise.all(
+      files.map(async (file) => {
+        const path = isAbsolute(file) ? file : join(root, file);
+        return [relative(root, path), await readFile(path, "utf8")] as const;
+      }),
+    ),
+  );
 }
 
 function coworkPath(homeDir: string, path = ""): string {
@@ -242,9 +253,11 @@ test("a failed lifecycle projection reports completed projection evidence and co
 
     await rm(blockedStartupContext, { recursive: true, force: true });
     const recovered = await installSomaForCodex({ homeDir });
+    const recoveredSnapshot = await readProjectionSnapshot(recovered.substrateHome.rootDir, recovered.substrateHome.files);
+    const converged = await installSomaForCodex({ homeDir });
 
-    expect(recovered.substrateHome.files).toContain(join(homeDir, ".codex/memories/soma/startup-context.md"));
-    await expect(readFile(join(homeDir, ".codex/memories/soma/startup-context.md"), "utf8")).resolves.toContain("Soma");
+    expect([...converged.substrateHome.files].sort()).toEqual([...recovered.substrateHome.files].sort());
+    expect(await readProjectionSnapshot(converged.substrateHome.rootDir, converged.substrateHome.files)).toEqual(recoveredSnapshot);
   });
 });
 

--- a/test/installation-execution.test.ts
+++ b/test/installation-execution.test.ts
@@ -4,7 +4,7 @@ import { SOMA_INSTALL_OPERATIONS } from "../src/installation-executor";
 
 test("installation errors preserve a redacted snapshot of completed operations", () => {
   const somaHome = { filesWritten: 1 };
-  const cause = new Error("projection write failed");
+  const cause = new Error("projection write failed at /private/soma-secret");
   const error = new SomaInstallError({
     operation: "write-home-projection",
     stage: "projection",
@@ -18,8 +18,9 @@ test("installation errors preserve a redacted snapshot of completed operations",
     operation: "write-home-projection",
     stage: "projection",
     partial: { substrate: "codex", somaHome: { filesWritten: 1 } },
-    cause,
   });
+  expect(error.message).toBe("Soma install failed during write-home-projection.");
+  expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
   expect(error.partial.somaHome).toEqual({ filesWritten: 1 });
   expect(() => ((error.partial.somaHome as { filesWritten: number }).filesWritten = 2)).toThrow(TypeError);
 });

--- a/test/installation-execution.test.ts
+++ b/test/installation-execution.test.ts
@@ -3,11 +3,7 @@ import { SomaInstallError } from "../src/installation-execution";
 import { SOMA_INSTALL_OPERATIONS } from "../src/installation-executor";
 
 test("installation errors preserve a redacted snapshot of completed operations", () => {
-  const somaHome = {
-    somaHome: "/tmp/soma",
-    context: {} as never,
-    files: [] as string[],
-  };
+  const somaHome = { filesWritten: 1 };
   const cause = new Error("projection write failed");
   const error = new SomaInstallError({
     operation: "write-home-projection",
@@ -15,18 +11,17 @@ test("installation errors preserve a redacted snapshot of completed operations",
     partial: { substrate: "codex", somaHome },
     cause,
   });
-  somaHome.files.push("/tmp/soma/later-file");
+  somaHome.filesWritten = 2;
 
   expect(error).toMatchObject({
     name: "SomaInstallError",
     operation: "write-home-projection",
     stage: "projection",
-    partial: { substrate: "codex", somaHome: { somaHome: "/tmp/soma", files: [] } },
+    partial: { substrate: "codex", somaHome: { filesWritten: 1 } },
     cause,
   });
-  expect(error.partial.somaHome?.files).toEqual([]);
-  expect(error.partial.somaHome).toEqual({ somaHome: "/tmp/soma", files: [] });
-  expect(() => (error.partial.somaHome?.files as string[]).push("/tmp/soma/mutated")).toThrow(TypeError);
+  expect(error.partial.somaHome).toEqual({ filesWritten: 1 });
+  expect(() => ((error.partial.somaHome as { filesWritten: number }).filesWritten = 2)).toThrow(TypeError);
 });
 
 test("exact installation labels remain available without becoming a public enum", () => {

--- a/test/installation-execution.test.ts
+++ b/test/installation-execution.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from "bun:test";
 import { SomaInstallError } from "../src/installation-execution";
-import type { SomaInstallOperation } from "../src/installation-execution";
 
-const OPERATIONS: SomaInstallOperation[] = [
+const OPERATIONS = [
   "require-bun",
   "bootstrap-soma-home",
   "stage-runtime-artifact",
@@ -20,9 +19,9 @@ const OPERATIONS: SomaInstallOperation[] = [
   "install-lifecycle-projection",
   "reconcile-owned-subtrees",
   "project-registry-skills",
-];
+] as const;
 
-test("installation errors preserve a snapshot of the durable prefix", () => {
+test("installation errors preserve a redacted snapshot of completed operations", () => {
   const somaHome = {
     somaHome: "/tmp/soma",
     context: {} as never,
@@ -31,6 +30,7 @@ test("installation errors preserve a snapshot of the durable prefix", () => {
   const cause = new Error("projection write failed");
   const error = new SomaInstallError({
     operation: "write-home-projection",
+    stage: "projection",
     partial: { substrate: "codex", somaHome },
     cause,
   });
@@ -39,16 +39,19 @@ test("installation errors preserve a snapshot of the durable prefix", () => {
   expect(error).toMatchObject({
     name: "SomaInstallError",
     operation: "write-home-projection",
-    partial: { substrate: "codex", somaHome: { ...somaHome, files: [] } },
+    stage: "projection",
+    partial: { substrate: "codex", somaHome: { somaHome: "/tmp/soma", files: [] } },
     cause,
   });
   expect(error.partial.somaHome?.files).toEqual([]);
+  expect(error.partial.somaHome).toEqual({ somaHome: "/tmp/soma", files: [] });
 });
 
-test("every declared installation operation can label a typed failure", () => {
+test("exact installation labels remain available without becoming a public enum", () => {
   for (const operation of OPERATIONS) {
     expect(new SomaInstallError({
       operation,
+      stage: "projection",
       partial: { substrate: "codex" },
       cause: new Error("failed"),
     })).toMatchObject({ operation });

--- a/test/installation-execution.test.ts
+++ b/test/installation-execution.test.ts
@@ -1,25 +1,6 @@
 import { expect, test } from "bun:test";
 import { SomaInstallError } from "../src/installation-execution";
-
-const OPERATIONS = [
-  "require-bun",
-  "bootstrap-soma-home",
-  "stage-runtime-artifact",
-  "prune-legacy-vsa-skill",
-  "install-soma-home-vsa-skill",
-  "install-bundled-skills",
-  "reload-soma-home-context",
-  "validate-substrate",
-  "prepare-substrate-vsa-skill",
-  "install-substrate-vsa-skill",
-  "build-projection-input",
-  "write-home-projection",
-  "remove-obsolete-home-files",
-  "run-post-projection",
-  "install-lifecycle-projection",
-  "reconcile-owned-subtrees",
-  "project-registry-skills",
-] as const;
+import { SOMA_INSTALL_OPERATIONS } from "../src/installation-executor";
 
 test("installation errors preserve a redacted snapshot of completed operations", () => {
   const somaHome = {
@@ -45,10 +26,11 @@ test("installation errors preserve a redacted snapshot of completed operations",
   });
   expect(error.partial.somaHome?.files).toEqual([]);
   expect(error.partial.somaHome).toEqual({ somaHome: "/tmp/soma", files: [] });
+  expect(() => (error.partial.somaHome?.files as string[]).push("/tmp/soma/mutated")).toThrow(TypeError);
 });
 
 test("exact installation labels remain available without becoming a public enum", () => {
-  for (const operation of OPERATIONS) {
+  for (const operation of SOMA_INSTALL_OPERATIONS) {
     expect(new SomaInstallError({
       operation,
       stage: "projection",

--- a/test/installation-execution.test.ts
+++ b/test/installation-execution.test.ts
@@ -1,14 +1,18 @@
 import { expect, test } from "bun:test";
-import { SomaInstallError, SomaInstallExecution } from "../src/installation-execution";
+import { SomaInstallError } from "../src/installation-execution";
 import type { SomaInstallOperation } from "../src/installation-execution";
 
 const OPERATIONS: SomaInstallOperation[] = [
   "require-bun",
   "bootstrap-soma-home",
   "stage-runtime-artifact",
-  "prepare-soma-home-skills",
+  "prune-legacy-vsa-skill",
+  "install-soma-home-vsa-skill",
+  "install-bundled-skills",
+  "reload-soma-home-context",
   "validate-substrate",
-  "install-vsa-skill",
+  "prepare-substrate-vsa-skill",
+  "install-substrate-vsa-skill",
   "build-projection-input",
   "write-home-projection",
   "remove-obsolete-home-files",
@@ -18,38 +22,35 @@ const OPERATIONS: SomaInstallOperation[] = [
   "project-registry-skills",
 ];
 
-test("installation execution throws the exact failed operation with its durable prefix", async () => {
-  const execution = new SomaInstallExecution("codex");
+test("installation errors preserve a snapshot of the durable prefix", () => {
   const somaHome = {
     somaHome: "/tmp/soma",
     context: {} as never,
-    files: [],
+    files: [] as string[],
   };
-  execution.record({ somaHome });
-
   const cause = new Error("projection write failed");
-  await expect(execution.run("write-home-projection", () => { throw cause; })).rejects.toMatchObject({
-    name: "SomaInstallError",
+  const error = new SomaInstallError({
     operation: "write-home-projection",
     partial: { substrate: "codex", somaHome },
     cause,
   });
-});
+  somaHome.files.push("/tmp/soma/later-file");
 
-test("installation execution preserves a typed error instead of nesting it", async () => {
-  const execution = new SomaInstallExecution("codex");
-  const original = new SomaInstallError({
-    operation: "bootstrap-soma-home",
-    partial: { substrate: "codex" },
-    cause: new Error("home unavailable"),
+  expect(error).toMatchObject({
+    name: "SomaInstallError",
+    operation: "write-home-projection",
+    partial: { substrate: "codex", somaHome: { ...somaHome, files: [] } },
+    cause,
   });
-
-  await expect(execution.run("write-home-projection", () => { throw original; })).rejects.toBe(original);
+  expect(error.partial.somaHome?.files).toEqual([]);
 });
 
-test("every installation operation reports its exact name", async () => {
+test("every declared installation operation can label a typed failure", () => {
   for (const operation of OPERATIONS) {
-    const execution = new SomaInstallExecution("codex");
-    await expect(execution.run(operation, () => { throw new Error("failed"); })).rejects.toMatchObject({ operation });
+    expect(new SomaInstallError({
+      operation,
+      partial: { substrate: "codex" },
+      cause: new Error("failed"),
+    })).toMatchObject({ operation });
   }
 });

--- a/test/installation-execution.test.ts
+++ b/test/installation-execution.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { SomaInstallError, SomaInstallExecution } from "../src/installation-execution";
+import type { SomaInstallOperation } from "../src/installation-execution";
+
+const OPERATIONS: SomaInstallOperation[] = [
+  "require-bun",
+  "bootstrap-soma-home",
+  "stage-runtime-artifact",
+  "prepare-soma-home-skills",
+  "validate-substrate",
+  "install-vsa-skill",
+  "build-projection-input",
+  "write-home-projection",
+  "remove-obsolete-home-files",
+  "run-post-projection",
+  "install-lifecycle-projection",
+  "reconcile-owned-subtrees",
+  "project-registry-skills",
+];
+
+test("installation execution throws the exact failed operation with its durable prefix", async () => {
+  const execution = new SomaInstallExecution("codex");
+  const somaHome = {
+    somaHome: "/tmp/soma",
+    context: {} as never,
+    files: [],
+  };
+  execution.record({ somaHome });
+
+  const cause = new Error("projection write failed");
+  await expect(execution.run("write-home-projection", () => { throw cause; })).rejects.toMatchObject({
+    name: "SomaInstallError",
+    operation: "write-home-projection",
+    partial: { substrate: "codex", somaHome },
+    cause,
+  });
+});
+
+test("installation execution preserves a typed error instead of nesting it", async () => {
+  const execution = new SomaInstallExecution("codex");
+  const original = new SomaInstallError({
+    operation: "bootstrap-soma-home",
+    partial: { substrate: "codex" },
+    cause: new Error("home unavailable"),
+  });
+
+  await expect(execution.run("write-home-projection", () => { throw original; })).rejects.toBe(original);
+});
+
+test("every installation operation reports its exact name", async () => {
+  for (const operation of OPERATIONS) {
+    const execution = new SomaInstallExecution("codex");
+    await expect(execution.run(operation, () => { throw new Error("failed"); })).rejects.toMatchObject({ operation });
+  }
+});


### PR DESCRIPTION
## Summary
- centralize substrate-neutral installation execution and completed-operation failure evidence
- preserve DD-4 adapter-owned install facts: no adapter install spec changes; only the substrate-neutral installer records receipts
- expose a path-free, frozen partial receipt with a stable stage and exact diagnostic operation
- update eight runtime-validation tests to assert that safe public error contract rather than raw validator or filesystem diagnostics

## DD-4 evidence
- Adapter-owned facts remain in `src/adapters/*/install.ts` and `SubstrateInstallSpec`; this PR changes no adapter spec.
- `src/install.ts` only records completed projection files between existing adapter-owned post-projection and lifecycle calls.
- The Codex failure/re-run test blocks an adapter-owned lifecycle path, asserts the substrate-neutral receipt, removes the blocker, and proves convergence.

## Verification
- Bun 1.4.0: focused Pi.dev and Grok redacted-error tests: 8 pass
- Bun 1.4.0: `bun run typecheck` and `bun run test:portability`: pass
- The local Bun 1.4 full suite currently reports two feedback-capture timing failures outside this change; GitHub required checks are pending on `bdc055f`.