### PR TITLE
fix: avoid duplicate assistant core projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-09-05
+
+### Fixed
+
+- **Assistant core projections no longer duplicate profile content.** Claude
+  Code, Cursor, Anthropic Cowork, Pi.dev, and Codex now keep assistant core in
+  one context artifact; profiles are concise pointers. Codex imports its eager
+  context through `AGENTS.md`, leaving the `soma` skill capability-only. ([#543])
+
 ## [0.19.0] - 2026-08-27
 
 ### Added

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -1,6 +1,6 @@
 schema: arc/v1
 name: soma
-version: 0.19.0
+version: 0.19.1
 type: tool
 tier: community
 description: Substrate-portable Personal AI Assistant core for identity, memory, VSA, skills, learning, and adapters.

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -4,11 +4,12 @@ Soma treats execution environments as substrates. One adapter per substrate
 projects the same Soma into different substrate-native primitives. See
 [CONTEXT.md](../CONTEXT.md) for glossary.
 
-Every projection has one eager assistant-core context artifact. A profile file
-is an on-demand pointer to that context with only assistant and principal names
-for fast orientation; it does not repeat assistant-core sections. This prevents
-two independently generated copies of the core from reaching a prompt when a
-substrate discovers both files.
+The Claude Code, Cursor, Anthropic Cowork, Pi.dev, and Codex projections use
+one eager assistant-core context artifact. Their profile files are on-demand
+pointers with only assistant and principal names for fast orientation; they do
+not repeat assistant-core sections. This prevents two independently generated
+copies of the core from reaching a prompt when those substrates discover both
+files.
 
 ## Codex
 

--- a/docs/substrate-adapters.md
+++ b/docs/substrate-adapters.md
@@ -4,6 +4,12 @@ Soma treats execution environments as substrates. One adapter per substrate
 projects the same Soma into different substrate-native primitives. See
 [CONTEXT.md](../CONTEXT.md) for glossary.
 
+Every projection has one eager assistant-core context artifact. A profile file
+is an on-demand pointer to that context with only assistant and principal names
+for fast orientation; it does not repeat assistant-core sections. This prevents
+two independently generated copies of the core from reaching a prompt when a
+substrate discovers both files.
+
 ## Codex
 
 Codex is a coding-agent substrate. The Codex projection should carry:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soma",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "private": true,
   "type": "module",
   "description": "Substrate-portable Personal AI Assistant core.",

--- a/src/adapters/anthropic-cowork.ts
+++ b/src/adapters/anthropic-cowork.ts
@@ -7,6 +7,7 @@ import {
   communicationContractFile,
   renderAssistantCore,
   renderPolicyProjection,
+  renderProfilePointer,
   renderSkills,
   SELF_HEALING_DOCTRINE_ADVISORY,
   SOMA_POLICY_PROJECTION_HEADING,
@@ -159,7 +160,7 @@ function renderMemorySnapshot(input: ProjectionInput): string {
 }
 
 function renderProfile(input: ProjectionInput): string {
-  return [COWORK_PROFILE_HEADING, "", renderAssistantCore(input)].join("\n");
+  return renderProfilePointer(input, ANTHROPIC_COWORK_INSTRUCTIONS_PATH);
 }
 
 function renderCaptureReadme(): string {

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -1,6 +1,6 @@
 import type { SkillsDiscoveryMode } from "../install-spec";
 import type { SomaAdapter, Projection, ProjectionInput } from "../types";
-import { buildPortableSkillFiles, communicationContractFile, projectedRulesFiles, skillCatalogFile, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills, SELF_HEALING_DOCTRINE_ADVISORY, withProvenance } from "./shared";
+import { buildPortableSkillFiles, communicationContractFile, projectedRulesFiles, skillCatalogFile, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderProfilePointer, renderSkills, SELF_HEALING_DOCTRINE_ADVISORY, withProvenance } from "./shared";
 import { activeVsaBundleFile } from "../adapter-active-vsa";
 import { behaviorPolicyAdvisory } from "../policy/behavior-policy";
 
@@ -150,7 +150,7 @@ function renderClaudeRulesContext(input: ProjectionInput): string {
 }
 
 function renderClaudeProfile(input: ProjectionInput): string {
-  return ["# Soma Profile Projection", "", renderAssistantCore(input)].join("\n");
+  return renderProfilePointer(input, "rules/soma/CONTEXT.md");
 }
 
 function renderClaudePurpose(input: ProjectionInput): string {

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -150,7 +150,7 @@ function renderClaudeRulesContext(input: ProjectionInput): string {
 }
 
 function renderClaudeProfile(input: ProjectionInput): string {
-  return renderProfilePointer(input, "rules/soma/CONTEXT.md");
+  return renderProfilePointer(input, "CONTEXT.md beside this file");
 }
 
 function renderClaudePurpose(input: ProjectionInput): string {

--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -90,15 +90,13 @@ export function codexMemoryIndexFile(input: ProjectionInput): { path: string; co
   return [{ path: "memories/soma/memory-index.md", content: indexContent }];
 }
 
-function renderHomeRules(input: ProjectionInput, somaHome: string): string {
+function renderHomeRules(somaHome: string): string {
   const contextLines = [
     "# Soma default availability",
     "",
     "Use Soma as the portable personal assistant context when the task involves identity, purpose, VSA, skills, memory, policy, or assistant continuity.",
     `Soma source of truth: ${somaHome}`,
     "This Codex home projection is generated from Soma and should not become the source of truth.",
-    "",
-    renderAssistantCore(input),
     "",
     "## Codex Home Rules",
     "- Prefer the Soma source files for durable identity, purpose, memory, and skill context.",
@@ -112,13 +110,13 @@ function renderHomeRules(input: ProjectionInput, somaHome: string): string {
   return [
     "# This file is parsed by Codex as Starlark permission rules.",
     "# Soma keeps it comment-only so it can mark the projection without changing permissions.",
-    "# The actual assistant context lives in ~/.codex/skills/soma/SKILL.md and ~/.codex/memories/soma/.",
+    "# The actual assistant context lives in ~/.codex/memories/soma/context.md.",
     "",
     ...context.split("\n").map((line) => (line === "" ? "#" : `# ${line}`)),
   ].join("\n");
 }
 
-function renderHomeSkill(input: ProjectionInput, somaHome: string): string {
+function renderHomeSkill(somaHome: string): string {
   return [
     "---",
     "name: soma",
@@ -147,10 +145,6 @@ function renderHomeSkill(input: ProjectionInput, somaHome: string): string {
     "- Read `~/.codex/memories/soma/memory-layout.md` before using persistent memory.",
     "- Read `~/.codex/memories/soma/communication.md`, when present, for how to communicate: patterns, banned phrases, reference codes, and aliases.",
     "- Treat project-local `.codex/soma/` context as an overlay.",
-    "",
-    "## Current Projection",
-    "",
-    renderAssistantCore(input),
   ].join("\n");
 }
 
@@ -376,7 +370,7 @@ export function projectCodex(input: ProjectionInput): Projection {
 }
 
 export function projectCodexHome(input: ProjectionInput, somaHome: string, homeDir?: string, somaRepoPath = defaultSomaRepoPath()): Projection {
-  const instructions = renderHomeRules(input, somaHome);
+  const instructions = renderHomeRules(somaHome);
   const portableSkillFiles = buildPortableSkillFiles(input.profile.skills, input.bundledSkillNames, "codex");
 
   return {
@@ -432,14 +426,18 @@ export function projectCodexHome(input: ProjectionInput, somaHome: string, homeD
         // investigation). Both already carry their own generated-by-Soma
         // notice in-band.
         path: "skills/soma/SKILL.md",
-        content: renderHomeSkill(input, somaHome),
+        content: renderHomeSkill(somaHome),
+      },
+      {
+        path: "memories/soma/context.md",
+        content: withProvenance("codex", renderAssistantCore(input)),
       },
       {
         // soma#370: plain markdown narrative files carry the byte-stable
         // provenance header so `soma doctor` can distinguish a managed
         // projection from a hand-replaced one.
         path: "memories/soma/profile.md",
-        content: withProvenance("codex", renderProfilePointer(input, "skills/soma/SKILL.md")),
+        content: withProvenance("codex", renderProfilePointer(input, "context.md beside this file")),
       },
       {
         path: "memories/soma/memory-layout.md",

--- a/src/adapters/codex/adapter.ts
+++ b/src/adapters/codex/adapter.ts
@@ -5,7 +5,7 @@ import { defaultSomaRepoPath } from "../../repo-path";
 import { resolveBunExecutable } from "../../bun-probe";
 import { readCodexHookAsset, renderCodexPolicyHook, renderCodexPolicyTargets } from "./hooks/assets";
 import { renderFeedbackHookModule } from "../shared/feedback-helper";
-import { buildPortableSkillFiles, communicationContractFile, renderAlgorithmRenderingContract, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills, renderSubstrateInstructions, SELF_HEALING_DOCTRINE_ADVISORY, withProvenance } from "../shared";
+import { buildPortableSkillFiles, communicationContractFile, renderAlgorithmRenderingContract, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderProfilePointer, renderSkills, renderSubstrateInstructions, SELF_HEALING_DOCTRINE_ADVISORY, withProvenance } from "../shared";
 import { activeVsaBundleFile } from "../../adapter-active-vsa";
 import { somaPolicyPrivateMarkers } from "../../policy";
 import { somaMemoryPrivateRoots, somaProjectionPrivateRoots } from "../../projection-private-roots";
@@ -439,7 +439,7 @@ export function projectCodexHome(input: ProjectionInput, somaHome: string, homeD
         // provenance header so `soma doctor` can distinguish a managed
         // projection from a hand-replaced one.
         path: "memories/soma/profile.md",
-        content: withProvenance("codex", ["# Soma Profile Projection", "", renderAssistantCore(input)].join("\n")),
+        content: withProvenance("codex", renderProfilePointer(input, "skills/soma/SKILL.md")),
       },
       {
         path: "memories/soma/memory-layout.md",

--- a/src/adapters/codex/install.ts
+++ b/src/adapters/codex/install.ts
@@ -18,6 +18,7 @@ export const CODEX_HOME_FILES = [
   "hooks/policy-marker.mjs",
   "skills/soma/SKILL.md",
   "skills/the-algorithm/SKILL.md",
+  "memories/soma/context.md",
   "memories/soma/profile.md",
   "memories/soma/startup-context.md",
   "memories/soma/lifecycle.md",
@@ -32,7 +33,7 @@ export const CODEX_HOME_FILES = [
   "config.toml",
 ] as const;
 
-export const CODEX_AGENTS_IMPORTS = ["@./skills/the-algorithm/SKILL.md", "@./memories/soma/startup-context.md"] as const;
+export const CODEX_AGENTS_IMPORTS = ["@./memories/soma/context.md", "@./skills/the-algorithm/SKILL.md", "@./memories/soma/startup-context.md"] as const;
 
 export async function configureCodexAgentsImport(codexHome: string): Promise<string[]> {
   const path = join(codexHome, "AGENTS.md");

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 import type { SomaAdapter, Projection, ProjectionInput } from "../types";
 import { activeVsaBundleFile } from "../adapter-active-vsa";
-import { buildPortableSkillFiles, communicationContractFile, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderSkills, SELF_HEALING_DOCTRINE_ADVISORY, withProvenance } from "./shared";
+import { buildPortableSkillFiles, communicationContractFile, renderAssistantCore, renderMemoryLayout, renderPolicyProjection, renderProfilePointer, renderSkills, SELF_HEALING_DOCTRINE_ADVISORY, withProvenance } from "./shared";
 import { behaviorPolicyAdvisory } from "../policy/behavior-policy";
 
 export const CURSOR_RULES_PATH = ".cursorrules";
@@ -102,7 +102,7 @@ function renderCursorRulesReadme(): string {
 }
 
 function renderCursorProfile(input: ProjectionInput): string {
-  return ["# Soma Profile Projection", "", renderAssistantCore(input)].join("\n");
+  return renderProfilePointer(input, CURSOR_CONTEXT_PATH);
 }
 
 function renderCursorPurpose(input: ProjectionInput): string {

--- a/src/adapters/pi-dev/adapter.ts
+++ b/src/adapters/pi-dev/adapter.ts
@@ -10,6 +10,7 @@ import {
   renderAssistantCore,
   renderMemoryLayout,
   renderPolicyProjection,
+  renderProfilePointer,
   renderSkills,
   SELF_HEALING_DOCTRINE_ADVISORY,
   withProvenance,
@@ -387,7 +388,6 @@ function renderHomeExtension(somaHome: string): string {
     '\tpi.on("before_agent_start", async (event) => {',
     "\t\tconst prompt = promptFromEvent(event);",
     "\t\tcaptureSomaFeedback(prompt);",
-    '\t\tconst profile = readOptional(`${PI_SOMA_HOME}/profile.md`);',
     "\t\t// Cached at session_start — no Soma subprocess on the message path.",
     "\t\tconst startupContext = cachedStartupContext || readOptional(`${PI_SOMA_HOME}/startup-context.md`);",
     '\t\tconst paiImports = readOptional(`${PI_SOMA_HOME}/pai-imports.md`);',
@@ -412,8 +412,6 @@ function renderHomeExtension(somaHome: string): string {
     "Use the soma_context tool or read paths listed below when deeper migrated PAI identity, values, goals, strategies, or decision context matters.",
     "Before durable claims that may depend on prior work, call soma_context action=memory_recall (note-aware), and action=memory_index for the durable INDEX.",
     "Pi has no SessionEnd digest hook: when wrapping up substantial work, author ONE session digest and run \\`cd $(cat ~/.pi/agent/soma/soma-repo.txt) && bun run soma memory digest --session <session-id> --body \"8-15 lines\"\\`. This capture is agent-invoked.",
-    "",
-    "${profile}",
     "",
     "${communication}",
     "",
@@ -634,7 +632,7 @@ export function projectPiDevHome(input: ProjectionInput, somaHome: string): Proj
       },
       {
         path: "agent/soma/profile.md",
-        content: withProvenance("pi-dev", ["# Soma Profile Projection", "", renderAssistantCore(input)].join("\n")),
+        content: withProvenance("pi-dev", renderProfilePointer(input, "context.md")),
       },
       {
         path: "agent/soma/memory-layout.md",

--- a/src/adapters/shared/index.ts
+++ b/src/adapters/shared/index.ts
@@ -191,6 +191,22 @@ export function renderAssistantCore(input: ProjectionInput): string {
 }
 
 /**
+ * Profiles are an explicit, on-demand orientation surface. They must not carry
+ * the assistant core because several substrates load their context and profile
+ * files into the same prompt.
+ */
+export function renderProfilePointer(input: ProjectionInput, contextPath: string): string {
+  return [
+    "# Soma Profile Projection",
+    "",
+    "This profile is an on-demand pointer and intentionally does not repeat the assistant core.",
+    `Assistant Name: ${input.profile.assistant.name}`,
+    `Principal Name: ${input.profile.principal.name}`,
+    `Read \`${contextPath}\` for the projected assistant identity, principal, purpose, and active VSA.`,
+  ].join("\n");
+}
+
+/**
  * The communication contract as a projected file, or `[]` when the home has
  * none. Content is the VERBATIM authored markdown — no provenance header and
  * no re-render, same contract as the memory INDEX and the active VSA: this is

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -74,6 +74,7 @@ test("builds codex home projection bundle for default availability", () => {
     "hooks/codex-policy-targets.mjs",
     "hooks/policy-marker.mjs",
     "skills/soma/SKILL.md",
+    "memories/soma/context.md",
     "memories/soma/profile.md",
     "memories/soma/memory-layout.md",
     "memories/soma/pai-imports.md",
@@ -415,7 +416,7 @@ test("installs codex home projection into a substrate home", async () => {
 
     expect(result.substrate).toBe("codex");
     expect(result.rootDir).toBe(join(homeDir, ".codex"));
-    expect(result.files).toHaveLength(19);
+    expect(result.files).toHaveLength(20);
 
     const rules = await readFile(join(homeDir, ".codex/rules/soma.rules"), "utf8");
     const hooks = await readFile(join(homeDir, ".codex/hooks.json"), "utf8");
@@ -426,6 +427,7 @@ test("installs codex home projection into a substrate home", async () => {
     const policyTargets = await readFile(join(homeDir, ".codex/hooks/codex-policy-targets.mjs"), "utf8");
     const skill = await readFile(join(homeDir, ".codex/skills/soma/SKILL.md"), "utf8");
     const algorithmSkill = await readFile(join(homeDir, ".codex/skills/the-algorithm/SKILL.md"), "utf8");
+    const context = await readFile(join(homeDir, ".codex/memories/soma/context.md"), "utf8");
     const profile = await readFile(join(homeDir, ".codex/memories/soma/profile.md"), "utf8");
     const paiImports = await readFile(join(homeDir, ".codex/memories/soma/pai-imports.md"), "utf8");
     const lifecycle = await readFile(join(homeDir, ".codex/memories/soma/lifecycle.md"), "utf8");
@@ -476,7 +478,7 @@ test("installs codex home projection into a substrate home", async () => {
     expect(algorithmSkill).toContain("━━━ 📃 SUMMARY ━━━ 7/7");
     expect(profile).toContain("on-demand pointer");
     expect(profile).toContain("Assistant Name: soma");
-    expect(skill).toContain("ISC-PORTABLE-1");
+    expect(context).toContain("ISC-PORTABLE-1");
     expect(paiImports).toContain(`${homeDir}/.soma/profile/imports/claude/DA_IDENTITY.md`);
     expect(lifecycle).toContain("Soma Lifecycle Projection");
     expect(lifecycle).toContain("soma-repo.txt");

--- a/test/home-projection.test.ts
+++ b/test/home-projection.test.ts
@@ -474,7 +474,9 @@ test("installs codex home projection into a substrate home", async () => {
     expect(skill).toContain("Do not assume a global `soma` binary exists");
     expect(algorithmSkill).toContain("━━━ ✅ VERIFY ━━━ 6/7");
     expect(algorithmSkill).toContain("━━━ 📃 SUMMARY ━━━ 7/7");
-    expect(profile).toContain("ISC-PORTABLE-1");
+    expect(profile).toContain("on-demand pointer");
+    expect(profile).toContain("Assistant Name: soma");
+    expect(skill).toContain("ISC-PORTABLE-1");
     expect(paiImports).toContain(`${homeDir}/.soma/profile/imports/claude/DA_IDENTITY.md`);
     expect(lifecycle).toContain("Soma Lifecycle Projection");
     expect(lifecycle).toContain("soma-repo.txt");
@@ -537,6 +539,7 @@ test("installs pi.dev home projection into a substrate home", async () => {
 
     const extension = await readFile(join(homeDir, ".pi/agent/extensions/soma.ts"), "utf8");
     const algorithmExtension = await readFile(join(homeDir, ".pi/agent/extensions/soma-algorithm.ts"), "utf8");
+    const context = await readFile(join(homeDir, ".pi/agent/soma/context.md"), "utf8");
     const profile = await readFile(join(homeDir, ".pi/agent/soma/profile.md"), "utf8");
     const paiImports = await readFile(join(homeDir, ".pi/agent/soma/pai-imports.md"), "utf8");
     const skill = await readFile(join(homeDir, ".pi/agent/skills/soma/SKILL.md"), "utf8");
@@ -554,7 +557,9 @@ test("installs pi.dev home projection into a substrate home", async () => {
     expect(extension).not.toContain('"memory_promote"');
     expect(extension).toContain("session_shutdown");
     expect(extension).toContain("resources_discover");
-    expect(profile).toContain("ISC-PORTABLE-1");
+    expect(profile).toContain("on-demand pointer");
+    expect(profile).toContain("Assistant Name: soma");
+    expect(context).toContain("ISC-PORTABLE-1");
     expect(paiImports).toContain(`${homeDir}/.soma/profile/imports/claude/DA_IDENTITY.md`);
     expect(skill).toContain("Do not assume a global `soma` binary exists");
     expect(skill).toContain("name: soma");

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -188,14 +188,14 @@ test("installs soma source home and codex home projection", async () => {
     expect(result.substrate).toBe("codex");
     expect(result.somaHome.somaHome).toBe(join(homeDir, ".soma"));
     expect(result.substrateHome.rootDir).toBe(join(homeDir, ".codex"));
-    // 21 static + 22 bundled-skill projections (Memory ×5, the-algorithm
+    // 22 static + 22 bundled-skill projections (Memory ×5, the-algorithm
     // Workflows ×1 and its eight references — algorithm, capabilities,
     // eval-guide, ideate-loop, mode-detection, optimize-loop, parameter-schema,
     // target-types — the portable the-algorithm/SKILL.md that the static
     // rendering contract overwrites — double-written by design, grok/codex —
     // migrate-pai-purpose/SKILL.md ×1, and orienteer ×6: SKILL.md, two
     // Workflows, three references).
-    expect(result.substrateHome.files).toHaveLength(44);
+    expect(result.substrateHome.files).toHaveLength(45);
 
     const telos = await readFile(join(homeDir, ".soma/profile/purpose.md"), "utf8");
     const rules = await readFile(join(homeDir, ".codex/rules/soma.rules"), "utf8");
@@ -222,6 +222,7 @@ test("installs soma source home and codex home projection", async () => {
     expect(hookEntry).not.toContain("__SOMA_FEEDBACK_TRIGGER_PATTERN_SOURCE__");
     expect(hookEntry).not.toContain("__SOMA_FEEDBACK_CAPTURE_HELPER__");
     expect(somaRepo).toContain("soma");
+    expect(agents).toContain("@./memories/soma/context.md");
     expect(agents).toContain("@./skills/the-algorithm/SKILL.md");
     expect(agents).toContain("@./memories/soma/startup-context.md");
     expect(skill).toContain("name: soma");

--- a/test/projection-duplication.test.ts
+++ b/test/projection-duplication.test.ts
@@ -40,7 +40,7 @@ test("profiles point to context without repeating assistant-core sections", () =
     {
       name: "codex",
       files: projectCodexHome(portableProjectionInput, "/tmp/soma-home").files,
-      contextPath: "skills/soma/SKILL.md",
+      contextPath: "memories/soma/context.md",
       profilePath: "memories/soma/profile.md",
     },
   ];
@@ -61,6 +61,17 @@ test("Claude profile points to its sibling context file", () => {
   const profile = contentAt(projectClaudeCodeHome(portableProjectionInput).files, "rules/soma/PROFILE.md");
 
   expect(profile).toContain("Read `CONTEXT.md beside this file`");
+});
+
+test("Codex keeps assistant core in its eager context artifact", () => {
+  const files = projectCodexHome(portableProjectionInput, "/tmp/soma-home").files;
+  const skill = contentAt(files, "skills/soma/SKILL.md");
+  const profile = contentAt(files, "memories/soma/profile.md");
+
+  for (const heading of ASSISTANT_CORE_HEADINGS) {
+    expect(skill).not.toContain(heading);
+  }
+  expect(profile).toContain("Read `context.md beside this file`");
 });
 
 test("pi.dev loads context, not profile, on each agent turn", () => {

--- a/test/projection-duplication.test.ts
+++ b/test/projection-duplication.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import { projectClaudeCodeHome, projectCodexHome, projectCursor, projectPiDevHome } from "../src/index";
+import { projectAnthropicCoworkHome } from "../src/adapters/anthropic-cowork";
+import { portableProjectionInput } from "./fixtures";
+
+const ASSISTANT_CORE_HEADINGS = ["## Assistant", "## Principal", "## Purpose", "## Active VSA"];
+
+function contentAt(files: { path: string; content: string }[], path: string): string {
+  const file = files.find((candidate) => candidate.path === path);
+  expect(file, `missing projected file ${path}`).toBeDefined();
+  return file?.content ?? "";
+}
+
+test("profiles point to context without repeating assistant-core sections", () => {
+  const projections = [
+    {
+      name: "claude-code",
+      files: projectClaudeCodeHome(portableProjectionInput).files,
+      contextPath: "rules/soma/CONTEXT.md",
+      profilePath: "rules/soma/PROFILE.md",
+    },
+    {
+      name: "cursor",
+      files: projectCursor(portableProjectionInput).files,
+      contextPath: ".cursor/rules/soma/CONTEXT.md",
+      profilePath: ".cursor/rules/soma/PROFILE.md",
+    },
+    {
+      name: "anthropic-cowork",
+      files: projectAnthropicCoworkHome(portableProjectionInput).files,
+      contextPath: "soma/instructions.md",
+      profilePath: "soma/profile.md",
+    },
+    {
+      name: "pi-dev",
+      files: projectPiDevHome(portableProjectionInput, "/tmp/soma-home").files,
+      contextPath: "agent/soma/context.md",
+      profilePath: "agent/soma/profile.md",
+    },
+    {
+      name: "codex",
+      files: projectCodexHome(portableProjectionInput, "/tmp/soma-home").files,
+      contextPath: "skills/soma/SKILL.md",
+      profilePath: "memories/soma/profile.md",
+    },
+  ];
+
+  for (const projection of projections) {
+    const context = contentAt(projection.files, projection.contextPath);
+    const profile = contentAt(projection.files, projection.profilePath);
+
+    for (const heading of ASSISTANT_CORE_HEADINGS) {
+      expect(context, `${projection.name} context must include ${heading}`).toContain(heading);
+      expect(profile, `${projection.name} profile must not repeat ${heading}`).not.toContain(heading);
+    }
+    expect(profile).toContain("on-demand pointer");
+  }
+});
+
+test("pi.dev loads context, not profile, on each agent turn", () => {
+  const extension = contentAt(projectPiDevHome(portableProjectionInput, "/tmp/soma-home").files, "agent/extensions/soma.ts");
+
+  expect(extension).toContain('if (action === "profile") return `${PI_SOMA_HOME}/profile.md`;');
+  expect(extension).toContain('readText(`${PI_SOMA_HOME}/profile.md`)');
+  expect(extension).not.toContain('const profile = readOptional(`${PI_SOMA_HOME}/profile.md`);');
+  expect(extension).not.toContain("${profile}");
+  expect(extension).toContain('const context = readOptional(`${PI_SOMA_HOME}/context.md`);');
+  expect(extension).toContain("${context}");
+});

--- a/test/projection-duplication.test.ts
+++ b/test/projection-duplication.test.ts
@@ -57,6 +57,12 @@ test("profiles point to context without repeating assistant-core sections", () =
   }
 });
 
+test("Claude profile points to its sibling context file", () => {
+  const profile = contentAt(projectClaudeCodeHome(portableProjectionInput).files, "rules/soma/PROFILE.md");
+
+  expect(profile).toContain("Read `CONTEXT.md beside this file`");
+});
+
 test("pi.dev loads context, not profile, on each agent turn", () => {
   const extension = contentAt(projectPiDevHome(portableProjectionInput, "/tmp/soma-home").files, "agent/extensions/soma.ts");
 

--- a/test/soma-home.test.ts
+++ b/test/soma-home.test.ts
@@ -92,7 +92,9 @@ test("bootstrapped soma home feeds codex home projection", async () => {
 
     expect(projection.somaHome).toBe(somaHome);
     expect(projection.bundle.instructions).toContain("Soma source of truth");
-    expect(projection.bundle.instructions).toContain("Establish Soma as the durable personal assistant home.");
+    expect(projection.bundle.files.find((file) => file.path === "memories/soma/context.md")?.content).toContain(
+      "Establish Soma as the durable personal assistant home.",
+    );
   });
 });
 


### PR DESCRIPTION
Fixes #543.

Profiles retain only assistant and principal names plus a pointer to the single full context. Pi.dev now injects context without profile.md on each turn.

Tests: bun test --reporter=dot; bun run typecheck; touched-file eslint.